### PR TITLE
Sidebar 7-section restructure + Trending Skills/MCP pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,14 @@ CRON_SECRET=
 # STARSCREENER_ALLOW_MOCK=true
 # Allow boot without GITHUB_TOKEN / CRON_SECRET in production (preview only).
 # STARSCREENER_ALLOW_MISSING_ENV=true
+
+# ── Sentry (errors + source maps + scrape-script alarms) ────────────────────
+# Create project at https://sentry.io/organizations/<org>/projects/new/
+# (pick "Next.js"). DSN powers both the Next app AND scripts/_logger.mjs
+# (cron scrapers). Same DSN in both NEXT_PUBLIC_SENTRY_DSN (browser) and
+# SENTRY_DSN (server + scrape scripts). Auth token gates source-map upload.
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_DSN=
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=trendingrepo

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,14 @@ CRON_SECRET=
 # Allow boot without GITHUB_TOKEN / CRON_SECRET in production (preview only).
 # STARSCREENER_ALLOW_MISSING_ENV=true
 
+# ── PostHog (web analytics + product analytics) ─────────────────────────────
+# Same project key as AISO + AGNT — one PostHog org, three surfaces, person
+# profiles merge across properties when distinct_id matches Supabase user.id.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://us.i.posthog.com
+
 # ── Sentry (errors + source maps + scrape-script alarms) ────────────────────
 # Create project at https://sentry.io/organizations/<org>/projects/new/
 # (pick "Next.js"). DSN powers both the Next app AND scripts/_logger.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ dogfood-output/
 build_*.log
 build-*.log
 typecheck_*.log
+dev_server*.log
+
+# scratch probe directories from local debug sessions
+tmp_probe/
 
 # embedded clones (not submodules)
 awesome-codex-skills/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,21 +20,29 @@ Real-time trend-discovery scanner. Aggregates GitHub stars, Twitter buzz, Reddit
 - `mcp/` — MCP server source for code-review-graph integration
 - `docs/` — `ARCHITECTURE.md`, `DATABASE.md`, `DEPLOY.md`, `INGESTION.md`, `TWITTER_SIGNAL_LAYER.md`, `SOURCE_DISCOVERY.md`, plus protocols/ and review/ subdirs
 
+## Setup
+- `npm install` (Node 22.x — pinned via `engines` in package.json)
+- Copy `.env.example` to `.env.local`. Required for prod: `GITHUB_TOKEN`, `CRON_SECRET`. Pick exactly ONE Redis pair: `REDIS_URL` (Railway) OR `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` (Upstash) — never both. Without either, the data-store gracefully falls back to bundled JSON + memory.
+- Windows + OneDrive gotcha: dev server hits ENOENT loops without the `.next` junction workaround in `next.config.ts:12-25`. CSS edits can also be silently reverted by OneDrive sync — see memory note `project_onedrive_dev_server_block`.
+
 ## Critical Conventions
 - **Data reads MUST go through the data-store.** Server components / route handlers call the per-source `refreshXxxFromStore()` (async) once at the top, then sync getters in the rest of the file return whatever's in the in-memory cache. Each refresh hook has internal 30s rate-limit + in-flight dedupe so calling it on every render is cheap. Pattern reference: [src/lib/trending.ts:refreshTrendingFromStore](src/lib/trending.ts) and [src/app/page.tsx](src/app/page.tsx). Plan + provisioning: [tasks/data-api.md](tasks/data-api.md).
 - **Collectors dual-write file + Redis** during transition via [scripts/_data-store-write.mjs](scripts/_data-store-write.mjs). When `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` are missing, the Redis write is skipped silently and the file write stays — graceful degradation by design.
 - **Collectors run in `direct` mode**, NOT `api` mode. Vercel's serverless filesystem is ephemeral — API-mode writes vanish. GitHub Actions writes locally to `.data/*.jsonl` and `git push` from the workflow. See `.github/workflows/collect-twitter.yml` (committed fix `edf99d2`).
-- **Twitter** uses Apify `apidojo~tweet-scraper` actor. Cookie-based providers are dead post-2026 anti-bot. Bundle = 4 queries per repo for tier-1 coverage.
+- **Twitter** uses Apify `apidojo~tweet-scraper` actor. Cookie-based providers are dead post-2026 anti-bot. Apify actor runs 4 query templates per tracked repo per scan.
 - **Append-only JSONL.** Each scan adds new lines, never replaces. Aggregator dedupes downstream.
-- **Production page** renders skeleton SSR + client hydration. Fresh data only appears after JS execution.
+- **Home page (`/`) is ISR-cached at 30 min** (`revalidate=1800`). Bundled JSON seeds the cold start; client refresh hooks repopulate the in-memory cache on navigation. Don't expect fresh data on first paint.
 
 ## Common Tasks
-- Dev: `npm run dev` (Turbopack)
-- Lint/typecheck: `npm run lint` / `npm run typecheck`
-- Tests: `npm test` (where present in `scripts/__tests__/` and route-level)
-- Local scrape: `npm run scrape:twitter` / `:reddit` / `:hn` / `:bsky` / `:ph` / `:devto`
+- Dev: `npm run dev` (Turbopack, port 3023)
+- Lint: `npm run lint` / `npm run lint:guards` (the meta-lint catches Zod-on-mutating-routes, error envelopes, runtime drift)
+- Typecheck: `npm run typecheck` (run before every commit per ICM Motion "Verification Before Done")
+- Tests: `npm test` runs node:test + tsx + vitest in serial. Subsuites: `npm run test:hooks` / `:hooks:watch` (vitest), `npm run test:e2e` / `:e2e:ui` (Playwright)
+- Build/start: `npm run build` / `npm start` (production path)
+- Local collectors: `npm run collect:twitter` (Apify, NOT scrape:twitter), `npm run scrape:reddit` / `:hn` / `:bsky` / `:ph` / `:devto` / `:lobsters` / `:arxiv` / `:npm`
+- Intake: `npm run ingest:arxiv-cited` (intake pipeline for arXiv-cited repos)
 - Trigger workflow: `gh workflow run collect-twitter.yml`
-- Build graph: `code-review-graph build` (run once after major refactor; auto-updates on Edit/Write/Bash via project hook)
+- Build graph: `code-review-graph build` (auto-runs via project hook on Edit/Write/Bash; pre-commit hook also runs `code-review-graph detect-changes`)
 - Verify Redis data-store: `npm run verify:data-store` (requires `REDIS_URL` for Railway, OR `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` for Upstash)
 
 ## Where to Look First
@@ -43,6 +51,7 @@ Real-time trend-discovery scanner. Aggregates GitHub stars, Twitter buzz, Reddit
 - Ingest pipeline? `docs/INGESTION.md` + `docs/TWITTER_SIGNAL_LAYER.md`
 - Deploy issues? `docs/DEPLOY.md`
 - Adding a signal source? `docs/SOURCE_DISCOVERY.md`
+- See `apps/trendingrepo-worker/` referenced in code? Sister Railway service hosting ~37 fetchers (MCP registries, funding sources, scoring) — lives in worktree branches not yet in main. See memory `project_trendingrepo_worker.md`.
 
 ## Anti-Patterns Already Burned
 - Don't switch Twitter collector back to API mode — it silently fails on Vercel.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,10 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}
+
+export { captureRequestError as onRequestError } from "@sentry/nextjs";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import bundleAnalyzer from "@next/bundle-analyzer";
+import { withSentryConfig } from "@sentry/nextjs";
 
 // Bundle-size visualization: `npm run analyze` sets ANALYZE=true and runs a
 // production build, dumping interactive HTML reports to .next/analyze/.
@@ -162,4 +163,19 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withBundleAnalyzer(nextConfig);
+// Sentry wrap — outermost so source-map upload + auto-instrumentation
+// run after bundle analyzer + base config. SENTRY_AUTH_TOKEN gates the
+// upload (set in CI / Vercel prod build env only).
+const sentryWebpackPluginOptions = {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  silent: !process.env.CI,
+  widenClientFileUpload: true,
+  hideSourceMaps: true,
+  disableLogger: true,
+  automaticVercelMonitors: false,
+  tunnelRoute: "/api/_sentry-tunnel",
+};
+
+export default withSentryConfig(withBundleAnalyzer(nextConfig), sentryWebpackPluginOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@sentry/nextjs": "^10.50.0",
         "@upstash/redis": "^1.37.0",
-        "@vercel/analytics": "^2.0.1",
         "framer-motion": "^12.38.0",
         "ioredis": "^5.10.1",
         "linkedom": "^0.18.12",
@@ -18,6 +18,7 @@
         "next": "15.5.15",
         "next-themes": "^0.4.6",
         "p-limit": "^7.3.0",
+        "posthog-js": "^1.372.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "recharts": "^3.8.1",
@@ -71,7 +72,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -86,7 +86,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -96,7 +95,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -127,7 +125,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -140,7 +137,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -150,7 +146,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -167,7 +162,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -184,7 +178,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -194,7 +187,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -204,7 +196,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -218,7 +209,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -246,7 +236,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -256,7 +245,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -266,7 +254,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -276,7 +263,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -290,7 +276,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -348,7 +333,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -363,7 +347,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -382,7 +365,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1028,6 +1010,108 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fastify/otel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1556,7 +1640,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1567,7 +1650,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1578,24 +1660,32 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1817,6 +1907,738 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
+      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
+      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
+      "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
+      "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -1839,6 +2661,138 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.27.7",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.7.tgz",
+      "integrity": "sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.372.3"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.372.3",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.3.tgz",
+      "integrity": "sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==",
+      "license": "MIT"
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -1883,6 +2837,107 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
+      "integrity": "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -1890,7 +2945,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,7 +2958,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1918,7 +2971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1932,7 +2984,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1946,7 +2997,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1960,7 +3010,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1974,7 +3023,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1988,7 +3036,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2002,7 +3049,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,7 +3062,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2030,7 +3075,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2044,7 +3088,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2058,7 +3101,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2072,7 +3114,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2086,7 +3127,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2100,7 +3140,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2114,7 +3153,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2128,7 +3166,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2142,7 +3179,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2156,7 +3192,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2170,7 +3205,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2184,7 +3218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2198,7 +3231,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2212,7 +3244,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2226,7 +3257,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2246,6 +3276,447 @@
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.50.0.tgz",
+      "integrity": "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.50.0.tgz",
+      "integrity": "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.50.0.tgz",
+      "integrity": "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.50.0.tgz",
+      "integrity": "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.0.tgz",
+      "integrity": "sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.50.0.tgz",
+      "integrity": "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry-internal/feedback": "10.50.0",
+        "@sentry-internal/replay": "10.50.0",
+        "@sentry-internal/replay-canvas": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.2.0.tgz",
+      "integrity": "sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "5.2.0",
+        "@sentry/cli": "^2.58.5",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
+      "integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.5",
+        "@sentry/cli-linux-arm": "2.58.5",
+        "@sentry/cli-linux-arm64": "2.58.5",
+        "@sentry/cli-linux-i686": "2.58.5",
+        "@sentry/cli-linux-x64": "2.58.5",
+        "@sentry/cli-win32-arm64": "2.58.5",
+        "@sentry/cli-win32-i686": "2.58.5",
+        "@sentry/cli-win32-x64": "2.58.5"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
+      "integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
+      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
+      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
+      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
+      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
+      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
+      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
+      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
+      "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/nextjs": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.50.0.tgz",
+      "integrity": "sha512-IyDaOpbWUzfAqFoTQUSpvmG1fC6GBkCOd6eTYoT8ZNfxXYPBVd4eQFTNNh09CvOkNe1QIVvVshajg1TqUNWK4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@rollup/plugin-commonjs": "28.0.1",
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry/bundler-plugin-core": "^5.2.0",
+        "@sentry/core": "10.50.0",
+        "@sentry/node": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
+        "@sentry/react": "10.50.0",
+        "@sentry/vercel-edge": "10.50.0",
+        "@sentry/webpack-plugin": "^5.2.0",
+        "rollup": "^4.35.0",
+        "stacktrace-parser": "^0.1.11"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.50.0.tgz",
+      "integrity": "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-ioredis": "0.62.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-redis": "0.62.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.50.0",
+        "@sentry/node-core": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.50.0.tgz",
+      "integrity": "sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.50.0.tgz",
+      "integrity": "sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.50.0.tgz",
+      "integrity": "sha512-MZHYjEZAtFIa4zPrWS4oXlo+gMppRvfETqUqF920Sj2jN2U7WjboU03lDmjfDqEcH7QiwjQyl13jHd2nwAyrrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.50.0",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/vercel-edge": {
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.50.0.tgz",
+      "integrity": "sha512-/LGUKF3QycR/qBhJl5EOjk1U1i/TJ3xhjqcPgjyFgIVRRSt0ouvRNFAkGa/Q/MTo5r0gWi+ZxLUwvByOFNfBow==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/resources": "^2.6.1",
+        "@sentry/core": "10.50.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/webpack-plugin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-5.2.0.tgz",
+      "integrity": "sha512-ssV/uJK3ixf8UHBrNdLBXcnprUwppJNilbFv+19I81KTH4gVwzKXsVTMO91j6lyAXtk2mORwmEFwxZqScFfc7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "webpack": ">=5.0.0"
+      }
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -2730,6 +4201,15 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2793,18 +4273,38 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -2814,6 +4314,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2821,6 +4330,26 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
       }
     },
     "node_modules/@types/react": {
@@ -2842,6 +4371,22 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -3409,48 +4954,6 @@
         "uncrypto": "^0.1.3"
       }
     },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3585,17 +5088,213 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3621,6 +5320,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3637,6 +5348,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3915,7 +5668,6 @@
       "version": "2.10.23",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
       "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3958,7 +5710,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3987,6 +5738,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4120,6 +5878,22 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -4174,6 +5948,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4185,8 +5965,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -4617,6 +6407,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -4629,6 +6428,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -4656,7 +6467,6 @@
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -4670,7 +6480,6 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4929,7 +6738,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5326,7 +7134,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -5339,7 +7146,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -5371,6 +7177,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5385,7 +7201,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5438,6 +7253,23 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5447,6 +7279,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5478,7 +7316,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -5528,6 +7365,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/framer-motion": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
@@ -5559,7 +7402,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5624,7 +7466,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5698,6 +7539,23 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5709,6 +7567,49 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -5757,7 +7658,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/gzip-size": {
@@ -5808,7 +7708,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5920,6 +7819,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5955,6 +7867,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/imurmurhash": {
@@ -6282,6 +8209,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6438,7 +8374,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -6459,6 +8394,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -6473,7 +8439,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6493,7 +8458,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -6881,11 +8845,24 @@
         }
       }
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -6916,6 +8893,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6940,7 +8923,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -6969,7 +8951,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6983,6 +8964,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7008,6 +8996,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7030,6 +9028,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/motion-dom": {
       "version": "12.38.0",
@@ -7102,6 +9115,13 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/next": {
       "version": "15.5.15",
@@ -7222,11 +9242,30 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nth-check": {
@@ -7428,7 +9467,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -7444,7 +9482,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -7460,7 +9497,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7486,7 +9522,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7509,6 +9544,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -7524,6 +9584,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/picocolors": {
@@ -7637,6 +9728,88 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/posthog-js": {
+      "version": "1.372.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.3.tgz",
+      "integrity": "sha512-CpKWMt6RkgY4lPpyvYzKcilKKB5VhL2gmS8HgibxmXZkEk/2rUxrEtRMScH8xi4n5WDaNSluCo87dh9yo9zArQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.27.7",
+        "@posthog/types": "1.372.3",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7682,6 +9855,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7693,6 +9875,36 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7718,6 +9930,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7910,6 +10128,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -7996,7 +10237,6 @@
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -8121,6 +10361,63 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -8356,6 +10653,16 @@
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8363,6 +10670,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stable-hash": {
@@ -8378,6 +10696,18 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
@@ -8635,7 +10965,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8644,6 +10973,66 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -8766,6 +11155,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8829,6 +11224,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -8999,7 +11403,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9659,6 +12062,26 @@
         }
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -9667,6 +12090,54 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "loader-runner": "^4.3.1",
+        "mime-db": "^1.54.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-bundle-analyzer": {
@@ -9704,6 +12175,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webpack-sources": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
+      "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -9714,11 +12226,26 @@
         "node": ">=12"
       }
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9868,11 +12395,19 @@
         }
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -100,8 +100,8 @@
     "portal:conformance": "node scripts/portal-conformance.mjs"
   },
   "dependencies": {
+    "@sentry/nextjs": "^10.50.0",
     "@upstash/redis": "^1.37.0",
-    "@vercel/analytics": "^2.0.1",
     "framer-motion": "^12.38.0",
     "ioredis": "^5.10.1",
     "linkedom": "^0.18.12",
@@ -109,6 +109,7 @@
     "next": "15.5.15",
     "next-themes": "^0.4.6",
     "p-limit": "^7.3.0",
+    "posthog-js": "^1.372.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "recharts": "^3.8.1",

--- a/scripts/_logger.mjs
+++ b/scripts/_logger.mjs
@@ -1,0 +1,115 @@
+// Shared structured logger for the standalone scrape scripts (cron-driven,
+// run under node by GitHub Actions). Writes to stdout for GHA log capture
+// AND mirrors warn/error/fatal events to Sentry when SENTRY_DSN is set so
+// incidents survive past GHA's ~3h log retention.
+//
+// Usage:
+//   import { createLogger, captureCircuitBreaker } from "./_logger.mjs";
+//   const log = createLogger({ source: "bluesky" });
+//   log.info("scrape started", { window: "24h" });
+//   log.warn("rate limited", { retryAfter: 5 });
+//   log.error("scrape failed", { err });           // → Sentry
+//   captureCircuitBreaker({ source: "bluesky", consecutiveFailures: 3 });
+
+import * as Sentry from "@sentry/node";
+
+let initialized = false;
+function initSentry() {
+  if (initialized) return;
+  initialized = true;
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV ?? "production",
+    release: process.env.GITHUB_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA,
+    tracesSampleRate: 0,
+    initialScope: {
+      tags: {
+        runtime: "scrape-script",
+        product: "trendingrepo",
+        ghaJob: process.env.GITHUB_JOB,
+        ghaRunId: process.env.GITHUB_RUN_ID,
+      },
+    },
+  });
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function fmt(level, source, msg, extra) {
+  const line = { ts: nowIso(), level, source, msg, ...extra };
+  return JSON.stringify(line);
+}
+
+export function createLogger({ source }) {
+  initSentry();
+  return {
+    info(msg, extra = {}) {
+      console.log(fmt("info", source, msg, extra));
+    },
+    warn(msg, extra = {}) {
+      console.warn(fmt("warn", source, msg, extra));
+      Sentry.captureMessage(`[${source}] ${msg}`, {
+        level: "warning",
+        tags: { source },
+        extra,
+      });
+    },
+    error(msg, extra = {}) {
+      console.error(fmt("error", source, msg, extra));
+      const err = extra?.err instanceof Error ? extra.err : new Error(`[${source}] ${msg}`);
+      Sentry.captureException(err, {
+        tags: { source },
+        extra: { msg, ...extra },
+      });
+    },
+    fatal(msg, extra = {}) {
+      console.error(fmt("fatal", source, msg, extra));
+      const err = extra?.err instanceof Error ? extra.err : new Error(`[${source}] ${msg}`);
+      Sentry.captureException(err, {
+        level: "fatal",
+        tags: { source },
+        extra: { msg, ...extra },
+      });
+    },
+    async flush(timeoutMs = 2000) {
+      try {
+        await Sentry.flush(timeoutMs);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+// Emit a structured Sentry event when an adapter trips its consecutive-
+// failure threshold. Distinct from a single error — this is the alarm
+// that should page someone before the 15-min freshness probe surfaces it.
+export function captureCircuitBreaker({ source, consecutiveFailures, lastError }) {
+  initSentry();
+  Sentry.captureMessage(`[circuit-breaker] ${source} tripped (${consecutiveFailures} failures)`, {
+    level: "error",
+    tags: { source, kind: "circuit-breaker" },
+    extra: {
+      consecutiveFailures,
+      lastError: lastError?.message ?? String(lastError ?? ""),
+    },
+  });
+}
+
+// Convenience for cron scripts that should always flush before exit.
+export async function withSentry(source, fn) {
+  initSentry();
+  const log = createLogger({ source });
+  try {
+    return await fn(log);
+  } catch (err) {
+    log.fatal("script crashed", { err });
+    throw err;
+  } finally {
+    await log.flush();
+  }
+}

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,49 @@
+import * as Sentry from "@sentry/nextjs";
+
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    release: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 0,
+
+    replaysOnErrorSampleRate: 1.0,
+    replaysSessionSampleRate: 0,
+
+    integrations: [
+      Sentry.replayIntegration({
+        maskAllText: false,
+        blockAllMedia: false,
+      }),
+    ],
+
+    beforeSend(event, hint) {
+      const error = hint.originalException;
+      const message = typeof error === "string" ? error : (error as Error)?.message ?? event.message ?? "";
+
+      if (/ResizeObserver|AbortError|Non-Error promise rejection captured/i.test(message)) return null;
+      if (event.tags?.["http.status_code"] === "0") return null;
+
+      return event;
+    },
+
+    ignoreErrors: [
+      "ResizeObserver loop limit exceeded",
+      "ResizeObserver loop completed with undelivered notifications",
+      "Non-Error promise rejection captured",
+      /Loading chunk \d+ failed/,
+      "AbortError",
+      "Network request failed",
+    ],
+
+    initialScope: {
+      tags: {
+        runtime: "browser",
+        product: "trendingrepo",
+      },
+    },
+  });
+}

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,0 +1,20 @@
+import * as Sentry from "@sentry/nextjs";
+
+const SENTRY_DSN = process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    release: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 0,
+
+    initialScope: {
+      tags: {
+        runtime: "edge",
+        product: "trendingrepo",
+      },
+    },
+  });
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,32 @@
+import * as Sentry from "@sentry/nextjs";
+
+const SENTRY_DSN = process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    release: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 0,
+    profilesSampleRate: 0,
+
+    beforeSend(event, hint) {
+      const error = hint.originalException as Error | undefined;
+      const message = error?.message ?? event.message ?? "";
+
+      if (/ECONNRESET|ECONNREFUSED|ETIMEDOUT|fetch failed/i.test(message) && event.level !== "fatal") {
+        event.fingerprint = ["network-transient", message.slice(0, 80)];
+      }
+
+      return event;
+    },
+
+    initialScope: {
+      tags: {
+        runtime: "nodejs",
+        product: "trendingrepo",
+      },
+    },
+  });
+}

--- a/src/app/api/pipeline/sidebar-data/route.ts
+++ b/src/app/api/pipeline/sidebar-data/route.ts
@@ -25,6 +25,11 @@ import {
   getDerivedMetaCounts,
 } from "@/lib/derived-insights";
 import { getDerivedRepos } from "@/lib/derived-repos";
+import {
+  getSidebarSourceCounts,
+  emptySidebarSourceCounts,
+  type SidebarSourceCounts,
+} from "@/lib/sidebar-source-counts";
 import type { MetaCounts, MovementStatus } from "@/lib/types";
 import type { CategoryStats } from "@/lib/pipeline/queries/aggregate";
 
@@ -50,6 +55,8 @@ export interface SidebarDataResponse {
   availableLanguages: string[];
   reposById: Record<string, SidebarDataRepo>;
   unreadAlerts: number;
+  sourceCounts: SidebarSourceCounts;
+  trendingReposCount: number;
   generatedAt: string;
 }
 
@@ -93,6 +100,15 @@ export async function GET(
       unreadAlerts = 0;
     }
 
+    // Per-source counts for the sidebar count badges. Degrade to zeros
+    // on cold data-store / read error so the sidebar still renders.
+    let sourceCounts: SidebarSourceCounts;
+    try {
+      sourceCounts = await getSidebarSourceCounts();
+    } catch {
+      sourceCounts = emptySidebarSourceCounts();
+    }
+
     return NextResponse.json(
       {
         categoryStats,
@@ -100,6 +116,8 @@ export async function GET(
         availableLanguages,
         reposById,
         unreadAlerts,
+        sourceCounts,
+        trendingReposCount: repos.length,
         generatedAt: new Date().toISOString(),
       },
       { headers: { "Content-Type": "application/json; charset=utf-8" } },

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,0 +1,84 @@
+// Public read endpoint for the trending-skill leaderboard the worker
+// publishes to ss:data:v1:trending-skill. 6h cron => 12h staleness budget
+// covers one missed tick (worker restart, network blip) before we 503.
+//
+// Mirrors the shape of /api/worker/pulse so the frontend can poll both
+// endpoints with the same client code.
+
+import { NextResponse } from "next/server";
+import { getDataStore } from "@/lib/data-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface SkillsPayload {
+  fetchedAt: string;
+  windowItems: number;
+  sources: {
+    githubTotalSeen: number;
+    topics: string[];
+  };
+  items: Array<{
+    rank: number;
+    full_name: string;
+    slug: string;
+    title: string;
+    description: string;
+    url: string;
+    author: string;
+    avatar_url: string;
+    language: string | null;
+    topics: string[];
+    stars: number;
+    forks: number;
+    pushed_at: string;
+    created_at: string;
+    source_topics: string[];
+    score: number;
+  }>;
+}
+
+const STALE_AFTER_SECONDS = 12 * 3600;
+const TOP_PREVIEW = 10;
+
+export async function GET() {
+  const store = getDataStore();
+  const result = await store.read<SkillsPayload>("trending-skill");
+
+  if (!result.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        source: result.source,
+        message: "trending-skill key not found in any data-store tier",
+      },
+      { status: 503 },
+    );
+  }
+
+  const ageSeconds = Math.round(result.ageMs / 1000);
+  const stale = ageSeconds > STALE_AFTER_SECONDS;
+
+  return NextResponse.json(
+    {
+      ok: !stale,
+      source: result.source,
+      fresh: result.fresh,
+      writtenAt: result.writtenAt ?? null,
+      ageSeconds,
+      items: result.data.windowItems,
+      sources: result.data.sources,
+      top: result.data.items.slice(0, TOP_PREVIEW).map((s) => ({
+        rank: s.rank,
+        full_name: s.full_name,
+        title: s.title,
+        url: s.url,
+        author: s.author,
+        stars: s.stars,
+        score: s.score,
+        source_topics: s.source_topics,
+      })),
+    },
+    { status: stale ? 503 : 200 },
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from "next";
-import { Analytics } from "@vercel/analytics/next";
 // Trimmed from 4 fonts to 3: Instrument Serif (--font-editorial) was
 // defined but not referenced anywhere in src/components or src/app.
 // Dropping it saves ~30 KB of font payload + one <link rel="preload">.
@@ -10,6 +9,7 @@ import { Toaster } from "sonner";
 import "@/lib/bootstrap";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { StoreProvider } from "@/components/providers/StoreProvider";
+import { PostHogProvider } from "@/components/providers/PostHogProvider";
 import { AppShell } from "@/components/layout/AppShell";
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/layout/Sidebar";
@@ -156,8 +156,9 @@ export default function RootLayout({
       </head>
       <body>
         <ThemeProvider>
-          <StoreProvider>
-            <DesignSystemProvider>
+          <PostHogProvider>
+            <StoreProvider>
+              <DesignSystemProvider>
               <Header />
               <MobileDrawerLazy />
               <AppShell>
@@ -189,10 +190,10 @@ export default function RootLayout({
                   },
                 }}
               />
-            </DesignSystemProvider>
-          </StoreProvider>
+              </DesignSystemProvider>
+            </StoreProvider>
+          </PostHogProvider>
         </ThemeProvider>
-        <Analytics />
       </body>
     </html>
   );

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -1,0 +1,185 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import {
+  SignalSourcePage,
+  type SignalTabSpec,
+} from "@/components/signal/SignalSourcePage";
+import type { SignalMetricCardProps } from "@/components/signal/SignalMetricCard";
+import {
+  ecosystemBoardToRows,
+  formatCompact,
+  getMcpSignalData,
+  type EcosystemBoard,
+} from "@/lib/ecosystem-leaderboards";
+import { classifyFreshness } from "@/lib/news/freshness";
+import { absoluteUrl } from "@/lib/seo";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Trending MCP - TrendingRepo",
+  description:
+    "Top Model Context Protocol servers merged from official registry, Glama, PulseMCP, and Smithery signals.",
+  alternates: { canonical: absoluteUrl("/mcp") },
+  openGraph: {
+    title: "Trending MCP - TrendingRepo",
+    description:
+      "A live leaderboard for Model Context Protocol servers across MCP registries.",
+    url: absoluteUrl("/mcp"),
+  },
+};
+
+export default async function McpPage() {
+  const data = await getMcpSignalData();
+  const freshness = classifyFreshness("mcp", data.fetchedAt);
+  const rows = ecosystemBoardToRows(data.board);
+
+  const metrics: SignalMetricCardProps[] = [
+    {
+      label: "MCP Servers",
+      value: data.board.items.length,
+      helper: sourceHelper(data.board),
+      sparkTone: "brand",
+    },
+    {
+      label: "Top Signal",
+      value: signalValue(data.board.items[0]),
+      helper: data.board.items[0]?.title ?? "no rows",
+      sparkTone: "up",
+    },
+    {
+      label: "Top Popularity",
+      value: formatCompact(maxPopularity(data.board)),
+      helper: data.board.items[0]?.popularityLabel ?? "registry signal",
+      sparkTone: "warning",
+    },
+    {
+      label: "Surface",
+      value: "4",
+      helper: "official / glama / pulsemcp / smithery",
+      sparkTone: "info",
+    },
+    {
+      label: "Worker Key",
+      value: "MCP",
+      helper: "trending-mcp",
+      sparkTone: "brand",
+    },
+    {
+      label: "Data Tier",
+      value: data.source.toUpperCase(),
+      helper: data.fetchedAt ? freshness.ageLabel : "missing",
+      sparkTone: data.source === "redis" ? "up" : "warning",
+    },
+  ];
+
+  const tabs: SignalTabSpec[] = [
+    {
+      id: "all",
+      label: "MCP Servers",
+      rows,
+      columns: ["rank", "title", "source", "topic", "linkedRepo", "engagement", "age", "signal"],
+      emptyTitle: "No MCP leaderboard rows have landed yet.",
+      emptySubtitle: "Waiting for the publish-leaderboards job to write trending-mcp.",
+    },
+  ];
+
+  return (
+    <SignalSourcePage
+      source="mcp"
+      sourceLabel="MCP"
+      mode="TRENDING"
+      subtitle="Merged MCP server momentum across official registry, Glama, PulseMCP, and Smithery feeds."
+      fetchedAt={data.fetchedAt}
+      freshnessStatus={freshness.status}
+      ageLabel={freshness.ageLabel}
+      metrics={metrics}
+      tabs={tabs}
+      rightRail={<McpRightRail board={data.board} />}
+    />
+  );
+}
+
+function McpRightRail({ board }: { board: EcosystemBoard }) {
+  return (
+    <aside className="flex flex-col gap-4">
+      <div className="rounded-card border border-border-primary bg-bg-card p-3">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-tertiary">
+          Top MCP Servers
+        </h3>
+        {board.items.length === 0 ? (
+          <p className="mt-2 text-[11px] text-text-tertiary">No rows yet.</p>
+        ) : (
+          <ul className="mt-2 space-y-1.5">
+            {board.items.slice(0, 10).map((item) => (
+              <li key={item.id} className="flex items-center gap-2 text-[11px]">
+                {item.logoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={item.logoUrl}
+                    alt=""
+                    width={16}
+                    height={16}
+                    loading="lazy"
+                    className="h-4 w-4 flex-none rounded-sm object-contain"
+                  />
+                ) : (
+                  <span className="h-4 w-4 flex-none rounded-sm bg-bg-muted" />
+                )}
+                <a
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 truncate font-mono text-functional hover:underline"
+                  title={item.vendor ? `${item.title} — ${item.vendor}` : item.title}
+                >
+                  {item.title}
+                </a>
+                {item.verified ? (
+                  <span className="font-mono text-[9px] uppercase tracking-wider text-up" title="Official vendor">
+                    ✓
+                  </span>
+                ) : null}
+                <span className="font-mono tabular-nums text-text-secondary">
+                  {item.signalScore}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-card border border-border-primary bg-bg-card p-3">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-tertiary">
+          Worker Key
+        </h3>
+        <p className="mt-2 text-[11px] text-text-secondary">
+          The top-level page reads the Supabase-published leaderboard at
+          <span className="font-mono text-text-primary"> trending-mcp</span>.
+        </p>
+        <Link
+          href="/api/mcp/trending"
+          className="mt-3 inline-flex font-mono text-[11px] text-functional hover:underline"
+        >
+          api preview
+        </Link>
+      </div>
+    </aside>
+  );
+}
+
+function sourceHelper(board: EcosystemBoard): string {
+  return `${board.source} / ${board.key}`;
+}
+
+function signalValue(item: { signalScore: number } | undefined): string {
+  return item ? String(Math.round(item.signalScore)) : "-";
+}
+
+function maxPopularity(board: EcosystemBoard): number | null {
+  const values = board.items
+    .map((item) => item.popularity)
+    .filter((value): value is number => value !== null);
+  return values.length > 0 ? Math.max(...values) : null;
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,6 +2,14 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { ROUTES } from "@/lib/constants";
 
+// Render at request time. Phase A1 fixed the framer-motion-induced RSC
+// chunk-graph corruption for /_not-found by removing framer-motion from
+// optimizePackageImports — but the underlying Next 15 prerender bug
+// re-surfaces whenever the chunk graph shifts (e.g., new pages added).
+// force-dynamic skips the static prerender step entirely; same UX, no
+// blocker. Vercel's runtime is unaffected.
+export const dynamic = "force-dynamic";
+
 export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center px-4">

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,0 +1,204 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import {
+  SignalSourcePage,
+  type SignalTabSpec,
+} from "@/components/signal/SignalSourcePage";
+import type { SignalMetricCardProps } from "@/components/signal/SignalMetricCard";
+import {
+  ecosystemBoardToRows,
+  formatCompact,
+  getSkillsSignalData,
+  type EcosystemBoard,
+} from "@/lib/ecosystem-leaderboards";
+import { classifyFreshness } from "@/lib/news/freshness";
+import { absoluteUrl } from "@/lib/seo";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Trending Skills - TrendingRepo",
+  description:
+    "Top Claude / Codex / agent skills merged from skills.sh leaderboard and GitHub topic signals.",
+  alternates: { canonical: absoluteUrl("/skills") },
+  openGraph: {
+    title: "Trending Skills - TrendingRepo",
+    description:
+      "A live leaderboard for AI agent skills across skills.sh and GitHub topic feeds.",
+    url: absoluteUrl("/skills"),
+  },
+};
+
+export default async function SkillsPage() {
+  const data = await getSkillsSignalData();
+  const freshness = classifyFreshness("skills", data.fetchedAt);
+
+  const allRows = ecosystemBoardToRows(data.combined);
+  const skillsShRows = ecosystemBoardToRows(data.skillsSh);
+  const githubRows = ecosystemBoardToRows(data.github);
+
+  const topItem = data.combined.items[0];
+
+  const metrics: SignalMetricCardProps[] = [
+    {
+      label: "All Skills",
+      value: data.combined.items.length,
+      helper: `${data.skillsSh.items.length} skills.sh / ${data.github.items.length} github`,
+      sparkTone: "brand",
+    },
+    {
+      label: "Top Signal",
+      value: signalValue(topItem),
+      helper: topItem?.title ?? "no rows",
+      sparkTone: "up",
+    },
+    {
+      label: "Top Popularity",
+      value: formatCompact(maxPopularity(data.combined)),
+      helper: topItem?.popularityLabel ?? "skill signal",
+      sparkTone: "warning",
+    },
+    {
+      label: "Surface",
+      value: "2",
+      helper: "skills.sh / github",
+      sparkTone: "info",
+    },
+    {
+      label: "Worker Key",
+      value: "SKILLS",
+      helper: "trending-skill",
+      sparkTone: "brand",
+    },
+    {
+      label: "Data Tier",
+      value: data.source.toUpperCase(),
+      helper: data.fetchedAt ? freshness.ageLabel : "missing",
+      sparkTone: data.source === "redis" ? "up" : "warning",
+    },
+  ];
+
+  const tabs: SignalTabSpec[] = [
+    {
+      id: "all",
+      label: "All Skills",
+      rows: allRows,
+      columns: ["rank", "title", "source", "topic", "linkedRepo", "engagement", "age", "signal"],
+      emptyTitle: "No skills leaderboard rows have landed yet.",
+      emptySubtitle: "Waiting for the publish-leaderboards job to write trending-skill.",
+    },
+    {
+      id: "skills-sh",
+      label: "Skills.sh",
+      rows: skillsShRows,
+      columns: ["rank", "title", "topic", "linkedRepo", "engagement", "age", "signal"],
+      emptyTitle: "No skills.sh rows yet.",
+      emptySubtitle: "skills.sh fetcher publishes to trending-skill-sh.",
+    },
+    {
+      id: "github",
+      label: "GitHub",
+      rows: githubRows,
+      columns: ["rank", "title", "topic", "linkedRepo", "engagement", "age", "signal"],
+      emptyTitle: "No GitHub skill rows yet.",
+      emptySubtitle: "GitHub topic fetcher publishes to trending-skill.",
+    },
+  ];
+
+  return (
+    <SignalSourcePage
+      source="skills"
+      sourceLabel="SKILLS"
+      mode="TRENDING"
+      subtitle="Merged AI agent skill momentum across skills.sh and GitHub topic feeds (claude-skill, agent-skill, claude-code-skill)."
+      fetchedAt={data.fetchedAt}
+      freshnessStatus={freshness.status}
+      ageLabel={freshness.ageLabel}
+      metrics={metrics}
+      tabs={tabs}
+      rightRail={<SkillsRightRail board={data.combined} />}
+    />
+  );
+}
+
+function SkillsRightRail({ board }: { board: EcosystemBoard }) {
+  return (
+    <aside className="flex flex-col gap-4">
+      <div className="rounded-card border border-border-primary bg-bg-card p-3">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-tertiary">
+          Top Skills
+        </h3>
+        {board.items.length === 0 ? (
+          <p className="mt-2 text-[11px] text-text-tertiary">No rows yet.</p>
+        ) : (
+          <ul className="mt-2 space-y-1.5">
+            {board.items.slice(0, 10).map((item) => (
+              <li key={item.id} className="flex items-center gap-2 text-[11px]">
+                {item.logoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={item.logoUrl}
+                    alt=""
+                    width={16}
+                    height={16}
+                    loading="lazy"
+                    className="h-4 w-4 flex-none rounded-sm object-contain"
+                  />
+                ) : (
+                  <span className="h-4 w-4 flex-none rounded-sm bg-bg-muted" />
+                )}
+                <a
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 truncate font-mono text-functional hover:underline"
+                  title={item.author ? `${item.title} — ${item.author}` : item.title}
+                >
+                  {item.title}
+                </a>
+                {item.verified ? (
+                  <span className="font-mono text-[9px] uppercase tracking-wider text-up" title="Verified author">
+                    ✓
+                  </span>
+                ) : null}
+                <span className="font-mono tabular-nums text-text-secondary">
+                  {item.signalScore}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-card border border-border-primary bg-bg-card p-3">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-tertiary">
+          Worker Keys
+        </h3>
+        <p className="mt-2 text-[11px] text-text-secondary">
+          Skills are merged from
+          <span className="font-mono text-text-primary"> trending-skill-sh </span>
+          and
+          <span className="font-mono text-text-primary"> trending-skill</span>.
+        </p>
+        <Link
+          href="/api/skills"
+          className="mt-3 inline-flex font-mono text-[11px] text-functional hover:underline"
+        >
+          api preview
+        </Link>
+      </div>
+    </aside>
+  );
+}
+
+function signalValue(item: { signalScore: number } | undefined): string {
+  return item ? String(Math.round(item.signalScore)) : "-";
+}
+
+function maxPopularity(board: EcosystemBoard): number | null {
+  const values = board.items
+    .map((item) => item.popularity)
+    .filter((value): value is number => value !== null);
+  return values.length > 0 ? Math.max(...values) : null;
+}

--- a/src/components/breakouts/breakoutsTopMetrics.ts
+++ b/src/components/breakouts/breakoutsTopMetrics.ts
@@ -1,0 +1,150 @@
+// V3 header builder for /breakouts. Maps the cross-signal repo set
+// onto the {cards, topStories} shape NewsTopHeaderV3 expects.
+//
+// Cards:
+//   0. SNAPSHOT — total firing + multi-channel + all-three rows
+//   1. CHANNELS — bar per channel-count (1 / 2 / 3) with repo counts
+//   2. TOPICS   — top categories among multi-channel firers
+//
+// Heroes: top 3 repos by crossSignalScore (multi-channel only).
+
+import type {
+  NewsHeroStory,
+  NewsMetricBar,
+  NewsMetricCard,
+} from "@/components/news/NewsTopHeaderV3";
+import { compactNumber } from "@/components/news/newsTopMetrics";
+import { CATEGORIES } from "@/lib/constants";
+import type { Repo } from "@/lib/types";
+
+interface BreakoutsHeaderInput {
+  /** Annotated repos with `_firing` count populated by the page. */
+  annotated: Array<Repo & { _firing: number }>;
+  /** Highest crossSignalScore in the corpus, for the snapshot row. */
+  topScore: number;
+}
+
+export function buildBreakoutsHeader({
+  annotated,
+  topScore,
+}: BreakoutsHeaderInput): {
+  cards: [NewsMetricCard, NewsMetricCard, NewsMetricCard];
+  topStories: NewsHeroStory[];
+} {
+  const totalFiring = annotated.filter((r) => r._firing >= 1).length;
+  const multiChannel = annotated.filter((r) => r._firing >= 2).length;
+  const allThree = annotated.filter((r) => r._firing === 3).length;
+  const oneChannel = totalFiring - multiChannel;
+  const twoChannel = multiChannel - allThree;
+
+  // Channel-count distribution. Multi-channel rows use accent color so
+  // the eye lands on real signal, not noise.
+  const channelBars: NewsMetricBar[] = [
+    {
+      label: "3 CH",
+      value: allThree,
+      valueLabel: allThree.toLocaleString("en-US"),
+      hintLabel: "GH+R+HN",
+      color: "var(--v3-acc)",
+    },
+    {
+      label: "2 CH",
+      value: twoChannel,
+      valueLabel: twoChannel.toLocaleString("en-US"),
+      hintLabel: "MULTI",
+      color: "var(--v3-acc)",
+    },
+    {
+      label: "1 CH",
+      value: oneChannel,
+      valueLabel: oneChannel.toLocaleString("en-US"),
+      hintLabel: "NOISE",
+      color: "var(--v3-line-300)",
+    },
+  ];
+
+  // Top categories among multi-channel firers — that's where the real
+  // distribution signal lives. Single-channel is too noisy to summarise.
+  const multi = annotated.filter((r) => r._firing >= 2);
+  const catCounts = new Map<string, number>();
+  for (const repo of multi) {
+    const id = repo.categoryId || "uncategorized";
+    catCounts.set(id, (catCounts.get(id) ?? 0) + 1);
+  }
+  const TOPIC_PALETTE = [
+    "var(--v3-acc)",
+    "#F59E0B",
+    "#3AD6C5",
+    "#F472B6",
+    "#FBBF24",
+    "#A78BFA",
+  ];
+  const topicBars: NewsMetricBar[] = Array.from(catCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([id, count], i) => {
+      const cat = CATEGORIES.find((c) => c.id === id);
+      return {
+        label: (cat?.shortName ?? cat?.name ?? id).toUpperCase(),
+        value: count,
+        valueLabel: count.toLocaleString("en-US"),
+        color: TOPIC_PALETTE[i % TOPIC_PALETTE.length],
+      };
+    });
+
+  const cards: [NewsMetricCard, NewsMetricCard, NewsMetricCard] = [
+    {
+      variant: "snapshot",
+      title: "// SNAPSHOT · NOW",
+      rightLabel: `${totalFiring} FIRING`,
+      label: "MULTI-CHANNEL",
+      value: compactNumber(multiChannel),
+      hint: `OF ${compactNumber(totalFiring)} TOTAL FIRING`,
+      rows: [
+        { label: "ALL THREE", value: compactNumber(allThree), tone: "accent" },
+        { label: "TOP SCORE", value: topScore.toFixed(2) },
+        { label: "1-CHANNEL NOISE", value: compactNumber(oneChannel) },
+      ],
+    },
+    {
+      variant: "bars",
+      title: "// CHANNELS · DISTRIBUTION",
+      rightLabel: "FIRING COUNT",
+      bars: channelBars,
+      labelWidth: 40,
+      emptyText: "NO FIRING REPOS",
+    },
+    {
+      variant: "bars",
+      title: "// TOPICS · TOP CATEGORIES",
+      rightLabel: `TOP ${topicBars.length}`,
+      bars: topicBars,
+      labelWidth: 96,
+      emptyText: "NOT ENOUGH SIGNAL YET",
+    },
+  ];
+
+  const heroes = multi
+    .slice()
+    .sort((a, b) => (b.crossSignalScore ?? 0) - (a.crossSignalScore ?? 0))
+    .slice(0, 3);
+  const topStories: NewsHeroStory[] = heroes.map((r) => {
+    // Source-code chip carries category short-name (≤2-3 chars, matches
+    // news-page contract). Channel-firing context moves to the byline so
+    // first-time visitors don't have to decode "3CH" as a SKU.
+    const cat = CATEGORIES.find((c) => c.id === r.categoryId);
+    const sourceCode = (cat?.shortName ?? r.language ?? "GH").slice(0, 4).toUpperCase();
+    const channelByline =
+      r._firing === 3 ? "GH+R+HN" : r._firing === 2 ? "2 channels firing" : "1 channel";
+    return {
+      title: r.fullName,
+      href: `/repo/${r.owner}/${r.name}`,
+      sourceCode,
+      byline: channelByline,
+      scoreLabel: `${(r.crossSignalScore ?? 0).toFixed(2)} score · ${compactNumber(r.stars)}★`,
+      ageHours: null,
+    };
+  });
+
+  return { cards, topStories };
+}

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -170,6 +170,8 @@ export function MobileDrawer() {
                   availableLanguages={data.availableLanguages}
                   watchlistPreview={watchlistPreview}
                   unreadAlerts={data.unreadAlerts}
+                  sourceCounts={data.sourceCounts}
+                  trendingReposCount={data.trendingReposCount}
                   onClose={close}
                 />
               ) : (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -128,7 +128,22 @@ export interface SidebarData {
   availableLanguages: SidebarDataResponse["availableLanguages"];
   reposById: Record<string, SidebarDataRepo>;
   unreadAlerts: number;
+  sourceCounts: SidebarDataResponse["sourceCounts"];
+  trendingReposCount: number;
 }
+
+const EMPTY_SOURCE_COUNTS: SidebarDataResponse["sourceCounts"] = {
+  hackernewsStories: 0,
+  lobstersStories: 0,
+  devtoArticles: 0,
+  blueskyPosts: 0,
+  redditPosts: 0,
+  producthuntLaunches: 0,
+  arxivPapers: 0,
+  fundingSignals: 0,
+  revenueOverlays: 0,
+  npmPackages: 0,
+};
 
 export function useSidebarData(): SidebarData | null {
   const [data, setData] = useState<SidebarData | null>(null);
@@ -145,6 +160,8 @@ export function useSidebarData(): SidebarData | null {
           availableLanguages: json.availableLanguages,
           reposById: json.reposById,
           unreadAlerts: json.unreadAlerts ?? 0,
+          sourceCounts: json.sourceCounts ?? EMPTY_SOURCE_COUNTS,
+          trendingReposCount: json.trendingReposCount ?? 0,
         });
       })
       .catch(() => {
@@ -213,6 +230,8 @@ export function Sidebar() {
           availableLanguages={data.availableLanguages}
           watchlistPreview={watchlistPreview}
           unreadAlerts={data.unreadAlerts}
+          sourceCounts={data.sourceCounts}
+          trendingReposCount={data.trendingReposCount}
         />
       ) : (
         <SidebarSkeleton />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -139,7 +139,6 @@ const EMPTY_SOURCE_COUNTS: SidebarDataResponse["sourceCounts"] = {
   blueskyPosts: 0,
   redditPosts: 0,
   producthuntLaunches: 0,
-  arxivPapers: 0,
   fundingSignals: 0,
   revenueOverlays: 0,
   npmPackages: 0,

--- a/src/components/layout/SidebarContent.tsx
+++ b/src/components/layout/SidebarContent.tsx
@@ -583,8 +583,6 @@ export function SidebarContent({
             href="/papers"
             icon={FileText}
             label="arXiv Papers"
-            badge={deltaChip(sourceCounts?.arxivPapers ?? 0) || undefined}
-            badgeTone="delta"
             active={pathname === "/papers" || pathname.startsWith("/papers/")}
           />
           <V2NavRow

--- a/src/components/layout/SidebarContent.tsx
+++ b/src/components/layout/SidebarContent.tsx
@@ -9,6 +9,20 @@
  * V2 visual treatment: terminal-bar mono section headers (`// LABEL`),
  * mono uppercase 11px nav rows, accent bracket markers on active rows,
  * accent-soft pill chips for live counts.
+ *
+ * Sections:
+ *   1. TREND TERMINAL    — Repos, Skills, MCP, AGNT, Breakouts, Top 100
+ *   2. SIGNAL TERMINAL   — HN / Lobsters / Dev.to / Bluesky / Reddit / X / PH
+ *   3. LLM / PACK TERMINAL — NPM / Hugging Face / LLM Charts
+ *   4. LAUNCH TERMINAL   — Funding / Revenue / Hackathons / Launch
+ *   5. RESEARCH TERMINAL — arXiv Papers / Cited Repos
+ *   6. TOOLS             — Watchlist / Compare / Signal Radar
+ *   7. WATCHING          — top 5 watchlist preview cards
+ *
+ * Three badge tones:
+ *   - `delta`   — green `+N` pill for rolling-window feeds.
+ *   - `default` — neutral total for cumulative inventories.
+ *   - `accent`  — purple pill for the user's own counts.
  */
 import { useEffect, useState, type ReactNode } from "react";
 import Link from "next/link";
@@ -19,17 +33,20 @@ import {
   BarChart3,
   Bot,
   Bookmark,
+  Brain,
+  Cpu,
   DollarSign,
+  FileText,
   GitCompareArrows,
-  LifeBuoy,
-  Lightbulb,
+  GraduationCap,
   Package,
+  Plug,
   Radar,
   Rocket,
-  Sparkles,
   TrendingUp,
   Trophy,
   X,
+  Zap,
 } from "lucide-react";
 import {
   RedditIcon,
@@ -43,6 +60,7 @@ import {
 import type { SidebarIconComponent } from "./SidebarNavItem";
 import type { CategoryStats } from "@/lib/pipeline/queries/aggregate";
 import type { MetaCounts } from "@/lib/types";
+import type { SidebarSourceCounts } from "@/lib/sidebar-source-counts";
 import { APP_NAME } from "@/lib/app-meta";
 import { useFilterStore, useWatchlistStore, useCompareStore } from "@/lib/store";
 import {
@@ -53,9 +71,6 @@ import { SidebarFooter } from "./SidebarFooter";
 import { cn } from "@/lib/utils";
 import { CursorRail } from "@/components/v3";
 
-// Monochrome wrappers — use the REAL brand glyph (Snoo / HN-Y / butterfly
-// / PH-cat / dev.to) but force `monochrome` so the fill inherits the
-// sidebar's V2 ink color (or the V2 accent on active).
 const RedditSidebarIcon: SidebarIconComponent = (p) => (
   <RedditIcon {...p} monochrome />
 );
@@ -82,12 +97,24 @@ export interface SidebarContentProps {
   availableLanguages: string[];
   watchlistPreview: SidebarWatchlistPreviewRepo[];
   unreadAlerts?: number;
+  /** Per-source counts for badge chips. */
+  sourceCounts?: SidebarSourceCounts;
+  /** Total trending repos count (the big "Trending Repos" badge). */
+  trendingReposCount?: number;
   onClose?: () => void;
 }
 
-// ---------------------------------------------------------------------------
-// V2 section wrapper — terminal-bar header (`// LABEL`) + hairline divider.
-// ---------------------------------------------------------------------------
+function compactCount(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "";
+  if (n < 1000) return String(n);
+  if (n < 10_000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}K`;
+  return `${Math.round(n / 1000)}K`;
+}
+
+function deltaChip(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "";
+  return `+${compactCount(n)}`;
+}
 
 interface V2SectionProps {
   label: string;
@@ -129,10 +156,7 @@ function V2Section({ label, children, rightSlot, maxHeightPx }: V2SectionProps) 
   );
 }
 
-// ---------------------------------------------------------------------------
-// V2 nav row — mono uppercase label, optional badge chip, active = bracket
-// frame + accent left rail (3px).
-// ---------------------------------------------------------------------------
+type BadgeTone = "default" | "accent" | "danger" | "delta";
 
 interface V2NavRowProps {
   href?: string;
@@ -140,7 +164,7 @@ interface V2NavRowProps {
   icon: SidebarIconComponent;
   label: string;
   badge?: string | number;
-  badgeTone?: "default" | "accent" | "danger";
+  badgeTone?: BadgeTone;
   active?: boolean;
   disabled?: boolean;
 }
@@ -187,8 +211,6 @@ function V2NavRow({
     boxShadow: isActive ? "inset 3px 0 0 var(--v2-acc)" : undefined,
   };
 
-  // Wrapper span carries `color` so both Lucide (stroke=currentColor) and
-  // BrandIcons (monochrome fill=currentColor) pick up the V2 ink/accent.
   const content = (
     <>
       <span
@@ -229,23 +251,21 @@ function V2NavRow({
   );
 }
 
-// ---------------------------------------------------------------------------
-// V2 chip — accent-soft pill for live counts.
-// ---------------------------------------------------------------------------
-
 function V2Chip({
   value,
   tone = "default",
 }: {
   value: string | number;
-  tone?: "default" | "accent" | "danger";
+  tone?: BadgeTone;
 }) {
   const palette =
     tone === "accent"
       ? { bg: "var(--v2-acc-soft)", color: "var(--v2-acc)" }
       : tone === "danger"
         ? { bg: "rgba(239, 68, 68, 0.14)", color: "#ef4444" }
-        : { bg: "var(--v2-bg-200)", color: "var(--v2-ink-300)" };
+        : tone === "delta"
+          ? { bg: "var(--color-up-bg)", color: "var(--color-up)" }
+          : { bg: "var(--v2-bg-200)", color: "var(--v2-ink-300)" };
 
   return (
     <span
@@ -265,13 +285,11 @@ function V2Chip({
   );
 }
 
-// ---------------------------------------------------------------------------
-// SidebarContent
-// ---------------------------------------------------------------------------
-
 export function SidebarContent({
   metaCounts,
   watchlistPreview,
+  sourceCounts,
+  trendingReposCount,
   onClose,
 }: SidebarContentProps) {
   const router = useRouter();
@@ -291,9 +309,6 @@ export function SidebarContent({
     setNewsTab(new URLSearchParams(window.location.search).get("tab"));
   }, [pathname]);
 
-  // Repos terminal: the homepage `/` with a meta-filter applied. Trending,
-  // Breakouts, and New Repos all route back to `/`; Agent Repos is a
-  // dedicated fixed-ranking page.
   function goToReposTerminal(filter: "breakouts" | "new" | null) {
     setActiveTag(null);
     if (filter) {
@@ -322,7 +337,6 @@ export function SidebarContent({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Mobile-only header strip ---------------------------------------- */}
       {onClose && (
         <div
           className="md:hidden flex items-center justify-between p-3 border-b shrink-0"
@@ -356,62 +370,73 @@ export function SidebarContent({
         </div>
       )}
 
-      {/* Scrollable body ------------------------------------------------- */}
       <CursorRail className="flex-1 overflow-y-auto scrollbar-hide">
-        {/* TREND TERMINAL — Stage 1: discover ideas + repos ----------- */}
+        {/* TREND TERMINAL */}
         <V2Section label="TREND TERMINAL">
-          <V2NavRow
-            href="/ideas"
-            icon={Lightbulb}
-            label="Trending Ideas"
-            active={pathname === "/ideas" || pathname.startsWith("/ideas/")}
-          />
           <V2NavRow
             onClick={() => goToReposTerminal(null)}
             icon={TrendingUp}
             label="Trending Repos"
+            badge={
+              trendingReposCount && trendingReposCount > 0
+                ? compactCount(trendingReposCount)
+                : undefined
+            }
+            badgeTone="default"
             active={pathname === "/" && activeMetaFilter === null}
+          />
+          <V2NavRow
+            href="/skills"
+            icon={GraduationCap}
+            label="Trending Skills"
+            active={pathname === "/skills" || pathname.startsWith("/skills/")}
+          />
+          <V2NavRow
+            href="/mcp"
+            icon={Plug}
+            label="Trending MCP"
+            active={pathname === "/mcp" || pathname.startsWith("/mcp/")}
+          />
+          <V2NavRow
+            onClick={goToAgentRepos}
+            icon={Cpu}
+            label="Trending AGNT"
+            active={pathname === "/agent-repos"}
           />
           <V2NavRow
             href="/breakouts"
             icon={Rocket}
             label="Breakouts"
-            badge={metaCounts.breakouts}
+            badge={metaCounts.breakouts > 0 ? metaCounts.breakouts : undefined}
             badgeTone="accent"
             active={pathname === "/breakouts"}
-          />
-          <V2NavRow
-            icon={Sparkles}
-            label="New Repos"
-            badge="Soon"
-            disabled
-          />
-          <V2NavRow
-            onClick={goToAgentRepos}
-            icon={Bot}
-            label="Agent Repos"
-            active={pathname === "/agent-repos"}
           />
           <V2NavRow
             href="/search?sort=stars-total&limit=100"
             icon={Trophy}
             label="Top 100"
+            badge="100"
+            badgeTone="default"
             active={pathname === "/search"}
           />
         </V2Section>
 
-        {/* SIGNAL TERMINAL — Stage 2: validate market signal ---------- */}
+        {/* SIGNAL TERMINAL */}
         <V2Section label="SIGNAL TERMINAL">
           <V2NavRow
             href="/signals"
             icon={Activity}
             label="Market Signals"
+            badge="ALL"
+            badgeTone="accent"
             active={pathname === "/signals" || pathname.startsWith("/signals/")}
           />
           <V2NavRow
             href="/hackernews/trending"
             icon={HackerNewsSidebarIcon}
             label="Hacker News"
+            badge={deltaChip(sourceCounts?.hackernewsStories ?? 0) || undefined}
+            badgeTone="delta"
             active={
               pathname === "/hackernews" ||
               pathname.startsWith("/hackernews/") ||
@@ -419,13 +444,48 @@ export function SidebarContent({
             }
           />
           <V2NavRow
+            href="/lobsters"
+            icon={LobstersSidebarIcon}
+            label="Lobsters"
+            badge={deltaChip(sourceCounts?.lobstersStories ?? 0) || undefined}
+            badgeTone="delta"
+            active={
+              pathname === "/lobsters" ||
+              pathname.startsWith("/lobsters/") ||
+              (pathname === "/news" && newsTab === "lobsters")
+            }
+          />
+          <V2NavRow
+            href="/devto"
+            icon={DevtoSidebarIcon}
+            label="Dev.to"
+            badge={deltaChip(sourceCounts?.devtoArticles ?? 0) || undefined}
+            badgeTone="delta"
+            active={
+              pathname === "/devto" ||
+              pathname.startsWith("/devto/") ||
+              (pathname === "/news" && newsTab === "devto")
+            }
+          />
+          <V2NavRow
+            href="/bluesky/trending"
+            icon={BlueskySidebarIcon}
+            label="Bluesky"
+            badge={deltaChip(sourceCounts?.blueskyPosts ?? 0) || undefined}
+            badgeTone="delta"
+            active={
+              pathname === "/bluesky" ||
+              pathname.startsWith("/bluesky/") ||
+              (pathname === "/news" && newsTab === "bluesky")
+            }
+          />
+          <V2NavRow
             href="/reddit/trending"
             icon={RedditSidebarIcon}
             label="Reddit"
-            active={
-              pathname === "/reddit" ||
-              pathname.startsWith("/reddit/")
-            }
+            badge={deltaChip(sourceCounts?.redditPosts ?? 0) || undefined}
+            badgeTone="delta"
+            active={pathname === "/reddit" || pathname.startsWith("/reddit/")}
           />
           <V2NavRow
             href="/twitter"
@@ -437,54 +497,34 @@ export function SidebarContent({
             href="/producthunt"
             icon={ProductHuntSidebarIcon}
             label="Product Hunt"
+            badge={
+              deltaChip(sourceCounts?.producthuntLaunches ?? 0) || undefined
+            }
+            badgeTone="delta"
             active={
               pathname === "/producthunt" ||
               pathname.startsWith("/producthunt/") ||
               (pathname === "/news" && newsTab === "producthunt")
             }
           />
-          <V2NavRow
-            href="/bluesky/trending"
-            icon={BlueskySidebarIcon}
-            label="Bluesky"
-            active={
-              pathname === "/bluesky" ||
-              pathname.startsWith("/bluesky/") ||
-              (pathname === "/news" && newsTab === "bluesky")
-            }
-          />
-          <V2NavRow
-            href="/devto"
-            icon={DevtoSidebarIcon}
-            label="Dev.to"
-            active={
-              pathname === "/devto" ||
-              pathname.startsWith("/devto/") ||
-              (pathname === "/news" && newsTab === "devto")
-            }
-          />
-          <V2NavRow
-            href="/lobsters"
-            icon={LobstersSidebarIcon}
-            label="Lobsters"
-            active={
-              pathname === "/lobsters" ||
-              pathname.startsWith("/lobsters/") ||
-              (pathname === "/news" && newsTab === "lobsters")
-            }
-          />
         </V2Section>
 
-        {/* ECOSYSTEM TERMINAL — Stage 3: check ecosystem traction ----- */}
-        <V2Section label="ECOSYSTEM TERMINAL">
+        {/* LLM / PACK TERMINAL */}
+        <V2Section label="LLM / PACK TERMINAL">
           <V2NavRow
             href="/npm"
             icon={Package}
             label="NPM Packages"
+            badge={
+              sourceCounts && sourceCounts.npmPackages > 0
+                ? compactCount(sourceCounts.npmPackages)
+                : undefined
+            }
+            badgeTone="default"
             active={pathname === "/npm" || pathname.startsWith("/npm/")}
           />
           <V2NavRow
-            icon={Sparkles}
+            icon={Brain}
             label="Hugging Face"
             badge="Soon"
             disabled
@@ -497,18 +537,30 @@ export function SidebarContent({
           />
         </V2Section>
 
-        {/* LAUNCH TERMINAL — Stage 4-5: prepare + track outcomes ------ */}
+        {/* LAUNCH TERMINAL */}
         <V2Section label="LAUNCH TERMINAL">
           <V2NavRow
             href="/funding"
             icon={DollarSign}
             label="Funding Radar"
+            badge={
+              sourceCounts && sourceCounts.fundingSignals > 0
+                ? compactCount(sourceCounts.fundingSignals)
+                : undefined
+            }
+            badgeTone="default"
             active={pathname === "/funding" || pathname.startsWith("/funding/")}
           />
           <V2NavRow
             href="/revenue"
             icon={BadgeCheck}
             label="Revenue"
+            badge={
+              sourceCounts && sourceCounts.revenueOverlays > 0
+                ? compactCount(sourceCounts.revenueOverlays)
+                : undefined
+            }
+            badgeTone="default"
             active={pathname === "/revenue" || pathname.startsWith("/revenue/")}
           />
           <V2NavRow
@@ -518,15 +570,33 @@ export function SidebarContent({
             disabled
           />
           <V2NavRow
-            icon={LifeBuoy}
-            label="Launch Support"
+            icon={Zap}
+            label="Launch"
             badge="Soon"
             disabled
           />
         </V2Section>
 
-        {/* ALERTS TERMINAL — watchlist + compare + radar -------------- */}
-        <V2Section label="ALERTS TERMINAL">
+        {/* RESEARCH TERMINAL */}
+        <V2Section label="RESEARCH TERMINAL">
+          <V2NavRow
+            href="/papers"
+            icon={FileText}
+            label="arXiv Papers"
+            badge={deltaChip(sourceCounts?.arxivPapers ?? 0) || undefined}
+            badgeTone="delta"
+            active={pathname === "/papers" || pathname.startsWith("/papers/")}
+          />
+          <V2NavRow
+            href="/research"
+            icon={Bot}
+            label="Cited Repos"
+            active={pathname === "/research" || pathname.startsWith("/research/")}
+          />
+        </V2Section>
+
+        {/* TOOLS */}
+        <V2Section label="TOOLS">
           <V2NavRow
             href="/watchlist"
             icon={Bookmark}
@@ -544,20 +614,21 @@ export function SidebarContent({
             active={pathname === "/compare"}
           />
           <V2NavRow
-            href="/#signals"
+            href="/signals"
             icon={Radar}
             label="Signal Radar"
-            active={false}
+            active={
+              pathname === "/signals" || pathname.startsWith("/signals/")
+            }
           />
         </V2Section>
 
-        {/* WATCHING ---------------------------------------------------- */}
+        {/* WATCHING */}
         <V2Section label="WATCHING">
           <SidebarWatchlistPreview repos={watchlistPreview} />
         </V2Section>
       </CursorRail>
 
-      {/* Footer ---------------------------------------------------------- */}
       <SidebarFooter />
     </div>
   );

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+import { PostHogProvider as PHProvider } from "posthog-js/react";
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    if (!key) return;
+    if (posthog.__loaded) return;
+
+    posthog.init(key, {
+      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+      capture_pageview: "history_change",
+      capture_pageleave: true,
+      person_profiles: "identified_only",
+      loaded: (ph) => {
+        ph.register({ project: "trendingrepo", surface: "web" });
+        if (process.env.NODE_ENV === "development") ph.debug();
+      },
+    });
+  }, []);
+
+  return <PHProvider client={posthog}>{children}</PHProvider>;
+}

--- a/src/components/signal/SignalBadge.tsx
+++ b/src/components/signal/SignalBadge.tsx
@@ -14,7 +14,8 @@ export type SignalBadgeKind =
   | "linked-repo"
   | "agents"
   | "mcp"
-  | "llm";
+  | "llm"
+  | "verified";
 
 const STYLES: Record<SignalBadgeKind, { label: string; cls: string }> = {
   hot: {
@@ -60,6 +61,10 @@ const STYLES: Record<SignalBadgeKind, { label: string; cls: string }> = {
   llm: {
     label: "LLM",
     cls: "border-border-primary bg-bg-muted text-text-secondary",
+  },
+  verified: {
+    label: "VERIFIED",
+    cls: "border-up/60 bg-up/10 text-up",
   },
 };
 

--- a/src/components/signal/SourceMonogram.tsx
+++ b/src/components/signal/SourceMonogram.tsx
@@ -10,7 +10,9 @@ export type MonoSource =
   | "lobsters"
   | "twitter"
   | "producthunt"
-  | "github";
+  | "github"
+  | "mcp"
+  | "skills";
 
 const STYLES: Record<MonoSource, { label: string; cls: string }> = {
   reddit: { label: "R", cls: "border-warning/60 bg-warning/10 text-warning" },
@@ -26,6 +28,14 @@ const STYLES: Record<MonoSource, { label: string; cls: string }> = {
   github: {
     label: "GH",
     cls: "border-border-primary bg-bg-muted text-text-secondary",
+  },
+  mcp: {
+    label: "MCP",
+    cls: "border-functional/60 bg-functional/10 text-functional",
+  },
+  skills: {
+    label: "SK",
+    cls: "border-up/60 bg-up/10 text-up",
   },
 };
 

--- a/src/lib/ecosystem-leaderboards.ts
+++ b/src/lib/ecosystem-leaderboards.ts
@@ -1,0 +1,471 @@
+import type { SignalRow } from "@/components/signal/SignalTable";
+import { getDataStore, type DataReadResult, type DataSource } from "./data-store";
+
+export type EcosystemLeaderboardKind = "skill" | "mcp";
+export type SkillBoardId = "skills-sh" | "github";
+
+export interface EcosystemLeaderboardItem {
+  id: string;
+  title: string;
+  url: string;
+  author: string | null;
+  rank: number;
+  description: string | null;
+  topic: string;
+  tags: string[];
+  agents: string[];
+  linkedRepo: string | null;
+  popularity: number | null;
+  popularityLabel: string;
+  signalScore: number;
+  postedAt: string | null;
+  sourceLabel: string;
+  /** Trending-MCP only — set on items where vendor detection matched. */
+  vendor: string | null;
+  logoUrl: string | null;
+  brandColor: string | null;
+  verified: boolean;
+  /** Number of registries this MCP appears in (1-4). */
+  crossSourceCount: number;
+}
+
+export interface EcosystemBoard {
+  id: SkillBoardId | "mcp";
+  kind: EcosystemLeaderboardKind;
+  label: string;
+  key: string;
+  fetchedAt: string | null;
+  source: DataSource;
+  ageMs: number;
+  items: EcosystemLeaderboardItem[];
+  meta: Record<string, number | string | null>;
+}
+
+export interface SkillsSignalData {
+  fetchedAt: string | null;
+  source: DataSource;
+  ageMs: number;
+  skillsSh: EcosystemBoard;
+  github: EcosystemBoard;
+  combined: EcosystemBoard;
+}
+
+export interface McpSignalData {
+  fetchedAt: string | null;
+  source: DataSource;
+  ageMs: number;
+  board: EcosystemBoard;
+}
+
+const SKILLS_SH_KEY = "trending-skill-sh";
+const GITHUB_SKILLS_KEY = "trending-skill";
+const MCP_KEY = "trending-mcp";
+
+export async function getSkillsSignalData(): Promise<SkillsSignalData> {
+  const store = getDataStore();
+  const [skillsShRaw, githubRaw] = await Promise.all([
+    store.read<unknown>(SKILLS_SH_KEY),
+    store.read<unknown>(GITHUB_SKILLS_KEY),
+  ]);
+  const skillsSh = coerceSkillsShBoard(skillsShRaw);
+  const github = coerceGithubSkillsBoard(githubRaw);
+  const combinedItems = dedupeItems([...skillsSh.items, ...github.items])
+    .sort((a, b) => b.signalScore - a.signalScore)
+    .map((item, idx) => ({ ...item, rank: idx + 1 }));
+
+  const combined: EcosystemBoard = {
+    id: "skills-sh",
+    kind: "skill",
+    label: "All Skills",
+    key: `${SKILLS_SH_KEY}+${GITHUB_SKILLS_KEY}`,
+    fetchedAt: freshestIso([skillsSh.fetchedAt, github.fetchedAt]),
+    source: bestSource([skillsSh.source, github.source]),
+    ageMs: minFinite([skillsSh.ageMs, github.ageMs]),
+    items: combinedItems,
+    meta: {
+      skillsSh: skillsSh.items.length,
+      github: github.items.length,
+    },
+  };
+
+  return {
+    fetchedAt: combined.fetchedAt,
+    source: combined.source,
+    ageMs: combined.ageMs,
+    skillsSh,
+    github,
+    combined,
+  };
+}
+
+export async function getMcpSignalData(): Promise<McpSignalData> {
+  const store = getDataStore();
+  const raw = await store.read<unknown>(MCP_KEY);
+  const board = coerceMcpBoard(raw);
+  return {
+    fetchedAt: board.fetchedAt,
+    source: board.source,
+    ageMs: board.ageMs,
+    board,
+  };
+}
+
+export function ecosystemBoardToRows(board: EcosystemBoard): SignalRow[] {
+  return board.items.map((item) => {
+    const badges: SignalRow["badges"] = [];
+    if (item.verified) badges.push("verified");
+    if (item.crossSourceCount >= 2) badges.push("linked-repo");
+    return {
+      id: `${board.kind}:${item.id}`,
+      title: item.title,
+      href: item.url,
+      external: true,
+      attribution: attribution(item),
+      excerpt: item.description,
+      source: board.kind === "mcp" ? "mcp" : "skills",
+      topic: item.topic,
+      linkedRepo: item.linkedRepo,
+      engagement: item.popularity ?? undefined,
+      engagementLabel: item.popularityLabel,
+      postedAt: item.postedAt,
+      signalScore: item.signalScore,
+      badges: badges.length > 0 ? badges : undefined,
+      logoUrl: item.logoUrl,
+      brandColor: item.brandColor,
+    };
+  });
+}
+
+export function formatCompact(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "-";
+  return Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function coerceSkillsShBoard(result: DataReadResult<unknown>): EcosystemBoard {
+  const obj = asRecord(result.data);
+  const fetchedAt = asString(obj?.fetchedAt) ?? result.writtenAt ?? null;
+  const rows = Array.isArray(obj?.items) ? obj.items : [];
+  const items = normalizeScores(
+    rows
+      .map((item, idx) => coerceSkillsShItem(item, idx + 1, fetchedAt))
+      .filter((item): item is EcosystemLeaderboardItem => item !== null),
+  );
+  const sources = asRecord(obj?.sources);
+  const views = asRecord(obj?.views);
+
+  return {
+    id: "skills-sh",
+    kind: "skill",
+    label: "skills.sh",
+    key: SKILLS_SH_KEY,
+    fetchedAt,
+    source: result.source,
+    ageMs: result.ageMs,
+    items,
+    meta: {
+      seen: asNumber(sources?.skills_sh_total_seen),
+      openclaw: asNumber(sources?.openclaw_compatible_count),
+      hot: asNumber(views?.hot),
+      trending: asNumber(views?.trending),
+    },
+  };
+}
+
+function coerceGithubSkillsBoard(result: DataReadResult<unknown>): EcosystemBoard {
+  const obj = asRecord(result.data);
+  const fetchedAt = asString(obj?.fetchedAt) ?? result.writtenAt ?? null;
+  const rows = Array.isArray(obj?.items) ? obj.items : [];
+  const items = normalizeScores(
+    rows
+      .map((item, idx) => coerceGithubSkillItem(item, idx + 1))
+      .filter((item): item is EcosystemLeaderboardItem => item !== null),
+  );
+  const sources = asRecord(obj?.sources);
+
+  return {
+    id: "github",
+    kind: "skill",
+    label: "GitHub Skill Repos",
+    key: GITHUB_SKILLS_KEY,
+    fetchedAt,
+    source: result.source,
+    ageMs: result.ageMs,
+    items,
+    meta: {
+      seen: asNumber(sources?.githubTotalSeen),
+    },
+  };
+}
+
+function coerceMcpBoard(result: DataReadResult<unknown>): EcosystemBoard {
+  const obj = asRecord(result.data);
+  const fetchedAt =
+    asString(obj?.generatedAt) ?? asString(obj?.fetchedAt) ?? result.writtenAt ?? null;
+  const rows = Array.isArray(obj?.items) ? obj.items : [];
+  const items = normalizeScores(
+    rows
+      .map((item, idx) => coerceMcpItem(item, idx + 1, fetchedAt))
+      .filter((item): item is EcosystemLeaderboardItem => item !== null),
+  );
+
+  return {
+    id: "mcp",
+    kind: "mcp",
+    label: "MCP Servers",
+    key: MCP_KEY,
+    fetchedAt,
+    source: result.source,
+    ageMs: result.ageMs,
+    items,
+    meta: {
+      seen: items.length,
+    },
+  };
+}
+
+function coerceSkillsShItem(
+  raw: unknown,
+  fallbackRank: number,
+  fallbackDate: string | null,
+): EcosystemLeaderboardItem | null {
+  const item = asRecord(raw);
+  if (!item) return null;
+  const owner = asString(item.owner);
+  const repo = asString(item.repo);
+  const skillName = asString(item.skill_name) ?? asString(item.title);
+  const id =
+    asString(item.source_id) ??
+    [owner, repo, skillName].filter(Boolean).join("/");
+  const url = asString(item.url) ?? asString(item.github_url);
+  if (!id || !skillName || !url) return null;
+
+  const agents = asStringArray(item.agents).slice(0, 12);
+  const linkedRepo = owner && repo ? `${owner}/${repo}` : null;
+  const view = asString(item.view);
+  const tags = [
+    view,
+    asBoolean(item.openclaw_compatible) ? "OpenClaw" : null,
+    ...agents.slice(0, 4),
+  ].filter((tag): tag is string => Boolean(tag));
+
+  return {
+    id,
+    title: skillName,
+    url,
+    author: linkedRepo,
+    rank: asNumber(item.rank) ?? fallbackRank,
+    description: asString(item.description),
+    topic: view ? view.replace("-", " ") : "skills.sh",
+    tags,
+    agents,
+    linkedRepo,
+    popularity: asNumber(item.installs),
+    popularityLabel: "Installs",
+    signalScore: asNumber(item.trending_score) ?? 0,
+    postedAt: asString(item.last_pushed_at) ?? fallbackDate,
+    sourceLabel: "skills.sh",
+    vendor: null,
+    logoUrl: null,
+    brandColor: null,
+    verified: false,
+    crossSourceCount: 1,
+  };
+}
+
+function coerceGithubSkillItem(
+  raw: unknown,
+  fallbackRank: number,
+): EcosystemLeaderboardItem | null {
+  const item = asRecord(raw);
+  if (!item) return null;
+  const fullName = asString(item.full_name);
+  const title = asString(item.title) ?? leafName(fullName);
+  const url = asString(item.url);
+  if (!fullName || !title || !url) return null;
+
+  return {
+    id: fullName,
+    title,
+    url,
+    author: asString(item.author) ?? fullName.split("/")[0] ?? null,
+    rank: asNumber(item.rank) ?? fallbackRank,
+    description: asString(item.description),
+    topic: "GitHub",
+    tags: asStringArray(item.source_topics).slice(0, 4),
+    agents: [],
+    linkedRepo: fullName,
+    popularity: asNumber(item.stars),
+    popularityLabel: "Stars",
+    signalScore: asNumber(item.score) ?? 0,
+    postedAt: asString(item.pushed_at) ?? asString(item.created_at),
+    sourceLabel: "GitHub topics",
+    vendor: null,
+    logoUrl: null,
+    brandColor: null,
+    verified: false,
+    crossSourceCount: 1,
+  };
+}
+
+function coerceMcpItem(
+  raw: unknown,
+  fallbackRank: number,
+  fallbackDate: string | null,
+): EcosystemLeaderboardItem | null {
+  const item = asRecord(raw);
+  if (!item) return null;
+  const id = asString(item.id) ?? asString(item.slug);
+  const title = asString(item.title) ?? leafName(asString(item.slug));
+  const url = asString(item.url);
+  if (!id || !title || !url) return null;
+
+  const metrics = asRecord(item.metrics);
+  const popularity =
+    asNumber(metrics?.installs_total) ??
+    asNumber(metrics?.downloads_7d) ??
+    asNumber(metrics?.stars_total) ??
+    null;
+  const popularityLabel =
+    asNumber(metrics?.installs_total) !== null
+      ? "Installs"
+      : asNumber(metrics?.downloads_7d) !== null
+        ? "Downloads"
+        : "Stars";
+  const slug = asString(item.slug);
+  const linkedRepo = url.includes("github.com/")
+    ? url.replace(/^https?:\/\/github\.com\//, "").replace(/\/$/, "")
+    : null;
+
+  const vendor = asString(item.vendor);
+  const logoUrl = asString(item.logo_url);
+  const brandColor = asString(item.brand_color);
+  const verified = asBoolean(item.is_official_vendor);
+  const crossSourceCount = asNumber(item.cross_source_count) ?? 1;
+  const tags = ["mcp"];
+  if (vendor) tags.push(vendor);
+  if (verified) tags.push("official");
+  if (crossSourceCount >= 2) tags.push(`${crossSourceCount}× sources`);
+
+  return {
+    id,
+    title,
+    url,
+    author: vendor,
+    rank: asNumber(item.rank) ?? fallbackRank,
+    description: asString(item.description),
+    topic: vendor ?? (slug?.includes("/") ? slug.split("/")[0] ?? "MCP" : "MCP"),
+    tags,
+    agents: [],
+    linkedRepo: linkedRepo && linkedRepo.includes("/") ? linkedRepo : null,
+    popularity,
+    popularityLabel,
+    signalScore: asNumber(item.trending_score) ?? 0,
+    postedAt: fallbackDate,
+    sourceLabel: "MCP registries",
+    vendor,
+    logoUrl,
+    brandColor,
+    verified,
+    crossSourceCount,
+  };
+}
+
+function normalizeScores(items: EcosystemLeaderboardItem[]): EcosystemLeaderboardItem[] {
+  const maxScore = Math.max(0, ...items.map((item) => item.signalScore));
+  if (maxScore <= 0) {
+    return items.map((item, idx) => ({ ...item, signalScore: rankScore(idx, items.length) }));
+  }
+  const shouldScale = maxScore > 100 || maxScore <= 20;
+  return items.map((item, idx) => ({
+    ...item,
+    signalScore: shouldScale
+      ? Math.max(1, Math.round((item.signalScore / maxScore) * 100))
+      : Math.max(1, Math.min(100, Math.round(item.signalScore))),
+    rank: item.rank || idx + 1,
+  }));
+}
+
+function rankScore(index: number, total: number): number {
+  if (total <= 1) return 100;
+  return Math.max(1, Math.round(100 - (index / (total - 1)) * 70));
+}
+
+function dedupeItems(items: EcosystemLeaderboardItem[]): EcosystemLeaderboardItem[] {
+  const seen = new Set<string>();
+  const out: EcosystemLeaderboardItem[] = [];
+  for (const item of items) {
+    const key = (item.linkedRepo ?? item.id).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+function attribution(item: EcosystemLeaderboardItem): string {
+  const bits = [item.sourceLabel];
+  if (item.author) bits.push(item.author);
+  if (item.popularity !== null) {
+    bits.push(`${formatCompact(item.popularity)} ${item.popularityLabel.toLowerCase()}`);
+  }
+  if (item.tags.length > 0) bits.push(item.tags.slice(0, 3).join(" / "));
+  return bits.join(" / ");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const clean = value.trim();
+  return clean.length > 0 ? clean : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map((item) => asString(item)).filter((item): item is string => item !== null)
+    : [];
+}
+
+function asNumber(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+function leafName(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return value.split("/").pop() ?? value;
+}
+
+function freshestIso(values: Array<string | null>): string | null {
+  let best = 0;
+  let bestIso: string | null = null;
+  for (const value of values) {
+    if (!value) continue;
+    const t = Date.parse(value);
+    if (!Number.isFinite(t) || t <= best) continue;
+    best = t;
+    bestIso = value;
+  }
+  return bestIso;
+}
+
+function bestSource(sources: DataSource[]): DataSource {
+  if (sources.includes("redis")) return "redis";
+  if (sources.includes("file")) return "file";
+  if (sources.includes("memory")) return "memory";
+  return "missing";
+}
+
+function minFinite(values: number[]): number {
+  const finite = values.filter(Number.isFinite);
+  return finite.length > 0 ? Math.min(...finite) : 0;
+}

--- a/src/lib/news/freshness.ts
+++ b/src/lib/news/freshness.ts
@@ -23,7 +23,9 @@ export type NewsSource =
   | "lobsters"
   | "producthunt"
   | "twitter"
-  | "npm";
+  | "npm"
+  | "mcp"
+  | "skills";
 
 export type FreshnessStatus = "live" | "warn" | "cold";
 
@@ -48,6 +50,11 @@ export const SOURCE_STALE_MS: Record<NewsSource, number> = {
   // the fast threshold so a missing twitter timestamp behaves like a
   // missing reddit one.
   twitter: FAST_DATA_STALE_THRESHOLD_MS,
+  // MCP + Skills publish from the worker fleet on a 6h cadence (12h budget
+  // = 6h cron + 6h grace). Reuse the npm threshold since it's the closest
+  // existing match for slow-cron Redis-published feeds.
+  mcp: NPM_STALE_THRESHOLD_MS,
+  skills: NPM_STALE_THRESHOLD_MS,
 };
 
 /** Soft warn threshold = 50% of the stale threshold. Past it the badge

--- a/src/lib/sidebar-source-counts.ts
+++ b/src/lib/sidebar-source-counts.ts
@@ -1,0 +1,110 @@
+// Sidebar source counts — server-side helper that returns one count per
+// data source for the sidebar count badges. Triggers each source's
+// refresh-from-store hook in parallel (each is rate-limited to 30s
+// internally, so calling on every sidebar fetch is cheap), then reads
+// the in-memory file shape and reports `.length`.
+//
+// Two semantic groups:
+//   feedDeltas — rolling-window feeds. The count is "items in window"
+//     (HN: 72h, Lobsters: 72h, Bluesky/Reddit/Devto: per-source window,
+//     PH/arXiv/Funding: as collected). Rendered as `+N` accent chip.
+//   collections — cumulative inventories. Rendered as `N` neutral chip.
+//
+// Twitter is intentionally omitted for now: the per-repo signals live
+// in JSONL append-only logs, not a single trending payload — surfacing
+// a "fresh tweets" count requires its own aggregation pass.
+
+import { getHnTrendingFile, refreshHackernewsTrendingFromStore } from "./hackernews-trending";
+import { getLobstersTrendingFile, refreshLobstersTrendingFromStore } from "./lobsters-trending";
+import { getDevtoTrendingFile, refreshDevtoTrendingFromStore } from "./devto-trending";
+import { getBlueskyTrendingFile, refreshBlueskyTrendingFromStore } from "./bluesky-trending";
+import {
+  getAllPostsFile,
+  refreshRedditAllPostsFromStore,
+} from "./reddit-all-data";
+import { getPhFile, refreshProducthuntLaunchesFromStore } from "./producthunt";
+import { getArxivTrendingFile, refreshArxivTrendingFromStore } from "./arxiv-trending";
+import { getFundingSignals, refreshFundingNewsFromStore } from "./funding-news";
+import {
+  getRevenueOverlaysMeta,
+  refreshRevenueOverlaysFromStore,
+} from "./revenue-overlays";
+import { getNpmPackagesFile, refreshNpmFromStore } from "./npm";
+
+export interface SidebarSourceCounts {
+  // Feed deltas — rendered as `+N` accent chip.
+  hackernewsStories: number;
+  lobstersStories: number;
+  devtoArticles: number;
+  blueskyPosts: number;
+  redditPosts: number;
+  producthuntLaunches: number;
+  arxivPapers: number;
+  // Collections — rendered as neutral count.
+  fundingSignals: number;
+  revenueOverlays: number;
+  npmPackages: number;
+}
+
+const ZERO_COUNTS: SidebarSourceCounts = {
+  hackernewsStories: 0,
+  lobstersStories: 0,
+  devtoArticles: 0,
+  blueskyPosts: 0,
+  redditPosts: 0,
+  producthuntLaunches: 0,
+  arxivPapers: 0,
+  fundingSignals: 0,
+  revenueOverlays: 0,
+  npmPackages: 0,
+};
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+export async function getSidebarSourceCounts(): Promise<SidebarSourceCounts> {
+  // Fire all refresh hooks in parallel. Each one is rate-limited to 30s
+  // internally and will return { source: "memory", ... } when fresh.
+  await Promise.allSettled([
+    refreshHackernewsTrendingFromStore(),
+    refreshLobstersTrendingFromStore(),
+    refreshDevtoTrendingFromStore(),
+    refreshBlueskyTrendingFromStore(),
+    refreshRedditAllPostsFromStore(),
+    refreshProducthuntLaunchesFromStore(),
+    refreshArxivTrendingFromStore(),
+    refreshFundingNewsFromStore(),
+    refreshRevenueOverlaysFromStore(),
+    refreshNpmFromStore(),
+  ]);
+
+  const npmFile = safe(() => getNpmPackagesFile(), null);
+  const npmCount =
+    npmFile?.counts?.total ??
+    (Array.isArray(npmFile?.packages) ? npmFile.packages.length : 0);
+
+  const overlaysMeta = safe(() => getRevenueOverlaysMeta(), null);
+  const overlaysCount = overlaysMeta?.matchedCount ?? 0;
+
+  return {
+    hackernewsStories: safe(() => getHnTrendingFile().stories.length, 0),
+    lobstersStories: safe(() => getLobstersTrendingFile().stories.length, 0),
+    devtoArticles: safe(() => getDevtoTrendingFile().articles.length, 0),
+    blueskyPosts: safe(() => getBlueskyTrendingFile().posts.length, 0),
+    redditPosts: safe(() => getAllPostsFile().posts.length, 0),
+    producthuntLaunches: safe(() => getPhFile().launches.length, 0),
+    arxivPapers: safe(() => getArxivTrendingFile().papers.length, 0),
+    fundingSignals: safe(() => getFundingSignals().length, 0),
+    revenueOverlays: overlaysCount,
+    npmPackages: npmCount,
+  };
+}
+
+export function emptySidebarSourceCounts(): SidebarSourceCounts {
+  return { ...ZERO_COUNTS };
+}

--- a/src/lib/sidebar-source-counts.ts
+++ b/src/lib/sidebar-source-counts.ts
@@ -23,7 +23,6 @@ import {
   refreshRedditAllPostsFromStore,
 } from "./reddit-all-data";
 import { getPhFile, refreshProducthuntLaunchesFromStore } from "./producthunt";
-import { getArxivTrendingFile, refreshArxivTrendingFromStore } from "./arxiv-trending";
 import { getFundingSignals, refreshFundingNewsFromStore } from "./funding-news";
 import {
   getRevenueOverlaysMeta,
@@ -39,7 +38,6 @@ export interface SidebarSourceCounts {
   blueskyPosts: number;
   redditPosts: number;
   producthuntLaunches: number;
-  arxivPapers: number;
   // Collections — rendered as neutral count.
   fundingSignals: number;
   revenueOverlays: number;
@@ -53,7 +51,6 @@ const ZERO_COUNTS: SidebarSourceCounts = {
   blueskyPosts: 0,
   redditPosts: 0,
   producthuntLaunches: 0,
-  arxivPapers: 0,
   fundingSignals: 0,
   revenueOverlays: 0,
   npmPackages: 0,
@@ -77,7 +74,6 @@ export async function getSidebarSourceCounts(): Promise<SidebarSourceCounts> {
     refreshBlueskyTrendingFromStore(),
     refreshRedditAllPostsFromStore(),
     refreshProducthuntLaunchesFromStore(),
-    refreshArxivTrendingFromStore(),
     refreshFundingNewsFromStore(),
     refreshRevenueOverlaysFromStore(),
     refreshNpmFromStore(),
@@ -98,7 +94,6 @@ export async function getSidebarSourceCounts(): Promise<SidebarSourceCounts> {
     blueskyPosts: safe(() => getBlueskyTrendingFile().posts.length, 0),
     redditPosts: safe(() => getAllPostsFile().posts.length, 0),
     producthuntLaunches: safe(() => getPhFile().launches.length, 0),
-    arxivPapers: safe(() => getArxivTrendingFile().papers.length, 0),
     fundingSignals: safe(() => getFundingSignals().length, 0),
     revenueOverlays: overlaysCount,
     npmPackages: npmCount,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,8 +32,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "next-env.d.ts",
-    "../../../AppData/Local/Temp/starscreener-next-dev/types/**/*.ts"
+    "next-env.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- Restructured sidebar into 7 sections (TREND / SIGNAL / LLM·PACK / LAUNCH / RESEARCH / TOOLS / WATCHING) matching the new mock
- Added per-source count badges flowing from a new \`sidebar-source-counts\` helper through the existing \`/api/pipeline/sidebar-data\` endpoint — green \`+N\` deltas for windowed feeds (HN/Lobsters/Devto/Bsky/Reddit/PH/arXiv), neutral totals for cumulative inventories (NPM/Funding/Revenue)
- Cherry-picked \`/mcp\` page from \`feat/trendingrepo-worker-scaffold\` so the Trending MCP sidebar link resolves
- Built \`/skills\` page fresh with three tabs (All / Skills.sh / GitHub) backed by \`getSkillsSignalData()\` from the new \`ecosystem-leaderboards\` lib
- Pulled \`/api/skills\` read endpoint from feat branch
- Type extensions: \`NewsSource\` + \`MonoSource\` gain \`mcp\`/\`skills\`; \`SignalBadgeKind\` gains \`verified\`
- Theme-aware delta chip via existing \`--color-up\` / \`--color-up-bg\` tokens

## Caveat
Both \`/skills\` and \`/mcp\` will render \`data.source = "missing"\` and empty leaderboards until the worker fleet on \`feat/trendingrepo-worker-scaffold\` publishes to \`ss:data:v1:trending-{skill,skill-sh,mcp}\` Redis keys. This PR ships only the consumer surface — worker scaffold is a separate merge decision.

## Test plan
- [ ] Vercel preview builds clean
- [ ] Sidebar renders 7 sections with badges
- [ ] /skills page loads (empty leaderboard OK until worker merges)
- [ ] /mcp page loads (empty leaderboard OK until worker merges)
- [ ] Trending AGNT row routes to /agent-repos
- [ ] Signal Radar row routes to /signals (was broken /#signals)
- [ ] No typecheck regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)