### PR TITLE
pre-flight: wire GH Actions cron + /api/health + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-flight runs for the same ref when a newer commit arrives.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Typecheck & test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+  mcp-build:
+    name: MCP server build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcp/package-lock.json
+
+      - name: Install MCP dependencies
+        working-directory: mcp
+        run: npm ci
+
+      - name: Build MCP server
+        working-directory: mcp
+        run: npm run build

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,80 @@
+name: pipeline
+
+# Drives the live ingestion pipeline against the deployed Railway host.
+# The runner holds no pipeline state — it only signals the long-lived
+# Next.js process to refresh its hot / warm / cold tiers. State lives in
+# the Railway container's in-memory stores + JSONL on the persistent
+# volume; see docs/INGESTION.md and docs/DATABASE.md.
+#
+# Required repository secrets:
+#   STARSCREENER_URL  — https://starscreener-production.up.railway.app
+#   CRON_SECRET       — matches the CRON_SECRET env on the Railway deploy
+#
+# Pre-flight cadence is intentionally conservative (*/15 hot) to stay
+# inside the GitHub Actions free-tier budget while proving the loop.
+# Migrate to Railway cron (railway.toml cron service) once confidence
+# is established — see REPORT.md recommendation #1.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # hot tier   — every 15 min
+    - cron: '17 */6 * * *'   # warm tier  — every 6h, offset to avoid collisions
+    - cron: '23 8 * * *'     # cold tier  — daily 08:23 UTC
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Tier to refresh'
+        required: true
+        default: hot
+        type: choice
+        options: [hot, warm, cold]
+
+concurrency:
+  group: pipeline
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Resolve tier from trigger
+        id: tier
+        run: |
+          case "${{ github.event.schedule }}" in
+            '*/15 * * * *') echo "tier=hot" >> "$GITHUB_OUTPUT" ;;
+            '17 */6 * * *') echo "tier=warm" >> "$GITHUB_OUTPUT" ;;
+            '23 8 * * *')   echo "tier=cold" >> "$GITHUB_OUTPUT" ;;
+            *)              echo "tier=${{ github.event.inputs.tier || 'hot' }}" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Ingest ${{ steps.tier.outputs.tier }}
+        env:
+          STARSCREENER_URL: ${{ secrets.STARSCREENER_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          TIER: ${{ steps.tier.outputs.tier }}
+        run: |
+          if [ -z "$STARSCREENER_URL" ] || [ -z "$CRON_SECRET" ]; then
+            echo "::error::STARSCREENER_URL and CRON_SECRET repo secrets must be set."
+            exit 1
+          fi
+          curl --fail-with-body \
+               --show-error \
+               --silent \
+               --retry 3 \
+               --retry-delay 5 \
+               --retry-all-errors \
+               --max-time 300 \
+               -X POST \
+               -H "Authorization: Bearer ${CRON_SECRET}" \
+               -H "Content-Type: application/json" \
+               "${STARSCREENER_URL%/}/api/cron/ingest?tier=${TIER}"
+
+      - name: Verify freshness via /api/health
+        env:
+          STARSCREENER_URL: ${{ secrets.STARSCREENER_URL }}
+        run: |
+          # Ingest completes synchronously — health should be ok on the
+          # same tier we just refreshed. 503 from /api/health fails the job.
+          curl --fail-with-body --silent --show-error --max-time 30 \
+               "${STARSCREENER_URL%/}/api/health"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,72 @@
+// GET /api/health
+//
+// Freshness-gated health endpoint designed for external uptime monitors
+// (UptimeRobot, BetterStack, etc.). Returns 503 when the pipeline is
+// stale or empty so a ping-style checker can alert without parsing JSON.
+//
+// Distinct from /api/pipeline/status, which is a data-counts snapshot
+// and always returns 200 on a dead pipeline (see REPORT.md finding #5).
+// Do not fold the two together — status is operator-facing telemetry,
+// health is a boolean uptime gate.
+
+import { NextResponse } from "next/server";
+import { pipeline } from "@/lib/pipeline/pipeline";
+
+// 2 hours ≈ 2× hot-tier cadence (see docs/INGESTION.md). Stale past this
+// means at least one hot pass has missed; operator should be paged.
+const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+
+type HealthStatus = "ok" | "stale" | "empty" | "error";
+
+interface HealthBody {
+  status: HealthStatus;
+  lastRefreshAt: string | null;
+  ageSeconds: number | null;
+  thresholdSeconds: number;
+  error?: string;
+}
+
+export async function GET(): Promise<NextResponse<HealthBody>> {
+  try {
+    await pipeline.ensureReady();
+    const stats = pipeline.getGlobalStats();
+    const lastRefreshAt = stats.lastRefreshAt;
+
+    if (!lastRefreshAt) {
+      return NextResponse.json(
+        {
+          status: "empty",
+          lastRefreshAt: null,
+          ageSeconds: null,
+          thresholdSeconds: STALE_THRESHOLD_MS / 1000,
+        },
+        { status: 503 },
+      );
+    }
+
+    const ageMs = Date.now() - new Date(lastRefreshAt).getTime();
+    const stale = ageMs > STALE_THRESHOLD_MS;
+
+    return NextResponse.json(
+      {
+        status: stale ? "stale" : "ok",
+        lastRefreshAt,
+        ageSeconds: Math.floor(ageMs / 1000),
+        thresholdSeconds: STALE_THRESHOLD_MS / 1000,
+      },
+      { status: stale ? 503 : 200 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      {
+        status: "error",
+        lastRefreshAt: null,
+        ageSeconds: null,
+        thresholdSeconds: STALE_THRESHOLD_MS / 1000,
+        error: message,
+      },
+      { status: 503 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- `pipeline.yml`: GH Actions cron — `*/15` hot, `17 */6` warm, `23 8` daily cold + `workflow_dispatch`. Pings Railway `/api/cron/ingest` with `CRON_SECRET`. Verifies `/api/health` post-ingest so a stale deploy fails the job.
- `/api/health`: returns 503 when `lastRefreshAt > 2h` (or missing). UptimeRobot-friendly. Distinct from `/api/pipeline/status` which stays a data-counts snapshot.
- `ci.yml`: typecheck + test on push/PR + separate `mcp-build` job. No secrets, no side effects.

## Required before merge fires anything useful
- Repo secrets `STARSCREENER_URL` + `CRON_SECRET` must exist at https://github.com/0motionguy/starscreener/settings/secrets/actions — otherwise `pipeline.yml` fails fast with a clear error.

## Test plan
- [ ] Add secrets
- [ ] Merge this PR
- [ ] `gh workflow run pipeline.yml` → `gh run watch` → verify green
- [ ] `curl /api/health` returns 200
- [ ] `.data/snapshots.jsonl` gets a fresh row
- [ ] Wait one */15 tick, confirm second row lands
- [ ] Wire UptimeRobot at `/api/health`
- [ ] Gate 4: `curl /api/categories` on 7 canonical AI repos

Closes the "200 OK on a dead pipeline" gap from the audit (finding #5) and gives the pipeline a scheduler at all (finding #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)