### PR TITLE
V4 W6: /tools hub page

### DIFF
--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,10 +1,13 @@
 // /tools — V4 hub.
 //
-// Landing surface for analyst tools. Mockup: tools.html.
+// Landing surface for analyst tools. Mockup: tools.html (master plan W6).
+// Three sections — Charts (Star History, Treemap), Estimators (Revenue
+// Estimate), Contribute (Submit Revenue). Pure composition; each tool
+// owns its own page and data fetching.
 //
-// Tile grid (4 col-3) + mini-list grid (4-6 MiniListCard) +
-// Revenue estimator callout. All composition; no per-tool data
-// fetching here — each tool owns its own page.
+// Server component. Inline styles use --v4-* tokens only — no hardcoded
+// hex values. Layout reuses the V4 page chrome shared with /breakouts,
+// /digest, /consensus etc. (`home-surface` + `grid` + `col-*`).
 
 import type { Metadata } from "next";
 
@@ -12,219 +15,206 @@ import { PageHead } from "@/components/ui/PageHead";
 import { SectionHead } from "@/components/ui/SectionHead";
 import { LiveDot } from "@/components/ui/LiveDot";
 import { ToolTile } from "@/components/tools/ToolTile";
-import { MiniListCard, type MiniListItem } from "@/components/tools/MiniListCard";
+import { absoluteUrl } from "@/lib/seo";
 
 export const runtime = "nodejs";
-// Static surface — tile metadata + mini-list seeds. ISR cadence matches
-// the 30-min refresh used elsewhere; the underlying mini-list data is
-// derived from the same momentum pipeline.
-export const revalidate = 1800;
+// Tool metadata changes only when a new tool ships. 10-min ISR keeps the
+// hub cheap to serve while picking up additions promptly.
+export const revalidate = 600;
 
-export const metadata: Metadata = {
-  title: "Tools — TrendingRepo",
-  description:
-    "Charts, lists, and exports built from the same momentum pipeline. Compare repos, plot star history, browse the consensus treemap.",
-};
+const HUB_TITLE = "Tools — TrendingRepo";
+const HUB_DESCRIPTION =
+  "Analyst tools for the open-source trend map: plot multi-repo star history, browse the consensus treemap, estimate repo revenue, and contribute self-reported MRR.";
 
-interface HubTile {
+export function generateMetadata(): Metadata {
+  return {
+    title: HUB_TITLE,
+    description: HUB_DESCRIPTION,
+    alternates: { canonical: absoluteUrl("/tools") },
+    openGraph: {
+      title: HUB_TITLE,
+      description: HUB_DESCRIPTION,
+      url: absoluteUrl("/tools"),
+      type: "website",
+    },
+  };
+}
+
+interface ToolEntry {
   num: string;
   title: string;
   desc: string;
   href: string;
   status: "live" | "soon";
-  active?: boolean;
 }
 
-const TILES: HubTile[] = [
+const CHART_TOOLS: ToolEntry[] = [
   {
     num: "// 01",
     title: "Star History",
-    desc: "Plot up to six repos head-to-head. Export as PNG with three editorial themes (Blueprint, Neon, NYT).",
+    desc: "Plot up to six repos head-to-head with editorial export themes (Blueprint, Neon, NYT).",
     href: "/tools/star-history",
-    status: "soon",
+    status: "live",
   },
   {
     num: "// 02",
-    title: "Tier List",
-    desc: "Drag the day's movers into S → F bands. Share a permalink with friends or coworkers.",
-    href: "/tierlist",
-    status: "live",
-    active: true,
+    title: "Treemap",
+    desc: "Sector treemap of trending repos — area scales with momentum, color encodes category.",
+    href: "/tools/treemap",
+    status: "soon",
   },
+];
+
+const ESTIMATOR_TOOLS: ToolEntry[] = [
   {
-    num: "// 03",
-    title: "Compare",
-    desc: "Multi-repo side-by-side: stars, momentum, cross-source agreement, contributors. Up to four at a time.",
-    href: "/compare",
-    status: "live",
-  },
-  {
-    num: "// 04",
-    title: "Mindshare",
-    desc: "The bubble map — momentum × scale across 220 movers. Click any bubble for its repo detail.",
-    href: "/mindshare",
+    num: "// 01",
+    title: "Revenue Estimate",
+    desc: "Drop a repo. Returns ARR overlays, self-reported MRR, and TrustMRR claim status.",
+    href: "/tools/revenue-estimate",
     status: "live",
   },
 ];
 
-interface MiniBoardSeed {
-  title: string;
-  badge?: string;
-  href: string;
-  items: MiniListItem[];
-  cta?: string;
+const CONTRIBUTE_TOOLS: ToolEntry[] = [
+  {
+    num: "// 01",
+    title: "Submit Revenue",
+    desc: "Add self-reported MRR/ARR for a project you maintain. Verified claims surface on the funding tape.",
+    href: "/submit/revenue",
+    status: "live",
+  },
+];
+
+// Tiny inline previews — pure decoration, mockup-canonical 60×34. Tokens
+// only; no hardcoded hex.
+function ChartIcon({ kind }: { kind: "star-history" | "treemap" }) {
+  if (kind === "star-history") {
+    return (
+      <svg width={60} height={34} viewBox="0 0 60 34" fill="none" aria-hidden="true">
+        <path
+          d="M2 30 L14 22 L26 24 L38 12 L50 6 L58 2"
+          stroke="var(--v4-acc)"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+        />
+        <path
+          d="M2 32 L14 28 L26 26 L38 22 L50 18 L58 14"
+          stroke="var(--v4-cyan)"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          opacity={0.65}
+        />
+      </svg>
+    );
+  }
+  return (
+    <svg width={60} height={34} viewBox="0 0 60 34" fill="none" aria-hidden="true">
+      <rect x={2} y={2} width={28} height={20} fill="var(--v4-acc)" opacity={0.85} />
+      <rect x={32} y={2} width={16} height={12} fill="var(--v4-cyan)" opacity={0.85} />
+      <rect x={50} y={2} width={8} height={12} fill="var(--v4-violet)" opacity={0.85} />
+      <rect x={32} y={16} width={26} height={6} fill="var(--v4-money)" opacity={0.85} />
+      <rect x={2} y={24} width={56} height={8} fill="var(--v4-amber)" opacity={0.7} />
+    </svg>
+  );
 }
 
-// Static seeds — the production wiring for these mini-lists comes
-// from /api/skills, /api/mcp, /api/agent-commerce, /api/repos. Keeping
-// the hub static here means it serves at edge speed regardless of
-// pipeline state; users one-click into the live page for fresh data.
-const MINI_BOARDS: MiniBoardSeed[] = [
-  {
-    title: "TOP · CLAUDE SKILLS",
-    badge: "7D",
-    href: "/skills",
-    items: [
-      { name: "anthropics/skills", value: "4.92" },
-      { name: "context-collapse", value: "4.71" },
-      { name: "skill-router", value: "4.55" },
-      { name: "memory-write", value: "4.41" },
-      { name: "delta-log-append", value: "4.30" },
-    ],
-    cta: "OPEN FULL BOARD",
-  },
-  {
-    title: "TOP · MCP SERVERS",
-    badge: "7D",
-    href: "/mcp",
-    items: [
-      { name: "github-mcp", value: "4.84" },
-      { name: "filesystem-mcp", value: "4.62" },
-      { name: "browser-mcp", value: "4.50" },
-      { name: "linear-mcp", value: "4.37" },
-      { name: "slack-mcp", value: "4.21" },
-    ],
-    cta: "OPEN FULL BOARD",
-  },
-  {
-    title: "TOP · AGENT COMMERCE",
-    badge: "24H",
-    href: "/agent-commerce",
-    items: [
-      { name: "x402 / Base", value: "+312%" },
-      { name: "OpenRouter agents", value: "+184%" },
-      { name: "AgentKit deals", value: "+97%" },
-      { name: "Coinbase agents", value: "+62%" },
-      { name: "Stripe AgentPay", value: "+41%" },
-    ],
-    cta: "OPEN FULL BOARD",
-  },
-  {
-    title: "TOP · REPOS",
-    badge: "24H",
-    href: "/top10",
-    items: [
-      { name: "anthropics/skills", value: "+18.2k" },
-      { name: "vercel/next.js", value: "+14.4k" },
-      { name: "openai/responses", value: "+9.8k" },
-      { name: "ggerganov/llama.cpp", value: "+8.4k" },
-      { name: "huggingface/transformers", value: "+7.1k" },
-    ],
-    cta: "OPEN FULL BOARD",
-  },
-  {
-    title: "TOP · LLMS",
-    badge: "7D",
-    href: "/model-usage",
-    items: [
-      { name: "Claude Sonnet 4.6", value: "4.92" },
-      { name: "GPT-5", value: "4.71" },
-      { name: "Claude Opus 4.7", value: "4.65" },
-      { name: "Gemini 2.5 Pro", value: "4.32" },
-      { name: "DeepSeek V3.2", value: "4.18" },
-    ],
-    cta: "OPEN FULL BOARD",
-  },
-  {
-    title: "TOP · BREAKOUTS",
-    badge: "24H",
-    href: "/breakouts",
-    items: [
-      { name: "claude-code-skills", value: "+812%" },
-      { name: "agno-agents", value: "+540%" },
-      { name: "smol-tools", value: "+412%" },
-      { name: "x402-mcp", value: "+288%" },
-      { name: "deepseek-router", value: "+211%" },
-    ],
-    cta: "OPEN FULL BOARD",
-  },
-];
+function EstimatorIcon() {
+  return (
+    <svg width={60} height={34} viewBox="0 0 60 34" fill="none" aria-hidden="true">
+      <path
+        d="M4 28 L4 8 M4 28 L56 28"
+        stroke="var(--v4-line-400)"
+        strokeWidth={1}
+        strokeLinecap="round"
+      />
+      {[12, 22, 32, 42, 52].map((x, i) => (
+        <rect
+          key={x}
+          x={x - 3}
+          y={26 - (i + 1) * 4}
+          width={6}
+          height={(i + 1) * 4}
+          fill="var(--v4-money)"
+          opacity={0.85}
+        />
+      ))}
+    </svg>
+  );
+}
 
-function ToolPreview({ kind }: { kind: HubTile["title"] }) {
-  // Tiny SVG placeholders for each tile. Mockup-canonical 60×34. Pure
-  // decoration — no data drives them.
-  switch (kind) {
+function ContributeIcon() {
+  return (
+    <svg width={60} height={34} viewBox="0 0 60 34" fill="none" aria-hidden="true">
+      <rect
+        x={6}
+        y={6}
+        width={48}
+        height={22}
+        rx={2}
+        fill="none"
+        stroke="var(--v4-acc)"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M14 14 L46 14 M14 20 L36 20"
+        stroke="var(--v4-cyan)"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function previewFor(title: string) {
+  switch (title) {
     case "Star History":
-      return (
-        <svg width={60} height={34} viewBox="0 0 60 34" fill="none">
-          <path
-            d="M2 30 L14 22 L26 24 L38 12 L50 6 L58 2"
-            stroke="var(--v4-acc)"
-            strokeWidth={1.5}
-            strokeLinecap="round"
-          />
-          <path
-            d="M2 32 L14 28 L26 26 L38 22 L50 18 L58 14"
-            stroke="var(--v4-cyan)"
-            strokeWidth={1.5}
-            strokeLinecap="round"
-            opacity={0.65}
-          />
-        </svg>
-      );
-    case "Tier List":
-      return (
-        <svg width={60} height={34} viewBox="0 0 60 34" fill="none">
-          {[0, 1, 2, 3, 4].map((i) => (
-            <rect
-              key={i}
-              x={2}
-              y={2 + i * 6}
-              width={56}
-              height={4}
-              fill={
-                ["var(--v4-tier-s)", "var(--v4-tier-a)", "var(--v4-tier-b)", "var(--v4-tier-c)", "var(--v4-tier-d)"][
-                  i
-                ]
-              }
-              opacity={0.85}
-            />
-          ))}
-        </svg>
-      );
-    case "Compare":
-      return (
-        <svg width={60} height={34} viewBox="0 0 60 34" fill="none">
-          <path d="M2 28 L18 18 L34 22 L50 8 L58 4" stroke="var(--v4-acc)" strokeWidth={1.5} fill="none" />
-          <path d="M2 30 L18 24 L34 14 L50 18 L58 10" stroke="var(--v4-violet)" strokeWidth={1.5} fill="none" />
-          <path d="M2 32 L18 28 L34 30 L50 24 L58 22" stroke="var(--v4-cyan)" strokeWidth={1.5} fill="none" />
-        </svg>
-      );
-    case "Mindshare":
-      return (
-        <svg width={60} height={34} viewBox="0 0 60 34" fill="none">
-          <circle cx={14} cy={20} r={8} fill="var(--v4-acc)" opacity={0.85} />
-          <circle cx={32} cy={14} r={6} fill="var(--v4-cyan)" opacity={0.85} />
-          <circle cx={44} cy={22} r={5} fill="var(--v4-violet)" opacity={0.85} />
-          <circle cx={52} cy={10} r={3} fill="var(--v4-money)" opacity={0.85} />
-        </svg>
-      );
+      return <ChartIcon kind="star-history" />;
+    case "Treemap":
+      return <ChartIcon kind="treemap" />;
+    case "Revenue Estimate":
+      return <EstimatorIcon />;
+    case "Submit Revenue":
+      return <ContributeIcon />;
     default:
       return null;
   }
 }
 
+function ToolGrid({ tools }: { tools: ToolEntry[] }) {
+  return (
+    <div className="grid">
+      {tools.map((tool) => (
+        <div className="col-6" key={`${tool.title}-${tool.href}`}>
+          <ToolTile
+            num={tool.status === "soon" ? `${tool.num} · SOON` : tool.num}
+            title={tool.title}
+            desc={tool.desc}
+            preview={previewFor(tool.title)}
+            href={tool.status === "live" ? tool.href : undefined}
+            foot={
+              tool.status === "live" ? (
+                <>
+                  <LiveDot label="LIVE" />
+                  <span>OPEN →</span>
+                </>
+              ) : (
+                <>
+                  <span style={{ color: "var(--v4-amber)" }}>● COMING SOON</span>
+                  <span>WAITLIST →</span>
+                </>
+              )
+            }
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function ToolsPage() {
+  const allTools = [...CHART_TOOLS, ...ESTIMATOR_TOOLS, ...CONTRIBUTE_TOOLS];
+  const liveCount = allTools.filter((t) => t.status === "live").length;
+
   return (
     <main className="home-surface">
       <PageHead
@@ -233,11 +223,13 @@ export default function ToolsPage() {
             <b>TOOLS</b> · TERMINAL · /TOOLS
           </>
         }
-        h1="Tools for analysts."
-        lede="Charts, lists, and exports built from the same momentum pipeline. Compare repos head-to-head, plot star history, browse the consensus treemap."
+        h1="Tools for the trend desk."
+        lede="Charts, estimators, and contributor surfaces built on the same momentum pipeline. Plot star history head-to-head, browse the consensus treemap, estimate repo revenue, or submit self-reported MRR for a project you maintain."
         clock={
           <>
-            <span className="big">{TILES.filter((t) => t.status === "live").length} / {TILES.length}</span>
+            <span className="big">
+              {liveCount} / {allTools.length}
+            </span>
             <span className="muted">TOOLS LIVE</span>
             <LiveDot label="PIPELINE LIVE" />
           </>
@@ -246,85 +238,28 @@ export default function ToolsPage() {
 
       <SectionHead
         num="// 01"
-        title="Featured tools"
+        title="Charts"
         meta={
           <>
-            <b>{TILES.length}</b> total · {TILES.filter((t) => t.status === "live").length} live
+            <b>{CHART_TOOLS.length}</b> tools · multi-repo plots
           </>
         }
       />
-      <div className="grid">
-        {TILES.map((tile) => (
-          <div className="col-3" key={tile.num}>
-            <ToolTile
-              num={tile.status === "soon" ? `${tile.num} · SOON` : tile.num}
-              title={tile.title}
-              desc={tile.desc}
-              active={tile.active}
-              preview={<ToolPreview kind={tile.title} />}
-              foot={
-                tile.status === "live" ? (
-                  <>
-                    <LiveDot label="LIVE" />
-                    <span>OPEN →</span>
-                  </>
-                ) : (
-                  <>
-                    <span style={{ color: "var(--v4-amber)" }}>● COMING SOON</span>
-                    <span>WAITLIST →</span>
-                  </>
-                )
-              }
-              href={tile.status === "live" ? tile.href : undefined}
-            />
-          </div>
-        ))}
-      </div>
+      <ToolGrid tools={CHART_TOOLS} />
 
       <SectionHead
         num="// 02"
-        title="Quick-browse · top boards"
-        meta={
-          <>
-            <b>6</b> categories · 5 picks each
-          </>
-        }
+        title="Estimators"
+        meta={<>ARR overlays · TrustMRR claims</>}
       />
-      <div className="grid">
-        {MINI_BOARDS.map((board) => (
-          <div className="col-4" key={board.title}>
-            <MiniListCard
-              title={board.title}
-              badge={board.badge}
-              items={board.items}
-              cta={board.cta}
-              href={board.href}
-            />
-          </div>
-        ))}
-      </div>
+      <ToolGrid tools={ESTIMATOR_TOOLS} />
 
       <SectionHead
         num="// 03"
-        title="Revenue estimator"
-        meta={<>self-reported + verified · ARR overlays</>}
+        title="Contribute"
+        meta={<>self-reported · verified surfaces</>}
       />
-      <div className="grid">
-        <div className="col-12">
-          <ToolTile
-            num="// 03 · TOOL"
-            title="Revenue Estimate"
-            desc="Drop a repo URL or owner/name. Returns ARR overlays, self-reported MRR, and TrustMRR claim status. Useful before pitching a partnership or investing time."
-            href="/tools/revenue-estimate"
-            foot={
-              <>
-                <LiveDot label="LIVE" />
-                <span>OPEN ESTIMATOR →</span>
-              </>
-            }
-          />
-        </div>
-      </div>
+      <ToolGrid tools={CONTRIBUTE_TOOLS} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- New `/tools` hub page composed from V4 primitives (PageHead, SectionHead, ToolTile, LiveDot)
- Three sections — `// 01 Charts`, `// 02 Estimators`, `// 03 Contribute` — surfacing Star History, Treemap, Revenue Estimate, and Submit Revenue
- Server component, ISR `revalidate = 600`, `generateMetadata` with title / description / canonical
- Zero hardcoded hex; all color tokens via `var(--v4-*)`

## Test plan

- [x] `npm run typecheck` passes
- [ ] `npm run dev` — visit `/tools`, confirm three sections render with PageHead chrome and ToolTiles linking to `/tools/star-history`, `/tools/treemap` (soon), `/tools/revenue-estimate`, `/submit/revenue`
- [ ] Visual diff vs `tools.html` mockup ≤ 5% drift on hero
- [ ] Mobile responsive at 375px / 768px / 1440px

🤖 Generated with [Claude Code](https://claude.com/claude-code)