### PR TITLE
V4 W1: layout shell V4-authoritative tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1157,9 +1157,9 @@ body::before {
    --------------------------------------------------------------------------- */
 .app-shell {
   display: grid;
-  grid-template-columns: var(--layout-sidebar-width) 1fr;
+  grid-template-columns: var(--v4-sidebar-width) 1fr;
   column-gap: 0;
-  min-height: calc(100vh - var(--layout-topbar-height));
+  min-height: calc(100vh - var(--v4-topbar-height));
 }
 
 .app-shell[data-mode="focused"] {
@@ -3753,18 +3753,18 @@ body::before {
   display: flex;
   align-items: center;
   width: 100%;
-  height: var(--layout-topbar-height);
+  height: var(--v4-topbar-height);
   gap: 14px;
   padding: 0 14px;
-  border-bottom: 1px solid var(--line-200);
-  background: var(--bg-025);
+  border-bottom: 1px solid var(--v4-line-200);
+  background: var(--v4-bg-025);
 }
 
 .brand {
   display: flex;
   align-items: center;
   gap: 10px;
-  min-width: var(--layout-sidebar-width);
+  min-width: var(--v4-sidebar-width);
 }
 
 .brand-mark {
@@ -3773,22 +3773,22 @@ body::before {
   justify-content: center;
   width: 24px;
   height: 24px;
-  border: 1px solid var(--acc);
-  color: var(--acc);
+  border: 1px solid var(--v4-acc);
+  color: var(--v4-acc);
   font-size: 13px;
   font-weight: var(--font-weight-bold);
   box-shadow: none;
 }
 
 .brand-name {
-  color: var(--ink-100);
+  color: var(--v4-ink-100);
   font-size: var(--font-size-4xl);
   font-weight: var(--font-weight-bold);
   letter-spacing: var(--tracking-wide);
 }
 
 .brand-sub {
-  color: var(--ink-400);
+  color: var(--v4-ink-400);
   font-size: var(--font-size-sm);
   letter-spacing: var(--tracking-ui);
   line-height: 1.2;
@@ -3803,13 +3803,13 @@ body::before {
 
 .sidebar {
   position: sticky;
-  top: var(--layout-topbar-height);
-  height: calc(100vh - var(--layout-topbar-height));
+  top: var(--v4-topbar-height);
+  height: calc(100vh - var(--v4-topbar-height));
   padding: 10px 0 24px;
   overflow: auto;
-  border-right: 1px solid var(--line-200);
-  background: var(--bg-025);
-  font-family: var(--font-mono);
+  border-right: 1px solid var(--v4-line-200);
+  background: var(--v4-bg-025);
+  font-family: var(--v4-mono);
 }
 
 .sidebar::-webkit-scrollbar {
@@ -3817,13 +3817,13 @@ body::before {
 }
 
 .sidebar::-webkit-scrollbar-thumb {
-  background: var(--line-200);
+  background: var(--v4-line-200);
 }
 
 .sidebar .group {
   margin-top: 4px;
   padding: 14px 0 4px;
-  border-top: 1px solid var(--line-200);
+  border-top: 1px solid var(--v4-line-200);
 }
 
 .sidebar .group:first-child {
@@ -3837,7 +3837,7 @@ body::before {
   align-items: center;
   gap: 8px;
   padding: 0 16px 8px;
-  color: var(--ink-400);
+  color: var(--v4-ink-400);
   font-size: var(--font-size-sm);
   letter-spacing: var(--tracking-ui);
   text-transform: uppercase;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ export function Header() {
 
             <span className="flex flex-col leading-none">
               <span className="brand-name inline-flex items-center leading-none">
-                TRENDING<span style={{ color: "var(--acc)" }}>REPO</span>
+                TRENDING<span style={{ color: "var(--v4-acc)" }}>REPO</span>
               </span>
               <span
                 aria-hidden="true"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -82,9 +82,9 @@ function LaunchpadStrip() {
               active && "v2-bracket",
             )}
             style={{
-              background: active ? "var(--acc-soft)" : "var(--bg-050)",
-              border: `1px solid ${active ? "var(--acc)" : "var(--line-200)"}`,
-              color: active ? "var(--acc)" : "var(--ink-200)",
+              background: active ? "var(--v4-acc-soft)" : "var(--v4-bg-050)",
+              border: `1px solid ${active ? "var(--v4-acc)" : "var(--v4-line-200)"}`,
+              color: active ? "var(--v4-acc)" : "var(--v4-ink-200)",
             }}
           >
             <Icon className="w-3.5 h-3.5" strokeWidth={2} aria-hidden />
@@ -107,14 +107,14 @@ function SidebarStatusHeader() {
     >
       <span
         className="group-label inline-flex items-center gap-2"
-        style={{ color: "var(--ink-300)", fontSize: 10 }}
+        style={{ color: "var(--v4-ink-300)", fontSize: 10 }}
       >
         <SystemMark size={12} />
         {"// TRENDINGREPO"}
       </span>
       <span
         className="font-mono tabular-nums"
-        style={{ color: "var(--ink-500)", fontSize: 9 }}
+        style={{ color: "var(--v4-ink-500)", fontSize: 9 }}
       >
         v{APP_VERSION}
       </span>


### PR DESCRIPTION
## Summary

Migrates the layout shell (Sidebar / Header / AppShell + their CSS) to V4 (CORPUS) tokens. Visual outcome: **identical** (V3 tokens are alias-by-value to V4), but the layout source no longer depends on V3 tokens and is ready for the next phase that strips the V3 alias shim.

## Changes

**TSX (inline styles):**
- `src/components/layout/Header.tsx` — \"TRENDING**REPO**\" accent → `var(--v4-acc)`
- `src/components/layout/Sidebar.tsx` — LaunchpadStrip tile colors + status header → `var(--v4-{acc,acc-soft,bg-050,line-200,ink-200,ink-300,ink-500})`

**CSS (`src/app/globals.css`):**
- `.app-shell` — grid + min-height: `var(--layout-*)` → `var(--v4-{sidebar-width,topbar-height})`
- `.topbar`, `.brand`, `.brand-mark`, `.brand-name`, `.brand-sub` — all V3 tokens → V4
- `.sidebar` (incl. scrollbar, `.group`, `.group-label`) — all V3 tokens → V4 including `font-family: var(--v4-mono)`

## Verification — compiled-CSS proof

After `npm run build`, the layout-bound rules in the production CSS bundle (`/.next/static/css/*.css`) reference V4 tokens exclusively:

| Selector | V4 tokens compiled in |
|---|---|
| `.app-shell` | `--v4-sidebar-width`, `--v4-topbar-height` |
| `.topbar` | `--v4-topbar-height`, `--v4-line-200`, `--v4-bg-025` |
| `.sidebar` | `--v4-topbar-height`, `--v4-line-200`, `--v4-bg-025`, `--v4-mono` |
| `.brand-mark` | `--v4-acc` (border + color) |

Layout dimensions unchanged (sidebar 230px / topbar 52px — same as the `--layout-*` aliases they replaced; rename only).

- `npm run build` — green
- Pre-commit hook ran clean

## Test plan

- [ ] Browse any V4-migrated route (`/`, `/signals`, `/consensus`, `/tools`, `/breakouts`, `/digest`, source feeds, `/u/[handle]`, etc.) — sidebar + topbar render identically pre/post merge
- [ ] DevTools → Computed styles on `.topbar`, `.sidebar`, `.app-shell` → confirm CSS variable references show `--v4-*`

## Notes

This is a **rename-only** migration; no behavior or visual change. Adjacent rules in globals.css that aren't layout-shell-bound still use V3 tokens — those will be migrated as their consuming pages get touched. The V3 alias shim in tokens.css remains intact for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)