### PR TITLE
feat(resilience): per-source circuit breaker + health tracker

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -38,6 +38,7 @@ import {
   getScannerSourceHealth,
   type ScannerSourceHealth,
 } from "@/lib/source-health";
+import { sourceHealthTracker } from "@/lib/source-health-tracker";
 import {
   deltasCoveragePct,
   deltasCoverageQuality,
@@ -123,8 +124,28 @@ interface HealthBody {
   };
   degradedSources?: string[];
   sources?: ScannerSourceHealth[];
+  circuitBreakers?: {
+    open: string[];
+    half_open: string[];
+  };
   warning?: string;
   error?: string;
+}
+
+function getCircuitBreakerSummary(): {
+  open: string[];
+  half_open: string[];
+} {
+  const all = sourceHealthTracker.getAllHealth();
+  const open: string[] = [];
+  const halfOpen: string[] = [];
+  for (const [id, snap] of Object.entries(all)) {
+    if (snap.state === "OPEN") open.push(id);
+    else if (snap.state === "HALF_OPEN") halfOpen.push(id);
+  }
+  open.sort();
+  halfOpen.sort();
+  return { open, half_open: halfOpen };
 }
 
 function ageMs(iso: string | null): number | null {
@@ -291,6 +312,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<HealthBody
       },
       degradedSources,
       sources,
+      circuitBreakers: getCircuitBreakerSummary(),
     };
 
     if (!anyStale && quality === "partial") {
@@ -384,6 +406,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<HealthBody
         },
         degradedSources: [],
         sources: [],
+        circuitBreakers: getCircuitBreakerSummary(),
         error: message,
       },
       { status: 503 },

--- a/src/app/api/health/sources/route.ts
+++ b/src/app/api/health/sources/route.ts
@@ -1,0 +1,130 @@
+// GET /api/health/sources
+//
+// Per-source circuit-breaker breakdown for upstream adapter health. Companion
+// to /api/health which still owns the freshness story (data-staleness based on
+// last successful refresh timestamp). This endpoint surfaces:
+//
+//   - state machine (CLOSED / OPEN / HALF_OPEN) per source
+//   - rolling success/failure counters and derived error rate
+//   - openedAt / nextProbeAt for OPEN circuits
+//   - lastSuccessAt + lastFailure (truncated message)
+//
+// Returned status:
+//   - 200 when all known sources are CLOSED
+//   - 207 (Multi-Status) when at least one breaker is OPEN or HALF_OPEN — the
+//     payload itself is fine, but the multi-status code lets uptime monitors
+//     differentiate "server up but degraded" from "server down".
+
+import { NextResponse } from "next/server";
+
+import {
+  KNOWN_SOURCES,
+  sourceHealthTracker,
+  type SourceHealthSnapshot,
+} from "@/lib/source-health-tracker";
+
+interface SourceBreakerView {
+  state: SourceHealthSnapshot["state"];
+  successCount: number;
+  failureCount: number;
+  errorRate: number;
+  totalAttempts: number;
+  windowSize: number;
+  consecutiveFailures: number;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  lastFailure: string | null;
+  openedAt: string | null;
+  nextProbeAt: string | null;
+}
+
+interface HealthSourcesBody {
+  fetchedAt: string;
+  summary: {
+    total: number;
+    closed: number;
+    open: number;
+    halfOpen: number;
+    openSources: string[];
+    halfOpenSources: string[];
+  };
+  options: {
+    windowSize: number;
+    failureThreshold: number;
+    cooldownMs: number;
+  };
+  sources: Record<string, SourceBreakerView>;
+}
+
+function toView(snapshot: SourceHealthSnapshot): SourceBreakerView {
+  return {
+    state: snapshot.state,
+    successCount: snapshot.successCount,
+    failureCount: snapshot.failureCount,
+    errorRate: Math.round(snapshot.errorRate * 1000) / 1000,
+    totalAttempts: snapshot.totalAttempts,
+    windowSize: snapshot.windowSize,
+    consecutiveFailures: snapshot.consecutiveFailures,
+    lastSuccessAt: snapshot.lastSuccessAt,
+    lastFailureAt: snapshot.lastFailureAt,
+    lastFailure: snapshot.lastFailure,
+    openedAt: snapshot.openedAt,
+    nextProbeAt: snapshot.nextProbeAt,
+  };
+}
+
+export async function GET(): Promise<NextResponse<HealthSourcesBody>> {
+  // Make sure the canonical list is always represented even before any
+  // traffic flows (cold-start scenario on a fresh process).
+  for (const id of KNOWN_SOURCES) {
+    sourceHealthTracker.register(id);
+  }
+
+  const all = sourceHealthTracker.getAllHealth();
+  const sources: Record<string, SourceBreakerView> = {};
+  let closed = 0;
+  let open = 0;
+  let halfOpen = 0;
+  const openSources: string[] = [];
+  const halfOpenSources: string[] = [];
+
+  for (const [id, snap] of Object.entries(all)) {
+    sources[id] = toView(snap);
+    if (snap.state === "OPEN") {
+      open += 1;
+      openSources.push(id);
+    } else if (snap.state === "HALF_OPEN") {
+      halfOpen += 1;
+      halfOpenSources.push(id);
+    } else {
+      closed += 1;
+    }
+  }
+
+  openSources.sort();
+  halfOpenSources.sort();
+
+  const opts = sourceHealthTracker.getOptions();
+  const body: HealthSourcesBody = {
+    fetchedAt: new Date().toISOString(),
+    summary: {
+      total: closed + open + halfOpen,
+      closed,
+      open,
+      halfOpen,
+      openSources,
+      halfOpenSources,
+    },
+    options: {
+      windowSize: opts.windowSize,
+      failureThreshold: opts.failureThreshold,
+      cooldownMs: opts.cooldownMs,
+    },
+    sources,
+  };
+
+  // 207 Multi-Status when degraded so monitors can split "down" from
+  // "degraded but serving".
+  const status = open + halfOpen > 0 ? 207 : 200;
+  return NextResponse.json(body, { status });
+}

--- a/src/lib/__tests__/source-health-tracker.test.ts
+++ b/src/lib/__tests__/source-health-tracker.test.ts
@@ -1,0 +1,369 @@
+// Tests for src/lib/source-health-tracker.ts.
+//
+// Covers:
+//   - state transitions CLOSED → OPEN → HALF_OPEN → CLOSED/OPEN
+//   - rolling window honours configured size
+//   - success/failure counters update correctly inside the window
+//   - openedAt + nextProbeAt populated when the breaker trips
+//   - reset clears state for tests
+//   - error message formatting truncates oversize payloads
+//
+// Run with: npx tsx --test src/lib/__tests__/source-health-tracker.test.ts
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { SourceHealthTracker } from "../source-health-tracker";
+
+// Helper that constructs a tracker with a controllable clock.
+function makeTracker(
+  options: Partial<{
+    windowSize: number;
+    failureThreshold: number;
+    cooldownMs: number;
+  }> = {},
+): {
+  tracker: SourceHealthTracker;
+  setNow: (ms: number) => void;
+} {
+  let now = Date.parse("2026-04-26T12:00:00.000Z");
+  const tracker = new SourceHealthTracker(
+    {
+      windowSize: options.windowSize ?? 5,
+      failureThreshold: options.failureThreshold ?? 3,
+      cooldownMs: options.cooldownMs ?? 10_000,
+    },
+    () => now,
+  );
+  return {
+    tracker,
+    setNow: (ms: number) => {
+      now = ms;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLOSED → OPEN transition
+// ---------------------------------------------------------------------------
+
+test("starts in CLOSED state with empty counters", () => {
+  const { tracker } = makeTracker();
+  const h = tracker.getHealth("hackernews");
+  assert.equal(h.state, "CLOSED");
+  assert.equal(h.successCount, 0);
+  assert.equal(h.failureCount, 0);
+  assert.equal(h.errorRate, 0);
+  assert.equal(h.openedAt, null);
+  assert.equal(h.nextProbeAt, null);
+});
+
+test("CLOSED → OPEN after N consecutive failures", () => {
+  const { tracker } = makeTracker({ failureThreshold: 3 });
+  tracker.recordFailure("hackernews", new Error("503"));
+  tracker.recordFailure("hackernews", new Error("503"));
+  assert.equal(tracker.getHealth("hackernews").state, "CLOSED");
+  tracker.recordFailure("hackernews", new Error("503"));
+  const h = tracker.getHealth("hackernews");
+  assert.equal(h.state, "OPEN");
+  assert.equal(h.consecutiveFailures, 3);
+  assert.ok(h.openedAt !== null, "openedAt should be set");
+  assert.ok(h.nextProbeAt !== null, "nextProbeAt should be set");
+  assert.equal(tracker.isOpen("hackernews"), true);
+});
+
+test("a single success resets the consecutive-failure counter", () => {
+  const { tracker } = makeTracker({ failureThreshold: 3 });
+  tracker.recordFailure("reddit", "boom");
+  tracker.recordFailure("reddit", "boom");
+  tracker.recordSuccess("reddit");
+  tracker.recordFailure("reddit", "boom");
+  tracker.recordFailure("reddit", "boom");
+  // Two-then-success-then-two should NOT trip a 3-threshold breaker.
+  assert.equal(tracker.getHealth("reddit").state, "CLOSED");
+});
+
+// ---------------------------------------------------------------------------
+// OPEN → HALF_OPEN → CLOSED / OPEN
+// ---------------------------------------------------------------------------
+
+test("OPEN → HALF_OPEN after cooldown elapses", () => {
+  const { tracker, setNow } = makeTracker({
+    failureThreshold: 2,
+    cooldownMs: 5_000,
+  });
+  const t0 = Date.parse("2026-04-26T12:00:00.000Z");
+  setNow(t0);
+  tracker.recordFailure("bluesky", "boom");
+  tracker.recordFailure("bluesky", "boom");
+  assert.equal(tracker.isOpen("bluesky"), true);
+
+  // Inside cooldown — still OPEN.
+  setNow(t0 + 4_000);
+  assert.equal(tracker.isOpen("bluesky"), true);
+  assert.equal(tracker.getHealth("bluesky").state, "OPEN");
+
+  // Cooldown elapsed — isOpen() flips to false and state moves to HALF_OPEN.
+  setNow(t0 + 6_000);
+  assert.equal(tracker.isOpen("bluesky"), false);
+  assert.equal(tracker.getHealth("bluesky").state, "HALF_OPEN");
+});
+
+test("HALF_OPEN + success → CLOSED", () => {
+  const { tracker, setNow } = makeTracker({
+    failureThreshold: 2,
+    cooldownMs: 5_000,
+  });
+  const t0 = Date.parse("2026-04-26T12:00:00.000Z");
+  setNow(t0);
+  tracker.recordFailure("devto", "boom");
+  tracker.recordFailure("devto", "boom");
+  setNow(t0 + 6_000);
+  // Trigger the OPEN → HALF_OPEN transition.
+  tracker.isOpen("devto");
+  assert.equal(tracker.getHealth("devto").state, "HALF_OPEN");
+
+  // Probe succeeded.
+  tracker.recordSuccess("devto");
+  const h = tracker.getHealth("devto");
+  assert.equal(h.state, "CLOSED");
+  assert.equal(h.openedAt, null);
+  assert.equal(h.nextProbeAt, null);
+  assert.equal(h.consecutiveFailures, 0);
+});
+
+test("HALF_OPEN + failure → back to OPEN with refreshed cooldown", () => {
+  const { tracker, setNow } = makeTracker({
+    failureThreshold: 2,
+    cooldownMs: 5_000,
+  });
+  const t0 = Date.parse("2026-04-26T12:00:00.000Z");
+  setNow(t0);
+  tracker.recordFailure("nitter", "boom");
+  tracker.recordFailure("nitter", "boom");
+  const firstOpenedAt = tracker.getHealth("nitter").openedAt;
+  assert.ok(firstOpenedAt);
+
+  setNow(t0 + 6_000);
+  tracker.isOpen("nitter"); // OPEN → HALF_OPEN
+  assert.equal(tracker.getHealth("nitter").state, "HALF_OPEN");
+
+  // Probe failed — back to OPEN with a fresh openedAt.
+  tracker.recordFailure("nitter", "still boom");
+  const h = tracker.getHealth("nitter");
+  assert.equal(h.state, "OPEN");
+  assert.notEqual(h.openedAt, firstOpenedAt, "openedAt should refresh");
+  assert.equal(tracker.isOpen("nitter"), true);
+});
+
+// ---------------------------------------------------------------------------
+// Rolling window
+// ---------------------------------------------------------------------------
+
+test("rolling window honours configured size", () => {
+  const { tracker } = makeTracker({ windowSize: 5, failureThreshold: 99 });
+  // Push 7 attempts — only the last 5 should appear in the window counts.
+  tracker.recordFailure("github", "x");
+  tracker.recordFailure("github", "x");
+  tracker.recordSuccess("github");
+  tracker.recordSuccess("github");
+  tracker.recordSuccess("github");
+  tracker.recordSuccess("github");
+  tracker.recordSuccess("github");
+  const h = tracker.getHealth("github");
+  // Window holds the most recent 5: SSSSS.
+  assert.equal(h.successCount + h.failureCount, 5);
+  assert.equal(h.successCount, 5);
+  assert.equal(h.failureCount, 0);
+  // Total attempts is unbounded.
+  assert.equal(h.totalAttempts, 7);
+});
+
+test("errorRate is failureCount / window length", () => {
+  const { tracker } = makeTracker({ windowSize: 4, failureThreshold: 99 });
+  tracker.recordSuccess("reddit");
+  tracker.recordFailure("reddit", "x");
+  tracker.recordFailure("reddit", "x");
+  tracker.recordFailure("reddit", "x");
+  const h = tracker.getHealth("reddit");
+  // 3 failures / 4 attempts = 0.75
+  assert.equal(h.errorRate, 0.75);
+  assert.equal(h.failureCount, 3);
+  assert.equal(h.successCount, 1);
+});
+
+// ---------------------------------------------------------------------------
+// isOpen() short-circuit signal
+// ---------------------------------------------------------------------------
+
+test("isOpen() returns true while OPEN, false once HALF_OPEN", () => {
+  const { tracker, setNow } = makeTracker({
+    failureThreshold: 1,
+    cooldownMs: 1_000,
+  });
+  const t0 = Date.parse("2026-04-26T12:00:00.000Z");
+  setNow(t0);
+  tracker.recordFailure("devto", "x");
+  assert.equal(tracker.isOpen("devto"), true);
+
+  // After cooldown: isOpen returns false (callers may probe), state = HALF_OPEN.
+  setNow(t0 + 2_000);
+  assert.equal(tracker.isOpen("devto"), false);
+  assert.equal(tracker.getHealth("devto").state, "HALF_OPEN");
+});
+
+// ---------------------------------------------------------------------------
+// getAllHealth + register
+// ---------------------------------------------------------------------------
+
+test("getAllHealth returns every registered source", () => {
+  const { tracker } = makeTracker();
+  tracker.register("hackernews");
+  tracker.register("reddit");
+  tracker.recordFailure("bluesky", "boom");
+  const all = tracker.getAllHealth();
+  assert.ok(all.hackernews);
+  assert.ok(all.reddit);
+  assert.ok(all.bluesky);
+  assert.equal(all.hackernews.state, "CLOSED");
+  assert.equal(all.bluesky.failureCount, 1);
+});
+
+test("reset() clears one source or all sources", () => {
+  const { tracker } = makeTracker({ failureThreshold: 2 });
+  tracker.recordFailure("hackernews", "x");
+  tracker.recordFailure("hackernews", "x");
+  tracker.recordFailure("reddit", "x");
+  assert.equal(tracker.getHealth("hackernews").state, "OPEN");
+  tracker.reset("hackernews");
+  assert.equal(tracker.getHealth("hackernews").state, "CLOSED");
+  assert.equal(tracker.getHealth("reddit").failureCount, 1);
+  tracker.reset();
+  assert.equal(tracker.getHealth("reddit").failureCount, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Error message formatting
+// ---------------------------------------------------------------------------
+
+test("recordFailure stores Error.message verbatim", () => {
+  const { tracker } = makeTracker();
+  tracker.recordFailure("bluesky", new Error("rate limited"));
+  assert.equal(tracker.getHealth("bluesky").lastFailure, "rate limited");
+});
+
+test("recordFailure stores raw strings as-is", () => {
+  const { tracker } = makeTracker();
+  tracker.recordFailure("bluesky", "HTTP 503");
+  assert.equal(tracker.getHealth("bluesky").lastFailure, "HTTP 503");
+});
+
+test("recordFailure truncates oversize messages", () => {
+  const { tracker } = makeTracker();
+  const huge = "x".repeat(500);
+  tracker.recordFailure("bluesky", huge);
+  const stored = tracker.getHealth("bluesky").lastFailure;
+  assert.ok(stored && stored.length < 300);
+  assert.ok(stored && stored.endsWith("…"));
+});
+
+test("recordFailure with undefined keeps lastFailure null", () => {
+  const { tracker } = makeTracker();
+  tracker.recordFailure("bluesky");
+  assert.equal(tracker.getHealth("bluesky").lastFailure, null);
+});
+
+// ---------------------------------------------------------------------------
+// Open circuit returns empty fallback (caller wiring contract)
+// ---------------------------------------------------------------------------
+//
+// The tracker itself doesn't know about "fallback values" — that lives in
+// the adapter wrappers. The contract is: when isOpen() returns true the
+// caller MUST short-circuit and return its empty fallback. This test
+// emulates that contract end-to-end so a regression in either layer is
+// caught.
+
+test("simulated adapter wraps tracker.isOpen and returns empty fallback when OPEN", async () => {
+  const { tracker } = makeTracker({ failureThreshold: 2, cooldownMs: 30_000 });
+
+  let upstreamCalled = 0;
+  const fakeAdapter = async (
+    fail: boolean,
+  ): Promise<readonly string[]> => {
+    if (tracker.isOpen("hackernews")) {
+      // Empty fallback — do not invoke upstream.
+      return [];
+    }
+    upstreamCalled += 1;
+    if (fail) {
+      tracker.recordFailure("hackernews", new Error("503"));
+      return [];
+    }
+    tracker.recordSuccess("hackernews");
+    return ["mention-1"];
+  };
+
+  // Two failures trip the breaker.
+  await fakeAdapter(true);
+  await fakeAdapter(true);
+  assert.equal(upstreamCalled, 2);
+  assert.equal(tracker.getHealth("hackernews").state, "OPEN");
+
+  // Subsequent calls short-circuit — upstream is NOT touched.
+  const out1 = await fakeAdapter(true);
+  const out2 = await fakeAdapter(false);
+  assert.deepEqual(out1, []);
+  assert.deepEqual(out2, []);
+  assert.equal(
+    upstreamCalled,
+    2,
+    "upstream must not be called while breaker is OPEN",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// HALF_OPEN probe path
+// ---------------------------------------------------------------------------
+
+test("HALF_OPEN probe success reopens upstream traffic", async () => {
+  const { tracker, setNow } = makeTracker({
+    failureThreshold: 2,
+    cooldownMs: 5_000,
+  });
+  const t0 = Date.parse("2026-04-26T12:00:00.000Z");
+  setNow(t0);
+  tracker.recordFailure("github", "x");
+  tracker.recordFailure("github", "x");
+  assert.equal(tracker.isOpen("github"), true);
+
+  // Cooldown elapses.
+  setNow(t0 + 6_000);
+
+  // Single probe — succeeds.
+  if (!tracker.isOpen("github")) {
+    tracker.recordSuccess("github");
+  }
+  assert.equal(tracker.getHealth("github").state, "CLOSED");
+  // Upstream is now usable again.
+  assert.equal(tracker.isOpen("github"), false);
+});
+
+test("HALF_OPEN probe failure schedules a fresh cooldown", () => {
+  const { tracker, setNow } = makeTracker({
+    failureThreshold: 2,
+    cooldownMs: 5_000,
+  });
+  const t0 = Date.parse("2026-04-26T12:00:00.000Z");
+  setNow(t0);
+  tracker.recordFailure("github", "x");
+  tracker.recordFailure("github", "x");
+
+  setNow(t0 + 6_000);
+  tracker.isOpen("github"); // OPEN → HALF_OPEN
+  tracker.recordFailure("github", "still bad");
+  const h = tracker.getHealth("github");
+  assert.equal(h.state, "OPEN");
+  // nextProbeAt should be at-or-after t0 + 6_000 + 5_000 = t0 + 11_000.
+  assert.ok(h.nextProbeAt);
+  assert.ok(Date.parse(h.nextProbeAt!) >= t0 + 11_000);
+});

--- a/src/lib/pipeline/adapters/bluesky-adapter.ts
+++ b/src/lib/pipeline/adapters/bluesky-adapter.ts
@@ -11,6 +11,7 @@
 import type { Sentiment, SocialPlatform } from "@/lib/types";
 import { bskyPostHref } from "@/lib/bluesky";
 import { slugToId } from "@/lib/utils";
+import { sourceHealthTracker } from "@/lib/source-health-tracker";
 import type { RepoMention, SocialAdapter } from "../types";
 import { inferSentiment } from "./social-adapters";
 
@@ -150,6 +151,9 @@ export class BlueskyAdapter implements SocialAdapter {
     since?: string,
   ): Promise<RepoMention[]> {
     if (!fullName.includes("/")) return [];
+    if (sourceHealthTracker.isOpen("bluesky")) {
+      return [];
+    }
     const repoId = slugToId(fullName);
 
     const params = new URLSearchParams({
@@ -171,6 +175,7 @@ export class BlueskyAdapter implements SocialAdapter {
       });
       if (!res.ok) {
         console.error(`[social:bluesky] HTTP ${res.status} for ${fullName}`);
+        sourceHealthTracker.recordFailure("bluesky", `HTTP ${res.status}`);
         return [];
       }
       const body: unknown = await res.json();
@@ -197,12 +202,14 @@ export class BlueskyAdapter implements SocialAdapter {
         }
         out.push(mention);
       }
+      sourceHealthTracker.recordSuccess("bluesky");
       return out;
     } catch (err) {
       console.error(
         `[social:bluesky] fetchMentionsForRepo ${fullName} failed`,
         err,
       );
+      sourceHealthTracker.recordFailure("bluesky", err);
       return [];
     } finally {
       clear();

--- a/src/lib/pipeline/adapters/devto-adapter.ts
+++ b/src/lib/pipeline/adapters/devto-adapter.ts
@@ -17,6 +17,7 @@
 
 import type { Sentiment, SocialPlatform } from "@/lib/types";
 import { slugToId } from "@/lib/utils";
+import { sourceHealthTracker } from "@/lib/source-health-tracker";
 import type { RepoMention, SocialAdapter } from "../types";
 import { inferSentiment } from "./social-adapters";
 
@@ -221,6 +222,9 @@ export class DevtoAdapter implements SocialAdapter {
     const owner = repoOwnerOf(fullName);
     const name = repoNameOf(fullName);
     if (!owner || !name) return [];
+    if (sourceHealthTracker.isOpen("devto")) {
+      return [];
+    }
 
     // top=7 biases toward high-engagement articles from the last week, which
     // matches the mention-store freshness window. per_page=100 gives us a
@@ -242,6 +246,7 @@ export class DevtoAdapter implements SocialAdapter {
       const res = await doFetch(url, { signal, headers });
       if (!res.ok) {
         console.error(`[social:devto] HTTP ${res.status} for ${fullName}`);
+        sourceHealthTracker.recordFailure("devto", `HTTP ${res.status}`);
         return [];
       }
       const body: unknown = await res.json();
@@ -258,12 +263,14 @@ export class DevtoAdapter implements SocialAdapter {
         }
         out.push(mention);
       }
+      sourceHealthTracker.recordSuccess("devto");
       return out;
     } catch (err) {
       console.error(
         `[social:devto] fetchMentionsForRepo ${fullName} failed`,
         err,
       );
+      sourceHealthTracker.recordFailure("devto", err);
       return [];
     } finally {
       clear();

--- a/src/lib/pipeline/adapters/github-adapter.ts
+++ b/src/lib/pipeline/adapters/github-adapter.ts
@@ -5,6 +5,7 @@
 // off proactively. All errors are swallowed and logged; the caller receives
 // null or a safe default instead of exceptions.
 
+import { sourceHealthTracker } from "@/lib/source-health-tracker";
 import type {
   GitHubAdapter,
   GitHubRepoRaw,
@@ -208,6 +209,12 @@ export class GitHubApiAdapter implements GitHubAdapter {
       );
       return null;
     }
+    if (sourceHealthTracker.isOpen("github")) {
+      console.warn(
+        `[github-adapter] breaker OPEN — short-circuiting request to ${path}`,
+      );
+      return null;
+    }
 
     const maxAttempts = 3; // 1 original + 2 retries
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -228,6 +235,7 @@ export class GitHubApiAdapter implements GitHubAdapter {
           await sleep(1000 * 2 ** attempt);
           continue;
         }
+        sourceHealthTracker.recordFailure("github", err);
         return null;
       } finally {
         clear();
@@ -251,10 +259,23 @@ export class GitHubApiAdapter implements GitHubAdapter {
         continue;
       }
 
+      // Final attempt for this request: record outcome. 4xx (except 429) and
+      // 2xx are both terminal — only the former counts as a failure for the
+      // breaker. 404 is a normal "not found" and treated as success since
+      // the upstream is responding correctly.
+      if (res.ok || res.status === 404) {
+        sourceHealthTracker.recordSuccess("github");
+      } else {
+        sourceHealthTracker.recordFailure(
+          "github",
+          `HTTP ${res.status} ${res.statusText}`,
+        );
+      }
       return res;
     }
 
     // Exhausted retries — return null so caller gets a safe failure.
+    sourceHealthTracker.recordFailure("github", "max retries exceeded");
     return null;
   }
 

--- a/src/lib/pipeline/adapters/nitter-adapter.ts
+++ b/src/lib/pipeline/adapters/nitter-adapter.ts
@@ -21,6 +21,7 @@
 
 import type { SocialPlatform } from "@/lib/types";
 import { slugToId } from "@/lib/utils";
+import { sourceHealthTracker } from "@/lib/source-health-tracker";
 import type { RepoMention, SocialAdapter } from "../types";
 import { inferSentiment } from "./social-adapters";
 
@@ -226,6 +227,7 @@ export class NitterAdapter implements SocialAdapter {
     try {
       await ensureProbed();
       if (!nitterHost) return [];
+      if (sourceHealthTracker.isOpen("nitter")) return [];
 
       await waitForRateLimit();
 
@@ -245,6 +247,7 @@ export class NitterAdapter implements SocialAdapter {
           console.error(
             `[social:nitter] HTTP ${res.status} for ${fullName} via ${nitterHost}`,
           );
+          sourceHealthTracker.recordFailure("nitter", `HTTP ${res.status}`);
           return [];
         }
         xml = await res.text();
@@ -300,12 +303,14 @@ export class NitterAdapter implements SocialAdapter {
         });
       }
 
+      sourceHealthTracker.recordSuccess("nitter");
       return out;
     } catch (err) {
       console.error(
         `[social:nitter] fetchMentionsForRepo ${fullName} failed`,
         err,
       );
+      sourceHealthTracker.recordFailure("nitter", err);
       return [];
     }
   }

--- a/src/lib/pipeline/adapters/social-adapters.ts
+++ b/src/lib/pipeline/adapters/social-adapters.ts
@@ -11,6 +11,7 @@
 
 import type { Sentiment, SocialPlatform } from "@/lib/types";
 import { slugToId } from "@/lib/utils";
+import { sourceHealthTracker } from "@/lib/source-health-tracker";
 import type { RepoMention, SocialAdapter } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -166,6 +167,9 @@ export class HackerNewsAdapter implements SocialAdapter {
     fullName: string,
     since?: string,
   ): Promise<RepoMention[]> {
+    if (sourceHealthTracker.isOpen("hackernews")) {
+      return [];
+    }
     const repoId = slugToId(fullName);
     const query = encodeURIComponent(fullName);
     const params = new URLSearchParams({ query: fullName, tags: "story" });
@@ -193,6 +197,10 @@ export class HackerNewsAdapter implements SocialAdapter {
         console.error(
           `[social:hackernews] HTTP ${res.status} for ${fullName}`,
         );
+        sourceHealthTracker.recordFailure(
+          "hackernews",
+          `HTTP ${res.status}`,
+        );
         return [];
       }
       const body: unknown = await res.json();
@@ -203,12 +211,14 @@ export class HackerNewsAdapter implements SocialAdapter {
         const mention = this.hitToMention(hit, repoId, now);
         if (mention) out.push(mention);
       }
+      sourceHealthTracker.recordSuccess("hackernews");
       return out;
     } catch (err) {
       console.error(
         `[social:hackernews] fetchMentionsForRepo ${fullName} failed`,
         err,
       );
+      sourceHealthTracker.recordFailure("hackernews", err);
       return [];
     } finally {
       clear();
@@ -308,6 +318,9 @@ export class RedditAdapter implements SocialAdapter {
     fullName: string,
     since?: string,
   ): Promise<RepoMention[]> {
+    if (sourceHealthTracker.isOpen("reddit")) {
+      return [];
+    }
     const repoId = slugToId(fullName);
     const repoName = repoNameOf(fullName);
     const owner = repoOwnerOf(fullName);
@@ -328,6 +341,7 @@ export class RedditAdapter implements SocialAdapter {
       });
       if (!res.ok) {
         console.error(`[social:reddit] HTTP ${res.status} for ${fullName}`);
+        sourceHealthTracker.recordFailure("reddit", `HTTP ${res.status}`);
         return [];
       }
       const body: unknown = await res.json();
@@ -359,12 +373,14 @@ export class RedditAdapter implements SocialAdapter {
         if (!mentionsRepo) continue;
         out.push(mention);
       }
+      sourceHealthTracker.recordSuccess("reddit");
       return out;
     } catch (err) {
       console.error(
         `[social:reddit] fetchMentionsForRepo ${fullName} failed`,
         err,
       );
+      sourceHealthTracker.recordFailure("reddit", err);
       return [];
     } finally {
       clear();
@@ -468,6 +484,9 @@ export class GitHubActivityAdapter implements SocialAdapter {
     fullName: string,
     since?: string,
   ): Promise<RepoMention[]> {
+    if (sourceHealthTracker.isOpen("github-search")) {
+      return [];
+    }
     const repoId = slugToId(fullName);
     const q = encodeURIComponent(`${fullName} in:body is:issue`);
     const url =
@@ -500,6 +519,10 @@ export class GitHubActivityAdapter implements SocialAdapter {
             `[social:github] HTTP ${res.status} for ${fullName}`,
           );
         }
+        sourceHealthTracker.recordFailure(
+          "github-search",
+          `HTTP ${res.status}`,
+        );
         return [];
       }
       const body: unknown = await res.json();
@@ -516,12 +539,14 @@ export class GitHubActivityAdapter implements SocialAdapter {
         }
         out.push(mention);
       }
+      sourceHealthTracker.recordSuccess("github-search");
       return out;
     } catch (err) {
       console.error(
         `[social:github] fetchMentionsForRepo ${fullName} failed`,
         err,
       );
+      sourceHealthTracker.recordFailure("github-search", err);
       return [];
     } finally {
       clear();

--- a/src/lib/source-health-tracker.ts
+++ b/src/lib/source-health-tracker.ts
@@ -1,0 +1,352 @@
+// StarScreener — Per-source circuit breaker + rolling failure window.
+//
+// Companion to source-health.ts. The freshness reporter answers "when did
+// the data last refresh?"; this tracker answers "is the upstream actually
+// responding right now?" Each source maintains a rolling window of the last
+// N attempts, a consecutive-failure counter, and a CLOSED → OPEN → HALF_OPEN
+// state machine. When OPEN, callers get a graceful "skip the network call"
+// signal so adapters can return an empty fallback instead of cascading
+// failures into the UI.
+//
+// Pure in-memory. Process-local. No persistence — Vercel serverless cold
+// starts reset state, which is the right behavior (a fresh process gets a
+// fresh chance). Long-lived servers (Railway, Fly, Render) keep state across
+// requests.
+//
+// Contract: NEVER throws from any tracker method. Recording a failure on an
+// unknown source auto-registers it. Logs use the `[breaker:<source>] …`
+// prefix so they're easy to filter from adapter logs.
+
+export type CircuitState = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+export interface SourceHealthSnapshot {
+  source: string;
+  state: CircuitState;
+  /** Successes inside the rolling window. */
+  successCount: number;
+  /** Failures inside the rolling window. */
+  failureCount: number;
+  /** failureCount / windowSize — 0 if window empty. */
+  errorRate: number;
+  /** Total attempts since last reset (not capped to window). */
+  totalAttempts: number;
+  /** Window size used to compute counters. */
+  windowSize: number;
+  /** Consecutive failures at the tail of the window. */
+  consecutiveFailures: number;
+  /** ISO8601 timestamp of the most recent success, or null. */
+  lastSuccessAt: string | null;
+  /** ISO8601 timestamp of the most recent failure, or null. */
+  lastFailureAt: string | null;
+  /** Truncated error message from the most recent failure, or null. */
+  lastFailure: string | null;
+  /** ISO8601 timestamp the breaker last transitioned to OPEN, or null. */
+  openedAt: string | null;
+  /**
+   * ISO8601 timestamp when the breaker will allow a probe (HALF_OPEN). Only
+   * meaningful when state === "OPEN".
+   */
+  nextProbeAt: string | null;
+}
+
+export interface CircuitBreakerOptions {
+  /** Rolling window length (most recent N attempts). */
+  windowSize: number;
+  /** Consecutive failures that flip CLOSED → OPEN. */
+  failureThreshold: number;
+  /** Milliseconds the breaker stays OPEN before allowing a HALF_OPEN probe. */
+  cooldownMs: number;
+}
+
+const DEFAULT_OPTIONS: CircuitBreakerOptions = {
+  windowSize: 50,
+  failureThreshold: 5,
+  cooldownMs: 60_000,
+};
+
+/** Truncate error messages so the snapshot stays small. */
+const ERROR_MESSAGE_MAX = 240;
+
+type Outcome = "success" | "failure";
+
+interface SourceState {
+  source: string;
+  state: CircuitState;
+  attempts: Outcome[]; // rolling window, oldest → newest
+  totalAttempts: number;
+  consecutiveFailures: number;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  lastFailure: string | null;
+  openedAt: string | null;
+  nextProbeAt: string | null;
+}
+
+/**
+ * Process-wide tracker. Constructed lazily on first import. Tests can build
+ * isolated instances to avoid cross-test pollution; production code uses the
+ * shared default exported from the bottom of the file.
+ */
+export class SourceHealthTracker {
+  private readonly options: CircuitBreakerOptions;
+  private readonly sources: Map<string, SourceState> = new Map();
+  /** Injection seam for tests — defaults to Date.now(). */
+  private readonly now: () => number;
+
+  constructor(
+    options: Partial<CircuitBreakerOptions> = {},
+    nowFn: () => number = Date.now,
+  ) {
+    this.options = {
+      windowSize: options.windowSize ?? DEFAULT_OPTIONS.windowSize,
+      failureThreshold:
+        options.failureThreshold ?? DEFAULT_OPTIONS.failureThreshold,
+      cooldownMs: options.cooldownMs ?? DEFAULT_OPTIONS.cooldownMs,
+    };
+    this.now = nowFn;
+  }
+
+  /**
+   * Record a successful call. Closes a HALF_OPEN circuit, resets the
+   * consecutive-failure counter, advances the rolling window.
+   */
+  recordSuccess(source: string): void {
+    const state = this.ensureSource(source);
+    const nowIso = new Date(this.now()).toISOString();
+    state.lastSuccessAt = nowIso;
+    state.consecutiveFailures = 0;
+    this.pushAttempt(state, "success");
+
+    if (state.state === "OPEN" || state.state === "HALF_OPEN") {
+      // Probe (or stale-OPEN auto-recovery) succeeded — close the circuit.
+      console.log(
+        `[breaker:${source}] state ${state.state} → CLOSED (success after recovery)`,
+      );
+      state.state = "CLOSED";
+      state.openedAt = null;
+      state.nextProbeAt = null;
+    }
+  }
+
+  /**
+   * Record a failed call. Trips the circuit when consecutive failures cross
+   * the threshold; in HALF_OPEN any failure re-opens the breaker with a
+   * fresh cooldown.
+   */
+  recordFailure(source: string, err?: unknown): void {
+    const state = this.ensureSource(source);
+    const nowMs = this.now();
+    const nowIso = new Date(nowMs).toISOString();
+    state.lastFailureAt = nowIso;
+    state.lastFailure = formatError(err);
+    state.consecutiveFailures += 1;
+    this.pushAttempt(state, "failure");
+
+    if (state.state === "HALF_OPEN") {
+      // Probe failed — back to OPEN with a fresh cooldown.
+      this.tripOpen(state, nowMs, "HALF_OPEN probe failed");
+      return;
+    }
+
+    if (
+      state.state === "CLOSED" &&
+      state.consecutiveFailures >= this.options.failureThreshold
+    ) {
+      this.tripOpen(
+        state,
+        nowMs,
+        `${state.consecutiveFailures} consecutive failures`,
+      );
+    }
+  }
+
+  /**
+   * Returns true iff the circuit is currently OPEN. Side effect: when the
+   * cooldown has elapsed, transitions OPEN → HALF_OPEN and returns false so
+   * the caller can issue one probe attempt.
+   *
+   * This is the gate adapters consult before making the upstream request.
+   */
+  isOpen(source: string): boolean {
+    const state = this.ensureSource(source);
+    if (state.state === "CLOSED" || state.state === "HALF_OPEN") {
+      return false;
+    }
+    // OPEN — see if cooldown has elapsed.
+    if (state.nextProbeAt && Date.parse(state.nextProbeAt) <= this.now()) {
+      console.log(
+        `[breaker:${source}] state OPEN → HALF_OPEN (cooldown elapsed)`,
+      );
+      state.state = "HALF_OPEN";
+      // Caller will invoke recordSuccess/recordFailure on the probe.
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Snapshot of one source. Always returns an entry — registers the source
+   * implicitly if it hasn't been seen before.
+   */
+  getHealth(source: string): SourceHealthSnapshot {
+    const state = this.ensureSource(source);
+    return this.buildSnapshot(state);
+  }
+
+  /**
+   * Snapshot of every source the tracker has seen. Preregister sources via
+   * `register()` to control which ones appear before any traffic.
+   */
+  getAllHealth(): Record<string, SourceHealthSnapshot> {
+    const out: Record<string, SourceHealthSnapshot> = {};
+    for (const state of this.sources.values()) {
+      out[state.source] = this.buildSnapshot(state);
+    }
+    return out;
+  }
+
+  /**
+   * Pre-register a source so it shows up in `/api/health/sources` even when
+   * it hasn't received traffic yet. Idempotent.
+   */
+  register(source: string): void {
+    this.ensureSource(source);
+  }
+
+  /**
+   * Reset one source's state, or every source if no id is given. Intended
+   * for tests; no production code path should rely on this.
+   */
+  reset(source?: string): void {
+    if (source) {
+      this.sources.delete(source);
+      return;
+    }
+    this.sources.clear();
+  }
+
+  /** Read the configured options (read-only copy). */
+  getOptions(): CircuitBreakerOptions {
+    return { ...this.options };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private ensureSource(source: string): SourceState {
+    const existing = this.sources.get(source);
+    if (existing) return existing;
+    const fresh: SourceState = {
+      source,
+      state: "CLOSED",
+      attempts: [],
+      totalAttempts: 0,
+      consecutiveFailures: 0,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      lastFailure: null,
+      openedAt: null,
+      nextProbeAt: null,
+    };
+    this.sources.set(source, fresh);
+    return fresh;
+  }
+
+  private pushAttempt(state: SourceState, outcome: Outcome): void {
+    state.attempts.push(outcome);
+    state.totalAttempts += 1;
+    if (state.attempts.length > this.options.windowSize) {
+      // Drop the oldest entry; rolling window holds the last N only.
+      state.attempts.shift();
+    }
+  }
+
+  private tripOpen(
+    state: SourceState,
+    nowMs: number,
+    reason: string,
+  ): void {
+    const previous = state.state;
+    state.state = "OPEN";
+    state.openedAt = new Date(nowMs).toISOString();
+    state.nextProbeAt = new Date(nowMs + this.options.cooldownMs).toISOString();
+    console.warn(
+      `[breaker:${state.source}] state ${previous} → OPEN (${reason}); next probe at ${state.nextProbeAt}`,
+    );
+  }
+
+  private buildSnapshot(state: SourceState): SourceHealthSnapshot {
+    let successes = 0;
+    let failures = 0;
+    for (const a of state.attempts) {
+      if (a === "success") successes += 1;
+      else failures += 1;
+    }
+    const window = state.attempts.length;
+    return {
+      source: state.source,
+      state: state.state,
+      successCount: successes,
+      failureCount: failures,
+      errorRate: window === 0 ? 0 : failures / window,
+      totalAttempts: state.totalAttempts,
+      windowSize: this.options.windowSize,
+      consecutiveFailures: state.consecutiveFailures,
+      lastSuccessAt: state.lastSuccessAt,
+      lastFailureAt: state.lastFailureAt,
+      lastFailure: state.lastFailure,
+      openedAt: state.openedAt,
+      nextProbeAt: state.nextProbeAt,
+    };
+  }
+}
+
+function formatError(err: unknown): string | null {
+  if (err === undefined || err === null) return null;
+  let raw: string;
+  if (err instanceof Error) {
+    raw = err.message || err.name || String(err);
+  } else if (typeof err === "string") {
+    raw = err;
+  } else {
+    try {
+      raw = JSON.stringify(err);
+    } catch {
+      raw = String(err);
+    }
+  }
+  if (raw.length > ERROR_MESSAGE_MAX) {
+    return raw.slice(0, ERROR_MESSAGE_MAX) + "…";
+  }
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide singleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical source ids tracked by the breaker. Registered up-front so the
+ * `/api/health/sources` endpoint reports them even before any traffic flows.
+ * Add new sources here when wiring a new adapter.
+ */
+export const KNOWN_SOURCES = [
+  "hackernews",
+  "reddit",
+  "bluesky",
+  "devto",
+  "github",
+  "github-search",
+  "nitter",
+  "lobsters",
+  "producthunt",
+] as const;
+
+export type KnownSource = (typeof KNOWN_SOURCES)[number];
+
+export const sourceHealthTracker = new SourceHealthTracker();
+
+for (const id of KNOWN_SOURCES) {
+  sourceHealthTracker.register(id);
+}


### PR DESCRIPTION
## Summary
- Adds per-source circuit breaker at `src/lib/source-health-tracker.ts` (process-local in-memory state)
- Wires breaker into pipeline adapters: bluesky, devto, github, nitter, social-adapters
- Augments `/api/health/route.ts` with per-source breaker state
- Adds `/api/health/sources/` monitoring route
- Full unit test coverage

## Background
This work was preserved from worktree `agent-a657e2a37bdc94a07` per the 2026-04-28 audit (see [tasks/AUDIT_TRENDINGREPO_2026-04-28.md](tasks/AUDIT_TRENDINGREPO_2026-04-28.md) and [tasks/WORKTREE_HOLD_FOR_REVIEW_DISPOSITIONS_2026-04-28.md](tasks/WORKTREE_HOLD_FOR_REVIEW_DISPOSITIONS_2026-04-28.md)). HEAD was already in main (ab4546e); the uncommitted module + tests are net-new.

## Notes
- Conceptually distinct from the worker fleet probe at `/api/worker/health` (queued in Phase 3.x worktrees) — that probes the worker, this tracks per-source breaker state inside the Next.js app. They coexist.

## Test plan
- [ ] CI green (lint + typecheck + unit tests)
- [ ] source-health-tracker.test.ts passes locally
- [ ] Manual probe: simulate adapter failure -> breaker trips -> recovery
- [ ] /api/health/sources returns expected shape

Generated with Claude Code.