### PR TITLE
V4 W7 unblocker: SourceFeedTemplate

### DIFF
--- a/src/components/templates/SourceFeedTemplate.tsx
+++ b/src/components/templates/SourceFeedTemplate.tsx
@@ -1,32 +1,46 @@
 // V4 — SourceFeedTemplate
 //
-// Layout primitive consumed by W7 (source-feeds-v4): one template, 13
-// pages (HN trending, Reddit, Bluesky, Dev.to, Lobsters, ProductHunt,
-// Twitter, NPM, arXiv, Papers, HuggingFace ×3, Breakouts).
+// W7 unblocker — layout primitive consumed by 16 source-feed routes:
 //
-// Mockup reference: design/screenshots/* + sub-pages.html § /hackernews.
+//   /hackernews/trending  /reddit/trending  /bluesky/trending
+//   /devto                /lobsters         /producthunt
+//   /twitter              /npm              /arxiv/trending
+//   /papers               /huggingface/trending
+//   /huggingface/datasets /huggingface/spaces
+//   /breakouts            (+ huggingface landing, +1 reserved)
 //
-// The template handles:
-//   - PageHead with crumb / title / lede / clock
-//   - Snapshot + Volume + Topics 3-column strip
-//   - Featured 3-card row with #1 lead treatment
-//   - Main list (table OR card grid)
+// Mockup reference: sub-pages.html § "/hackernews" — the canonical "source
+// feed" shape: PageHead, optional KpiBand, filter strip (sources × window),
+// optional tab strip (Trending / All / Top), main feed with optional right
+// rail, optional pagination footer.
 //
-// All content slots are nodes — caller composes with V4 primitives
-// (PanelHead, KpiBand, RankRow, FeaturedCard, etc.). Template is purely
-// structural; no data fetching, no business logic.
+// The template is a pure server component — no `'use client'`, no data
+// fetching, no business logic. All slots are nodes; caller composes with
+// V4 primitives (PanelHead, KpiBand, Chip, ChipGroup, FilterBar, TabBar,
+// SectionHead, …).
+//
+// Layout:
+//   PageHead
+//   ├─ KpiBand (slot)
+//   ├─ FilterBar (slot — Chip/ChipGroup/FilterBar)
+//   ├─ TabBar (slot — optional Trending/All/Top tabs)
+//   ├─ Body (1 col, or 2 col when rightRail set)
+//   │   ├─ mainPanels — the feed
+//   │   └─ rightRail  — optional sidebar (freshness, related, etc.)
+//   └─ Footer (slot — pagination / "load more")
 //
 // Usage:
 //   <SourceFeedTemplate
 //     crumb={<><b>HN</b> · TERMINAL · /HACKERNEWS</>}
 //     title="Hacker News · trending"
-//     lede="Stories from the past 72 hours, scored by velocity..."
+//     lede="Stories from the past 72 hours, scored by velocity…"
 //     clock={<LiveClock />}
-//     snapshot={<SnapshotPanel ... />}
-//     volume={<VolumePanel ... />}
-//     topics={<TopicsPanel ... />}
-//     featured={[<FeaturedCard ... />, ...]}
-//     list={<table>...</table>}
+//     kpiBand={<KpiBand cells={[…]} />}
+//     filterBar={<FilterBar><ChipGroup label="WINDOW">…</ChipGroup></FilterBar>}
+//     tabBar={<TabBar items={…} active="trending" hrefFor={(id) => `?tab=${id}`} />}
+//     mainPanels={<HnFeedTable rows={rows} />}
+//     rightRail={<SourceRunFreshnessPanel … />}
+//     footer={<Pagination page={1} total={42} />}
 //   />
 
 import type { ReactNode } from "react";
@@ -34,31 +48,56 @@ import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 import { PageHead } from "@/components/ui/PageHead";
-import { SectionHead } from "@/components/ui/SectionHead";
 
 export interface SourceFeedTemplateProps {
-  // PageHead slots
+  // PageHead slots — caller can pass either (title + lede) for the standard
+  // case, or override the entire head via `head` for fully custom heros
+  // (e.g. /huggingface landing with a model picker).
+  /** Top crumb. Example: <><b>HN</b> · TERMINAL · /HACKERNEWS</> */
   crumb?: ReactNode;
+  /** H1 — sans 30px, ink-000. */
   title?: ReactNode;
+  /** Lede paragraph below H1. */
   lede?: ReactNode;
+  /** Right-aligned clock / actions slot inside PageHead. */
   clock?: ReactNode;
+  /**
+   * Escape hatch — when set, replaces the default <PageHead> entirely.
+   * Use only when the standard head shape isn't enough (e.g. /huggingface
+   * landing with a model-family picker).
+   */
+  head?: ReactNode;
 
-  // Top strip — 3 panels: Snapshot · Volume · Topics
-  snapshot?: ReactNode;
-  volume?: ReactNode;
-  topics?: ReactNode;
+  /** KPI band slot — typically <KpiBand cells={…} />. */
+  kpiBand?: ReactNode;
+  /** Filter strip slot — typically <FilterBar><ChipGroup …/>…</FilterBar>. */
+  filterBar?: ReactNode;
+  /** Tab bar slot — typically <TabBar items={…} active=… />. */
+  tabBar?: ReactNode;
 
-  // Featured cards (3 expected; #1 emphasized via FeaturedCard's `lead` prop)
-  featured?: ReactNode[];
-  featuredEyebrow?: ReactNode;
+  /** Main body — the feed list / table / cards. */
+  mainPanels?: ReactNode;
+  /** Optional right rail — freshness, related sources, share/embed. */
+  rightRail?: ReactNode;
 
-  // Main list — typically a <table> or list of <RankRow>s
-  listEyebrow?: ReactNode;
-  list?: ReactNode;
+  /** Optional bottom slot — pagination / "load more" / live wire. */
+  footer?: ReactNode;
 
-  /** Optional ticker/foot strip (e.g. live wire). */
-  foot?: ReactNode;
   className?: string;
+  /**
+   * Optional class overrides per slot — useful when a single page needs
+   * tweak (e.g. wider rail). Each value is appended via cn().
+   */
+  classNames?: {
+    head?: string;
+    kpi?: string;
+    filters?: string;
+    tabs?: string;
+    body?: string;
+    main?: string;
+    rail?: string;
+    footer?: string;
+  };
 }
 
 export function SourceFeedTemplate({
@@ -66,49 +105,73 @@ export function SourceFeedTemplate({
   title,
   lede,
   clock,
-  snapshot,
-  volume,
-  topics,
-  featured,
-  featuredEyebrow = "FEATURED · TODAY",
-  listEyebrow = "LIST · TOP 50",
-  list,
-  foot,
+  head,
+  kpiBand,
+  filterBar,
+  tabBar,
+  mainPanels,
+  rightRail,
+  footer,
   className,
+  classNames,
 }: SourceFeedTemplateProps) {
-  const hasTopStrip = snapshot || volume || topics;
-  const hasFeatured = featured && featured.length > 0;
   return (
     <div className={cn("v4-source-feed-template", className)}>
-      <PageHead crumb={crumb} h1={title} lede={lede} clock={clock} />
+      <div className={cn("v4-source-feed-template__head", classNames?.head)}>
+        {head ?? (
+          <PageHead crumb={crumb} h1={title} lede={lede} clock={clock} />
+        )}
+      </div>
 
-      {hasTopStrip ? (
-        <section className="v4-source-feed-template__strip">
-          {snapshot ? <div>{snapshot}</div> : null}
-          {volume ? <div>{volume}</div> : null}
-          {topics ? <div>{topics}</div> : null}
-        </section>
+      {kpiBand ? (
+        <div className={cn("v4-source-feed-template__kpi", classNames?.kpi)}>
+          {kpiBand}
+        </div>
       ) : null}
 
-      {hasFeatured ? (
-        <>
-          <SectionHead num="// 02" title={featuredEyebrow} />
-          <div className="v4-source-feed-template__featured">
-            {featured.map((card, i) => (
-              <div key={i}>{card}</div>
-            ))}
-          </div>
-        </>
+      {filterBar ? (
+        <div
+          className={cn(
+            "v4-source-feed-template__filters",
+            classNames?.filters,
+          )}
+        >
+          {filterBar}
+        </div>
       ) : null}
 
-      {list ? (
-        <>
-          <SectionHead num="// 03" title={listEyebrow} />
-          <div className="v4-source-feed-template__list">{list}</div>
-        </>
+      {tabBar ? (
+        <div className={cn("v4-source-feed-template__tabs", classNames?.tabs)}>
+          {tabBar}
+        </div>
       ) : null}
 
-      {foot ? <div className="v4-source-feed-template__foot">{foot}</div> : null}
+      <div
+        className={cn(
+          "v4-source-feed-template__body",
+          Boolean(rightRail) && "v4-source-feed-template__body--with-rail",
+          classNames?.body,
+        )}
+      >
+        <div className={cn("v4-source-feed-template__main", classNames?.main)}>
+          {mainPanels}
+        </div>
+        {rightRail ? (
+          <aside
+            className={cn("v4-source-feed-template__rail", classNames?.rail)}
+          >
+            {rightRail}
+          </aside>
+        ) : null}
+      </div>
+
+      {footer ? (
+        <div
+          className={cn("v4-source-feed-template__footer", classNames?.footer)}
+        >
+          {footer}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/templates/__tests__/v4-source-feed-template.test.tsx
+++ b/src/components/templates/__tests__/v4-source-feed-template.test.tsx
@@ -1,0 +1,193 @@
+// Unit tests for V4 SourceFeedTemplate (W7 unblocker).
+//
+// Verifies the slot-based composition contract: each named slot renders
+// inside its own block with the matching v4-source-feed-template__* class,
+// and the --with-rail body modifier flips on only when rightRail is set.
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SourceFeedTemplate", () => {
+  it("renders crumb / title / lede through the default PageHead", () => {
+    const { container, getByText } = render(
+      <SourceFeedTemplate
+        crumb={
+          <>
+            <b>HN</b> · TERMINAL · /HACKERNEWS
+          </>
+        }
+        title="Hacker News · trending"
+        lede="Stories from the past 72 hours, scored by velocity."
+      />,
+    );
+    expect(container.querySelector(".v4-source-feed-template__head")).not.toBeNull();
+    expect(container.querySelector(".v4-page-head__h1")?.textContent).toBe(
+      "Hacker News · trending",
+    );
+    expect(getByText("HN").tagName).toBe("B");
+  });
+
+  it("uses the head escape hatch when `head` is provided (skips PageHead)", () => {
+    const { container } = render(
+      <SourceFeedTemplate
+        title="ignored"
+        head={<div data-testid="custom-head">custom</div>}
+      />,
+    );
+    // Default PageHead H1 must NOT be rendered when head is overridden.
+    expect(container.querySelector(".v4-page-head__h1")).toBeNull();
+    expect(container.querySelector('[data-testid="custom-head"]')).not.toBeNull();
+  });
+
+  it("renders kpiBand slot only when prop is provided", () => {
+    const { container, rerender } = render(<SourceFeedTemplate title="x" />);
+    expect(container.querySelector(".v4-source-feed-template__kpi")).toBeNull();
+    rerender(
+      <SourceFeedTemplate title="x" kpiBand={<div data-testid="k">k</div>} />,
+    );
+    expect(
+      container.querySelector(".v4-source-feed-template__kpi"),
+    ).not.toBeNull();
+  });
+
+  it("renders filterBar slot only when prop is provided", () => {
+    const { container, rerender } = render(<SourceFeedTemplate title="x" />);
+    expect(
+      container.querySelector(".v4-source-feed-template__filters"),
+    ).toBeNull();
+    rerender(
+      <SourceFeedTemplate
+        title="x"
+        filterBar={<div data-testid="fb">fb</div>}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-source-feed-template__filters"),
+    ).not.toBeNull();
+  });
+
+  it("renders tabBar slot only when prop is provided", () => {
+    const { container, rerender } = render(<SourceFeedTemplate title="x" />);
+    expect(
+      container.querySelector(".v4-source-feed-template__tabs"),
+    ).toBeNull();
+    rerender(
+      <SourceFeedTemplate
+        title="x"
+        tabBar={<div data-testid="tb">tb</div>}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-source-feed-template__tabs"),
+    ).not.toBeNull();
+  });
+
+  it("always renders body + main even when mainPanels is empty", () => {
+    const { container } = render(<SourceFeedTemplate title="x" />);
+    expect(
+      container.querySelector(".v4-source-feed-template__body"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".v4-source-feed-template__main"),
+    ).not.toBeNull();
+  });
+
+  it("renders rightRail only when prop is provided + applies --with-rail modifier", () => {
+    const { container, rerender } = render(<SourceFeedTemplate title="x" />);
+    expect(
+      container.querySelector(".v4-source-feed-template__rail"),
+    ).toBeNull();
+    expect(
+      container.querySelector(".v4-source-feed-template__body")?.className,
+    ).not.toContain("--with-rail");
+    rerender(
+      <SourceFeedTemplate
+        title="x"
+        rightRail={<aside data-testid="r">rail</aside>}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-source-feed-template__rail"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".v4-source-feed-template__body")?.className,
+    ).toContain("--with-rail");
+  });
+
+  it("renders footer slot only when prop is provided", () => {
+    const { container, rerender } = render(<SourceFeedTemplate title="x" />);
+    expect(
+      container.querySelector(".v4-source-feed-template__footer"),
+    ).toBeNull();
+    rerender(
+      <SourceFeedTemplate
+        title="x"
+        footer={<div data-testid="f">f</div>}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-source-feed-template__footer"),
+    ).not.toBeNull();
+  });
+
+  it("merges className on the root wrapper", () => {
+    const { container } = render(
+      <SourceFeedTemplate title="x" className="custom-root" />,
+    );
+    const root = container.querySelector(".v4-source-feed-template");
+    expect(root?.className).toContain("custom-root");
+  });
+
+  it("applies per-slot classNames overrides", () => {
+    const { container } = render(
+      <SourceFeedTemplate
+        title="x"
+        kpiBand={<div />}
+        filterBar={<div />}
+        tabBar={<div />}
+        rightRail={<aside />}
+        footer={<div />}
+        classNames={{
+          head: "h-x",
+          kpi: "k-x",
+          filters: "f-x",
+          tabs: "t-x",
+          body: "b-x",
+          main: "m-x",
+          rail: "r-x",
+          footer: "ft-x",
+        }}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-source-feed-template__head")?.className,
+    ).toContain("h-x");
+    expect(
+      container.querySelector(".v4-source-feed-template__kpi")?.className,
+    ).toContain("k-x");
+    expect(
+      container.querySelector(".v4-source-feed-template__filters")?.className,
+    ).toContain("f-x");
+    expect(
+      container.querySelector(".v4-source-feed-template__tabs")?.className,
+    ).toContain("t-x");
+    expect(
+      container.querySelector(".v4-source-feed-template__body")?.className,
+    ).toContain("b-x");
+    expect(
+      container.querySelector(".v4-source-feed-template__main")?.className,
+    ).toContain("m-x");
+    expect(
+      container.querySelector(".v4-source-feed-template__rail")?.className,
+    ).toContain("r-x");
+    expect(
+      container.querySelector(".v4-source-feed-template__footer")?.className,
+    ).toContain("ft-x");
+  });
+});

--- a/src/components/templates/__tests__/v4-templates.test.tsx
+++ b/src/components/templates/__tests__/v4-templates.test.tsx
@@ -1,10 +1,9 @@
-// Unit tests for V4 layout templates: SourceFeedTemplate, LeaderboardTemplate,
-// ProfileTemplate.
+// Unit tests for V4 layout templates: LeaderboardTemplate, ProfileTemplate.
+// SourceFeedTemplate has its own dedicated suite at v4-source-feed-template.test.tsx.
 
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import {
   LeaderboardTemplate,
   type LeaderboardBand,
@@ -13,71 +12,6 @@ import { ProfileTemplate } from "@/components/templates/ProfileTemplate";
 
 afterEach(() => {
   cleanup();
-});
-
-describe("SourceFeedTemplate", () => {
-  it("renders crumb / h1 / lede via PageHead", () => {
-    const { container, getByText } = render(
-      <SourceFeedTemplate
-        crumb={
-          <>
-            <b>HN</b> · TERMINAL
-          </>
-        }
-        title="Hacker News"
-        lede="Stories from the past 72 hours"
-      />,
-    );
-    expect(container.querySelector(".v4-page-head__h1")?.textContent).toBe(
-      "Hacker News",
-    );
-    expect(getByText("HN").tagName).toBe("B");
-  });
-
-  it("only renders top strip when at least one of snapshot/volume/topics is set", () => {
-    const { container, rerender } = render(
-      <SourceFeedTemplate title="x" />,
-    );
-    expect(
-      container.querySelector(".v4-source-feed-template__strip"),
-    ).toBeNull();
-    rerender(
-      <SourceFeedTemplate
-        title="x"
-        snapshot={<div data-testid="snap">snap</div>}
-      />,
-    );
-    expect(
-      container.querySelector(".v4-source-feed-template__strip"),
-    ).not.toBeNull();
-  });
-
-  it("renders one featured slot per array entry", () => {
-    const { container } = render(
-      <SourceFeedTemplate
-        title="x"
-        featured={[<div key="1">a</div>, <div key="2">b</div>, <div key="3">c</div>]}
-      />,
-    );
-    expect(
-      container.querySelector(".v4-source-feed-template__featured")
-        ?.children.length,
-    ).toBe(3);
-  });
-
-  it("renders list section only when list prop is provided", () => {
-    const { container, rerender } = render(<SourceFeedTemplate title="x" />);
-    expect(container.querySelector(".v4-source-feed-template__list")).toBeNull();
-    rerender(<SourceFeedTemplate title="x" list={<div data-testid="l">l</div>} />);
-    expect(container.querySelector(".v4-source-feed-template__list")).not.toBeNull();
-  });
-
-  it("renders foot only when prop is provided", () => {
-    const { container } = render(
-      <SourceFeedTemplate title="x" foot={<span data-testid="ft">ft</span>} />,
-    );
-    expect(container.querySelector(".v4-source-feed-template__foot")).not.toBeNull();
-  });
 });
 
 describe("LeaderboardTemplate", () => {

--- a/src/components/ui/v4.css
+++ b/src/components/ui/v4.css
@@ -16,6 +16,36 @@
 /* ---------------------------------------------------------------------------
  * 01. CornerDots — three 4×4px squares for panel-head decoration
  * --------------------------------------------------------------------------- */
+.v4-root {
+  min-height: 100vh;
+  background:
+    radial-gradient(1100px 520px at 8% -12%, var(--v4-acc-soft), transparent 58%),
+    radial-gradient(850px 440px at 100% 112%, rgba(34, 197, 94, 0.055), transparent 60%),
+    var(--v4-bg-000);
+  color: var(--v4-ink-100);
+  --color-bg-primary: var(--v4-bg-000);
+  --color-bg-secondary: var(--v4-bg-100);
+  --color-bg-tertiary: var(--v4-bg-200);
+  --color-bg-card: var(--v4-bg-050);
+  --color-bg-card-hover: var(--v4-bg-100);
+  --color-bg-row-hover: var(--v4-bg-100);
+  --color-bg-elevated: var(--v4-bg-200);
+  --color-bg-inset: var(--v4-bg-000);
+  --color-text-primary: var(--v4-ink-000);
+  --color-text-secondary: var(--v4-ink-200);
+  --color-text-tertiary: var(--v4-ink-300);
+  --color-text-muted: var(--v4-ink-400);
+  --color-border-primary: var(--v4-line-200);
+  --color-border-secondary: var(--v4-line-100);
+  --color-border-strong: var(--v4-line-300);
+  --color-border-focus: var(--v4-acc);
+  --color-brand: var(--v4-acc);
+  --color-brand-hover: var(--v4-acc-hover);
+  --color-brand-active: var(--v4-acc-dim);
+  --color-brand-glow: var(--v4-acc-soft);
+  --color-brand-glow-strong: var(--v4-acc-glow);
+}
+
 .v4-corner-dots {
   display: inline-flex;
   gap: 3px;
@@ -111,6 +141,66 @@
 /* ---------------------------------------------------------------------------
  * 03. PanelHead — every panel's top strip
  * --------------------------------------------------------------------------- */
+.v4-panel {
+  background: var(--v4-bg-025);
+  border: var(--v4-stroke-1) solid var(--v4-line-200);
+  border-radius: var(--v4-radius-2);
+}
+
+.v4-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--v4-space-3);
+  min-height: 28px;
+  padding: 0 var(--v4-space-6);
+  border: var(--v4-stroke-1) solid var(--v4-line-300);
+  border-radius: var(--v4-radius-2);
+  background: var(--v4-bg-050);
+  color: var(--v4-ink-200);
+  font-family: var(--v4-mono);
+  font-size: var(--v4-text-11);
+  font-weight: 600;
+  letter-spacing: var(--v4-track-14);
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition:
+    background-color var(--v4-duration-fast) var(--v4-ease),
+    border-color var(--v4-duration-fast) var(--v4-ease),
+    color var(--v4-duration-fast) var(--v4-ease),
+    box-shadow var(--v4-duration-fast) var(--v4-ease);
+}
+
+.v4-button:hover {
+  background: var(--v4-bg-100);
+  border-color: var(--v4-line-400);
+  color: var(--v4-ink-100);
+}
+
+.v4-button:focus-visible {
+  outline: 2px solid var(--v4-acc);
+  outline-offset: 2px;
+}
+
+.v4-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.v4-button-primary {
+  background: var(--v4-acc);
+  border-color: var(--v4-acc);
+  color: #1a0a04;
+  font-weight: 700;
+}
+
+.v4-button-primary:hover {
+  background: var(--v4-acc-hover);
+  border-color: var(--v4-acc-hover);
+  color: #1a0a04;
+}
+
 .v4-panel-head {
   display: flex;
   align-items: center;
@@ -2246,32 +2336,57 @@
 
 /* ---------------------------------------------------------------------------
  * 31. SourceFeedTemplate — W7 source-feed pages
+ *
+ * Consumed by 16 source-feed routes (HN, Reddit, Bluesky, Dev.to, Lobsters,
+ * ProductHunt, Twitter, NPM, arXiv, Papers, HuggingFace×3, Breakouts).
+ * Mockup reference: sub-pages.html § "/hackernews".
+ *
+ * Slots: head → kpi → filters → tabs → body{ main + optional rail } → footer.
+ * Mirrors the .v4-profile-template idiom; the --with-rail modifier flips the
+ * body to a 2-column grid (1fr · 320px).
  * --------------------------------------------------------------------------- */
 .v4-source-feed-template {
   display: flex;
   flex-direction: column;
 }
-.v4-source-feed-template__strip {
+.v4-source-feed-template__head {
+  /* PageHead carries its own border + spacing; this wrapper exists purely
+     so callers can target it with the classNames.head escape hatch. */
+}
+.v4-source-feed-template__kpi {
+  margin-bottom: var(--v4-space-5);
+}
+.v4-source-feed-template__filters {
+  margin-bottom: var(--v4-space-5);
+}
+.v4-source-feed-template__tabs {
+  margin-bottom: var(--v4-space-5);
+}
+.v4-source-feed-template__body {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: var(--v4-grid-gap);
-  margin-bottom: var(--v4-space-7);
 }
-.v4-source-feed-template__featured {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.v4-source-feed-template__body--with-rail {
+  grid-template-columns: minmax(0, 1fr) 320px;
+}
+.v4-source-feed-template__main {
+  display: flex;
+  flex-direction: column;
   gap: var(--v4-grid-gap);
-  margin-bottom: var(--v4-space-7);
+  min-width: 0;
 }
-.v4-source-feed-template__list {
-  margin-bottom: var(--v4-space-7);
+.v4-source-feed-template__rail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--v4-grid-gap);
+  min-width: 0;
 }
-.v4-source-feed-template__foot {
+.v4-source-feed-template__footer {
   margin-top: var(--v4-space-7);
 }
 @media (max-width: 1023px) {
-  .v4-source-feed-template__strip,
-  .v4-source-feed-template__featured {
+  .v4-source-feed-template__body--with-rail {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

Slot-based layout template that unblocks W7 (source-feeds-v4) — 16 source-feed routes (HN, Reddit, Bluesky, Dev.to, Lobsters, ProductHunt, Twitter, NPM, arXiv, Papers, HuggingFace×3, Breakouts) will consume this template once landed.

- New slots: `crumb` / `head` / `kpiBand` / `filterBar` / `tabBar` / `mainPanels` / `rightRail` / `footer` plus per-slot `classNames` overrides
- Mirrors `ProfileTemplate`'s composition idiom (header → bands → 2-col body → footer); `--with-rail` modifier flips the body to `1fr · 320px` when `rightRail` is set
- Pure server component — no `'use client'`, no data fetching, no business logic
- CSS lives under v4.css §31 with the same `var(--v4-*)` token discipline as the other two templates
- `v4-templates.test.tsx` retains LeaderboardTemplate + ProfileTemplate coverage; SourceFeedTemplate gets its own dedicated 10-case suite

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npx vitest run src/components/templates/__tests__/v4-source-feed-template.test.tsx` — 10/10 passing
- [x] `npx vitest run src/components/templates/__tests__/v4-templates.test.tsx` — 9/9 passing (no regression on Leaderboard/Profile)
- [ ] Wire one source page (e.g. `/hackernews/trending`) to the new template in a follow-up commit and visually QA the chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)