### PR TITLE
V4: /top10 migration

### DIFF
--- a/src/app/top10/page.tsx
+++ b/src/app/top10/page.tsx
@@ -1,80 +1,46 @@
-// TrendingRepo — /top10
+// TrendingRepo — /top10 (V4)
 //
-// TOOL · 05. Pick a category, snapshot a chart, and post it. Eight rankings
-// (REPOS · LLMS · AGENTS · MCPS · SKILLS · MOVERS · NEWS · FUNDING) backed
-// by the live corpus, each renderable as a 4-aspect share card.
+// Today's leaderboard. Composes V4 primitives directly: PageHead +
+// VerdictRibbon + KpiBand + two SectionHead bands. The first lists the
+// canonical top-10 repos via <RankRow>, the second points operators
+// at the per-category surfaces under /categories.
 //
-// All readers are wired to the data-store. Async refresh hooks run in
-// parallel up front so a fresh Redis payload swaps in before the sync
-// getters fire; everything degrades to bundled JSON when Redis is absent.
-// Promise.allSettled on the refreshes means a single failed source can't
-// block the page.
+// All readers are wired to the data-store. The repo set comes from
+// getDerivedRepos(), which is hydrated by the ambient refresh hooks of
+// the surfaces that share its caches (homepage, /repos, the /top10
+// per-category sub-routes). On a cold Lambda the bundled JSON snapshot
+// seeds the cache, so the page never blanks out.
 
+import Link from "next/link";
 import type { Metadata } from "next";
 
 import { getDerivedRepos } from "@/lib/derived-repos";
-import { getHfModelsTrending, refreshHfModelsFromStore } from "@/lib/huggingface";
-import {
-  getSkillsSignalData,
-  getMcpSignalData,
-} from "@/lib/ecosystem-leaderboards";
-import {
-  getHnTopStories,
-  refreshHackernewsTrendingFromStore,
-} from "@/lib/hackernews-trending";
-import {
-  getBlueskyTopPosts,
-  refreshBlueskyTrendingFromStore,
-} from "@/lib/bluesky-trending";
-import {
-  getDevtoTopArticles,
-  refreshDevtoTrendingFromStore,
-} from "@/lib/devto-trending";
-import {
-  getLobstersTopStories,
-  refreshLobstersTrendingFromStore,
-} from "@/lib/lobsters-trending";
-import {
-  getRecentLaunches,
-  refreshProducthuntLaunchesFromStore,
-} from "@/lib/producthunt";
-import {
-  getFundingSignalsThisWeek,
-  refreshFundingNewsFromStore,
-} from "@/lib/funding-news";
 
 import { SITE_NAME, absoluteUrl } from "@/lib/seo";
-import { AGENT_REPO_SET } from "@/lib/agent-repos";
 import {
-  buildAgentTop10,
-  buildFundingTop10,
-  buildLlmTop10,
-  buildMcpTop10,
-  buildMoversTop10,
-  buildNewsTop10,
   buildRepoTop10,
-  buildSkillsTop10,
   emptyBundle,
-  reposToSlice,
-  type BuildExtras,
 } from "@/lib/top10/builders";
-import { loadPriorTopSlugs } from "@/lib/top10/snapshots";
-import { readSparklineBatch } from "@/lib/top10/sparkline-store";
-import {
-  CATEGORY_META,
-  type RepoSliceLite,
-  type Top10Category,
-  type Top10Payload,
-} from "@/lib/top10/types";
-import { Top10Page } from "@/components/top10/Top10Page";
+import { CATEGORIES } from "@/lib/constants";
+import { formatNumber, getRelativeTime } from "@/lib/utils";
 
-// 30-min ISR — same cadence as homepage; underlying readers refresh every
-// 6 hours via cron, so a tighter cache wastes work without buying freshness.
-export const revalidate = 1800;
+// V4 primitives.
+import { PageHead } from "@/components/ui/PageHead";
+import { SectionHead } from "@/components/ui/SectionHead";
+import { KpiBand } from "@/components/ui/KpiBand";
+import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
+import { LiveDot } from "@/components/ui/LiveDot";
+import { RankRow } from "@/components/ui/RankRow";
+
+// ISR — 10-minute cadence matches the V4 leaderboard surfaces. Underlying
+// readers refresh every 6 hours via cron; tighter cache wastes work
+// without buying freshness, looser one drifts from the consensus board
+// users land on next.
+export const revalidate = 600;
 
 const TITLE = `Top 10 — ${SITE_NAME}`;
 const DESCRIPTION =
-  "Top 10 across eight surfaces — repos, LLMs, agents, MCPs, skills, movers, news, funding. One-click share to X, IG, YT, Square. Updated every 6 hours.";
+  "Top 10 repos by cross-signal score — GitHub stars, Reddit, Hacker News, ProductHunt, Bluesky, dev.to, Lobsters. Updated every 6 hours.";
 const OG_IMAGE = absoluteUrl("/api/og/top10?cat=repos&window=7d&aspect=h");
 
 export const metadata: Metadata = {
@@ -104,126 +70,300 @@ export const metadata: Metadata = {
   },
 };
 
+// V4 inline panel chrome — line-200 border, bg-050 fill, no rounded
+// corners (V4 cards use radius 2). Inline rather than via a class so the
+// migration is grep-clean of v2-* / v3-* shells.
+const PANEL_STYLE = {
+  border: "1px solid var(--v4-line-200)",
+  background: "var(--v4-bg-050)",
+  borderRadius: 2,
+};
+
+// V4 mono header strip — sits above each panel body. Caps mono key in
+// --v4-acc + ink-400 trailing detail. Mirrors the .panel-head pattern
+// the consensus + funding pages use, minus the v3 vars.
+const PANEL_HEAD_STYLE = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "10px 14px",
+  borderBottom: "1px solid var(--v4-line-200)",
+  fontFamily: "var(--v4-mono)",
+  fontSize: 11,
+  letterSpacing: "0.14em",
+  textTransform: "uppercase" as const,
+  color: "var(--v4-ink-400)",
+};
+
 export default async function Top10RootPage() {
-  // Refresh all async sources in parallel. Each call is rate-limited (30s
-  // floor) and never throws — Promise.allSettled is belt + braces in case
-  // a future revision regresses that contract.
-  await Promise.allSettled([
-    refreshHfModelsFromStore(),
-    refreshHackernewsTrendingFromStore(),
-    refreshBlueskyTrendingFromStore(),
-    refreshDevtoTrendingFromStore(),
-    refreshLobstersTrendingFromStore(),
-    refreshProducthuntLaunchesFromStore(),
-    refreshFundingNewsFromStore(),
-  ]);
-
-  // Sync getters now read from the in-memory cache the refreshes just primed.
-  // getDerivedRepos drives REPOS / AGENTS / MOVERS in one pass.
+  // Repo set is the only signal this page renders. getDerivedRepos pulls
+  // from the same in-memory cache the homepage primes; the bundled JSON
+  // seed handles cold-start. No per-render refresh hook needed —
+  // cross-signal score on a 7d window is steady across 10-minute ticks.
   const repos = getDerivedRepos();
-  const hfModels = getHfModelsTrending(40);
-  const hn = getHnTopStories(40);
-  const bsky = getBlueskyTopPosts(40);
-  const devto = getDevtoTopArticles(40);
-  const lobsters = getLobstersTopStories(40);
-  const ph = getRecentLaunches(7, 40);
-  const funding = getFundingSignalsThisWeek();
 
-  const [skillsRes, mcpRes, priorSlugsRes] = await Promise.allSettled([
-    getSkillsSignalData(),
-    getMcpSignalData(),
-    // Yesterday's snapshot drives the NEW ENTRY badge. allSettled because the
-    // snapshot may not exist yet (cold-start before any cron has run).
-    loadPriorTopSlugs(),
-  ]);
-
-  const skillsBoard =
-    skillsRes.status === "fulfilled" ? skillsRes.value.combined : null;
-  const mcpBoard = mcpRes.status === "fulfilled" ? mcpRes.value.board : null;
-  const priorSlugs =
-    priorSlugsRes.status === "fulfilled" ? priorSlugsRes.value : null;
-
-  // Resolve the "today's slugs" we need sparklines for, then batch-read them.
-  // Per-category slug lists drive 5 small batched Redis reads (one per
-  // non-repo category, fanned out 8-at-a-time inside the helper) so the
-  // sparkline payload arrives with the rest of the bundle data.
-  const llmSlugs = hfModels.slice(0, 10).map((m) => m.id);
-  const mcpSlugs = (mcpBoard?.items ?? []).slice(0, 10).map((it) => it.id);
-  const skillSlugs = (skillsBoard?.items ?? []).slice(0, 10).map((it) => it.id);
-  const fundingSlugs = funding.slice(0, 10).map((s) => s.id);
-  const newsSlugs = buildNewsTop10({
-    hn,
-    bluesky: bsky,
-    devto,
-    lobsters,
-    producthunt: ph,
-  }).items.map((i) => i.slug);
-
-  const [llmSpark, mcpSpark, skillSpark, newsSpark, fundingSpark] =
-    await Promise.all([
-      readSparklineBatch("llms", llmSlugs).catch(() => new Map()),
-      readSparklineBatch("mcps", mcpSlugs).catch(() => new Map()),
-      readSparklineBatch("skills", skillSlugs).catch(() => new Map()),
-      readSparklineBatch("news", newsSlugs).catch(() => new Map()),
-      readSparklineBatch("funding", fundingSlugs).catch(() => new Map()),
-    ]);
-
-  // Per-category extras package — NEW ENTRY badge from prior snapshot +
-  // sparklines from the per-category ring buffer.
-  const extras = (cat: Top10Category, sparklines?: Map<string, number[]>): BuildExtras => ({
-    priorTopSlugs: priorSlugs ? priorSlugs[cat] : undefined,
-    sparklines,
-  });
-
-  // Build all 8 bundles. Each builder handles empty input gracefully (returns
-  // an emptyBundle when its slice is empty) so the page still renders even on
-  // a cold lambda with no Redis.
-  const payload: Top10Payload = {
-    repos:
-      repos.length > 0
-        ? buildRepoTop10(repos, "7d", "cross-signal", extras("repos"))
-        : emptyBundle("7d"),
-    llms:
-      hfModels.length > 0
-        ? buildLlmTop10(hfModels, "7d", extras("llms", llmSpark))
-        : emptyBundle("7d"),
-    agents:
-      repos.length > 0
-        ? buildAgentTop10(repos, "7d", "cross-signal", extras("agents"))
-        : emptyBundle("7d"),
-    mcps: buildMcpTop10(mcpBoard, "7d", extras("mcps", mcpSpark)),
-    skills: buildSkillsTop10(skillsBoard, "7d", extras("skills", skillSpark)),
-    movers:
-      repos.length > 0
-        ? buildMoversTop10(repos, "24h", extras("movers"))
-        : emptyBundle("24h"),
-    news: buildNewsTop10(
-      { hn, bluesky: bsky, devto, lobsters, producthunt: ph },
-      extras("news", newsSpark),
-    ),
-    funding:
-      funding.length > 0
-        ? buildFundingTop10(funding, extras("funding", fundingSpark))
-        : emptyBundle("7d"),
-  };
-
-  // Top-80 repo slice for client-side window/metric switching of REPOS /
-  // AGENTS / MOVERS. Tag agents up-front so the client doesn't need to
-  // re-import the AGENT_REPO_SET. ~30 KB serialised — cheaper than pre-baking
-  // every (window, metric) combination server-side.
-  const repoSlice: RepoSliceLite[] =
+  // Reuse the canonical top-10 repo bundle so /top10 and the per-category
+  // sub-routes stay in lock-step. emptyBundle handles the cold-start case.
+  const bundle =
     repos.length > 0
-      ? reposToSlice(repos, 80).map((r) => ({
-          ...r,
-          isAgent: AGENT_REPO_SET.has(r.fullName.toLowerCase()),
-        }))
-      : [];
+      ? buildRepoTop10(repos, "7d", "cross-signal")
+      : emptyBundle("7d");
+  const topItems = bundle.items;
+  const topRepo = topItems[0];
+
+  // repoToItem encodes slug = repo.fullName, so the slug round-trips back
+  // into the underlying derived row for the language / topics / delta lookups
+  // the KPI band needs.
+  const repoByFullName = new Map(repos.map((r) => [r.fullName, r]));
+  const totalStars24h = topItems.reduce((sum, item) => {
+    const row = repoByFullName.get(item.slug);
+    return sum + (row?.starsDelta24h ?? 0);
+  }, 0);
+
+  // Top language across the top 10 — most frequent non-empty language.
+  const langCounts = new Map<string, number>();
+  for (const item of topItems) {
+    const lang = repoByFullName.get(item.slug)?.language;
+    if (lang) langCounts.set(lang, (langCounts.get(lang) ?? 0) + 1);
+  }
+  const topLanguage =
+    [...langCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "—";
+
+  // Hottest tag — most frequent topic across the top-10's underlying repos.
+  const tagCounts = new Map<string, number>();
+  for (const item of topItems) {
+    const topics = repoByFullName.get(item.slug)?.topics ?? [];
+    for (const t of topics) tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+  }
+  const hottestTag =
+    [...tagCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "—";
+
+  // Computed-ago label for the verdict ribbon.
+  const computedAt = new Date().toISOString();
+  const computedAgo = getRelativeTime(computedAt);
+  const computedClock = computedAt.slice(11, 19);
 
   return (
-    <Top10Page
-      payload={payload}
-      categoryMeta={CATEGORY_META}
-      repoSlice={repoSlice}
-    />
+    <main className="home-surface">
+      <PageHead
+        crumb={
+          <>
+            <b>TOP 10</b> · TERMINAL · /TOP10
+          </>
+        }
+        h1="Today's leaders — the cross-signal top 10."
+        lede="The ten repos with the strongest 7-day cross-signal score across GitHub, Reddit, Hacker News, ProductHunt, Bluesky, dev.to, Lobsters, and our own ranker."
+        clock={
+          <>
+            <span className="big">{computedClock}</span>
+            <span className="muted">UTC · COMPUTED</span>
+            <LiveDot label="FEED LIVE" />
+          </>
+        }
+      />
+
+      <VerdictRibbon
+        tone="acc"
+        stamp={{
+          eyebrow: "// TODAY'S LEADERS",
+          headline: computedAt.replace("T", " · ").slice(0, 16) + " UTC",
+          sub: `computed ${computedAgo} · ${topItems.length} ranked`,
+        }}
+        text={
+          topRepo ? (
+            <>
+              led by <b>{topRepo.slug}</b> with a cross-signal score of{" "}
+              <b>{topRepo.score.toFixed(2)}</b> / 5.0.
+            </>
+          ) : (
+            <>Top-10 pool is warming. Awaiting first ranker pass.</>
+          )
+        }
+        actionHref="#top10-leaderboard"
+        actionLabel="JUMP TO BOARD →"
+      />
+
+      <KpiBand
+        cells={[
+          {
+            label: "TOP REPO",
+            value: topRepo ? topRepo.slug : "—",
+            sub: topRepo ? `score ${topRepo.score.toFixed(2)} / 5.0` : "warming",
+            tone: "acc",
+            pip: "var(--v4-acc)",
+          },
+          {
+            label: "TOTAL STARS · 24H",
+            value: `+${formatNumber(totalStars24h)}`,
+            sub: "across top 10",
+            tone: "money",
+            pip: "var(--v4-money)",
+          },
+          {
+            label: "TOP LANGUAGE",
+            value: topLanguage,
+            sub: "most-represented",
+          },
+          {
+            label: "HOTTEST TAG",
+            value: hottestTag,
+            sub: "most-shared topic",
+            tone: "amber",
+            pip: "var(--v4-amber)",
+          },
+        ]}
+      />
+
+      <SectionHead
+        num="// 01"
+        title="Today's top 10"
+        meta={
+          <>
+            <b>{topItems.length}</b> ranked · 7-day window
+          </>
+        }
+      />
+
+      <section id="top10-leaderboard" style={PANEL_STYLE}>
+        <div style={PANEL_HEAD_STYLE}>
+          <span style={{ color: "var(--v4-acc)" }}>{"// LEADERBOARD"}</span>
+          <span>· CROSS-SIGNAL · 7D</span>
+          <span style={{ marginLeft: "auto" }}>
+            <LiveDot label="LIVE" />
+          </span>
+        </div>
+        {topItems.length === 0 ? (
+          <div
+            style={{
+              padding: 24,
+              color: "var(--v4-ink-300)",
+              fontSize: 13,
+            }}
+          >
+            Top-10 pool is warming. The ranker publishes after the cross-signal
+            fetchers refresh.
+          </div>
+        ) : (
+          topItems.map((item, i) => (
+            <RankRow
+              key={item.slug}
+              rank={item.rank}
+              title={
+                item.owner ? (
+                  <>
+                    {item.owner}{" "}
+                    <span style={{ color: "var(--v4-ink-400)" }}>/</span>{" "}
+                    {item.title}
+                  </>
+                ) : (
+                  item.title
+                )
+              }
+              desc={item.description}
+              metric={{ value: item.score.toFixed(2), label: "/ 5.0" }}
+              delta={
+                item.deltaPct !== undefined
+                  ? {
+                      value: `${item.deltaPct >= 0 ? "+" : ""}${item.deltaPct.toFixed(0)}%`,
+                      direction:
+                        item.deltaPct > 0
+                          ? "up"
+                          : item.deltaPct < 0
+                            ? "down"
+                            : "flat",
+                    }
+                  : undefined
+              }
+              href={item.href}
+              first={i === 0}
+            />
+          ))
+        )}
+      </section>
+
+      <SectionHead
+        num="// 02"
+        title="Categories"
+        meta={
+          <>
+            <b>{CATEGORIES.length}</b> sectors · drill in
+          </>
+        }
+      />
+
+      <section style={PANEL_STYLE}>
+        <div style={PANEL_HEAD_STYLE}>
+          <span style={{ color: "var(--v4-acc)" }}>{"// CATEGORIES"}</span>
+          <span>· OPEN ANY SECTOR FOR ITS OWN MOMENTUM BOARD</span>
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+            gap: 1,
+            background: "var(--v4-line-200)",
+          }}
+        >
+          {CATEGORIES.map((cat) => (
+            <Link
+              key={cat.id}
+              href={`/categories/${cat.id}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "12px 14px",
+                background: "var(--v4-bg-050)",
+                color: "var(--v4-ink-100)",
+                fontSize: 13,
+                textDecoration: "none",
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 1,
+                  background: cat.color,
+                  flex: "none",
+                }}
+              />
+              <span style={{ fontWeight: 500 }}>{cat.shortName}</span>
+              <span
+                style={{
+                  marginLeft: "auto",
+                  fontFamily: "var(--v4-mono)",
+                  fontSize: 10,
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  color: "var(--v4-ink-400)",
+                }}
+              >
+                /{cat.id} →
+              </span>
+            </Link>
+          ))}
+        </div>
+        <div
+          style={{
+            padding: "10px 14px",
+            borderTop: "1px solid var(--v4-line-200)",
+            fontFamily: "var(--v4-mono)",
+            fontSize: 10,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "var(--v4-ink-400)",
+          }}
+        >
+          <Link
+            href="/categories"
+            style={{ color: "var(--v4-acc)", textDecoration: "none" }}
+          >
+            VIEW ALL CATEGORIES →
+          </Link>
+        </div>
+      </section>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

Migrate `/top10` from legacy V2/V3 chrome to V4 primitives — the surface had zero V4 imports per the audit. Composes `PageHead`, `VerdictRibbon` (acc tone), `KpiBand` (4 cells), and two `SectionHead` bands directly without going through `LeaderboardTemplate` (still in PR #61).

- **// 01 Today's top 10** — top 10 repos rendered as `<RankRow>` × 10 with cross-signal score, delta %, and rank-1 first-row treatment
- **// 02 Categories** — small grid of links to `/categories/<id>` with sector dot + slug
- **KpiBand** — top repo, total stars 24h across the 10, top language, hottest tag
- **VerdictRibbon** — "today's leaders" stamp + computed-ago summary
- ISR cadence dropped to `revalidate = 600` to match the other V4 leaderboard surfaces
- Metadata + canonical preserved verbatim (no JSON-LD existed on this route)

## Implementation notes

- Uses inline `var(--v4-*)` tokens throughout; no `var(--v2-*)` / `var(--v3-*)` / Tailwind `text-text-*` / `border-border-*` / `rounded-card`
- Panel chrome is inline (`border + bg + radius:2`) — drops the legacy `v2-card` / `v2-term-bar` shells
- Panel header strips use V4 mono caps with `--v4-acc` keys, mirroring the consensus + funding pages

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint:guards` — 7/7 pass
- [x] grep on `src/app/top10/page.tsx` for `var(--v[23]-`, `v2-`, `v3-`, `text-text-`, `border-border-`, `bg-bg-`, `text-up`, `text-down`, `text-warning`, `rounded-card` — only one match, the migration intent comment
- [ ] Visual smoke (preview deploy) — verify top-10 list renders, category grid links resolve, KpiBand cells populate