### PR TITLE
fix(skills): populate logoUrl in skill coercers (regression from #41)

### DIFF
--- a/src/lib/ecosystem-leaderboards.ts
+++ b/src/lib/ecosystem-leaderboards.ts
@@ -1,6 +1,7 @@
 import type { SignalRow } from "@/components/signal/SignalTable";
 import { getDataStore, type DataReadResult, type DataSource } from "./data-store";
 import { resolveLogoUrl } from "./logo-url";
+import { repoLogoUrl } from "./logos";
 import { skillScorer, type SkillItem } from "./pipeline/scoring/domain/skill";
 import { mcpScorer, type McpItem } from "./pipeline/scoring/domain/mcp";
 import { computeCrossDomainMomentum } from "./pipeline/scoring/cross-domain";
@@ -766,7 +767,12 @@ function coerceSkillsShItem(
       postedAt: asString(item.last_pushed_at) ?? fallbackDate,
       sourceLabel: "skills.sh",
       vendor: null,
-      logoUrl: null,
+      // Resolve the GitHub owner avatar from the linked repo when present;
+      // fall back to a favicon derived from the entry's URL host. Skills.sh
+      // doesn't ship logo_url, so this is what makes /skills render avatars
+      // instead of blank monogram tiles.
+      logoUrl:
+        repoLogoUrl(linkedRepo, 80) ?? resolveLogoUrl(url, skillName, 64),
       brandColor: null,
       verified: false,
       crossSourceCount: 1,
@@ -805,7 +811,9 @@ function coerceGithubSkillItem(
       postedAt: asString(item.pushed_at) ?? asString(item.created_at),
       sourceLabel: "GitHub topics",
       vendor: null,
-      logoUrl: null,
+      // Always derivable here — `fullName` is always "owner/repo" for the
+      // GitHub topic feed, so the GitHub owner avatar is the right logo.
+      logoUrl: repoLogoUrl(fullName, 80),
       brandColor: null,
       verified: false,
       crossSourceCount: 1,


### PR DESCRIPTION
## Summary

PR #41's `/skills` rebuild renders `<EntityLogo src={item.logoUrl} />` directly. Both `coerceSkillsShItem` and `coerceGithubSkillItem` were hardcoding `logoUrl: null` — every row on production now shows a blank monogram tile.

The fallback logic (line 605-607) only fired in the legacy `SignalRow` path used by `SignalTable`. The new direct-render in `/skills/page.tsx` and the right-rail Top Skills list bypass it.

## Fix

Derive the avatar in the coercer itself, same as the legacy fallback:
- skills.sh items: `repoLogoUrl(linkedRepo, 80) ?? resolveLogoUrl(url, skillName, 64)` — GitHub owner avatar from `linkedRepo`, favicon from URL host as last resort
- GitHub-topic items: `repoLogoUrl(fullName, 80)` — `fullName` is always `owner/repo`, so always derivable

MCP coercer is unaffected (already populates from upstream `logo_url`).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:guards` passes
- [ ] After merge, `/skills` rows show GitHub owner avatars instead of blank monograms

Single commit, cherry-picked from `feat/consensus-scoring-star-activity` (`f5b3086e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)