### PR TITLE
docs(governance): add Code of Conduct, Security, Contributing, PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- 1–3 sentences: what changed and why. Link relevant issue(s). -->
+
+## Test plan
+
+<!-- Bullet list of what you ran / observed locally. Examples:
+- [ ] `npm run typecheck` clean
+- [ ] `npm run lint:guards` clean
+- [ ] `npm test` passes
+- [ ] Hit the affected route locally and verified the new behavior
+- [ ] Vercel preview URL renders without errors
+-->
+
+## Checklist
+
+- [ ] Branch is up to date with `main`
+- [ ] Conventional-commits style commit messages
+- [ ] No `console.log` left in production paths (`src/`)
+- [ ] No `.env*` files committed
+- [ ] If a workflow was touched: `permissions:`, `concurrency:`, and a comment explaining the schedule are present
+- [ ] If a new collector was added: it dual-writes via `scripts/_data-store-write.mjs`
+- [ ] Documentation updated (`docs/`, `README.md`, or inline) if user-visible behavior changed
+
+## Screenshots / output
+
+<!-- Optional. Drag-drop screenshots for UI changes; paste curl output or test results for backend changes. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+This project has adopted the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct. By participating you agree to abide by its terms.
+
+## Reporting
+
+If you observe behavior that violates the Covenant, please report it by opening a confidential issue via [GitHub's private vulnerability reporting](https://github.com/0motionguy/starscreener/security/advisories/new) or by contacting a project maintainer through the repo's issue tracker.
+
+All reports will be reviewed and handled with discretion. Maintainers are obligated to respect the privacy and safety of reporters.
+
+## Scope
+
+This Code applies in all project spaces — issues, pull requests, discussions, the project Discord/Slack if any, and any external space where someone is representing the project.
+
+## Enforcement
+
+Maintainers may take any action they deem appropriate, up to and including a temporary or permanent ban from project spaces, in response to behavior they consider in violation of this Code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to TrendingRepo
+
+Thanks for your interest. This guide gets you from clone to a merged PR.
+
+## Prerequisites
+
+- **Node 22.x** (pinned via `engines` in `package.json`)
+- **npm** (lockfile is `package-lock.json`)
+- A GitHub PAT for collectors that hit GitHub's API (set as `GITHUB_TOKEN` in `.env.local`)
+- *Optional:* a Redis URL (`REDIS_URL` for Railway-native, or `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` for Upstash REST). Without one, the data-store gracefully falls back to bundled JSON + memory.
+
+## Setup
+
+```bash
+git clone https://github.com/0motionguy/starscreener.git
+cd starscreener
+npm install
+cp .env.example .env.local   # then fill in the required values
+npm run dev                  # starts at http://localhost:3023
+```
+
+## Where things live
+
+- `src/app/` — Next.js 15 App Router pages + API routes
+- `src/lib/pipeline/` — ingestion, scoring, classification core
+- `scripts/` — data collectors and one-shot maintenance scripts
+- `apps/trendingrepo-worker/` — sister microservice (deployed separately on Railway)
+- `mcp/` — MCP server source for agent integrations
+- `docs/` — architecture, ingestion, deploy, source-discovery guides — **start with [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)**
+
+## Branching
+
+- Branch off `main` for everything.
+- Branch naming: `feat/<area>-<short-name>`, `fix/<area>-<short-name>`, `chore/<scope>`, `docs/<scope>`.
+- Keep branches focused — one concern per PR makes review tractable.
+
+## Commit messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Examples from the repo's history:
+
+```
+feat(scoring): Phase 3.1 — engagement composite scoring
+fix(test): de-flake tampered-signature auth test
+chore(workflows): add npm ci + stage data/_meta files
+docs(deploy): document Vercel preview env vars
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ci`, `perf`.
+
+## Pre-PR checklist
+
+Run locally before pushing:
+
+```bash
+npm run typecheck       # tsc --noEmit, must be clean
+npm run lint            # ESLint
+npm run lint:guards     # meta-lints (Zod on mutating routes, error envelopes, runtime drift)
+npm test                # node:test + tsx + vitest, runs in serial
+```
+
+If you touched a workflow under `.github/workflows/`, confirm it parses (no YAML errors) and has appropriate `permissions:` and `concurrency:` blocks where relevant.
+
+## Pull requests
+
+- Open the PR against `main`.
+- Fill out the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — Summary + Test plan + checklist.
+- Wait for CI green (Typecheck/lint/build/e2e + MCP server build + Vercel preview).
+- Squash-merge is the convention; one PR = one commit on `main`.
+
+## Data conventions
+
+- **Reads must go through the data-store.** Server components / API routes call the per-source `refreshXxxFromStore()` once at the top, then sync getters return cached values.
+- **Collectors dual-write file + Redis** via `scripts/_data-store-write.mjs`. File mirror is acceptable during transitions; Redis is the source of truth.
+- **JSONL append-only.** Don't replace; append. The aggregator dedupes downstream.
+- **Don't** `readFileSync(process.cwd(), "data", ...)` for new sources — go through the data-store.
+
+## Anti-patterns to avoid
+
+These have all bitten us before:
+
+- Switching the Twitter collector back to API mode (silently fails on Vercel — use `direct` mode).
+- Mocking Redis in tests that exercise scoring logic.
+- Adding `./.next/**/*` to `outputFileTracingExcludes` in `next.config.ts` — strips the chunk graph and 500s every dynamic route.
+- Cookie-based Twitter scrapers (dead provider post-2026 anti-bot).
+
+## Questions?
+
+Open a [discussion](https://github.com/0motionguy/starscreener/discussions) or an issue. For security-sensitive reports, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue in TrendingRepo, **please do not open a public issue.** Instead, report it privately via [GitHub's private vulnerability reporting](https://github.com/0motionguy/starscreener/security/advisories/new).
+
+We aim to:
+- Acknowledge receipt within **3 business days**
+- Provide an initial assessment within **7 business days**
+- Coordinate a fix and disclosure timeline with the reporter
+
+## Supported Versions
+
+Only the `main` branch (currently deployed to https://trendingrepo.com) receives security updates. Tagged releases prior to `v0.1.0` are not supported.
+
+## Scope
+
+In scope:
+- The Next.js application under `src/`
+- The MCP server under `mcp/`
+- The CLI under `cli/` and `bin/`
+- The worker microservice under `apps/trendingrepo-worker/`
+- GitHub Actions workflows under `.github/workflows/`
+
+Out of scope:
+- Bundled JSON snapshots in `data/` (public, by design — these are scrape outputs)
+- Third-party services (Vercel, GitHub, Apify, Upstash) — report to those vendors directly
+- DDoS / rate-limit-bypass reports (the project relies on upstream provider protections)
+
+## Recognition
+
+We're happy to credit reporters in release notes once a fix has shipped, if desired. Let us know your preferred attribution.


### PR DESCRIPTION
## Summary
Adds the four standard governance files. Lifts the GitHub community-health score from 42% to ~90% — visible on the repo's Insights → Community Standards page.

## Files added
- `CODE_OF_CONDUCT.md` — adopts Contributor Covenant 2.1 by reference (links to canonical text rather than embedding it)
- `SECURITY.md` — vulnerability reporting routes via GitHub's private security advisories
- `CONTRIBUTING.md` — setup (Node 22.x, env), branching, conventional commits, pre-PR checklist, data-store conventions, anti-pattern list
- `.github/PULL_REQUEST_TEMPLATE.md` — Summary / Test plan / Checklist matching the style of recent PRs

## Test plan
- [ ] CI green (no source code changed; only docs)
- [ ] After merge: Insights → Community Standards shows the four checkmarks
- [ ] After merge: opening a new PR auto-fills with the template

## Out of scope (deferred)
- Issue templates (`.github/ISSUE_TEMPLATE/*.yml`) — separate PR
- `CODEOWNERS`, `dependabot.yml`, `.nvmrc`, `.editorconfig` — Tier 2 polish
- `CHANGELOG.md` — defer until release cadence settles

🤖 Generated with [Claude Code](https://claude.com/claude-code)