### PR TITLE
fix(workflows): add npm ci + stage data/_meta files in cron workflows

### DIFF
--- a/.github/workflows/enrich-repo-profiles.yml
+++ b/.github/workflows/enrich-repo-profiles.yml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        # Defensive: scripts/enrich-repo-profiles.mjs imports
+        # _data-store-write.mjs which dynamic-imports `ioredis` when
+        # REDIS_URL is set. (PR #9 boundary.)
+        run: npm ci
 
       - name: Refresh repo profiles incrementally
         env:

--- a/.github/workflows/refresh-collection-rankings.yml
+++ b/.github/workflows/refresh-collection-rankings.yml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        # Defensive: scripts/scrape-trending.mjs imports _data-store-write.mjs
+        # which dynamic-imports `ioredis` when REDIS_URL is set. (PR #9
+        # boundary.)
+        run: npm ci
 
       - name: Refresh OSSInsight collection rankings
         run: node scripts/scrape-trending.mjs --only-collection-rankings

--- a/.github/workflows/scrape-bluesky.yml
+++ b/.github/workflows/scrape-bluesky.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git config user.name  "trendingrepo-bot"
           git config user.email "bot@trendingrepo.local"
-          git add data/bluesky-mentions.json data/bluesky-trending.json
+          git add data/bluesky-mentions.json data/bluesky-trending.json data/_meta/bluesky-*.json
           if git diff --quiet --staged; then
             echo "no changes - skipping commit"
             exit 0

--- a/.github/workflows/scrape-devto.yml
+++ b/.github/workflows/scrape-devto.yml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        # Defensive: scripts/scrape-devto.mjs imports _data-store-write.mjs
+        # which dynamic-imports `ioredis` when REDIS_URL is set. (PR #9
+        # boundary.)
+        run: npm ci
 
       - name: Refresh dev.to mentions + AI-tag trending
         env:

--- a/.github/workflows/scrape-lobsters.yml
+++ b/.github/workflows/scrape-lobsters.yml
@@ -29,6 +29,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        # Defensive: the scrape script imports _data-store-write.mjs which
+        # dynamic-imports `ioredis` when REDIS_URL is set. Lobsters doesn't
+        # currently pass REDIS_URL but the import would break the moment
+        # someone adds it. (PR #9 / 89273868 boundary.)
+        run: npm ci
 
       - name: Refresh Lobsters mentions + trending snapshot
         # No auth required — Lobsters exposes hottest/active/newest as
@@ -40,7 +48,7 @@ jobs:
         run: |
           git config user.name  "trendingrepo-bot"
           git config user.email "bot@trendingrepo.com"
-          git add data/lobsters-mentions.json data/lobsters-trending.json
+          git add data/lobsters-mentions.json data/lobsters-trending.json data/_meta/lobsters-*.json
           if git diff --quiet --staged; then
             echo "no changes - skipping commit"
             exit 0

--- a/.github/workflows/scrape-npm.yml
+++ b/.github/workflows/scrape-npm.yml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        # Defensive: scripts/scrape-npm.mjs imports _data-store-write.mjs
+        # which dynamic-imports `ioredis` when REDIS_URL is set. (PR #9
+        # boundary — same shape as scrape-trending/sync-trustmrr.)
+        run: npm ci
 
       - name: Scrape npm packages
         run: node scripts/scrape-npm.mjs

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -25,6 +25,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        # _data-store-write.mjs dynamically imports `ioredis` when REDIS_URL
+        # is set on a step. Without node_modules the import throws
+        # ERR_MODULE_NOT_FOUND and the whole pipeline fails. (Boundary:
+        # PR #9 / 89273868, 2026-04-28T12:00Z added the import.)
+        run: npm ci
 
       - name: Refresh OSSInsight trending + hot collections
         env:

--- a/.github/workflows/sync-trustmrr.yml
+++ b/.github/workflows/sync-trustmrr.yml
@@ -36,6 +36,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        # _data-store-write.mjs dynamically imports `ioredis` when REDIS_URL
+        # is set on a step. Without node_modules the import throws
+        # ERR_MODULE_NOT_FOUND. (Boundary: PR #9 / 89273868.)
+        run: npm ci
 
       - name: Decide mode
         id: mode


### PR DESCRIPTION
## Summary
Resolves 5 of 6 failing cron workflows on \`main\` since 2026-04-28T12:00Z. Two distinct root causes, both introduced by recent merges; one external issue (uptime-monitor agnt-api shard) is out of scope for this repo.

### Cause A — \`ioredis\` import without \`npm ci\` (3 of 6 jobs)
PR #9 / commit 89273868 added \`await import("ioredis")\` to [scripts/_data-store-write.mjs](scripts/_data-store-write.mjs#L57) (gated on \`REDIS_URL\` being set). Workflows that pass \`REDIS_URL\` but don't run \`npm ci\` fail at the first script invocation with \`ERR_MODULE_NOT_FOUND\`.

**Fixed (currently failing):**
- \`.github/workflows/scrape-trending.yml\` — also kills downstream Reddit/HN/repo-metadata/deltas → cascades into the freshness-check 503
- \`.github/workflows/sync-trustmrr.yml\`

**Fixed defensively (timebombs — would break the moment someone adds REDIS_URL):**
- \`.github/workflows/scrape-npm.yml\`
- \`.github/workflows/scrape-lobsters.yml\`
- \`.github/workflows/scrape-devto.yml\`
- \`.github/workflows/refresh-collection-rankings.yml\`
- \`.github/workflows/enrich-repo-profiles.yml\`

### Cause B — \`data/_meta/*\` files written but not staged (2 of 6 jobs)
Recent commit added [scripts/_data-meta.mjs](scripts/_data-meta.mjs) writes producing \`data/_meta/<source>-*.json\` side-files. The bluesky + lobsters workflows only \`git add\` the main JSONs, so \`git pull --rebase\` fails with \"unstaged changes\".

**Fixed:**
- \`.github/workflows/scrape-bluesky.yml\` — added \`data/_meta/bluesky-*.json\`
- \`.github/workflows/scrape-lobsters.yml\` — added \`data/_meta/lobsters-*.json\`

### Out of scope
- \`Cron - freshness check\` is a downstream symptom of Cause A; it'll go green once \`scrape-trending\` heals.
- \`Uptime monitor (agnt-api shard)\` is a stale CNAME on a sister Railway project — not in this repo.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge: monitor \`gh run list --branch main --status failure --created '>2026-04-29T15:00:00Z'\` for the 6 affected workflows. The 5 in scope should flip to success on next scheduled run.
- [ ] Confirm \`/api/health\` returns \`status: "fresh"\` (or at least non-503) within ~2 hours of the next \`scrape-trending\` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)