### PR TITLE
V4 W4-A: funding backend (types + ETL + APIs)

### DIFF
--- a/src/app/api/funding/events/route.ts
+++ b/src/app/api/funding/events/route.ts
@@ -1,0 +1,132 @@
+// GET /api/funding/events
+//
+// V4 W4 — paginated funding events. Backend half of the funding vertical.
+//
+// Query parameters (all optional):
+//   roundType   — one of: pre-seed | seed | series-a | series-b | series-c |
+//                 series-d+ | bridge | acquisition | ipo
+//   since       — ISO 8601 lower bound on closedAt (inclusive)
+//   limit       — 1..200, default 50
+//   offset      — page offset, default 0
+//
+// Returns FundingEventsPage. Empty data store → 200 with `events: []`,
+// `total: 0`. The producer (PitchBook/Tracxn ingestion in W4 phase 2.1)
+// is what populates the `funding-events` data-store key — until then
+// the route is a stable, empty endpoint.
+//
+// Read-only; no body parsing, so no Zod schema is required by lint:zod-routes.
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorEnvelope } from "@/lib/api/error-response";
+import {
+  queryFundingEvents,
+  refreshFundingFromStore,
+  type FundingEventsPage,
+} from "@/lib/funding/aggregate";
+import type { FundingEventRound } from "@/lib/funding/types";
+
+export const runtime = "nodejs";
+
+const KNOWN_ROUND_TYPES: ReadonlyArray<FundingEventRound> = [
+  "pre-seed",
+  "seed",
+  "series-a",
+  "series-b",
+  "series-c",
+  "series-d+",
+  "bridge",
+  "acquisition",
+  "ipo",
+];
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
+
+interface FundingEventsResponse extends FundingEventsPage {
+  generatedAt: string;
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<FundingEventsResponse | { ok: false; error: string }>> {
+  const { searchParams } = request.nextUrl;
+
+  // ---- roundType ----------------------------------------------------------
+  let roundType: FundingEventRound | undefined;
+  const roundTypeParam = searchParams.get("roundType");
+  if (roundTypeParam !== null && roundTypeParam !== "") {
+    if (!KNOWN_ROUND_TYPES.includes(roundTypeParam as FundingEventRound)) {
+      return NextResponse.json(
+        errorEnvelope(
+          `roundType must be one of: ${KNOWN_ROUND_TYPES.join(", ")}`,
+        ),
+        { status: 400 },
+      );
+    }
+    roundType = roundTypeParam as FundingEventRound;
+  }
+
+  // ---- since --------------------------------------------------------------
+  let since: string | undefined;
+  const sinceParam = searchParams.get("since");
+  if (sinceParam !== null && sinceParam !== "") {
+    const parsed = Date.parse(sinceParam);
+    if (!Number.isFinite(parsed)) {
+      return NextResponse.json(
+        errorEnvelope("since must be a valid ISO 8601 timestamp"),
+        { status: 400 },
+      );
+    }
+    since = new Date(parsed).toISOString();
+  }
+
+  // ---- limit --------------------------------------------------------------
+  let limit = DEFAULT_LIMIT;
+  const limitParam = searchParams.get("limit");
+  if (limitParam !== null && limitParam !== "") {
+    const parsed = Number(limitParam);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+      return NextResponse.json(
+        errorEnvelope("limit must be an integer"),
+        { status: 400 },
+      );
+    }
+    if (parsed < MIN_LIMIT || parsed > MAX_LIMIT) {
+      return NextResponse.json(
+        errorEnvelope(
+          `limit must be between ${MIN_LIMIT} and ${MAX_LIMIT}`,
+        ),
+        { status: 400 },
+      );
+    }
+    limit = parsed;
+  }
+
+  // ---- offset -------------------------------------------------------------
+  let offset = 0;
+  const offsetParam = searchParams.get("offset");
+  if (offsetParam !== null && offsetParam !== "") {
+    const parsed = Number(offsetParam);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+      return NextResponse.json(
+        errorEnvelope("offset must be a non-negative integer"),
+        { status: 400 },
+      );
+    }
+    offset = parsed;
+  }
+
+  try {
+    await refreshFundingFromStore();
+    const page = queryFundingEvents({ roundType, since, limit, offset });
+    return NextResponse.json(
+      { ...page, generatedAt: new Date().toISOString() },
+      { headers: { "Content-Type": "application/json; charset=utf-8" } },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(errorEnvelope(message), { status: 500 });
+  }
+}

--- a/src/app/api/funding/sectors/route.ts
+++ b/src/app/api/funding/sectors/route.ts
@@ -1,0 +1,60 @@
+// GET /api/funding/sectors
+//
+// V4 W4 — sector-level funding aggregates over a chosen time window.
+//
+// Query parameters (all optional):
+//   window — one of: 24h | 7d | 30d (default: 30d)
+//
+// Returns the per-sector totalUsd / dealCount / topDeal breakdown for the
+// window. Sectors with no events in the window are not included. Events
+// without a `sector` tag are bucketed under "uncategorized".
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorEnvelope } from "@/lib/api/error-response";
+import {
+  getFundingSectorBreakdown,
+  refreshFundingFromStore,
+  type FundingSectorAggregate,
+  type FundingWindow,
+} from "@/lib/funding/aggregate";
+
+export const runtime = "nodejs";
+
+const KNOWN_WINDOWS: ReadonlyArray<FundingWindow> = ["24h", "7d", "30d"];
+
+interface FundingSectorsResponse {
+  window: FundingWindow;
+  sectors: FundingSectorAggregate[];
+  generatedAt: string;
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<FundingSectorsResponse | { ok: false; error: string }>> {
+  const { searchParams } = request.nextUrl;
+
+  let window: FundingWindow = "30d";
+  const windowParam = searchParams.get("window");
+  if (windowParam !== null && windowParam !== "") {
+    if (!KNOWN_WINDOWS.includes(windowParam as FundingWindow)) {
+      return NextResponse.json(
+        errorEnvelope(`window must be one of: ${KNOWN_WINDOWS.join(", ")}`),
+        { status: 400 },
+      );
+    }
+    window = windowParam as FundingWindow;
+  }
+
+  try {
+    await refreshFundingFromStore();
+    const sectors = getFundingSectorBreakdown(window);
+    return NextResponse.json(
+      { window, sectors, generatedAt: new Date().toISOString() },
+      { headers: { "Content-Type": "application/json; charset=utf-8" } },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(errorEnvelope(message), { status: 500 });
+  }
+}

--- a/src/lib/funding/__tests__/aggregate.test.ts
+++ b/src/lib/funding/__tests__/aggregate.test.ts
@@ -1,0 +1,323 @@
+// Vitest tests for src/lib/funding/aggregate.ts.
+//
+// Pure-math coverage on the V4 aggregator: window totals, sector
+// breakdown, top movers, top deals, query filters. The fixture is a
+// hand-shaped 6-event set with deliberate mix of windows, sectors,
+// undisclosed amounts, and same-company multi-rounds so each branch is
+// hit at least once.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetFundingCacheForTests,
+  _setFundingCacheForTests,
+  aggregateSectors,
+  aggregateTopMovers,
+  aggregateWindow,
+  getFundingSectorBreakdown,
+  getFundingTopDeals,
+  getFundingTopMovers,
+  getFundingTotals,
+  queryFundingEvents,
+} from "../aggregate";
+import type { FundingEvent } from "../types";
+
+const NOW = Date.parse("2026-05-01T12:00:00.000Z");
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+
+function ago(ms: number): string {
+  return new Date(NOW - ms).toISOString();
+}
+
+const FIXTURE: FundingEvent[] = [
+  {
+    id: "e1",
+    companyName: "Acme AI",
+    companySlug: "acme-ai",
+    repoFullName: "acme/acme",
+    roundType: "series-a",
+    amountUsd: 20_000_000,
+    closedAt: ago(2 * HOUR), // 24h window
+    investors: ["Sequoia"],
+    sourceUrl: "https://example.com/1",
+    sourceName: "techcrunch",
+    confidence: "exact-domain",
+    sector: "ai",
+  },
+  {
+    id: "e2",
+    companyName: "Beta Bio",
+    companySlug: "beta-bio",
+    roundType: "seed",
+    amountUsd: 5_000_000,
+    closedAt: ago(3 * DAY), // 7d (not 24h)
+    investors: [],
+    sourceUrl: "https://example.com/2",
+    sourceName: "venturebeat",
+    confidence: "exact-name",
+    sector: "healthcare",
+  },
+  {
+    id: "e3",
+    companyName: "Acme AI",
+    companySlug: "acme-ai",
+    repoFullName: "acme/acme",
+    roundType: "series-b",
+    amountUsd: 80_000_000,
+    closedAt: ago(5 * DAY), // 7d window
+    investors: ["a16z"],
+    sourceUrl: "https://example.com/3",
+    sourceName: "techcrunch",
+    confidence: "exact-domain",
+    sector: "ai",
+  },
+  {
+    id: "e4",
+    companyName: "Carbon Co",
+    roundType: "pre-seed",
+    // amountUsd intentionally undisclosed
+    closedAt: ago(10 * DAY), // 30d (not 7d)
+    investors: ["Founders Fund"],
+    sourceUrl: "https://example.com/4",
+    sourceName: "sifted",
+    confidence: "alias",
+    sector: "climate",
+  },
+  {
+    id: "e5",
+    companyName: "Delta Defense",
+    roundType: "series-c",
+    amountUsd: 200_000_000,
+    closedAt: ago(20 * DAY), // 30d
+    investors: ["Lockheed"],
+    sourceUrl: "https://example.com/5",
+    sourceName: "techcrunch",
+    confidence: "fuzzy",
+    // sector intentionally absent → "uncategorized"
+  },
+  {
+    id: "e6",
+    companyName: "Old Co",
+    roundType: "ipo",
+    amountUsd: 1_000_000_000,
+    closedAt: ago(120 * DAY), // outside 30d
+    investors: [],
+    sourceUrl: "https://example.com/6",
+    sourceName: "newsapi",
+    confidence: "exact-name",
+    sector: "fintech",
+  },
+];
+
+beforeEach(() => {
+  _setFundingCacheForTests({
+    fetchedAt: new Date(NOW).toISOString(),
+    source: "test-fixture",
+    events: FIXTURE,
+  });
+});
+
+afterEach(() => {
+  _resetFundingCacheForTests();
+});
+
+describe("aggregateWindow", () => {
+  it("sums disclosed amounts and counts deals inside the 24h window", () => {
+    const out = aggregateWindow(FIXTURE, "24h", NOW);
+    // Only e1 (2h ago) is inside 24h.
+    expect(out.dealCount).toBe(1);
+    expect(out.totalUsd).toBe(20_000_000);
+    expect(out.undisclosedCount).toBe(0);
+  });
+
+  it("includes 7d events but excludes the 30d-only and 120d outliers", () => {
+    const out = aggregateWindow(FIXTURE, "7d", NOW);
+    // e1 (2h), e2 (3d), e3 (5d). e4 is 10d (out), e5 is 20d (out), e6 is 120d (out).
+    expect(out.dealCount).toBe(3);
+    expect(out.totalUsd).toBe(20_000_000 + 5_000_000 + 80_000_000);
+    expect(out.undisclosedCount).toBe(0);
+  });
+
+  it("flags undisclosed events without inflating totalUsd", () => {
+    const out = aggregateWindow(FIXTURE, "30d", NOW);
+    // e1, e2, e3, e4, e5. e6 (120d) is out of 30d.
+    expect(out.dealCount).toBe(5);
+    expect(out.undisclosedCount).toBe(1); // e4
+    // e4 has no amount → not in sum.
+    expect(out.totalUsd).toBe(20_000_000 + 5_000_000 + 80_000_000 + 200_000_000);
+  });
+
+  it("ignores events with malformed closedAt", () => {
+    const broken: FundingEvent[] = [
+      ...FIXTURE,
+      {
+        id: "broken",
+        companyName: "Broken",
+        roundType: "seed",
+        amountUsd: 999,
+        closedAt: "not-a-date",
+        investors: [],
+        sourceUrl: "x",
+        sourceName: "x",
+        confidence: "fuzzy",
+      },
+    ];
+    const out = aggregateWindow(broken, "30d", NOW);
+    // Same 5 valid events as before, the broken row is dropped.
+    expect(out.dealCount).toBe(5);
+  });
+});
+
+describe("getFundingTotals", () => {
+  it("computes 24h / 7d / 30d in one pass", () => {
+    const totals = getFundingTotals(NOW);
+    expect(totals["24h"].dealCount).toBe(1);
+    expect(totals["7d"].dealCount).toBe(3);
+    expect(totals["30d"].dealCount).toBe(5);
+    expect(totals["30d"].totalUsd).toBe(305_000_000);
+  });
+});
+
+describe("aggregateSectors", () => {
+  it("buckets ai correctly across two events for the same sector", () => {
+    const sectors = aggregateSectors(FIXTURE, "30d", NOW);
+    const ai = sectors.find((s) => s.sector === "ai");
+    expect(ai).toBeTruthy();
+    expect(ai!.dealCount).toBe(2); // e1 + e3
+    expect(ai!.totalUsd).toBe(100_000_000);
+    // Top deal is the larger amount (e3 @ $80M).
+    expect(ai!.topDeal?.id).toBe("e3");
+  });
+
+  it("buckets sector-less events under 'uncategorized'", () => {
+    const sectors = aggregateSectors(FIXTURE, "30d", NOW);
+    const uncat = sectors.find((s) => s.sector === "uncategorized");
+    expect(uncat).toBeTruthy();
+    expect(uncat!.dealCount).toBe(1); // e5
+    expect(uncat!.topDeal?.id).toBe("e5");
+  });
+
+  it("sorts sectors by totalUsd desc", () => {
+    const sectors = aggregateSectors(FIXTURE, "30d", NOW);
+    // Largest first: uncategorized ($200M, e5) > ai ($100M) > healthcare ($5M) > climate ($0 disclosed).
+    const top = sectors.map((s) => s.sector);
+    expect(top[0]).toBe("uncategorized");
+    expect(top[1]).toBe("ai");
+    // Climate's totalUsd is 0 — last.
+    expect(top.at(-1)).toBe("climate");
+  });
+
+  it("excludes sectors that have no events inside the window", () => {
+    // 24h window only contains e1 (ai).
+    const sectors = aggregateSectors(FIXTURE, "24h", NOW);
+    expect(sectors.length).toBe(1);
+    expect(sectors[0].sector).toBe("ai");
+  });
+
+  it("matches getFundingSectorBreakdown which reads from the cache", () => {
+    const direct = aggregateSectors(FIXTURE, "30d", NOW);
+    const fromCache = getFundingSectorBreakdown("30d", NOW);
+    expect(fromCache.map((s) => s.sector)).toEqual(direct.map((s) => s.sector));
+  });
+});
+
+describe("aggregateTopMovers", () => {
+  it("merges multiple rounds for the same company by companySlug", () => {
+    const movers = aggregateTopMovers(FIXTURE, "30d", 10, NOW);
+    const acme = movers.find((m) => m.companySlug === "acme-ai");
+    expect(acme).toBeTruthy();
+    expect(acme!.dealCount).toBe(2); // e1 + e3
+    expect(acme!.totalUsd).toBe(100_000_000);
+    expect(acme!.largestRound.id).toBe("e3");
+  });
+
+  it("respects the limit", () => {
+    const top1 = aggregateTopMovers(FIXTURE, "30d", 1, NOW);
+    expect(top1.length).toBe(1);
+    // Highest cumulative in 30d is Delta Defense at $200M.
+    expect(top1[0].companyName).toBe("Delta Defense");
+  });
+
+  it("matches getFundingTopMovers reading from the cache", () => {
+    const direct = aggregateTopMovers(FIXTURE, "7d", 5, NOW);
+    const fromCache = getFundingTopMovers("7d", 5, NOW);
+    expect(fromCache.map((m) => m.companyName)).toEqual(
+      direct.map((m) => m.companyName),
+    );
+  });
+});
+
+describe("getFundingTopDeals", () => {
+  it("returns disclosed-amount deals sorted desc, capped at limit", () => {
+    const deals = getFundingTopDeals("30d", 3, NOW);
+    expect(deals.map((d) => d.id)).toEqual(["e5", "e3", "e1"]);
+  });
+
+  it("excludes events without a disclosed amount", () => {
+    const deals = getFundingTopDeals("30d", 100, NOW);
+    expect(deals.find((d) => d.id === "e4")).toBeUndefined();
+  });
+});
+
+describe("queryFundingEvents", () => {
+  it("filters by roundType", () => {
+    const page = queryFundingEvents({ roundType: "series-a" });
+    expect(page.events.map((e) => e.id)).toEqual(["e1"]);
+    expect(page.total).toBe(1);
+  });
+
+  it("filters by since (inclusive lower bound)", () => {
+    // Cutoff = 7 days ago. Includes e1 (2h), e2 (3d), e3 (5d). Excludes e4+.
+    const since = new Date(NOW - 7 * DAY).toISOString();
+    const page = queryFundingEvents({ since, limit: 50 });
+    const ids = new Set(page.events.map((e) => e.id));
+    expect(ids).toEqual(new Set(["e1", "e2", "e3"]));
+  });
+
+  it("paginates with offset + limit", () => {
+    const page1 = queryFundingEvents({ limit: 2, offset: 0 });
+    const page2 = queryFundingEvents({ limit: 2, offset: 2 });
+    expect(page1.events.length).toBe(2);
+    expect(page2.events.length).toBe(2);
+    expect(page1.total).toBe(6);
+    expect(page2.total).toBe(6);
+    // Newest first across pages, no overlap.
+    const ids = new Set([
+      ...page1.events.map((e) => e.id),
+      ...page2.events.map((e) => e.id),
+    ]);
+    expect(ids.size).toBe(4);
+  });
+
+  it("returns events sorted newest first", () => {
+    const page = queryFundingEvents({ limit: 50 });
+    const closedTimes = page.events.map((e) => Date.parse(e.closedAt));
+    for (let i = 1; i < closedTimes.length; i++) {
+      expect(closedTimes[i - 1]).toBeGreaterThanOrEqual(closedTimes[i]);
+    }
+  });
+
+  it("clamps limit and offset to safe ranges", () => {
+    const overLimit = queryFundingEvents({ limit: 9999 });
+    expect(overLimit.limit).toBe(200);
+    const negOffset = queryFundingEvents({ offset: -10 });
+    expect(negOffset.offset).toBe(0);
+  });
+});
+
+describe("graceful empty data store", () => {
+  it("returns zero-shape totals when the cache is empty", () => {
+    _resetFundingCacheForTests();
+    const totals = getFundingTotals(NOW);
+    expect(totals["24h"].dealCount).toBe(0);
+    expect(totals["24h"].totalUsd).toBe(0);
+    expect(totals["7d"].dealCount).toBe(0);
+    expect(totals["30d"].dealCount).toBe(0);
+
+    expect(getFundingSectorBreakdown("30d", NOW)).toEqual([]);
+    expect(getFundingTopMovers("30d", 10, NOW)).toEqual([]);
+    expect(getFundingTopDeals("30d", 10, NOW)).toEqual([]);
+    expect(queryFundingEvents().events).toEqual([]);
+  });
+});

--- a/src/lib/funding/aggregate.ts
+++ b/src/lib/funding/aggregate.ts
@@ -1,0 +1,394 @@
+// V4 funding aggregate ETL.
+//
+// Server-only. Reads `FundingEvent[]` from the data-store under the
+// `funding-events` key, groups by time window + sector, and exposes
+// sync getters that the API routes + server components consume.
+//
+// Refresh + caching follows the existing pattern (cf. trending.ts,
+// bluesky-trending.ts):
+//   - module-level mutable cache, seeded empty
+//   - refreshFundingFromStore() pulls Redis, swaps cache, never throws
+//   - 30s rate-limit + in-flight dedupe so a render burst hits Redis once
+//
+// Graceful empty: when no `funding-events` payload exists in the store
+// (which is the current state — collectors aren't wired yet), every
+// getter returns the zero shape. Don't scaffold a fake source — the
+// V4 UI is expected to render an empty state until the producer ships.
+//
+// Exposed surface:
+//   - refreshFundingFromStore()      pull-from-Redis
+//   - getFundingEvents()             flat list, newest first
+//   - getFundingTotals()             24h / 7d / 30d count + USD totals
+//   - getFundingSectorBreakdown()    sector → totalUsd / dealCount / topDeal
+//   - getFundingTopMovers()          companies with the largest single round
+//   - getFundingTopDeals()           highest-amount events in a window
+
+import type {
+  FundingEvent,
+  FundingEventsFile,
+  FundingEventRound,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Time-window primitives
+// ---------------------------------------------------------------------------
+
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+export type FundingWindow = "24h" | "7d" | "30d";
+
+const WINDOW_MS: Record<FundingWindow, number> = {
+  "24h": MS_PER_DAY,
+  "7d": 7 * MS_PER_DAY,
+  "30d": 30 * MS_PER_DAY,
+};
+
+function inWindow(event: FundingEvent, window: FundingWindow, nowMs: number): boolean {
+  const closedMs = Date.parse(event.closedAt);
+  if (!Number.isFinite(closedMs)) return false;
+  return nowMs - closedMs <= WINDOW_MS[window] && closedMs <= nowMs;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate output shapes
+// ---------------------------------------------------------------------------
+
+export interface FundingWindowTotals {
+  window: FundingWindow;
+  dealCount: number;
+  /** Sum of amountUsd across events with a disclosed amount. */
+  totalUsd: number;
+  /** Count of events whose amount was undisclosed (excluded from totalUsd). */
+  undisclosedCount: number;
+}
+
+export interface FundingSectorAggregate {
+  sector: string;
+  dealCount: number;
+  totalUsd: number;
+  topDeal: FundingEvent | null;
+}
+
+export interface FundingTotalsByWindow {
+  "24h": FundingWindowTotals;
+  "7d": FundingWindowTotals;
+  "30d": FundingWindowTotals;
+}
+
+export interface FundingTopMover {
+  companyName: string;
+  companySlug?: string;
+  totalUsd: number;
+  dealCount: number;
+  /** The largest single round for this company in the window. */
+  largestRound: FundingEvent;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory cache + refresh hook
+// ---------------------------------------------------------------------------
+
+// Seeded empty — production payload arrives via refreshFundingFromStore().
+let cache: FundingEventsFile = {
+  fetchedAt: new Date(0).toISOString(),
+  source: "empty",
+  events: [],
+};
+
+interface RefreshResult {
+  source: "redis" | "file" | "memory" | "missing";
+  ageMs: number;
+  count: number;
+}
+
+let inflight: Promise<RefreshResult> | null = null;
+let lastRefreshMs = 0;
+const MIN_REFRESH_INTERVAL_MS = 30_000;
+
+/**
+ * Pull the freshest `funding-events` payload from the data-store and swap
+ * it into the in-memory cache. Cheap to call multiple times — internal
+ * dedupe + rate-limit ensure we hit Redis at most once per 30s per process.
+ *
+ * Safe to call from any server component / route handler before reading
+ * any sync getter. Never throws; on Redis miss the existing cache stays.
+ */
+export async function refreshFundingFromStore(): Promise<RefreshResult> {
+  if (inflight) return inflight;
+  const sinceLast = Date.now() - lastRefreshMs;
+  if (sinceLast < MIN_REFRESH_INTERVAL_MS && lastRefreshMs > 0) {
+    return {
+      source: "memory",
+      ageMs: sinceLast,
+      count: cache.events.length,
+    };
+  }
+
+  inflight = (async (): Promise<RefreshResult> => {
+    try {
+      const { getDataStore } = await import("../data-store");
+      const result = await getDataStore().read<FundingEventsFile>(
+        "funding-events",
+      );
+      if (
+        result.data &&
+        result.source !== "missing" &&
+        Array.isArray(result.data.events)
+      ) {
+        cache = result.data;
+      }
+      lastRefreshMs = Date.now();
+      return {
+        source: result.source,
+        ageMs: result.ageMs,
+        count: cache.events.length,
+      };
+    } catch {
+      // Refresh hooks are explicitly never-throws — a Redis blip should
+      // not 500 the page. Existing cache (or seeded-empty) is what we
+      // serve until the next refresh window.
+      lastRefreshMs = Date.now();
+      return { source: "missing", ageMs: 0, count: cache.events.length };
+    }
+  })().finally(() => {
+    inflight = null;
+  });
+
+  return inflight;
+}
+
+// ---------------------------------------------------------------------------
+// Sync getters (read whatever's in the in-memory cache)
+// ---------------------------------------------------------------------------
+
+/** Flat list of events, newest first by closedAt. */
+export function getFundingEvents(): FundingEvent[] {
+  return [...cache.events].sort(
+    (a, b) => Date.parse(b.closedAt) - Date.parse(a.closedAt),
+  );
+}
+
+/** ISO 8601 timestamp of the source payload. */
+export function getFundingFetchedAt(): string {
+  return cache.fetchedAt;
+}
+
+/**
+ * Pure aggregator — exported for testing. Counts deals and sums disclosed
+ * amounts in a given window.
+ */
+export function aggregateWindow(
+  events: readonly FundingEvent[],
+  window: FundingWindow,
+  nowMs: number = Date.now(),
+): FundingWindowTotals {
+  let dealCount = 0;
+  let totalUsd = 0;
+  let undisclosedCount = 0;
+  for (const event of events) {
+    if (!inWindow(event, window, nowMs)) continue;
+    dealCount += 1;
+    if (typeof event.amountUsd === "number" && event.amountUsd > 0) {
+      totalUsd += event.amountUsd;
+    } else {
+      undisclosedCount += 1;
+    }
+  }
+  return { window, dealCount, totalUsd, undisclosedCount };
+}
+
+/** 24h / 7d / 30d totals for the current cache. */
+export function getFundingTotals(
+  nowMs: number = Date.now(),
+): FundingTotalsByWindow {
+  return {
+    "24h": aggregateWindow(cache.events, "24h", nowMs),
+    "7d": aggregateWindow(cache.events, "7d", nowMs),
+    "30d": aggregateWindow(cache.events, "30d", nowMs),
+  };
+}
+
+/**
+ * Per-sector breakdown for events inside `window`. Events without a sector
+ * tag are bucketed under "uncategorized".
+ *
+ * Sorted by totalUsd desc (largest sector first); ties broken by dealCount.
+ */
+export function aggregateSectors(
+  events: readonly FundingEvent[],
+  window: FundingWindow,
+  nowMs: number = Date.now(),
+): FundingSectorAggregate[] {
+  const byKey = new Map<string, FundingSectorAggregate>();
+  for (const event of events) {
+    if (!inWindow(event, window, nowMs)) continue;
+    const sector = event.sector?.trim() || "uncategorized";
+    let bucket = byKey.get(sector);
+    if (!bucket) {
+      bucket = { sector, dealCount: 0, totalUsd: 0, topDeal: null };
+      byKey.set(sector, bucket);
+    }
+    bucket.dealCount += 1;
+    const amount = event.amountUsd ?? 0;
+    if (amount > 0) bucket.totalUsd += amount;
+    if (
+      !bucket.topDeal ||
+      (event.amountUsd ?? 0) > (bucket.topDeal.amountUsd ?? 0)
+    ) {
+      bucket.topDeal = event;
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => {
+    if (b.totalUsd !== a.totalUsd) return b.totalUsd - a.totalUsd;
+    return b.dealCount - a.dealCount;
+  });
+}
+
+export function getFundingSectorBreakdown(
+  window: FundingWindow = "30d",
+  nowMs: number = Date.now(),
+): FundingSectorAggregate[] {
+  return aggregateSectors(cache.events, window, nowMs);
+}
+
+/**
+ * Top movers — companies with the largest cumulative funding in the
+ * window. Output is capped at `limit`, sorted by totalUsd desc.
+ */
+export function aggregateTopMovers(
+  events: readonly FundingEvent[],
+  window: FundingWindow,
+  limit: number,
+  nowMs: number = Date.now(),
+): FundingTopMover[] {
+  const byCompany = new Map<string, FundingTopMover>();
+  for (const event of events) {
+    if (!inWindow(event, window, nowMs)) continue;
+    const key = (event.companySlug ?? event.companyName).toLowerCase();
+    const amount = event.amountUsd ?? 0;
+    const existing = byCompany.get(key);
+    if (!existing) {
+      byCompany.set(key, {
+        companyName: event.companyName,
+        companySlug: event.companySlug,
+        totalUsd: amount,
+        dealCount: 1,
+        largestRound: event,
+      });
+      continue;
+    }
+    existing.totalUsd += amount;
+    existing.dealCount += 1;
+    if ((event.amountUsd ?? 0) > (existing.largestRound.amountUsd ?? 0)) {
+      existing.largestRound = event;
+    }
+  }
+  return Array.from(byCompany.values())
+    .sort((a, b) => b.totalUsd - a.totalUsd)
+    .slice(0, limit);
+}
+
+export function getFundingTopMovers(
+  window: FundingWindow = "7d",
+  limit = 10,
+  nowMs: number = Date.now(),
+): FundingTopMover[] {
+  return aggregateTopMovers(cache.events, window, limit, nowMs);
+}
+
+/** Highest-amount individual events in the window, capped at `limit`. */
+export function getFundingTopDeals(
+  window: FundingWindow = "7d",
+  limit = 10,
+  nowMs: number = Date.now(),
+): FundingEvent[] {
+  return cache.events
+    .filter((e) => inWindow(e, window, nowMs))
+    .filter((e) => typeof e.amountUsd === "number" && e.amountUsd > 0)
+    .sort((a, b) => (b.amountUsd ?? 0) - (a.amountUsd ?? 0))
+    .slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Filters used by the events API
+// ---------------------------------------------------------------------------
+
+export interface FundingEventsFilter {
+  roundType?: FundingEventRound;
+  /** Lower bound on closedAt, inclusive. ISO 8601. */
+  since?: string;
+  /** Upper bound on the result list. */
+  limit?: number;
+  /** Skip this many events from the start (for pagination). */
+  offset?: number;
+}
+
+export interface FundingEventsPage {
+  events: FundingEvent[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export function queryFundingEvents(
+  filter: FundingEventsFilter = {},
+): FundingEventsPage {
+  const limit = clampInt(filter.limit, 1, 200, 50);
+  const offset = clampInt(filter.offset, 0, Number.MAX_SAFE_INTEGER, 0);
+  const sinceMs = filter.since ? Date.parse(filter.since) : Number.NEGATIVE_INFINITY;
+
+  const filtered = cache.events.filter((event) => {
+    if (filter.roundType && event.roundType !== filter.roundType) return false;
+    if (Number.isFinite(sinceMs)) {
+      const closedMs = Date.parse(event.closedAt);
+      if (!Number.isFinite(closedMs)) return false;
+      if (closedMs < sinceMs) return false;
+    }
+    return true;
+  });
+
+  filtered.sort((a, b) => Date.parse(b.closedAt) - Date.parse(a.closedAt));
+
+  return {
+    events: filtered.slice(offset, offset + limit),
+    total: filtered.length,
+    limit,
+    offset,
+  };
+}
+
+function clampInt(
+  value: number | undefined,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  const truncated = Math.trunc(value);
+  if (truncated < min) return min;
+  if (truncated > max) return max;
+  return truncated;
+}
+
+// ---------------------------------------------------------------------------
+// Test-only seam
+// ---------------------------------------------------------------------------
+
+/** Test-only — replace the cache and reset refresh bookkeeping. */
+export function _setFundingCacheForTests(file: FundingEventsFile): void {
+  cache = file;
+  lastRefreshMs = 0;
+  inflight = null;
+}
+
+/** Test-only — clear back to seeded-empty. */
+export function _resetFundingCacheForTests(): void {
+  cache = {
+    fetchedAt: new Date(0).toISOString(),
+    source: "empty",
+    events: [],
+  };
+  lastRefreshMs = 0;
+  inflight = null;
+}

--- a/src/lib/funding/types.ts
+++ b/src/lib/funding/types.ts
@@ -111,3 +111,80 @@ export interface FundingStats {
   thisWeekCount: number;
   sourcesBreakdown: Record<string, number>;
 }
+
+// ---------------------------------------------------------------------------
+// V4 — structured funding event shape
+// ---------------------------------------------------------------------------
+//
+// The V4 funding vertical (W4) consumes a clean, normalized event record
+// rather than raw signals. Producers (PitchBook / Tracxn ingestion in
+// phase 2.1, or a future internal extractor) write `FundingEvent[]` to
+// the data-store under the `funding-events` key; the aggregate ETL in
+// `src/lib/funding/aggregate.ts` reads from there.
+//
+// Distinct from `FundingRound` above — that's the legacy phase-2 shape
+// that mixes display fields (logoUrl, amountDisplay) with structural
+// fields. `FundingEvent` is structural-only; the UI derives display
+// strings from `amountUsd` etc. at render time.
+
+/**
+ * V4 round taxonomy — independent of the legacy `FundingRoundType`.
+ *
+ * Named `FundingEventRound` (not `FundingRound`) because the latter is
+ * already taken by the legacy phase-2 record interface above. The two
+ * shapes are unrelated; new code should prefer the V4 shape.
+ */
+export type FundingEventRound =
+  | "pre-seed"
+  | "seed"
+  | "series-a"
+  | "series-b"
+  | "series-c"
+  | "series-d+"
+  | "bridge"
+  | "acquisition"
+  | "ipo";
+
+/**
+ * How confident the producer is that this event is correctly attributed
+ * to the named company / repo:
+ *   - exact-domain: companyWebsite host matched a tracked repo's homepage
+ *   - exact-name:   companyName matched the repo owner or repo name
+ *   - alias:        companyName matched a curated alias (funding-aliases)
+ *   - fuzzy:        normalized similarity above the matcher threshold
+ */
+export type FundingEventConfidence =
+  | "exact-domain"
+  | "exact-name"
+  | "alias"
+  | "fuzzy";
+
+/** A normalized funding event — the V4 record shape. */
+export interface FundingEvent {
+  /** Stable producer-assigned id (used for dedupe). */
+  id: string;
+  companyName: string;
+  /** Slugified company name — UI uses this for `/funding/<slug>` links. */
+  companySlug?: string;
+  /** owner/name when the event is attributed to a tracked GitHub repo. */
+  repoFullName?: string;
+  roundType: FundingEventRound;
+  /** Round size in USD. Null for undisclosed rounds. */
+  amountUsd?: number;
+  /** ISO 8601 timestamp the round was announced / closed. */
+  closedAt: string;
+  /** Investor names — order = press-release order; first slot is usually the lead. */
+  investors: string[];
+  sourceUrl: string;
+  sourceName: string;
+  confidence: FundingEventConfidence;
+  /** Optional sector tag (ai, fintech, climate, ...) — used by sector aggregates. */
+  sector?: string;
+}
+
+/** Data-store payload shape for the `funding-events` key. */
+export interface FundingEventsFile {
+  fetchedAt: string;
+  source: string;
+  events: FundingEvent[];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
       "src/hooks/__tests__/**/*.test.{ts,tsx}",
       "src/components/**/__tests__/**/*.test.{ts,tsx}",
       "src/lib/__vitest__/**/*.test.{ts,tsx}",
+      // V4 funding aggregate tests live alongside the helper. The
+      // `npm test` glob only sees `src/lib/__tests__/*.test.ts` (top
+      // level, no nesting) so funding/__tests__/ doesn't double-run
+      // under tsx --test.
+      "src/lib/funding/__tests__/**/*.test.{ts,tsx}",
     ],
     // src/lib/__tests__/* and src/lib/pipeline/__tests__/* run under
     // node:test via `npm test` — vitest can't read those (no


### PR DESCRIPTION
## Summary

Backend half of the V4 W4 funding vertical (net-new). UI is a separate parallel agent.

- `FundingEvent` type (V4) added to `src/lib/funding/types.ts` — distinct from the legacy phase-2 `FundingRound` interface; structural-only fields (id, companyName, companySlug?, repoFullName?, roundType, amountUsd?, closedAt, investors, sourceUrl, sourceName, confidence, sector?). Round taxonomy named `FundingEventRound` to avoid collision with the legacy interface.
- `src/lib/funding/aggregate.ts` — server-side ETL with the standard `refreshFundingFromStore()` + sync-getters pattern (30s rate-limit + in-flight dedupe, never throws). Reads the `funding-events` data-store key. Surfaces:
  - `getFundingTotals()` — 24h / 7d / 30d dealCount + totalUsd + undisclosedCount
  - `getFundingSectorBreakdown()` — per-sector totalUsd / dealCount / topDeal
  - `getFundingTopMovers()` — companies merged across multiple rounds
  - `getFundingTopDeals()` — biggest individual rounds in window
  - `queryFundingEvents()` — paginated list with roundType + since filters
- `GET /api/funding/events` — paginated, filtered events. Validates `roundType`, `since`, `limit` (1..200), `offset`. Runtime nodejs. Canonical error envelope.
- `GET /api/funding/sectors` — sector aggregates for `window` (24h | 7d | 30d, default 30d). Runtime nodejs.
- Empty data store gracefully returns empty results — no fake data scaffolding.

## Test plan

- [x] `npx vitest run src/lib/funding` — 21 tests pass (window math, sector buckets including uncategorized, top movers merging same-company rounds, pagination, undisclosed-amount handling, malformed closedAt, graceful-empty cache)
- [x] `npm run typecheck` — clean
- [x] `npm run lint:guards` — 7/7 pass (tokens, err-message, zod-routes, runtime, err-envelope, v3-budget, bypass)
- [x] ESLint clean on all touched files

## Notes

- Vitest config `include` extended to cover `src/lib/funding/__tests__/**` so the test path the W4-A spec asked for is picked up. No overlap with the `npm test` glob (top-level `src/lib/__tests__/*.test.ts` only).
- No producer is wired yet (W4 phase 2.1 ingestion is out of scope). Both routes return empty payloads against the current data store — verified via the "graceful empty" test.