### PR TITLE
V4: /categories list + [slug] detail

### DIFF
--- a/src/app/categories/[slug]/page.tsx
+++ b/src/app/categories/[slug]/page.tsx
@@ -1,16 +1,31 @@
-// StarScreener - Category detail.
+// /categories/[slug] — V4 ProfileTemplate consumer.
+//
+// Migrated off the legacy TerminalLayout chrome to the V4 ProfileTemplate
+// signature (per master plan §312, same envelope used by /collections/[slug]
+// and /repo/[owner]/[name]). The category becomes the "entity" — identity
+// strip with category title + repo count + topic chips, KpiBand summary,
+// repo grid (RelatedRepoCard) as // 01, About card + Related categories in
+// the right rail.
 
-import type { Metadata } from "next";
 import Link from "next/link";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-export const revalidate = 1800;
 import { CATEGORIES } from "@/lib/constants";
 import { getCategoryIcon } from "@/lib/category-icons";
 import { getDerivedRepos } from "@/lib/derived-repos";
+import { getDerivedCategoryStats } from "@/lib/derived-insights";
 import { absoluteUrl, SITE_NAME } from "@/lib/seo";
-import { TerminalLayout } from "@/components/terminal/TerminalLayout";
-import { CategoryNewsRollup } from "@/components/categories/CategoryNewsRollup";
+import { formatNumber } from "@/lib/utils";
+import type { Repo } from "@/lib/types";
+
+import { ProfileTemplate } from "@/components/templates/ProfileTemplate";
+import { SectionHead } from "@/components/ui/SectionHead";
+import { KpiBand } from "@/components/ui/KpiBand";
+import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
+import { RelatedRepoCard } from "@/components/repo-detail/RelatedRepoCard";
+
+export const revalidate = 1800;
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -63,51 +78,440 @@ export default async function CategoryDetailPage({ params }: PageProps) {
   const category = CATEGORIES.find((c) => c.id === slug);
   if (!category) notFound();
 
-  const repos = getDerivedRepos().filter((repo) => repo.categoryId === slug);
-  const Icon = getCategoryIcon(category.icon);
+  const repos = getDerivedRepos().filter((r) => r.categoryId === slug);
 
-  const heading = (
-    <>
-      <section className="page-head category-detail-head">
-        <div>
-          <div className="crumb">
-            <Link href="/categories">Trend terminal / categories</Link>
-            <span> / </span>
-            <b>{category.name}</b>
-          </div>
-          <h1>
-            {Icon && (
-              <Icon
-                size={28}
-                style={{ color: category.color }}
-                aria-hidden="true"
-              />
-            )}
-            <span>{category.name}</span>
-          </h1>
-          <p className="lede">{category.description}</p>
-        </div>
-        <div className="clock">
-          <span className="big">{repos.length}</span>
-          <span className="live">repos tracked</span>
-        </div>
-      </section>
+  // Aggregates for the KPI band.
+  const totalStars = repos.reduce((sum, r) => sum + r.stars, 0);
+  const languageSet = new Set<string>();
+  for (const r of repos) {
+    if (r.language) languageSet.add(r.language);
+  }
+  const languageCount = languageSet.size;
 
-      <CategoryNewsRollup
-        repos={repos}
-        categorySlug={slug}
-        categoryLabel={category.name}
-      />
-    </>
-  );
+  // Most-active 7d — top repo by 7d star delta in this sector.
+  const mostActive7d = [...repos]
+    .filter((r) => !r.starsDelta7dMissing && r.starsDelta7d > 0)
+    .sort((a, b) => b.starsDelta7d - a.starsDelta7d)[0];
+
+  // Avg momentum across the sector.
+  const avgMomentum =
+    repos.length > 0
+      ? Number(
+          (
+            repos.reduce((sum, r) => sum + r.momentumScore, 0) / repos.length
+          ).toFixed(2),
+        )
+      : 0;
+
+  // Movement counts feed the verdict tone.
+  const breakouts = repos.filter((r) => r.movementStatus === "breakout").length;
+  const hot = repos.filter((r) => r.movementStatus === "hot").length;
+  const moving = breakouts + hot;
+  const verdictTone: "money" | "acc" | "amber" =
+    breakouts > 0 ? "money" : moving > 0 ? "acc" : "amber";
+
+  // Topic chips — most-frequent topics across this category's repos.
+  const topicChips = collectTopTopics(repos, 5);
+
+  // Repos sorted for the grid — momentum-first, then stars.
+  const sortedRepos = [...repos].sort((a, b) => {
+    if (b.momentumScore !== a.momentumScore) {
+      return b.momentumScore - a.momentumScore;
+    }
+    return b.stars - a.stars;
+  });
+  const gridRepos = sortedRepos.slice(0, 24);
+
+  // Related categories — siblings in the same constants order, excluding
+  // this one. Sorted by repo count so the most-populated neighbours appear
+  // first.
+  const allStats = getDerivedCategoryStats();
+  const statsById = new Map(allStats.map((s) => [s.categoryId, s]));
+  const relatedCategories = CATEGORIES.filter((c) => c.id !== slug)
+    .map((c) => {
+      const s = statsById.get(c.id);
+      return {
+        id: c.id,
+        name: c.name,
+        color: c.color,
+        repoCount: s?.repoCount ?? 0,
+      };
+    })
+    .sort((a, b) => b.repoCount - a.repoCount)
+    .slice(0, 6);
 
   return (
-    <TerminalLayout
-      repos={repos}
-      className="home-surface terminal-page category-detail-page"
-      filterBarVariant="category"
-      featuredCount={4}
-      heading={heading}
-    />
+    <main className="home-surface category-detail-page">
+      <ProfileTemplate
+        crumb={
+          <>
+            <b>CATEGORY</b> · TERMINAL · /CATEGORIES/{slug.toUpperCase()}
+          </>
+        }
+        identity={
+          <CategoryIdentity
+            name={category.name}
+            description={category.description}
+            color={category.color}
+            iconName={category.icon}
+            repoCount={repos.length}
+            topics={topicChips}
+          />
+        }
+        clock={
+          <span
+            style={{
+              fontFamily: "var(--font-geist-mono), monospace",
+              fontSize: 10,
+              color: "var(--v4-ink-300)",
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+            }}
+          >
+            {formatNumber(repos.length)} REPOS · TRACKED
+          </span>
+        }
+        verdict={
+          <VerdictRibbon
+            tone={verdictTone}
+            stamp={{
+              eyebrow: "// CATEGORY",
+              headline: `${repos.length} repos tracked`,
+              sub: `${breakouts} breakout · ${hot} hot · avg mom ${avgMomentum.toFixed(1)}`,
+            }}
+            text={
+              <>
+                <b>{category.name}</b> tracks{" "}
+                <span style={{ color: "var(--v4-ink-100)" }}>
+                  {repos.length}
+                </span>{" "}
+                repos.{" "}
+                {breakouts > 0 ? (
+                  <>
+                    <span style={{ color: "var(--v4-money)" }}>
+                      {breakouts} breaking out
+                    </span>{" "}
+                    right now,{" "}
+                  </>
+                ) : null}
+                <span style={{ color: "var(--v4-acc)" }}>{moving} moving</span>{" "}
+                across the sector.
+              </>
+            }
+            actionHref="/categories"
+            actionLabel="ALL CATEGORIES →"
+          />
+        }
+        kpiBand={
+          <KpiBand
+            cells={[
+              {
+                label: "REPOS",
+                value: formatNumber(repos.length),
+                sub: "in this sector",
+                pip: category.color,
+              },
+              {
+                label: "TOTAL STARS",
+                value: formatNumber(totalStars),
+                sub: "lifetime",
+                tone: "money",
+                pip: "var(--v4-money)",
+              },
+              {
+                label: "LANGUAGES",
+                value: formatNumber(languageCount),
+                sub: languageCount > 0 ? "distinct" : "no data",
+                pip: "var(--v4-ink-300)",
+              },
+              {
+                label: "MOST ACTIVE · 7D",
+                value: mostActive7d
+                  ? `+${formatNumber(mostActive7d.starsDelta7d)}`
+                  : "—",
+                sub: mostActive7d ? mostActive7d.fullName : "no movement",
+                tone: mostActive7d ? "money" : "default",
+                pip: "var(--v4-amber)",
+              },
+            ]}
+          />
+        }
+        mainPanels={
+          <>
+            <SectionHead
+              num="// 01"
+              title="Repos · ranked"
+              meta={
+                <>
+                  <b>{gridRepos.length}</b> shown ·{" "}
+                  {repos.length > gridRepos.length
+                    ? `${repos.length} total`
+                    : "all"}
+                </>
+              }
+            />
+            {gridRepos.length > 0 ? (
+              <div className="v4-profile-template__related">
+                {gridRepos.map((repo) => {
+                  const [owner, name] = repo.fullName.split("/");
+                  const href =
+                    owner && name ? `/repo/${owner}/${name}` : undefined;
+                  return (
+                    <RelatedRepoCard
+                      key={repo.fullName}
+                      fullName={repo.fullName}
+                      description={repo.description?.trim() || undefined}
+                      language={
+                        repo.language
+                          ? repo.language.toUpperCase()
+                          : undefined
+                      }
+                      stars={formatNumber(repo.stars)}
+                      similarity={
+                        repo.movementStatus
+                          ? repo.movementStatus.toUpperCase().replace("_", " ")
+                          : undefined
+                      }
+                      href={href}
+                    />
+                  );
+                })}
+              </div>
+            ) : (
+              <p
+                style={{
+                  fontFamily: "var(--font-geist-mono), monospace",
+                  fontSize: 12,
+                  color: "var(--v4-ink-300)",
+                  padding: "12px 0",
+                }}
+              >
+                No repos in this category yet — pool is warming.
+              </p>
+            )}
+          </>
+        }
+        rightRail={
+          <>
+            <SectionHead num="// 02" title="About" as="h3" />
+            <div className="v4-collection-rail-card">
+              <div className="v4-collection-rail-card__row">
+                <span className="v4-collection-rail-card__label">Sector</span>
+                <span className="v4-collection-rail-card__value">
+                  {category.name}
+                </span>
+              </div>
+              <div className="v4-collection-rail-card__row">
+                <span className="v4-collection-rail-card__label">Short</span>
+                <span className="v4-collection-rail-card__value">
+                  {category.shortName}
+                </span>
+              </div>
+              <div className="v4-collection-rail-card__row">
+                <span className="v4-collection-rail-card__label">Repos</span>
+                <span className="v4-collection-rail-card__value">
+                  {formatNumber(repos.length)}
+                </span>
+              </div>
+              <div className="v4-collection-rail-card__row">
+                <span className="v4-collection-rail-card__label">
+                  Avg momentum
+                </span>
+                <span className="v4-collection-rail-card__value">
+                  {avgMomentum.toFixed(1)}
+                </span>
+              </div>
+              <div className="v4-collection-rail-card__row">
+                <span className="v4-collection-rail-card__label">Source</span>
+                <span className="v4-collection-rail-card__value">
+                  src/lib/constants.ts
+                </span>
+              </div>
+            </div>
+
+            <SectionHead num="// 03" title="Related categories" as="h3" />
+            {relatedCategories.length > 0 ? (
+              <ul className="v4-collection-rail-list">
+                {relatedCategories.map((c) => (
+                  <li
+                    key={c.id}
+                    className="v4-collection-rail-list__item"
+                  >
+                    <Link
+                      href={`/categories/${c.id}`}
+                      className="v4-collection-rail-list__link"
+                    >
+                      <span
+                        style={{
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: 8,
+                        }}
+                      >
+                        <span
+                          aria-hidden
+                          style={{
+                            width: 6,
+                            height: 6,
+                            background: c.color,
+                            borderRadius: 1,
+                            flexShrink: 0,
+                          }}
+                        />
+                        <span>{c.name}</span>
+                      </span>
+                      <span className="v4-collection-rail-list__count">
+                        {c.repoCount}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p
+                style={{
+                  fontFamily: "var(--font-geist-mono), monospace",
+                  fontSize: 11,
+                  color: "var(--v4-ink-300)",
+                  padding: "8px 0",
+                }}
+              >
+                No related categories.
+              </p>
+            )}
+          </>
+        }
+      />
+    </main>
   );
+}
+
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  return CATEGORIES.map((c) => ({ slug: c.id }));
+}
+
+// --- Composition helpers --------------------------------------------------
+
+interface CategoryIdentityProps {
+  name: string;
+  description: string;
+  color: string;
+  iconName: string;
+  repoCount: number;
+  topics: string[];
+}
+
+function CategoryIdentity({
+  name,
+  description,
+  color,
+  iconName,
+  repoCount,
+  topics,
+}: CategoryIdentityProps) {
+  const Icon = getCategoryIcon(iconName);
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 16,
+        alignItems: "flex-start",
+        marginTop: 8,
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          width: 56,
+          height: 56,
+          borderRadius: 4,
+          background: "var(--v4-bg-100)",
+          border: `1px solid ${color}`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        {Icon ? (
+          <Icon size={26} style={{ color }} aria-hidden="true" />
+        ) : (
+          <span
+            style={{
+              fontFamily: "var(--font-geist-mono), monospace",
+              fontSize: 22,
+              color,
+              textTransform: "uppercase",
+            }}
+          >
+            {name.slice(0, 2)}
+          </span>
+        )}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <h1
+          className="v4-page-head__h1"
+          style={{ marginTop: 0, marginBottom: 4 }}
+        >
+          {name}
+        </h1>
+        <p
+          className="v4-page-head__lede"
+          style={{ marginTop: 0, marginBottom: 10 }}
+        >
+          {description}.
+        </p>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 12,
+            fontFamily: "var(--font-geist-mono), monospace",
+            fontSize: 11,
+            color: "var(--v4-ink-300)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+          }}
+        >
+          {topics.map((topic) => (
+            <span
+              key={topic}
+              style={{
+                padding: "1px 6px",
+                border: "1px solid var(--v4-line-200)",
+                borderRadius: 2,
+                color: "var(--v4-ink-300)",
+              }}
+            >
+              {topic}
+            </span>
+          ))}
+          <span>
+            REPOS{" "}
+            <b style={{ color: "var(--v4-ink-100)" }}>
+              {formatNumber(repoCount)}
+            </b>
+          </span>
+          {repoCount > 0 ? (
+            <span style={{ color: "var(--v4-money)" }}>● TRACKED</span>
+          ) : (
+            <span style={{ color: "var(--v4-amber)" }}>● WARMING</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function collectTopTopics(repos: Repo[], limit: number): string[] {
+  const counts = new Map<string, number>();
+  for (const repo of repos) {
+    for (const topic of repo.topics ?? []) {
+      counts.set(topic, (counts.get(topic) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([topic]) => topic);
 }

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,16 +1,28 @@
-// StarScreener - Categories hub.
+// /categories — V4 list page.
+//
+// Migrated off the legacy `home-surface` chrome to V4 PageHead + VerdictRibbon
+// + KpiBand + SectionHead. The grid keeps the per-category `<Link>` cards but
+// styled with V4 tokens (--v4-*) instead of the V2/V3 `tool-grid` shells.
+//
+// Mockup reference: home.html § "// 02 Trending now" feel — caps mono headers
+// with an accent verdict ribbon up top. Detail pages live at /categories/[slug].
 
 import Link from "next/link";
 import type { Metadata } from "next";
 
-export const revalidate = 1800;
-
 import { CATEGORIES } from "@/lib/constants";
 import { getCategoryIcon } from "@/lib/category-icons";
 import { getDerivedCategoryStats } from "@/lib/derived-insights";
-import { MomentumBadge } from "@/components/shared/MomentumBadge";
 import { formatNumber } from "@/lib/utils";
 import { absoluteUrl, SITE_NAME } from "@/lib/seo";
+
+import { KpiBand } from "@/components/ui/KpiBand";
+import { LiveDot } from "@/components/ui/LiveDot";
+import { PageHead } from "@/components/ui/PageHead";
+import { SectionHead } from "@/components/ui/SectionHead";
+import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
+
+export const revalidate = 1800;
 
 const CATEGORIES_DESCRIPTION =
   "Browse every tracked GitHub repo sector: AI and ML, web frameworks, devtools, infra, databases, security, mobile, data, crypto, and Rust.";
@@ -39,62 +51,221 @@ export const metadata: Metadata = {
 };
 
 export default async function CategoriesPage() {
-  const stats = new Map(
-    getDerivedCategoryStats().map((s) => [s.categoryId, s]),
-  );
+  const statsList = getDerivedCategoryStats();
+  const stats = new Map(statsList.map((s) => [s.categoryId, s]));
+
+  // KPI aggregates across the populated cohort.
+  const totalRepos = statsList.reduce((sum, s) => sum + s.repoCount, 0);
+  const totalStars = statsList.reduce((sum, s) => sum + s.totalStars, 0);
+  const populated = statsList.filter((s) => s.repoCount > 0).length;
+  const liveCategories = statsList.filter((s) => s.repoCount > 0);
+  const avgMomentum =
+    liveCategories.length > 0
+      ? Number(
+          (
+            liveCategories.reduce((sum, s) => sum + s.avgMomentum, 0) /
+            liveCategories.length
+          ).toFixed(2),
+        )
+      : 0;
+
+  // Hottest sector = highest avg momentum among populated categories.
+  const hottest = [...liveCategories]
+    .sort((a, b) => b.avgMomentum - a.avgMomentum)[0];
+  const hottestCategory = hottest
+    ? CATEGORIES.find((c) => c.id === hottest.categoryId)
+    : undefined;
 
   return (
     <main className="home-surface categories-page">
-      <section className="page-head">
-        <div>
-          <div className="crumb">
-            <b>Trend terminal</b> / categories
-          </div>
-          <h1>Repo sectors ranked by momentum.</h1>
-          <p className="lede">
-            Browse every tracked GitHub repo sector with live repo counts,
-            average momentum, and direct jumps into each terminal surface.
-          </p>
-        </div>
-        <div className="clock">
-          <span className="big">{CATEGORIES.length}</span>
-          <span className="live">sectors live</span>
-        </div>
-      </section>
+      <PageHead
+        crumb={
+          <>
+            <b>CATEGORIES</b> · TERMINAL · /CATEGORIES
+          </>
+        }
+        h1="Repo sectors ranked by momentum."
+        lede="Browse every tracked GitHub repo sector with live repo counts, average momentum, and direct jumps into each terminal surface."
+        clock={
+          <>
+            <span className="big">{CATEGORIES.length}</span>
+            <span className="muted">SECTORS</span>
+            <LiveDot label="LIVE" />
+          </>
+        }
+      />
 
-      <section className="tool-grid categories-grid" aria-label="Categories">
+      <VerdictRibbon
+        tone="acc"
+        stamp={{
+          eyebrow: "// SECTOR INDEX",
+          headline: `${populated} / ${CATEGORIES.length} populated`,
+          sub: `${formatNumber(totalRepos)} repos tracked`,
+        }}
+        text={
+          hottestCategory ? (
+            <>
+              Hottest sector right now is{" "}
+              <span style={{ color: "var(--v4-acc)" }}>
+                {hottestCategory.name}
+              </span>{" "}
+              with average momentum{" "}
+              <b style={{ color: "var(--v4-ink-100)" }}>
+                {hottest!.avgMomentum.toFixed(1)}
+              </b>{" "}
+              across <b>{formatNumber(hottest!.repoCount)}</b> repos.
+            </>
+          ) : (
+            <>
+              {CATEGORIES.length} sectors live. Pool is warming — repo counts
+              repopulate after the next collector cycle.
+            </>
+          )
+        }
+        actionHref="#categories-grid"
+        actionLabel="JUMP TO GRID →"
+      />
+
+      <KpiBand
+        cells={[
+          {
+            label: "SECTORS · LIVE",
+            value: `${populated} / ${CATEGORIES.length}`,
+            sub: populated === CATEGORIES.length ? "all populated" : "with repo data",
+            tone: populated === CATEGORIES.length ? "money" : "default",
+            pip: "var(--v4-acc)",
+          },
+          {
+            label: "REPOS · TRACKED",
+            value: formatNumber(totalRepos),
+            sub: "across all sectors",
+            pip: "var(--v4-ink-300)",
+          },
+          {
+            label: "COMBINED STARS",
+            value: formatNumber(totalStars),
+            sub: "lifetime totals",
+            tone: "money",
+            pip: "var(--v4-money)",
+          },
+          {
+            label: "AVG MOMENTUM",
+            value: avgMomentum.toFixed(1),
+            sub: liveCategories.length > 0 ? "live cohort" : "no data",
+            tone: "acc",
+            pip: "var(--v4-amber)",
+          },
+        ]}
+      />
+
+      <SectionHead
+        num="// 01"
+        title="Sectors · ranked by momentum"
+        meta={
+          <>
+            <b>{CATEGORIES.length}</b> total · <b>{populated}</b> populated
+          </>
+        }
+      />
+
+      <section
+        id="categories-grid"
+        className="v4-categories-grid"
+        aria-label="Categories"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+          gap: 12,
+          padding: "12px 0",
+        }}
+      >
         {CATEGORIES.map((cat) => {
           const Icon = getCategoryIcon(cat.icon);
           const s = stats.get(cat.id);
+          const repoCount = s?.repoCount ?? 0;
+          const avg = s?.avgMomentum ?? 0;
           return (
             <Link
               key={cat.id}
               href={`/categories/${cat.id}`}
-              className="tool category-card"
-              style={{ borderTopColor: cat.color }}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                padding: 14,
+                background: "var(--v4-bg-100)",
+                border: "1px solid var(--v4-line-200)",
+                borderTop: `2px solid ${cat.color}`,
+                borderRadius: 4,
+                color: "var(--v4-ink-100)",
+                textDecoration: "none",
+                transition: "background 120ms ease, border-color 120ms ease",
+              }}
             >
-              <span className="t-num">
-                {formatNumber(s?.repoCount ?? 0)} repos
+              <span
+                style={{
+                  fontFamily: "var(--font-geist-mono), monospace",
+                  fontSize: 10,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "var(--v4-ink-400)",
+                }}
+              >
+                {formatNumber(repoCount)} REPOS
               </span>
-              <span className="category-card-title">
+              <span
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  fontSize: 14,
+                  fontWeight: 500,
+                  color: "var(--v4-ink-000)",
+                }}
+              >
                 {Icon && (
                   <Icon
                     size={18}
-                    style={{ color: cat.color }}
-                    className="shrink-0"
+                    style={{ color: cat.color, flexShrink: 0 }}
                     aria-hidden="true"
                   />
                 )}
                 <span>{cat.name}</span>
               </span>
-              <span className="t-d">{cat.description}</span>
-              <span className="t-foot">
-                <MomentumBadge
-                  score={s?.avgMomentum ?? 0}
-                  size="sm"
-                  showLabel
-                />
-                <span className="ar">-&gt;</span>
+              <span
+                style={{
+                  fontSize: 12,
+                  lineHeight: 1.45,
+                  color: "var(--v4-ink-300)",
+                  flex: 1,
+                }}
+              >
+                {cat.description}
+              </span>
+              <span
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 8,
+                  paddingTop: 6,
+                  borderTop: "1px solid var(--v4-line-200)",
+                  fontFamily: "var(--font-geist-mono), monospace",
+                  fontSize: 10,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "var(--v4-ink-400)",
+                }}
+              >
+                <span>
+                  AVG MOM{" "}
+                  <b style={{ color: "var(--v4-ink-100)" }}>
+                    {avg.toFixed(1)}
+                  </b>
+                </span>
+                <span style={{ color: "var(--v4-acc)" }} aria-hidden="true">
+                  →
+                </span>
               </span>
             </Link>
           );


### PR DESCRIPTION
## Summary

- `/categories` list page migrated to V4: PageHead crumb (`CATEGORIES · TERMINAL · /CATEGORIES`), VerdictRibbon (acc tone, hottest-sector callout), KpiBand (sectors live · repos · stars · avg momentum), SectionHead grid of category cards. ISR `revalidate = 1800`.
- `/categories/[slug]` detail page wrapped in `<ProfileTemplate>` per master plan §312: identity (icon + title + repo count + topic chips), KpiBand (Repos, Total stars, Languages, Most-active 7d), main panels with `RelatedRepoCard` grid, right rail with About card + Related categories list.
- Drops `TerminalLayout`, `MomentumBadge`, and the legacy `tool-grid`/`category-card` shells. Verdict tone derives from breakout / hot counts (money / acc / amber).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint:guards` 7/7 pass
- [x] No V2/V3 tokens, no Tailwind utility classes in the changed files
- [ ] Visual smoke on a Vercel preview — list page + 2-3 sector slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)