### PR TITLE
perf: ISR on /u/[handle] public profile page

### DIFF
--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -17,7 +17,11 @@ import type { ReactionCounts } from "@/lib/reactions-shape";
 import { ProfileView } from "@/components/profile/ProfileView";
 import { absoluteUrl, SITE_NAME } from "@/lib/seo";
 
-export const dynamic = "force-dynamic";
+// ISR with 10-min revalidate. Public profile, no cookies/headers, each
+// handle gets its own ISR cache entry. Activity (ideas, reactions)
+// updates on the cron cadence — 10 min freshness is plenty for a
+// public profile view.
+export const revalidate = 600;
 
 // Loose handle validation — same character set as the idea authorHandle
 // intake (USER_TOKENS_JSON can carry arbitrary ids, but browser URLs


### PR DESCRIPTION
## Summary

Last \`force-dynamic\` page that was safely convertible. Public user profile, no cookies/headers, no forms. Now \`revalidate = 600\` — each handle gets its own ISR cache entry; activity (ideas, reactions) refreshes on the 10-min cadence.

Continuation of the perf wave (#45, #47, #48). After this lands, the only remaining \`force-dynamic\` pages are:
- \`admin/*\` (7 routes — internal, intentionally dynamic)
- \`/compare\`, \`/ideas\`, \`/ideas/[id]\` — user-driven query / live reactions
- \`/tools/revenue-estimate\` — interactive calculator

All three groups are correct to leave dynamic.

## Verification

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint:guards\` clean
- [ ] Vercel preview: visit \`/u/some-handle\`, second hit shows \`x-vercel-cache: HIT\`
- [ ] Vercel preview: a handle that doesn't exist still renders the empty-state UI (not 404)

Net diff: 1 file, +5/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)