### PR TITLE
V4 W1: layout shell migration

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -17,10 +17,19 @@ const FOOTER_LINKS = [
 
 export function Footer() {
   return (
-    <footer className="w-full bg-bg-primary px-4 md:px-6 py-6 pb-24 md:pb-6">
+    <footer
+      className="w-full px-4 md:px-6 py-6 pb-24 md:pb-6"
+      style={{ background: "var(--v4-bg-000)" }}
+    >
       <FooterBar as="div" className="mx-auto max-w-7xl">
-        <p className="text-xs text-text-muted">
-          <span className="font-mono font-medium text-text-tertiary">
+        <p
+          className="text-xs"
+          style={{ color: "var(--v4-ink-400)" }}
+        >
+          <span
+            className="font-mono font-medium"
+            style={{ color: "var(--v4-ink-300)" }}
+          >
             TrendingRepo
           </span>{" "}
           by{" "}
@@ -28,7 +37,8 @@ export function Footer() {
             href="https://agntdot.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-text-tertiary hover:text-text-secondary transition-colors"
+            className="transition-colors hover:[color:var(--v4-ink-200)]"
+            style={{ color: "var(--v4-ink-300)" }}
           >
             AGNTDOT.com
           </a>

--- a/src/components/layout/HamburgerButton.tsx
+++ b/src/components/layout/HamburgerButton.tsx
@@ -5,8 +5,8 @@ import { useSidebarStore } from "@/lib/store";
 /**
  * HamburgerButton — mobile-only trigger that opens the MobileDrawer.
  *
- * V2 chrome (visual only): 1.5px-stroke icon at `--v2-ink-200`, no border
- * at rest, `--v2-line-200` 1px border + faint `--v2-bg-050` wash on hover.
+ * V4 chrome (visual only): 1.5px-stroke icon at `--v4-ink-200`, no border
+ * at rest, `--v4-line-200` 1px border + faint `--v4-bg-050` wash on hover.
  * Open behavior, accessibility, and store wiring are unchanged.
  */
 export function HamburgerButton() {
@@ -20,17 +20,17 @@ export function HamburgerButton() {
         background: "transparent",
         border: "1px solid transparent",
         borderRadius: 2,
-        color: "var(--v3-ink-200)",
+        color: "var(--v4-ink-200)",
       }}
       onMouseEnter={(e) => {
-        e.currentTarget.style.borderColor = "var(--v3-line-200)";
-        e.currentTarget.style.background = "var(--v3-bg-050)";
-        e.currentTarget.style.color = "var(--v3-ink-100)";
+        e.currentTarget.style.borderColor = "var(--v4-line-200)";
+        e.currentTarget.style.background = "var(--v4-bg-050)";
+        e.currentTarget.style.color = "var(--v4-ink-100)";
       }}
       onMouseLeave={(e) => {
         e.currentTarget.style.borderColor = "transparent";
         e.currentTarget.style.background = "transparent";
-        e.currentTarget.style.color = "var(--v3-ink-200)";
+        e.currentTarget.style.color = "var(--v4-ink-200)";
       }}
       aria-label="Open menu"
     >

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -7,15 +7,15 @@
  * maintain one navigation layout. Framer Motion drives the slide + fade,
  * with a `prefers-reduced-motion` bypass that snaps the drawer open/closed.
  *
- * V2 chrome:
- *   - Panel: `--v2-bg-050` background, `--v2-line-200` right hairline,
- *     2px corner radius (matches V2 cards).
- *   - Backdrop: black/60 (unchanged) — V2 has no opinion on overlay tint.
+ * V4 chrome:
+ *   - Panel: bg-025 background, line-200 right hairline,
+ *     2px corner radius.
+ *   - Backdrop: black/60 (unchanged) — V4 has no opinion on overlay tint.
  *   - Header strip: terminal-bar `// MENU · MOBILE` (mono uppercase,
- *     `--v2-line-std` bottom border) + ghost close button.
- *   - The inner V1 mobile-only header strip rendered by SidebarContent
+ *     line-200 bottom border) + ghost close button.
+ *   - The inner mobile-only header strip rendered by SidebarContent
  *     (when `onClose` is provided) is suppressed via a scoped arbitrary
- *     selector so we present a single V2 header. We still pass `onClose`
+ *     selector so we present a single V4 header. We still pass `onClose`
  *     because SidebarContent's nav handlers call it to dismiss the drawer
  *     after a tap — that behavior must remain identical.
  *
@@ -90,9 +90,11 @@ export function MobileDrawer() {
             role="dialog"
             aria-modal="true"
             aria-label="Navigation"
-            className="v3-panel md:hidden fixed inset-y-0 left-0 w-[85vw] max-w-[320px] z-[60] flex flex-col"
+            className="md:hidden fixed inset-y-0 left-0 w-[85vw] max-w-[320px] z-[60] flex flex-col min-w-0"
             style={{
-              borderRight: "1px solid var(--v3-line-200)",
+              background: "var(--v4-bg-025)",
+              border: "1px solid var(--v4-line-200)",
+              borderRight: "1px solid var(--v4-line-200)",
               borderTopRightRadius: 2,
               borderBottomRightRadius: 2,
             }}
@@ -107,29 +109,31 @@ export function MobileDrawer() {
             <div
               className="shrink-0 flex items-center gap-2 px-3 py-2"
               style={{
-                borderBottom: "1px solid var(--v3-line-std)",
-                background: "var(--v3-bg-050)",
+                borderBottom: "1px solid var(--v4-line-200)",
+                background: "var(--v4-bg-050)",
               }}
             >
               <span aria-hidden className="flex items-center gap-1.5">
                 <span
                   className="block w-1.5 h-1.5 rounded-full"
-                  style={{ background: "var(--v3-acc)" }}
+                  style={{ background: "var(--v4-acc)" }}
                 />
                 <span
                   className="block w-1.5 h-1.5 rounded-full"
-                  style={{ background: "var(--v3-line-200)" }}
+                  style={{ background: "var(--v4-line-200)" }}
                 />
                 <span
                   className="block w-1.5 h-1.5 rounded-full"
-                  style={{ background: "var(--v3-line-200)" }}
+                  style={{ background: "var(--v4-line-200)" }}
                 />
               </span>
               <span
-                className="v2-mono flex-1 truncate"
+                className="flex-1 truncate uppercase"
                 style={{
+                  fontFamily: "var(--v4-mono)",
                   fontSize: 11,
-                  color: "var(--v3-ink-200)",
+                  letterSpacing: "var(--v4-track-18)",
+                  color: "var(--v4-ink-200)",
                 }}
               >
                 {"// MENU · MOBILE"}
@@ -138,7 +142,6 @@ export function MobileDrawer() {
                 type="button"
                 onClick={close}
                 aria-label="Close menu"
-                className="v3-button"
                 style={{
                   height: 28,
                   width: 28,
@@ -147,22 +150,25 @@ export function MobileDrawer() {
                   alignItems: "center",
                   justifyContent: "center",
                   borderRadius: 2,
+                  border: "1px solid var(--v4-line-300)",
+                  background: "var(--v4-bg-050)",
+                  color: "var(--v4-ink-200)",
                 }}
               >
                 <X className="w-3.5 h-3.5" strokeWidth={1.5} aria-hidden="true" />
               </button>
             </div>
 
-            {/* Body wrapper. Suppress the V1 mobile-only header strip
+            {/* Body wrapper. Suppress the inner mobile-only header strip
                 that SidebarContent renders when `onClose` is provided —
-                we already show our V2 terminal-bar above. The scoped
-                style hides only the V1 strip (the first child div of
+                we already show our V4 terminal-bar above. The scoped
+                style hides only the inner strip (the first child div of
                 SidebarContent's root that is itself `md:hidden`) without
                 touching the shared component. */}
             <style>{`
-              .v2-mobile-drawer-body > div > div.md\\:hidden:first-child { display: none; }
+              .v4-mobile-drawer-body > div > div.md\\:hidden:first-child { display: none; }
             `}</style>
-            <div className="v2-mobile-drawer-body flex-1 min-h-0 flex flex-col">
+            <div className="v4-mobile-drawer-body flex-1 min-h-0 flex flex-col">
               {data ? (
                 <SidebarContent
                   categoryStats={data.categoryStats}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -9,10 +9,10 @@ import { ROUTES } from "@/lib/constants";
 /**
  * MobileNav — fixed bottom navigation for <md breakpoint.
  *
- * V2 chrome: `--v2-bg-000` bar with `--v2-line-200` top hairline. Each
- * tab is a `--v2-bg-050` card with `--v2-line-std` 1px / 2px-corner
- * border. Active tab is signaled by a 2px `--v2-acc` indicator BAR
- * above the icon (not a filled pill) plus an `--v2-acc` icon + label.
+ * V4 chrome: `--v4-bg-000` bar with `--v4-line-200` top hairline. Each
+ * tab is a `--v4-bg-050` card with `--v4-line-200` 1px / 2px-corner
+ * border. Active tab is signaled by a 2px `--v4-acc` indicator BAR
+ * above the icon (not a filled pill) plus an `--v4-acc` icon + label.
  * Labels are mono uppercase 9px tracking 0.18em.
  *
  * Trimmed to 3 tabs as of Phase 1C: Home, Watchlist, Search. Categories and
@@ -36,8 +36,8 @@ export function MobileNav() {
         "pb-[env(safe-area-inset-bottom)]",
       )}
       style={{
-        background: "var(--v3-bg-000)",
-        borderTop: "1px solid var(--v3-line-200)",
+        background: "var(--v4-bg-000)",
+        borderTop: "1px solid var(--v4-line-200)",
       }}
     >
       <div className="flex items-stretch justify-around gap-2 px-2 py-2 h-[80px]">
@@ -56,10 +56,10 @@ export function MobileNav() {
                 "transition-colors",
               )}
               style={{
-                background: "var(--v3-bg-050)",
-                border: "1px solid var(--v3-line-std)",
+                background: "var(--v4-bg-050)",
+                border: "1px solid var(--v4-line-200)",
                 borderRadius: 2,
-                color: isActive ? "var(--v3-acc)" : "var(--v3-ink-300)",
+                color: isActive ? "var(--v4-acc)" : "var(--v4-ink-300)",
               }}
               aria-current={isActive ? "page" : undefined}
             >
@@ -69,9 +69,9 @@ export function MobileNav() {
                 className="absolute top-0 left-3 right-3"
                 style={{
                   height: 2,
-                  background: isActive ? "var(--v3-acc)" : "transparent",
+                  background: isActive ? "var(--v4-acc)" : "transparent",
                   boxShadow: isActive
-                    ? "0 0 8px var(--v3-acc-glow)"
+                    ? "0 0 8px var(--v4-acc-glow)"
                     : undefined,
                 }}
               />
@@ -81,8 +81,9 @@ export function MobileNav() {
                 aria-hidden="true"
               />
               <span
-                className="v2-mono leading-none"
+                className="leading-none uppercase"
                 style={{
+                  fontFamily: "var(--v4-mono)",
                   fontSize: 9,
                   letterSpacing: "0.18em",
                 }}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -79,7 +79,6 @@ function LaunchpadStrip() {
             className={cn(
               "nav relative flex h-8 items-center justify-center gap-1.5 px-1",
               "text-[10px] transition-colors duration-150",
-              active && "v2-bracket",
             )}
             style={{
               background: active ? "var(--v4-acc-soft)" : "var(--v4-bg-050)",

--- a/src/components/layout/SidebarContent.tsx
+++ b/src/components/layout/SidebarContent.tsx
@@ -322,18 +322,26 @@ export function SidebarContent({
       {onClose && (
         <div
           className="md:hidden flex items-center justify-between p-3 border-b shrink-0"
-          style={{ borderColor: "var(--v2-line-100)" }}
+          style={{ borderColor: "var(--v4-line-100)" }}
         >
           <span
-            className="inline-flex items-center gap-2 v2-mono"
-            style={{ color: "var(--v2-ink-100)", fontSize: 12 }}
+            className="inline-flex items-center gap-2 uppercase"
+            style={{
+              fontFamily: "var(--v4-mono)",
+              letterSpacing: "var(--v4-track-18)",
+              color: "var(--v4-ink-100)",
+              fontSize: 12,
+            }}
           >
             {APP_NAME}
             <span
-              className="v2-tag"
+              className="uppercase"
               style={{
-                color: "var(--v2-acc)",
-                borderColor: "var(--v2-acc)",
+                fontFamily: "var(--v4-mono)",
+                letterSpacing: "var(--v4-track-18)",
+                color: "var(--v4-acc)",
+                border: "1px solid var(--v4-acc)",
+                padding: "1px 4px",
                 fontSize: 9,
               }}
             >
@@ -345,7 +353,7 @@ export function SidebarContent({
             onClick={onClose}
             aria-label="Close menu"
             className="w-9 h-9 flex items-center justify-center"
-            style={{ color: "var(--v2-ink-300)" }}
+            style={{ color: "var(--v4-ink-300)" }}
           >
             <X className="w-4 h-4" />
           </button>

--- a/src/components/layout/SidebarFooter.tsx
+++ b/src/components/layout/SidebarFooter.tsx
@@ -12,7 +12,7 @@ export function SidebarFooter() {
   return (
     <div
       className="shrink-0 space-y-3 border-t px-3 py-3"
-      style={{ borderColor: "var(--v3-line-100)" }}
+      style={{ borderColor: "var(--v4-line-100)" }}
     >
       <BgThemePicker compact />
       <AccentPicker compact />

--- a/src/components/layout/SidebarSection.tsx
+++ b/src/components/layout/SidebarSection.tsx
@@ -41,7 +41,10 @@ export function SidebarSection({
   const bodyId = `sidebar-section-body-${id}`;
 
   return (
-    <section className="border-b border-border-secondary last:border-b-0">
+    <section
+      className="last:border-b-0"
+      style={{ borderBottom: "1px solid var(--v4-line-100)" }}
+    >
       <button
         type="button"
         id={headerId}
@@ -50,16 +53,23 @@ export function SidebarSection({
         aria-controls={bodyId}
         className={cn(
           "group w-full flex items-center justify-between",
-          "px-3 pt-4 pb-2",
-          "hover:bg-bg-card-hover transition-colors",
+          "px-3 pt-4 pb-2 transition-colors",
         )}
+        style={{ background: "transparent" }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = "var(--v4-bg-100)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = "transparent";
+        }}
       >
         <span className="flex items-center gap-2">
           <ChevronDown
             className={cn(
-              "w-3 h-3 text-text-tertiary shrink-0 transition-transform duration-200 motion-reduce:transition-none",
+              "w-3 h-3 shrink-0 transition-transform duration-200 motion-reduce:transition-none",
               collapsed ? "-rotate-90" : "rotate-0",
             )}
+            style={{ color: "var(--v4-ink-300)" }}
             strokeWidth={2.5}
             aria-hidden="true"
           />

--- a/src/components/layout/SidebarSkeleton.tsx
+++ b/src/components/layout/SidebarSkeleton.tsx
@@ -41,7 +41,10 @@ export function SidebarSkeleton() {
         <Row />
         <Row />
       </div>
-      <div className="h-12 border-t border-border-primary" />
+      <div
+        className="h-12"
+        style={{ borderTop: "1px solid var(--v4-line-200)" }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

V4 W1 layout shell migration — extends the previously-merged globals.css token swap (PR #69) by retokenizing the React layout shell components.

- Replaces all `var(--v3-*)` inline-style refs with `var(--v4-*)` across HamburgerButton, MobileNav, MobileDrawer, SidebarFooter
- Replaces V3 Tailwind utility classes (`bg-bg-primary`, `text-text-tertiary`, `border-border-secondary`, `bg-bg-card-hover`) with inline `var(--v4-*)` styles in Footer, SidebarSection, SidebarSkeleton
- Replaces `v2-mono`, `v2-bracket`, `v3-panel`, `v3-button` legacy classes with V4 equivalents (mono via `--v4-mono` + uppercase + `--v4-track-18`; chrome via `--v4-bg-*` + `--v4-line-*` inline borders)
- Brand mark + active route indicator use `--v4-acc` exclusively (no other accent)
- Layout structure preserved: nav links, route handlers, mobile responsive breakpoints, server/client boundaries unchanged

## Verification

- `npm run typecheck` — pass
- `npm run lint:guards` — 7/7 pass (v3-budget reports drops, never increases)
- Per-file V2/V3 grep across all 14 layout files: 0/0 across the board (`v2-`, `var(--v2-`, `var(--v3-`, `border-border-(primary|secondary)`, `bg-bg-(primary|secondary|tertiary|card)`, `text-text-(primary|secondary|tertiary)`)

## Test plan

- [ ] Vercel preview boots `/`, `/signals`, `/twitter` without 500s
- [ ] Header brand mark renders in `--v4-acc` (Liquid Lava)
- [ ] Sidebar launchpad active state shows V4 acc-soft fill + acc border
- [ ] Mobile drawer opens/closes; backdrop tappable
- [ ] Bottom MobileNav active tab shows V4 acc bar + acc-glow shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)