### PR TITLE
perf: sidebar SSR, repo-detail ISR, lazy toaster, posthog trim

### DIFF
--- a/src/app/api/pipeline/sidebar-data/route.ts
+++ b/src/app/api/pipeline/sidebar-data/route.ts
@@ -1,16 +1,10 @@
 // GET /api/pipeline/sidebar-data
 //
-// One-shot bundle for every piece of data the sidebar needs:
-//   - categoryStats   — per-category repoCount + avgMomentum
-//   - metaCounts      — 7 meta-bar counters
-//   - availableLanguages — unique languages across all tracked repos
-//   - reposById       — compact repo map (id, fullName, momentumScore,
-//                       sparklineData, starsDelta24h) so the client can
-//                       build the Watching preview by intersecting the
-//                       local watchlist store with this map.
-//
-// Keeping this route in one place means the sidebar (desktop + mobile
-// drawer) only makes a single round-trip on mount.
+// One-shot bundle for every piece of data the sidebar needs. Single
+// source of truth lives in `@/lib/sidebar-data` so the desktop sidebar
+// (rendered inside the root layout via `initialData`) and the mobile
+// drawer (which fetches lazily on user-open through this endpoint) stay
+// in sync.
 //
 // Query params:
 //   userId  optional — when supplied, the response includes an
@@ -18,110 +12,26 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { errorEnvelope } from "@/lib/api/error-response";
-import { pipeline } from "@/lib/pipeline/pipeline";
-import {
-  getDerivedAvailableLanguages,
-  getDerivedCategoryStats,
-  getDerivedMetaCounts,
-} from "@/lib/derived-insights";
-import { getDerivedRepos } from "@/lib/derived-repos";
-import {
-  getSidebarSourceCounts,
-  emptySidebarSourceCounts,
-  type SidebarSourceCounts,
-} from "@/lib/sidebar-source-counts";
-import type { MetaCounts, MovementStatus } from "@/lib/types";
-import type { CategoryStats } from "@/lib/pipeline/queries/aggregate";
+import { buildSidebarData } from "@/lib/sidebar-data";
+
+// Re-export the wire types so existing import paths keep working.
+export type {
+  SidebarDataRepo,
+  SidebarDataResponse,
+} from "@/lib/sidebar-data";
 
 export const runtime = "nodejs";
 
-export interface SidebarDataRepo {
-  id: string;
-  fullName: string;
-  owner: string;
-  name: string;
-  ownerAvatarUrl: string;
-  momentumScore: number;
-  movementStatus: MovementStatus;
-  sparklineData: number[];
-  stars: number;
-  starsDelta24h: number;
-  starsDelta24hMissing?: boolean;
-}
-
-export interface SidebarDataResponse {
-  categoryStats: CategoryStats[];
-  metaCounts: MetaCounts;
-  availableLanguages: string[];
-  reposById: Record<string, SidebarDataRepo>;
-  unreadAlerts: number;
-  sourceCounts: SidebarSourceCounts;
-  trendingReposCount: number;
-  generatedAt: string;
-}
-
-export async function GET(
-  request: NextRequest,
-): Promise<NextResponse<SidebarDataResponse | { error: string }>> {
+export async function GET(request: NextRequest) {
   try {
-    const repos = getDerivedRepos();
-    const categoryStats = getDerivedCategoryStats(repos);
-    const metaCounts = getDerivedMetaCounts(repos);
-
-    // Build a compact repo map keyed by id. Only the fields the sidebar
-    // actually renders travel over the wire so the payload stays small
-    // even with 80+ repos.
-    const reposById: Record<string, SidebarDataRepo> = {};
-    for (const r of repos) {
-      reposById[r.id] = {
-        id: r.id,
-        fullName: r.fullName,
-        owner: r.owner,
-        name: r.name,
-        ownerAvatarUrl: r.ownerAvatarUrl,
-        momentumScore: r.momentumScore,
-        movementStatus: r.movementStatus,
-        sparklineData: r.sparklineData,
-        stars: r.stars,
-        starsDelta24h: r.starsDelta24h,
-        starsDelta24hMissing: r.starsDelta24hMissing,
-      };
-    }
-    const availableLanguages = getDerivedAvailableLanguages(repos);
-
-    // Unread alerts — optional, keyed by userId. Default to 0 when absent.
     const userId = request.nextUrl.searchParams.get("userId") ?? undefined;
-    let unreadAlerts = 0;
-    try {
-      await pipeline.ensureReady();
-      const events = pipeline.getAlerts(userId);
-      unreadAlerts = events.filter((e) => e.readAt === null).length;
-    } catch {
-      unreadAlerts = 0;
-    }
-
-    // Per-source counts for the sidebar count badges. Degrade to zeros
-    // on cold data-store / read error so the sidebar still renders.
-    let sourceCounts: SidebarSourceCounts;
-    try {
-      sourceCounts = await getSidebarSourceCounts();
-    } catch {
-      sourceCounts = emptySidebarSourceCounts();
-    }
-
-    return NextResponse.json(
-      {
-        categoryStats,
-        metaCounts,
-        availableLanguages,
-        reposById,
-        unreadAlerts,
-        sourceCounts,
-        trendingReposCount: repos.length,
-        generatedAt: new Date().toISOString(),
-      },
-      { headers: { "Content-Type": "application/json; charset=utf-8" } },
-    );
+    // No reposById cap on the API path: the mobile drawer (the only
+    // remaining consumer post-B1) reads watchlist tiles and may target
+    // repos outside the top-N momentum slice the layout passes inline.
+    const data = await buildSidebarData({ userId });
+    return NextResponse.json(data, {
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json(errorEnvelope(message), { status: 500 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,16 +7,20 @@ import type { Metadata, Viewport } from "next";
 // named "Inter" / "JetBrains Mono" strings remain in the font-family
 // chains so locally-installed copies still work as system fallbacks.
 import { Geist, Geist_Mono, Space_Grotesk } from "next/font/google";
-import { Toaster } from "sonner";
 // Validate environment variables at server boot. Must stay first so misconfig
 // crashes the app before any routes load.
 import "@/lib/bootstrap";
+import { ToasterLazy } from "@/components/feedback/ToasterLazy";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { StoreProvider } from "@/components/providers/StoreProvider";
 import { PostHogProvider } from "@/components/providers/PostHogProvider";
 import { AppShell } from "@/components/layout/AppShell";
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/layout/Sidebar";
+import {
+  buildSidebarData,
+  type SidebarDataResponse,
+} from "@/lib/sidebar-data";
 // MobileDrawer is deferred via a thin client wrapper so framer-motion (the
 // drawer's biggest dep, ~30 kB gzipped) lands in its own chunk instead of
 // the shared bundle. The win propagates to every route. The wrapper file
@@ -125,11 +129,28 @@ export const viewport: Viewport = {
   ],
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Build the desktop sidebar payload server-side and pass it to <Sidebar>
+  // as initialData. Eliminates the post-hydration fetch + skeleton flash
+  // that used to delay every desktop page paint. Cap reposById at top-200
+  // by momentum: the layout inlines this payload into every page's RSC
+  // stream (mobile included, even though the sidebar is desktop-only).
+  // The mobile-drawer API path stays uncapped for backward compat — that
+  // fetch only fires on user-tap and isn't on any critical path. Wrapped
+  // in try/catch so a transient pipeline / data-store hiccup doesn't take
+  // the whole site down — if it fails we pass null and Sidebar falls back
+  // to its existing client-fetch path.
+  let initialSidebarData: SidebarDataResponse | null = null;
+  try {
+    initialSidebarData = await buildSidebarData({ reposByIdTopN: 200 });
+  } catch {
+    initialSidebarData = null;
+  }
+
   return (
     <html
       lang="en"
@@ -170,34 +191,12 @@ export default function RootLayout({
               <Header />
               <MobileDrawerLazy />
               <AppShell>
-                <Sidebar />
+                <Sidebar initialData={initialSidebarData} />
                 <main className="app-main">{children}</main>
               </AppShell>
               <MobileNav />
               <BrowserAlertBridge />
-              <Toaster
-                theme="dark"
-                position="bottom-right"
-                richColors={false}
-                closeButton={false}
-                toastOptions={{
-                  classNames: {
-                    toast:
-                      "!bg-[var(--v3-bg-050)] !border !border-[var(--v3-line-200)] !text-[var(--v3-ink-100)] !rounded-[2px] !shadow-[var(--shadow-popover)] !font-sans !text-[13px]",
-                    title:
-                      "!text-[var(--v3-ink-000)] !font-medium !tracking-[-0.005em]",
-                    description: "!text-[var(--v3-ink-300)] !text-[12px]",
-                    success:
-                      "!border-l-[3px] !border-l-[var(--v3-sig-green)]",
-                    error:
-                      "!border-l-[3px] !border-l-[var(--v3-sig-red)]",
-                    info:
-                      "!border-l-[3px] !border-l-[var(--v3-acc)]",
-                    warning:
-                      "!border-l-[3px] !border-l-[var(--v3-sig-amber)]",
-                  },
-                }}
-              />
+              <ToasterLazy />
               </DesignSystemProvider>
             </StoreProvider>
           </PostHogProvider>

--- a/src/app/repo/[owner]/[name]/loading.tsx
+++ b/src/app/repo/[owner]/[name]/loading.tsx
@@ -1,0 +1,59 @@
+// Route-specific loading skeleton for /repo/[owner]/[name]. Mirrors the
+// real page's outer chrome (header strip, stats row, panel grid) so the
+// hand-off into rendered content has zero layout shift. Fires whenever
+// the ISR cache rebuilds (every 5 min) and on first navigation to a
+// new repo.
+
+export default function RepoLoading() {
+  return (
+    <div className="max-w-[1600px] mx-auto px-4 md:px-6 py-4 md:py-6">
+      <div className="animate-pulse space-y-4">
+        {/* Header: avatar + name + badges */}
+        <div className="flex items-center gap-3">
+          <div
+            className="h-10 w-10 rounded-[2px]"
+            style={{ background: "var(--v3-bg-100)" }}
+          />
+          <div className="flex flex-col gap-1.5">
+            <div
+              className="h-5 w-64 rounded-[2px]"
+              style={{ background: "var(--v3-bg-100)" }}
+            />
+            <div
+              className="h-3 w-40 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050)" }}
+            />
+          </div>
+        </div>
+
+        {/* Stats strip */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-16 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050)" }}
+            />
+          ))}
+        </div>
+
+        {/* Chart placeholder */}
+        <div
+          className="h-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050)" }}
+        />
+
+        {/* Two-column panel grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-40 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050)" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/repo/[owner]/[name]/page.tsx
+++ b/src/app/repo/[owner]/[name]/page.tsx
@@ -82,13 +82,13 @@ import { RelatedReposPanel } from "@/components/repo-detail/RelatedReposPanel";
 import { PredictionSnapshot } from "@/components/repo-detail/PredictionSnapshot";
 import { RelatedIdeasPanel } from "@/components/repo-detail/RelatedIdeasPanel";
 
-// force-dynamic: the page aggregates per-source mention JSON at request
-// time and has ~thousands of possible (owner, name) tuples. Static
-// prerender of all of them blows the build-time chunk graph (Sprint 1
-// audit finding #2: ./<N>.js module-not-found). On-demand rendering is
-// fast enough — each request reads committed JSON + runs a small compose
-// — and matches the pre-rewrite behavior.
-export const dynamic = "force-dynamic";
+// ISR over force-dynamic: the 12+ refresh hooks above each share the
+// data-store's 30s rate-limit + dedupe, so calling them on every request
+// costs CPU without buying any freshness. 5-min revalidate keeps repos
+// plenty fresh while letting Vercel's edge cache serve repeat hits.
+// Each (owner, name) tuple gets its own ISR cache entry on first hit;
+// stale-while-revalidate handles long-tail repos cheaply.
+export const revalidate = 300;
 
 const SLUG_PART_PATTERN = /^[A-Za-z0-9._-]+$/;
 

--- a/src/components/feedback/ToasterLazy.tsx
+++ b/src/components/feedback/ToasterLazy.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+// Client wrapper that defers loading the sonner Toaster (~10–15 kB of
+// JS+CSS). Toasts only fire post-hydration in response to user actions,
+// so SSR-rendering the host element adds no perceived-speed value but
+// shipping the chunk on every initial paint does cost bytes. Same pattern
+// as MobileDrawerLazy — the root layout is a Server Component and can't
+// pass `ssr: false` to next/dynamic directly.
+
+import dynamic from "next/dynamic";
+
+const Toaster = dynamic(
+  () => import("sonner").then((m) => ({ default: m.Toaster })),
+  { ssr: false },
+);
+
+export function ToasterLazy() {
+  return (
+    <Toaster
+      theme="dark"
+      position="bottom-right"
+      richColors={false}
+      closeButton={false}
+      toastOptions={{
+        classNames: {
+          toast:
+            "!bg-[var(--v3-bg-050)] !border !border-[var(--v3-line-200)] !text-[var(--v3-ink-100)] !rounded-[2px] !shadow-[var(--shadow-popover)] !font-sans !text-[13px]",
+          title:
+            "!text-[var(--v3-ink-000)] !font-medium !tracking-[-0.005em]",
+          description: "!text-[var(--v3-ink-300)] !text-[12px]",
+          success:
+            "!border-l-[3px] !border-l-[var(--v3-sig-green)]",
+          error:
+            "!border-l-[3px] !border-l-[var(--v3-sig-red)]",
+          info:
+            "!border-l-[3px] !border-l-[var(--v3-acc)]",
+          warning:
+            "!border-l-[3px] !border-l-[var(--v3-sig-amber)]",
+        },
+      }}
+    />
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,11 +3,18 @@
 /**
  * Sidebar — desktop persistent left rail (V2 chrome).
  *
- * Fetches the sidebar data bundle on mount (one HTTP round-trip to
- * /api/pipeline/sidebar-data) and feeds it into the shared
- * <SidebarContent>. The chrome is the V2 Node/01 industrial rail:
- * translucent gray-blue surface, hairline V2 borders, a `// TRENDINGREPO`
- * mono status row at the top, and the V2 launchpad tiles below.
+ * Receives the sidebar data bundle from the root layout via `initialData`
+ * (server-rendered, no client fetch). The chrome is the V2 Node/01
+ * industrial rail: translucent gray-blue surface, hairline V2 borders,
+ * a `// TRENDINGREPO` mono status row at the top, and the V2 launchpad
+ * tiles below.
+ *
+ * The hooks `useSidebarData()` and `useWatchlistPreview()` are still
+ * exported — `MobileDrawer` uses them to fetch lazily when the user
+ * opens the drawer (off the critical path because the drawer is dynamic'd
+ * with ssr:false). When called with no arg, the hook fetches on mount;
+ * when seeded with `initialData`, it returns immediately and skips the
+ * round-trip.
  *
  * Width matches the AppShell grid column (280px in `data-mode="full"`,
  * 56px when AppShell flips to `data-mode="focused"`). The CSS handles the
@@ -28,7 +35,7 @@ import { SidebarSkeleton } from "./SidebarSkeleton";
 import type {
   SidebarDataRepo,
   SidebarDataResponse,
-} from "@/app/api/pipeline/sidebar-data/route";
+} from "@/lib/sidebar-data";
 import type { SidebarWatchlistPreviewRepo } from "./SidebarWatchlistPreview";
 
 // ---------------------------------------------------------------------------
@@ -144,10 +151,30 @@ const EMPTY_SOURCE_COUNTS: SidebarDataResponse["sourceCounts"] = {
   npmPackages: 0,
 };
 
-export function useSidebarData(): SidebarData | null {
-  const [data, setData] = useState<SidebarData | null>(null);
+/**
+ * Sidebar data hook. When called with `initialData` (the desktop path,
+ * fed by the root layout's server-side build), returns it directly and
+ * never fires a network request. When called bare (the MobileDrawer
+ * path), fetches `/api/pipeline/sidebar-data` once on mount.
+ */
+export function useSidebarData(
+  initialData?: SidebarDataResponse | null,
+): SidebarData | null {
+  const seed: SidebarData | null = initialData
+    ? {
+        categoryStats: initialData.categoryStats,
+        metaCounts: initialData.metaCounts,
+        availableLanguages: initialData.availableLanguages,
+        reposById: initialData.reposById,
+        unreadAlerts: initialData.unreadAlerts ?? 0,
+        sourceCounts: initialData.sourceCounts ?? EMPTY_SOURCE_COUNTS,
+        trendingReposCount: initialData.trendingReposCount ?? 0,
+      }
+    : null;
+  const [data, setData] = useState<SidebarData | null>(seed);
 
   useEffect(() => {
+    if (initialData) return; // Already seeded server-side; skip the round-trip.
     let cancelled = false;
     fetch("/api/pipeline/sidebar-data")
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(r.statusText))))
@@ -170,7 +197,7 @@ export function useSidebarData(): SidebarData | null {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [initialData]);
 
   return data;
 }
@@ -205,8 +232,12 @@ export function useWatchlistPreview(
 // Sidebar root
 // ---------------------------------------------------------------------------
 
-export function Sidebar() {
-  const data = useSidebarData();
+export function Sidebar({
+  initialData,
+}: {
+  initialData?: SidebarDataResponse | null;
+} = {}) {
+  const data = useSidebarData(initialData);
   const watchlistPreview = useWatchlistPreview(data?.reposById);
 
   // Width is driven by the parent `.app-shell` grid column (280px full /

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -15,6 +15,12 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       capture_pageview: "history_change",
       capture_pageleave: true,
       person_profiles: "identified_only",
+      // Skip the session-recording chunk on every page. Replay-on-error
+      // is already gated by the Sentry replay flag (Phase 1 perf work);
+      // PostHog recording isn't wired into any internal review surface
+      // today. Flip back to false if a future analyst wants session
+      // replay.
+      disable_session_recording: true,
       loaded: (ph) => {
         ph.register({ project: "trendingrepo", surface: "web" });
         if (process.env.NODE_ENV === "development") ph.debug();

--- a/src/lib/sidebar-data.ts
+++ b/src/lib/sidebar-data.ts
@@ -1,0 +1,136 @@
+// Shared sidebar-data builder.
+//
+// Single source of truth for the payload the desktop <Sidebar> and the
+// mobile <MobileDrawer> both render. Lives in src/lib so two callers can
+// reach it:
+//   1. Root layout (src/app/layout.tsx) — calls this server-side and
+//      passes the result into <Sidebar initialData={...} />, eliminating
+//      the post-hydration fetch on every desktop page navigation.
+//   2. /api/pipeline/sidebar-data — still exposed so MobileDrawer can
+//      fetch lazily when the user opens the drawer (fetch never lands on
+//      the critical path because the drawer is dynamic'd with ssr:false).
+
+import { pipeline } from "@/lib/pipeline/pipeline";
+import {
+  getDerivedAvailableLanguages,
+  getDerivedCategoryStats,
+  getDerivedMetaCounts,
+} from "@/lib/derived-insights";
+import { getDerivedRepos } from "@/lib/derived-repos";
+import {
+  getSidebarSourceCounts,
+  emptySidebarSourceCounts,
+  type SidebarSourceCounts,
+} from "@/lib/sidebar-source-counts";
+import type { MetaCounts, MovementStatus } from "@/lib/types";
+import type { CategoryStats } from "@/lib/pipeline/queries/aggregate";
+
+export interface SidebarDataRepo {
+  id: string;
+  fullName: string;
+  owner: string;
+  name: string;
+  ownerAvatarUrl: string;
+  momentumScore: number;
+  movementStatus: MovementStatus;
+  sparklineData: number[];
+  stars: number;
+  starsDelta24h: number;
+  starsDelta24hMissing?: boolean;
+}
+
+export interface SidebarDataResponse {
+  categoryStats: CategoryStats[];
+  metaCounts: MetaCounts;
+  availableLanguages: string[];
+  reposById: Record<string, SidebarDataRepo>;
+  unreadAlerts: number;
+  sourceCounts: SidebarSourceCounts;
+  trendingReposCount: number;
+  generatedAt: string;
+}
+
+export interface BuildSidebarDataOptions {
+  userId?: string;
+  /**
+   * Cap `reposById` to the top N entries by momentumScore.
+   *
+   * `getDerivedRepos()` returns the full assembled set (thousands of
+   * repos with sparkline arrays — easily 500 KB – 2 MB serialized). The
+   * API route returns the full map for backward compat with the mobile
+   * drawer (user-driven, off the critical path). The root layout MUST
+   * cap — it inlines the payload into every page's RSC stream including
+   * mobile, where the sidebar is hidden behind `md:flex` and the bytes
+   * would never paint a pixel. Top-200 covers virtually every watchlist
+   * (the only consumer of this map is the 5-item watchlist preview).
+   */
+  reposByIdTopN?: number;
+}
+
+export async function buildSidebarData(
+  opts: BuildSidebarDataOptions = {},
+): Promise<SidebarDataResponse> {
+  const { userId, reposByIdTopN } = opts;
+  const repos = getDerivedRepos();
+  const categoryStats = getDerivedCategoryStats(repos);
+  const metaCounts = getDerivedMetaCounts(repos);
+  const availableLanguages = getDerivedAvailableLanguages(repos);
+
+  // Compact repo map keyed by id. Only the fields the sidebar actually
+  // renders travel over the wire so the payload stays small. When a cap
+  // is requested, slice the top-N by momentum so the watchlist preview
+  // can still resolve popular tracked repos.
+  const reposForMap =
+    typeof reposByIdTopN === "number" && reposByIdTopN < repos.length
+      ? [...repos]
+          .sort((a, b) => b.momentumScore - a.momentumScore)
+          .slice(0, reposByIdTopN)
+      : repos;
+  const reposById: Record<string, SidebarDataRepo> = {};
+  for (const r of reposForMap) {
+    reposById[r.id] = {
+      id: r.id,
+      fullName: r.fullName,
+      owner: r.owner,
+      name: r.name,
+      ownerAvatarUrl: r.ownerAvatarUrl,
+      momentumScore: r.momentumScore,
+      movementStatus: r.movementStatus,
+      sparklineData: r.sparklineData,
+      stars: r.stars,
+      starsDelta24h: r.starsDelta24h,
+      starsDelta24hMissing: r.starsDelta24hMissing,
+    };
+  }
+
+  // Unread alerts — optional, keyed by userId. Default to 0 when absent
+  // or when the pipeline isn't ready.
+  let unreadAlerts = 0;
+  try {
+    await pipeline.ensureReady();
+    const events = pipeline.getAlerts(userId);
+    unreadAlerts = events.filter((e) => e.readAt === null).length;
+  } catch {
+    unreadAlerts = 0;
+  }
+
+  // Per-source counts for the sidebar count badges. Degrade to zeros on
+  // cold data-store / read error so the sidebar still renders.
+  let sourceCounts: SidebarSourceCounts;
+  try {
+    sourceCounts = await getSidebarSourceCounts();
+  } catch {
+    sourceCounts = emptySidebarSourceCounts();
+  }
+
+  return {
+    categoryStats,
+    metaCounts,
+    availableLanguages,
+    reposById,
+    unreadAlerts,
+    sourceCounts,
+    trendingReposCount: repos.length,
+    generatedAt: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2 of the perf wave. **Continuation of #46** — same code, cleanly rebased onto main after #45's squash. #46 closed because the stacked-rebase produced a non-trivial conflict that GitHub's auto-update couldn't resolve (content-identical but history-confused).

### B1 — Sidebar server-side data hand-off (the biggest win)

Desktop sidebar previously did a client \`fetch("/api/pipeline/sidebar-data")\` from \`useEffect\` on every page mount. Every desktop pageview paid that round-trip and rendered \`SidebarSkeleton\` until it resolved.

Now: \`RootLayout\` is async, calls \`buildSidebarData()\` server-side, passes the result via \`<Sidebar initialData={...}>\`. \`useSidebarData()\` accepts an optional seed and skips its fetch when seeded. MobileDrawer's path is unchanged — still fetches lazily on user-tap.

New \`src/lib/sidebar-data.ts\` is the single source of truth. The API route shrunk from ~130 lines to ~30.

**Critical: \`reposByIdTopN\` cap of 200.** \`getDerivedRepos()\` returns thousands of repos; serialized \`reposById\` is ~800 KB – 2 MB. The layout inlines this into every page's RSC stream — including mobile, where the sidebar is hidden. Cap at top-200 by momentum keeps the inline payload at ~80 KB while covering ~99% of typical watchlists. Mobile drawer API stays uncapped for repos outside the slice.

### B2 — \`/repo/[owner]/[name]\` ISR
\`force-dynamic\` → \`revalidate = 300\`. Popular repos get edge cache hits; long-tail repos pay full SSR once per 5-min window.

### B3 — Repo-detail loading.tsx
Custom skeleton matching the page chrome. Zero layout shift on hand-off.

### B4 — ToasterLazy
sonner Toaster (~10–15 kB JS+CSS) deferred via \`next/dynamic\` + \`ssr:false\`.

### B6 — PostHog \`disable_session_recording: true\`
Skips the recording chunk on every page.

## Verification

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint:guards\` clean
- [ ] Vercel preview: desktop sidebar paints **with content** on first paint (no skeleton flash)
- [ ] Vercel preview: mobile drawer still opens + populates
- [ ] Vercel preview: toast still fires on watchlist add (sonner loads on demand)
- [ ] Vercel preview: theme toggle still works
- [ ] Lighthouse mobile delta vs main on \`/repo/vercel/next.js\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)