### PR TITLE
perf: phase 3 — 5 more ISR conversions (trending/skills/research/etc)

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/lib/collection-rankings";
 import { absoluteUrl, SITE_NAME } from "@/lib/seo";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 const DESCRIPTION =
   "Curated AI repo collections — agents, RAG, inference, vector DBs, MCP, and more — ranked live against current trending data.";

--- a/src/app/mcp/[slug]/page.tsx
+++ b/src/app/mcp/[slug]/page.tsx
@@ -33,10 +33,11 @@ import { absoluteUrl, SITE_NAME } from "@/lib/seo";
 import { TerminalBar } from "@/components/v2";
 import { McpDownloadsSparklineLazy } from "./_components/McpDownloadsSparklineLazy";
 
-// force-dynamic mirrors the /mcp index page's posture: data is read at
-// request time from the publish payload, which is small (~few KB) and
-// cheap to refresh.
-export const dynamic = "force-dynamic";
+// ISR mirrors the /mcp index page's revalidate cadence (10 min). Data
+// is read at request time from the publish payload, which is small
+// (~few KB); ISR caches the rendered HTML per-slug so repeat hits to
+// popular MCPs serve from edge.
+export const revalidate = 600;
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/src/app/reddit/trending/page.tsx
+++ b/src/app/reddit/trending/page.tsx
@@ -15,7 +15,7 @@ import { buildRedditHeader } from "@/components/news/newsTopMetrics";
 
 const REDDIT_ACCENT = "rgba(255, 77, 77, 0.85)";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 300;
 
 function formatRelative(iso: string): string {
   const t = new Date(iso).getTime();

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/research-signals";
 import { TerminalBar, MonoLabel, BarcodeTicker } from "@/components/v2";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: "Research - TrendingRepo",

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -18,7 +18,7 @@ import { SkillsTerminalTable, type SkillSourceFilter } from "@/components/skills
 const SKILLS_ACCENT = "rgba(167, 139, 250, 0.85)";
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: "Trending Skills - TrendingRepo",


### PR DESCRIPTION
## Summary

Continuation of the perf wave (#45, #47). Five more public anonymous routes converted from \`force-dynamic\` to ISR. Same surgical pattern as Phase 1 — each is a 1-line export change.

| Route | Cadence | Why |
|---|---|---|
| \`/reddit/trending\` | revalidate=300 | Paired with \`/reddit\` from Phase 1 |
| \`/mcp/[slug]\` | revalidate=600 | Paired with \`/mcp\` index from Phase 1 |
| \`/collections\` | revalidate=600 | Paired with \`/collections/[slug]\` from Phase 1 |
| \`/research\` | revalidate=600 | HF + arXiv signal feed |
| \`/skills\` | revalidate=600 | Skills leaderboard |

All non-personalized. No \`cookies()\` / \`headers()\` use. ISR cache keys by URL including query string, so tab/slug variants still work.

## Verification

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint:guards\` clean (pre-commit hook)
- [ ] Vercel preview: second hit shows \`x-vercel-cache: HIT\` on \`/reddit/trending\`, \`/research\`, \`/skills\`, \`/collections\`
- [ ] Vercel preview: \`/mcp/[slug]\` (e.g. \`/mcp/anthropic-claude\`) loads, shows liveness pill + chart

Net diff: 5 files, +9/-8 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)