### PR TITLE
fix(consensus): forward-compat reader for v3 payload shape

### DIFF
--- a/src/lib/consensus-trending.ts
+++ b/src/lib/consensus-trending.ts
@@ -60,14 +60,49 @@ export interface RefreshResult {
   writtenAt: string | null;
 }
 
+function emptyComponent(): ConsensusSourceComponent {
+  return { present: false, rank: null, score: null, normalized: 0 };
+}
+
+// Forward-compat: the worker's consensus-v3 payload uses an expanded sources
+// map (gh/hf/hn/x/r/pdh/dev/bs/ours) — the legacy oss/trendshift slots may be
+// absent. Without this guard, the page renders `item.sources.oss.present` and
+// crashes during SSR when the new shape arrives. Fill missing slots with
+// emptyComponent so the page degrades to "−" placeholders cleanly.
+function normalizeItem(input: unknown): ConsensusItem | null {
+  if (!input || typeof input !== "object") return null;
+  const it = input as Partial<ConsensusItem> & { sources?: unknown };
+  if (typeof it.fullName !== "string" || !it.fullName.includes("/")) return null;
+  const rawSources =
+    it.sources && typeof it.sources === "object"
+      ? (it.sources as Record<string, ConsensusSourceComponent | undefined>)
+      : {};
+  const sources: Record<ConsensusSource, ConsensusSourceComponent> = {
+    ours: rawSources.ours ?? emptyComponent(),
+    oss: rawSources.oss ?? emptyComponent(),
+    trendshift: rawSources.trendshift ?? emptyComponent(),
+  };
+  return {
+    fullName: it.fullName,
+    rank: typeof it.rank === "number" ? it.rank : 0,
+    consensusScore: typeof it.consensusScore === "number" ? it.consensusScore : 0,
+    sourceCount: typeof it.sourceCount === "number" ? it.sourceCount : 0,
+    badges: Array.isArray(it.badges) ? (it.badges as ConsensusBadge[]) : [],
+    sources,
+  };
+}
+
 function normalizePayload(input: unknown): ConsensusTrendingPayload {
   if (!input || typeof input !== "object") return EMPTY_PAYLOAD;
   const parsed = input as Partial<ConsensusTrendingPayload>;
+  const items = Array.isArray(parsed.items)
+    ? parsed.items.map(normalizeItem).filter((x): x is ConsensusItem => x !== null)
+    : [];
   return {
     computedAt: typeof parsed.computedAt === "string" ? parsed.computedAt : "",
-    itemCount: typeof parsed.itemCount === "number" ? parsed.itemCount : 0,
+    itemCount: typeof parsed.itemCount === "number" ? parsed.itemCount : items.length,
     weights: parsed.weights ?? EMPTY_PAYLOAD.weights,
-    items: Array.isArray(parsed.items) ? parsed.items : [],
+    items,
   };
 }
 


### PR DESCRIPTION
## What

Adds a defensive `normalizeItem` step in [src/lib/consensus-trending.ts](src/lib/consensus-trending.ts) so the reader gracefully handles **both** the legacy 3-source payload shape and the upcoming 9-source v3 shape (PR #50).

Single-file diff: **+37 / -2** lines.

## Why now

The consensus worker on Railway is being upgraded to publish a v3 payload (8 external sources + 1 internal, plus verdict bands and AI analyst output). The legacy `oss` and `trendshift` slots are absent on the new shape.

When the new payload hit production Redis during a wiring test today, the `/consensus` page **crashed during SSR** — React error digest \`3189002311\` — because the page renders \`item.sources.oss.present\` which throws when \`oss\` is undefined.

I rolled back Redis to an empty payload to restore the page, but that means consensus data is paused until either:
1. **This PR merges** — page becomes resilient to the new shape, then PR #50 merges, then worker publishes v3
2. PR #50 merges first — but that has a 5-30 min ISR-cache window where /consensus 500s before Vercel deploys

Option 1 is the safer rollout. This PR unblocks it.

## How

- Adds `emptyComponent()` helper (4 lines)
- Adds `normalizeItem(input)` which validates `fullName`, defaults `sources.{ours,oss,trendshift}` to `emptyComponent()` if missing in input
- `normalizePayload` now maps items through `normalizeItem`

## Behavior matrix

| Payload shape | Before | After |
|---|---|---|
| Legacy 3-source | items pass through unchanged | items pass through unchanged (sources copied as-is) |
| New 9-source (no oss/trendshift) | **SSR crash** on `sources.oss.present` | oss/trendshift = `emptyComponent`; page renders "−" placeholders |
| Garbage/unknown | items array used as-is, may crash later | invalid items dropped at normalize, never reach the page |

## Verification

- ✅ `tsc --noEmit` clean
- ✅ `npm run lint:guards` clean
- ✅ Diff scope minimal: one file, 37 inserted / 2 deleted

## Out of scope (intentionally)

- Worker scoring changes (in PR #50)
- Page rebuild / new UI components (in PR #50)
- AI analyst / Kimi wiring (in PR #50)

This is purely a forward-compat shim so production survives the worker upgrade. PR #50 lands the actual feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)