### PR TITLE
fix(cron): route */15 to warm until hot tier is populated

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,11 +41,16 @@ jobs:
       - name: Resolve tier from trigger
         id: tier
         run: |
+          # Interim: */15 fires warm instead of hot because the hot-tier
+          # assignTier filter returns zero repos under the current seed
+          # (verified 2026-04-18 — tier=hot returns processed:0 in 5ms,
+          # so every /api/health verify step fails). Route */15 to warm
+          # until P0.3 populates the hot tier from WATCHLIST_SEED.md.
           case "${{ github.event.schedule }}" in
-            '*/15 * * * *') echo "tier=hot" >> "$GITHUB_OUTPUT" ;;
+            '*/15 * * * *') echo "tier=warm" >> "$GITHUB_OUTPUT" ;;
             '17 */6 * * *') echo "tier=warm" >> "$GITHUB_OUTPUT" ;;
             '23 8 * * *')   echo "tier=cold" >> "$GITHUB_OUTPUT" ;;
-            *)              echo "tier=${{ github.event.inputs.tier || 'hot' }}" >> "$GITHUB_OUTPUT" ;;
+            *)              echo "tier=${{ github.event.inputs.tier || 'warm' }}" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Ingest ${{ steps.tier.outputs.tier }}


### PR DESCRIPTION
## Summary
Interim one-line fix (plus comment explaining why).

\`/api/cron/ingest?tier=hot\` returns \`processed:0\` in 5ms on the current seed — the hot-tier \`assignTier\` filter yields zero repos. Every \`*/15\` cron run was succeeding at ingest but failing the post-ingest \`/api/health\` verify step because \`lastRefreshAt\` never moved.

Routing \`*/15\` to warm keeps the freshness gate green between \`*/6h\` warm ticks and ensures each GH Actions run does real work.

## Scope
- `.github/workflows/pipeline.yml` — `*/15` case arm: `hot` → `warm`. `workflow_dispatch` default: `hot` → `warm`. Added comment pointing at the P0.3 follow-up.

## Test plan
- [ ] Merge
- [ ] Wait for next `*/15` tick
- [ ] `gh run view --log` shows green verify step
- [ ] `curl /api/health` stays 200 between ticks
- [ ] Revert this arm to `hot` once P0.3 populates hot from `WATCHLIST_SEED.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)