### PR TITLE
fix(test): de-flake tampered-signature auth test (mutate interior byte)

### DIFF
--- a/src/lib/pipeline/__tests__/auth.test.ts
+++ b/src/lib/pipeline/__tests__/auth.test.ts
@@ -388,9 +388,18 @@ test("verifyUserAuth: ss_user cookie with tampered signature → not promoted", 
     },
     () => {
       const valid = signSession({ userId: "u_real", issuedAt: Date.now() });
-      // Flip the last character of the signature half.
+      // Flip a character in the *middle* of the signature half. We avoid the
+      // last char on purpose: a 32-byte HMAC encodes to 43 base64url chars,
+      // and the trailing char carries only 4 bits of real data — the other 2
+      // bits are padding that base64-decoders silently truncate. Flipping
+      // the trailing char between e.g. `A`(0000) and `B`(00001) decodes to
+      // the *same* 32 bytes ~6% of the time, which made this test flaky in
+      // CI. Mutating an interior char guarantees the decoded buffer differs.
       const [p, sig] = valid.split(".");
-      const tampered = `${p}.${sig!.slice(0, -1)}${sig!.endsWith("A") ? "B" : "A"}`;
+      const flipIdx = Math.floor(sig!.length / 2);
+      const flipChar = sig![flipIdx]!;
+      const replacement = flipChar === "A" ? "B" : "A";
+      const tampered = `${p}.${sig!.slice(0, flipIdx)}${replacement}${sig!.slice(flipIdx + 1)}`;
       const v = verifyUserAuth(
         mkRequest({ cookie: `${SESSION_COOKIE_NAME}=${tampered}` }),
       );


### PR DESCRIPTION
Cherry-picked from PR #19 (commit 6f23426e). Pre-existing flake: auth.test.ts:381 mutates the LAST char of a 43-char base64 signature, but base64 last-char only carries 4 real bits (the rest are padding). Switching A↔B swaps padding bits which Node's base64 decoder truncates, so ~6% of HMACs decode identically — false test pass. Fix mutates an interior byte where all 6 bits of the encoding are decoded. Reproduced empirically: 1000 random sigs → 58 last-char-A failures.

Landing this on main protects every other branch from the same false-pass risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)