### PR TITLE
fix(tests): unblock 8 main-side test failures across 4 files

### DIFF
--- a/src/app/api/repos/[owner]/[name]/route.ts
+++ b/src/app/api/repos/[owner]/[name]/route.ts
@@ -145,7 +145,10 @@ async function handleV2(owner: string, name: string) {
 async function handleV1(owner: string, name: string) {
   const repo = getDerivedRepoByFullName(`${owner}/${name}`);
   if (!repo) {
-    return NextResponse.json(errorEnvelope("Repo not found"), { status: 404 });
+    // Legacy v=1 contract is intentionally byte-compatible with the
+    // pre-canonical endpoint: bare `{ error }`, no `ok` discriminator.
+    // CLI tools + MCP consumers pinned to v=1 rely on this shape.
+    return NextResponse.json({ error: "Repo not found" }, { status: 404 });
   }
 
   // Fan out to the live social adapters. Each adapter swallows its own

--- a/src/lib/pipeline/__tests__/cross-signal.test.ts
+++ b/src/lib/pipeline/__tests__/cross-signal.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import type { Repo } from "../../types";
+import { getDevtoLeaderboard } from "../../devto";
 import { attachCrossSignal, getChannelStatus, __test } from "../cross-signal";
 
 const { githubComponent, hnComponent, blueskyComponent, devtoComponent } = __test;
@@ -86,10 +87,13 @@ test("devtoComponent: returns 0 for an unknown repo", () => {
 });
 
 test("devtoComponent: real repo with mentions ≥1 lights at least 0.4", () => {
-  // Pulled from live data: NousResearch/hermes-agent had count7d=3 on the
-  // first scraper run. If the data file rotates and this repo loses
-  // mentions later, swap for whichever leaderboard top-row currently exists.
-  const score = devtoComponent("NousResearch/hermes-agent");
+  // Pick whichever repo currently leads the dev.to leaderboard with
+  // count7d >= 1 — committed data rotates as the scraper refreshes, so
+  // hardcoding a single repo (e.g. an early "NousResearch/hermes-agent"
+  // pick) bit-rots within days.
+  const row = getDevtoLeaderboard().find((entry) => entry.count7d >= 1);
+  assert.ok(row, "expected committed dev.to data to include a leaderboard row");
+  const score = devtoComponent(row.fullName);
   assert.ok(score >= 0.4, `expected dev.to signal, got ${score}`);
 });
 

--- a/src/lib/pipeline/__tests__/predictions-writer.test.ts
+++ b/src/lib/pipeline/__tests__/predictions-writer.test.ts
@@ -212,6 +212,7 @@ test("generatePredictionsBatch: throws on unsupported horizon", () => {
 interface PostArg {
   headers: Headers;
   text(): Promise<string>;
+  json(): Promise<Record<string, unknown>>;
 }
 
 function mkRequest(
@@ -223,6 +224,14 @@ function mkRequest(
     headers: new Headers(headers),
     async text() {
       return payload;
+    },
+    async json() {
+      // The predictions cron handler uses the generic parseBody() helper
+      // which calls request.json() (not request.text()). Without this
+      // method, parseBody() catches the missing-method error and returns
+      // {} — losing fullNames and horizons fields that drive the test
+      // assertions for empty-slate (645) and invalid-horizon (646).
+      return body === null ? {} : JSON.parse(payload);
     },
   };
 }

--- a/src/lib/pipeline/__tests__/webhooks.test.ts
+++ b/src/lib/pipeline/__tests__/webhooks.test.ts
@@ -32,6 +32,10 @@ const TMP_DATA_DIR = mkdtempSync(path.join(os.tmpdir(), "ss-webhooks-"));
 process.env.STARSCREENER_DATA_DIR = TMP_DATA_DIR;
 process.env.STARSCREENER_PERSIST = "false";
 process.env.CRON_SECRET = "test-cron-secret-0123456789abcdef";
+// Webhook flush/scan routes gate their test-only override symbol bags on
+// NODE_ENV === "test"; without this, mocked fetchers + injected repos are
+// silently ignored and the route attempts real network/data lookups.
+process.env.NODE_ENV = "test";
 
 const TARGETS_FILE = path.join(TMP_DATA_DIR, "webhook-targets.json");
 process.env.WEBHOOK_TARGETS_PATH = TARGETS_FILE;

--- a/src/lib/pipeline/__tests__/webhooks.test.ts
+++ b/src/lib/pipeline/__tests__/webhooks.test.ts
@@ -35,7 +35,8 @@ process.env.CRON_SECRET = "test-cron-secret-0123456789abcdef";
 // Webhook flush/scan routes gate their test-only override symbol bags on
 // NODE_ENV === "test"; without this, mocked fetchers + injected repos are
 // silently ignored and the route attempts real network/data lookups.
-process.env.NODE_ENV = "test";
+// NodeJS.ProcessEnv types NODE_ENV as readonly; cast to bypass for tests.
+(process.env as Record<string, string | undefined>).NODE_ENV = "test";
 
 const TARGETS_FILE = path.join(TMP_DATA_DIR, "webhook-targets.json");
 process.env.WEBHOOK_TARGETS_PATH = TARGETS_FILE;


### PR DESCRIPTION
## Summary
Fixes the 8 test failures on `main` that PR #23 surfaced once the reddit-shared assertions were corrected. **Local result: 55 pass / 0 fail across all 4 files** (was 47 pass / 8 fail).

| File | Failures fixed | Fix |
|---|---|---|
| `webhooks.test.ts` | 890/891/893/894 (4) | Add `process.env.NODE_ENV = "test"` in test setup |
| `predictions-writer.test.ts` | 645/646 (2) | Add `.json()` method to `PostArg` mock |
| `cross-signal.test.ts` | 350 (1) | Restore leaderboard-based lookup from `1223b4b` (caught in v2-foundation revert) |
| `canonical-profile-endpoint.test.ts` | 299 (1) | v=1 legacy 404 returns bare `{ error }` (no `ok`) per legacy contract |

## Background
PR #23 fixed 3 reddit-shared assertion bugs. After that fix, CI surfaced 8 more failures that had been silently masked. All 8 turned out to be real test/code drift introduced 2026-04-24 to 2026-04-27 (one is a casualty of the PR #15 revert). See [tasks/MAIN_TEST_FAILURES_2026-04-28.md](tasks/MAIN_TEST_FAILURES_2026-04-28.md) for the full triage.

Three of the four fixes are test-only changes. The one production-code change (`route.ts`) restores the documented v=1 legacy contract that was unintentionally broken when `errorEnvelope` was applied uniformly.

## Why this is safe to ship
- No new behavior introduced. Each fix aligns test or code with the contract they should already have honored.
- `webhooks.test.ts`: just adds an env-var the route's own gate requires.
- `predictions-writer.test.ts`: mock object now matches the `Request` shape the handler reads.
- `cross-signal.test.ts`: pure test maintenance — comment in the original test even predicted this exact rotation problem.
- `canonical-profile-endpoint.test.ts`: documented v=1 contract (line 6 of route.ts: "legacy shape (kept byte-compatible with the pre-canonical endpoint)").

## Test plan
- [ ] CI green on `Typecheck, guards, tests, build, e2e`
- [ ] Local `npx tsx --test` on all 4 files: 55/0 — already verified
- [ ] Once merged, the 6 audit-wave PRs (#19, #20, #21, #22, #23, #24) should turn green on next CI run

## Audit references
- [tasks/AUDIT_TRENDINGREPO_2026-04-28.md](tasks/AUDIT_TRENDINGREPO_2026-04-28.md)
- [tasks/MAIN_TEST_FAILURES_2026-04-28.md](tasks/MAIN_TEST_FAILURES_2026-04-28.md)

Generated with Claude Code.