### PR TITLE
V4 W8 unblocker: LeaderboardTemplate

### DIFF
--- a/src/components/templates/LeaderboardTemplate.tsx
+++ b/src/components/templates/LeaderboardTemplate.tsx
@@ -1,21 +1,30 @@
 // V4 — LeaderboardTemplate
 //
-// Layout primitive consumed by W8 (ecosystem-leaderboards-v4): one
-// template, 8 pages (Skills, MCP, AgentRepos, AgentCommerce, ModelUsage,
-// Categories, Collections + their /[slug] details).
+// Layout primitive consumed by W8 (ecosystem-leaderboards-v4): one template,
+// 6 leaderboard pages — Skills, MCP, Agents, AgentCommerce, ModelUsage,
+// Categories — plus their /[slug] details (which use ProfileTemplate).
 //
 // Reference: home.html top10 panel + consensus.html banded leaderboard
-// chrome.
+// chrome (master plan §223–226).
 //
-// Layout:
-//   PageHead
-//   KpiBand (caller composes)
-//   FilterBar (caller composes — Chip + ChipGroup + TabBar)
-//   Banded leaderboard rows OR flat list
+// Slot composition (mirrors ProfileTemplate):
+//   PageHead             — crumb / h1 / lede / clock pass-through
+//   __kpi                — KpiBand slot (caller composes)
+//   __filters            — FilterBar slot (Chip + ChipGroup + TabBar)
+//   __featured           — hero band for the #1 entry (consensus banding)
+//   __body               — 1- or 2-col grid (with-rail modifier)
+//     __main             — main __leaderboard slot (RankRow × N or bands)
+//     __rail             — optional right rail (methodology, related)
+//   __footer             — optional related / methodology / collections
 //
-// Bands are optional: pass `bands` for the consensus-style verdict groups
-// (Strong / Early / Divergence / External / Single), or just `rows` for a
-// flat ranked list.
+// Two body modes are supported:
+//   1. `leaderboard` — caller passes a flat <RankRow> stack (canonical W8
+//      shape per master plan).
+//   2. `bands` — caller passes consensus-style verdict groups (Strong /
+//      Early / Divergence / External / Single). Mutually exclusive with
+//      `leaderboard`; bands win when both are provided.
+//
+// Server component — no `'use client'`. Tokens only — zero hardcoded hex.
 
 import type { ReactNode } from "react";
 
@@ -38,47 +47,75 @@ export interface LeaderboardBand {
 }
 
 export interface LeaderboardTemplateProps {
-  // PageHead slots
+  /** Top crumb. */
   crumb?: ReactNode;
-  title?: ReactNode;
+  /** H1 — sans 30px, weight 500, leading 1.05, ink-000. */
+  h1?: ReactNode;
+  /** Lede paragraph. */
   lede?: ReactNode;
+  /** Right-aligned clock / metadata column in PageHead. */
   clock?: ReactNode;
 
-  // Above-fold composition
+  /** KPI band slot (caller passes <KpiBand cells=…/>). */
   kpiBand?: ReactNode;
+  /** Category / window filters strip (caller composes). */
   filterBar?: ReactNode;
+  /** Featured band — hero treatment for the #1 entry. */
+  featuredBand?: ReactNode;
 
-  // Body — ONE of these:
+  /** Main leaderboard slot — typically <RankRow> × N. */
+  leaderboard?: ReactNode;
+  /** Eyebrow above the leaderboard slot when used. */
+  leaderboardEyebrow?: ReactNode;
+  /** Mono prefix for the leaderboard SectionHead (e.g. "// 01"). */
+  leaderboardNum?: string;
+
+  /**
+   * Optional banded leaderboard (consensus.html shape) — mutually exclusive
+   * with `leaderboard`. When provided, replaces the flat list with one
+   * `__band` section per entry. Bands win if both props are set.
+   */
   bands?: LeaderboardBand[];
-  rows?: ReactNode;
-  rowsEyebrow?: ReactNode;
 
-  /** Optional right-rail panel (e.g. methodology, recent activity). */
+  /** Optional right-rail panel (methodology, recent activity, etc.). */
   rightRail?: ReactNode;
+
+  /** Optional footer block — related leaderboards, methodology link, etc. */
+  footer?: ReactNode;
 
   className?: string;
 }
 
 export function LeaderboardTemplate({
   crumb,
-  title,
+  h1,
   lede,
   clock,
   kpiBand,
   filterBar,
+  featuredBand,
+  leaderboard,
+  leaderboardEyebrow = "LEADERBOARD",
+  leaderboardNum = "// 01",
   bands,
-  rows,
-  rowsEyebrow = "LEADERBOARD",
   rightRail,
+  footer,
   className,
 }: LeaderboardTemplateProps) {
-  const hasBands = bands && bands.length > 0;
+  const hasBands = Boolean(bands && bands.length > 0);
   return (
     <div className={cn("v4-leaderboard-template", className)}>
-      <PageHead crumb={crumb} h1={title} lede={lede} clock={clock} />
+      <PageHead crumb={crumb} h1={h1} lede={lede} clock={clock} />
 
-      {kpiBand ? <div className="v4-leaderboard-template__kpi">{kpiBand}</div> : null}
-      {filterBar ? <div className="v4-leaderboard-template__filter">{filterBar}</div> : null}
+      {kpiBand ? (
+        <div className="v4-leaderboard-template__kpi">{kpiBand}</div>
+      ) : null}
+      {filterBar ? (
+        <div className="v4-leaderboard-template__filters">{filterBar}</div>
+      ) : null}
+      {featuredBand ? (
+        <div className="v4-leaderboard-template__featured">{featuredBand}</div>
+      ) : null}
 
       <div
         className={cn(
@@ -88,7 +125,7 @@ export function LeaderboardTemplate({
       >
         <div className="v4-leaderboard-template__main">
           {hasBands ? (
-            bands.map((band) => (
+            bands!.map((band) => (
               <section
                 key={band.key}
                 className={cn(
@@ -97,7 +134,10 @@ export function LeaderboardTemplate({
                 )}
               >
                 <header className="v4-leaderboard-template__band-head">
-                  <span className="v4-leaderboard-template__band-pip" aria-hidden="true" />
+                  <span
+                    className="v4-leaderboard-template__band-pip"
+                    aria-hidden="true"
+                  />
                   <div>
                     {band.num ? (
                       <div className="v4-leaderboard-template__band-num">
@@ -119,10 +159,12 @@ export function LeaderboardTemplate({
                 </div>
               </section>
             ))
-          ) : rows ? (
+          ) : leaderboard ? (
             <>
-              <SectionHead num="// 01" title={rowsEyebrow} />
-              <div className="v4-leaderboard-template__rows">{rows}</div>
+              <SectionHead num={leaderboardNum} title={leaderboardEyebrow} />
+              <div className="v4-leaderboard-template__leaderboard">
+                {leaderboard}
+              </div>
             </>
           ) : null}
         </div>
@@ -130,6 +172,10 @@ export function LeaderboardTemplate({
           <aside className="v4-leaderboard-template__rail">{rightRail}</aside>
         ) : null}
       </div>
+
+      {footer ? (
+        <div className="v4-leaderboard-template__footer">{footer}</div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/templates/__tests__/v4-leaderboard-template.test.tsx
+++ b/src/components/templates/__tests__/v4-leaderboard-template.test.tsx
@@ -1,0 +1,239 @@
+// V4 — LeaderboardTemplate unit tests
+//
+// Verifies slot markers (PageHead, kpi, filters, featuredBand, leaderboard,
+// rightRail, footer, bands) and RankRow integration in the canonical
+// `leaderboard` slot.
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  LeaderboardTemplate,
+  type LeaderboardBand,
+} from "@/components/templates/LeaderboardTemplate";
+import { RankRow } from "@/components/ui/RankRow";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LeaderboardTemplate — PageHead pass-through", () => {
+  it("renders crumb / h1 / lede / clock through PageHead", () => {
+    const { container, getByText } = render(
+      <LeaderboardTemplate
+        crumb={
+          <>
+            <b>SKILLS</b> · TERMINAL
+          </>
+        }
+        h1="Trending Claude Skills"
+        lede="Curated weekly across the ecosystem."
+        clock={<span data-testid="clock">12:00 UTC</span>}
+      />,
+    );
+    expect(container.querySelector(".v4-page-head__h1")?.textContent).toBe(
+      "Trending Claude Skills",
+    );
+    expect(container.querySelector(".v4-page-head__lede")?.textContent).toBe(
+      "Curated weekly across the ecosystem.",
+    );
+    expect(getByText("SKILLS").tagName).toBe("B");
+    expect(container.querySelector(".v4-page-head__clock")).not.toBeNull();
+  });
+});
+
+describe("LeaderboardTemplate — slot markers", () => {
+  it("renders __kpi only when kpiBand is provided", () => {
+    const { container, rerender } = render(<LeaderboardTemplate h1="x" />);
+    expect(container.querySelector(".v4-leaderboard-template__kpi")).toBeNull();
+    rerender(<LeaderboardTemplate h1="x" kpiBand={<div data-testid="kpi" />} />);
+    expect(
+      container.querySelector(".v4-leaderboard-template__kpi"),
+    ).not.toBeNull();
+  });
+
+  it("renders __filters only when filterBar is provided", () => {
+    const { container, rerender } = render(<LeaderboardTemplate h1="x" />);
+    expect(
+      container.querySelector(".v4-leaderboard-template__filters"),
+    ).toBeNull();
+    rerender(
+      <LeaderboardTemplate h1="x" filterBar={<div data-testid="fil" />} />,
+    );
+    expect(
+      container.querySelector(".v4-leaderboard-template__filters"),
+    ).not.toBeNull();
+  });
+
+  it("renders __featured only when featuredBand is provided", () => {
+    const { container, rerender } = render(<LeaderboardTemplate h1="x" />);
+    expect(
+      container.querySelector(".v4-leaderboard-template__featured"),
+    ).toBeNull();
+    rerender(
+      <LeaderboardTemplate
+        h1="x"
+        featuredBand={<div data-testid="hero">#1 hero</div>}
+      />,
+    );
+    const featured = container.querySelector(
+      ".v4-leaderboard-template__featured",
+    );
+    expect(featured).not.toBeNull();
+    expect(featured?.textContent).toContain("#1 hero");
+  });
+
+  it("renders __footer only when footer is provided", () => {
+    const { container, rerender } = render(<LeaderboardTemplate h1="x" />);
+    expect(
+      container.querySelector(".v4-leaderboard-template__footer"),
+    ).toBeNull();
+    rerender(
+      <LeaderboardTemplate
+        h1="x"
+        footer={<div data-testid="ft">methodology</div>}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-leaderboard-template__footer"),
+    ).not.toBeNull();
+  });
+});
+
+describe("LeaderboardTemplate — body modes", () => {
+  it("renders __leaderboard slot in flat mode", () => {
+    const { container } = render(
+      <LeaderboardTemplate
+        h1="x"
+        leaderboard={<div data-testid="rows" />}
+        leaderboardEyebrow="LIST"
+      />,
+    );
+    expect(container.querySelector(".v4-leaderboard-template__band")).toBeNull();
+    expect(
+      container.querySelector(".v4-leaderboard-template__leaderboard"),
+    ).not.toBeNull();
+  });
+
+  it("integrates RankRow children inside the __leaderboard slot", () => {
+    const { container } = render(
+      <LeaderboardTemplate
+        h1="Trending"
+        leaderboard={
+          <>
+            <RankRow rank={1} title="anthropic/claude-code" first />
+            <RankRow rank={2} title="openai/codex" />
+            <RankRow rank={3} title="microsoft/vscode" />
+          </>
+        }
+      />,
+    );
+    const slot = container.querySelector(
+      ".v4-leaderboard-template__leaderboard",
+    );
+    expect(slot).not.toBeNull();
+    const rows = slot?.querySelectorAll(".v4-rank-row");
+    expect(rows).toHaveLength(3);
+    expect(rows?.[0].className).toContain("v4-rank-row--first");
+    expect(rows?.[0].textContent).toContain("anthropic/claude-code");
+  });
+
+  it("uses leaderboardNum for the SectionHead prefix", () => {
+    const { container } = render(
+      <LeaderboardTemplate
+        h1="x"
+        leaderboard={<div />}
+        leaderboardEyebrow="EYEBROW"
+        leaderboardNum="// 03"
+      />,
+    );
+    expect(container.querySelector(".v4-section-head__num")?.textContent).toBe(
+      "// 03",
+    );
+  });
+
+  it("renders one __band per entry when bands is provided", () => {
+    const bands: LeaderboardBand[] = [
+      { key: "cons", title: "STRONG CONSENSUS", rows: <div>a</div> },
+      { key: "early", title: "EARLY CALL", rows: <div>b</div> },
+      { key: "div", title: "DIVERGENCE", rows: <div>c</div> },
+    ];
+    const { container } = render(
+      <LeaderboardTemplate h1="x" bands={bands} />,
+    );
+    const sections = container.querySelectorAll(
+      ".v4-leaderboard-template__band",
+    );
+    expect(sections).toHaveLength(3);
+    expect(sections[0].className).toContain("--cons");
+    expect(sections[1].className).toContain("--early");
+    expect(sections[2].className).toContain("--div");
+  });
+
+  it("renders band meta + num when provided", () => {
+    const bands: LeaderboardBand[] = [
+      {
+        key: "cons",
+        title: "BAND",
+        num: "// 01",
+        rows: <div />,
+        meta: "7 · in band",
+      },
+    ];
+    const { getByText } = render(
+      <LeaderboardTemplate h1="x" bands={bands} />,
+    );
+    expect(getByText("7 · in band")).not.toBeNull();
+    expect(getByText("// 01")).not.toBeNull();
+  });
+
+  it("prefers bands over leaderboard when both are provided", () => {
+    const bands: LeaderboardBand[] = [
+      { key: "cons", title: "B", rows: <div>band-row</div> },
+    ];
+    const { container } = render(
+      <LeaderboardTemplate
+        h1="x"
+        bands={bands}
+        leaderboard={<div data-testid="flat">flat-row</div>}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-leaderboard-template__band"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(".v4-leaderboard-template__leaderboard"),
+    ).toBeNull();
+  });
+});
+
+describe("LeaderboardTemplate — rail layout", () => {
+  it("applies --with-rail modifier only when rightRail is set", () => {
+    const { container, rerender } = render(<LeaderboardTemplate h1="x" />);
+    expect(
+      container.querySelector(".v4-leaderboard-template__body")?.className,
+    ).not.toContain("--with-rail");
+    rerender(
+      <LeaderboardTemplate
+        h1="x"
+        rightRail={<aside data-testid="rail">methodology</aside>}
+      />,
+    );
+    expect(
+      container.querySelector(".v4-leaderboard-template__body")?.className,
+    ).toContain("--with-rail");
+    expect(
+      container.querySelector(".v4-leaderboard-template__rail"),
+    ).not.toBeNull();
+  });
+});
+
+describe("LeaderboardTemplate — className passthrough", () => {
+  it("merges className onto root element", () => {
+    const { container } = render(
+      <LeaderboardTemplate h1="x" className="custom-class" />,
+    );
+    const root = container.querySelector(".v4-leaderboard-template");
+    expect(root?.className).toContain("custom-class");
+  });
+});

--- a/src/components/templates/__tests__/v4-templates.test.tsx
+++ b/src/components/templates/__tests__/v4-templates.test.tsx
@@ -84,13 +84,13 @@ describe("LeaderboardTemplate", () => {
   it("renders kpi + filter slots when provided", () => {
     const { container } = render(
       <LeaderboardTemplate
-        title="x"
+        h1="x"
         kpiBand={<div data-testid="kpi" />}
         filterBar={<div data-testid="fil" />}
       />,
     );
     expect(container.querySelector(".v4-leaderboard-template__kpi")).not.toBeNull();
-    expect(container.querySelector(".v4-leaderboard-template__filter")).not.toBeNull();
+    expect(container.querySelector(".v4-leaderboard-template__filters")).not.toBeNull();
   });
 
   it("renders one section per band with the correct band class", () => {
@@ -99,7 +99,7 @@ describe("LeaderboardTemplate", () => {
       { key: "early", title: "EARLY CALL", rows: <div>r</div> },
       { key: "div", title: "DIVERGENCE", rows: <div>r</div> },
     ];
-    const { container } = render(<LeaderboardTemplate title="x" bands={bands} />);
+    const { container } = render(<LeaderboardTemplate h1="x" bands={bands} />);
     const sections = container.querySelectorAll(".v4-leaderboard-template__band");
     expect(sections).toHaveLength(3);
     expect(sections[0].className).toContain("--cons");
@@ -107,25 +107,27 @@ describe("LeaderboardTemplate", () => {
     expect(sections[2].className).toContain("--div");
   });
 
-  it("falls back to flat rows mode when bands is omitted", () => {
+  it("falls back to flat leaderboard mode when bands is omitted", () => {
     const { container } = render(
       <LeaderboardTemplate
-        title="x"
-        rows={<div data-testid="rows" />}
-        rowsEyebrow="LIST"
+        h1="x"
+        leaderboard={<div data-testid="rows" />}
+        leaderboardEyebrow="LIST"
       />,
     );
     expect(container.querySelector(".v4-leaderboard-template__band")).toBeNull();
-    expect(container.querySelector(".v4-leaderboard-template__rows")).not.toBeNull();
+    expect(
+      container.querySelector(".v4-leaderboard-template__leaderboard"),
+    ).not.toBeNull();
   });
 
   it("applies with-rail class only when rightRail is set", () => {
-    const { container, rerender } = render(<LeaderboardTemplate title="x" />);
+    const { container, rerender } = render(<LeaderboardTemplate h1="x" />);
     expect(
       container.querySelector(".v4-leaderboard-template__body")?.className,
     ).not.toContain("--with-rail");
     rerender(
-      <LeaderboardTemplate title="x" rightRail={<aside data-testid="rail" />} />,
+      <LeaderboardTemplate h1="x" rightRail={<aside data-testid="rail" />} />,
     );
     expect(
       container.querySelector(".v4-leaderboard-template__body")?.className,
@@ -136,7 +138,7 @@ describe("LeaderboardTemplate", () => {
     const bands: LeaderboardBand[] = [
       { key: "cons", title: "X", rows: <div />, meta: "7 · in band" },
     ];
-    const { getByText } = render(<LeaderboardTemplate title="x" bands={bands} />);
+    const { getByText } = render(<LeaderboardTemplate h1="x" bands={bands} />);
     expect(getByText("7 · in band")).not.toBeNull();
   });
 });

--- a/src/components/ui/v4.css
+++ b/src/components/ui/v4.css
@@ -2286,7 +2286,11 @@
 .v4-leaderboard-template__kpi {
   margin-bottom: var(--v4-space-5);
 }
+.v4-leaderboard-template__filters,
 .v4-leaderboard-template__filter {
+  margin-bottom: var(--v4-space-5);
+}
+.v4-leaderboard-template__featured {
   margin-bottom: var(--v4-space-5);
 }
 .v4-leaderboard-template__body {
@@ -2296,6 +2300,25 @@
 }
 .v4-leaderboard-template__body--with-rail {
   grid-template-columns: minmax(0, 1fr) 320px;
+}
+.v4-leaderboard-template__main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--v4-grid-gap);
+  min-width: 0;
+}
+.v4-leaderboard-template__rail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--v4-grid-gap);
+  min-width: 0;
+}
+.v4-leaderboard-template__leaderboard {
+  display: flex;
+  flex-direction: column;
+}
+.v4-leaderboard-template__footer {
+  margin-top: var(--v4-space-7);
 }
 @media (max-width: 1023px) {
   .v4-leaderboard-template__body--with-rail {


### PR DESCRIPTION
## Summary

- Slot-based `LeaderboardTemplate` for the 6 V4 W8 leaderboard pages (Skills, MCP, Agents, AgentCommerce, ModelUsage, Categories).
- Canonical slots: `crumb` / `h1` / `lede` / `clock` (PageHead pass-through), `kpiBand`, `filterBar`, `featuredBand` (hero #1), `leaderboard` (RankRow × N), `rightRail`, `footer`, plus optional consensus-style `bands[]` for the banded variant.
- Mirrors `ProfileTemplate`'s slot composition + class naming. Server component, tokens only, zero hardcoded hex.

## Changes

- `src/components/templates/LeaderboardTemplate.tsx` — replaced ad-hoc `title`/`rows` API with the canonical W8 slot list (`h1`, `featuredBand`, `leaderboard`, `footer`); kept `bands[]` for consensus banding.
- `src/components/ui/v4.css` — extended section 32 with `__filters`, `__featured`, `__leaderboard`, `__main`, `__rail`, `__footer` classes (kept `__filter` legacy alias to avoid breaking style rules).
- `src/components/templates/__tests__/v4-leaderboard-template.test.tsx` — new dedicated suite, 13 tests covering every slot marker + RankRow integration.
- `src/components/templates/__tests__/v4-templates.test.tsx` — updated existing LeaderboardTemplate describe block to the new `h1`/`leaderboard` API.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/components/templates/__tests__/v4-leaderboard-template.test.tsx` — 13/13 passing
- [x] `npx vitest run src/components/templates/__tests__/v4-templates.test.tsx` — 14/14 passing (no regression)
- [ ] W8 worktree consumes the new slot API across the 6 leaderboard pages

Reference: master plan §223–226 (LeaderboardTemplate), `design/v4/COMPONENT_INVENTORY.md` row 20.

Generated with [Claude Code](https://claude.com/claude-code)