### PR TITLE
fix(top10,agent-repos): restore avatars on RankRow

### DIFF
--- a/src/app/agent-repos/page.tsx
+++ b/src/app/agent-repos/page.tsx
@@ -24,6 +24,7 @@ import { KpiBand } from "@/components/ui/KpiBand";
 import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
 import { RankRow } from "@/components/ui/RankRow";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+import { LetterAvatar } from "@/components/shared/LetterAvatar";
 
 export const revalidate = 1800;
 
@@ -162,6 +163,12 @@ export default async function AgentReposPage() {
               <RankRow
                 key={repo.id}
                 rank={index + 1}
+                avatar={
+                  <LetterAvatar
+                    seed={repo.owner ?? repo.name ?? repo.id}
+                    size={28}
+                  />
+                }
                 title={
                   <>
                     {repo.owner}{" "}

--- a/src/app/top10/page.tsx
+++ b/src/app/top10/page.tsx
@@ -32,6 +32,7 @@ import { KpiBand } from "@/components/ui/KpiBand";
 import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
 import { RankRow } from "@/components/ui/RankRow";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+import { LetterAvatar } from "@/components/shared/LetterAvatar";
 
 // ISR — 10-minute cadence matches the V4 leaderboard surfaces. Underlying
 // readers refresh every 6 hours via cron; tighter cache wastes work
@@ -246,6 +247,12 @@ export default async function Top10RootPage() {
             <RankRow
               key={item.slug}
               rank={item.rank}
+              avatar={
+                <LetterAvatar
+                  seed={item.owner ?? item.title ?? item.slug}
+                  size={28}
+                />
+              }
               title={
                 item.owner ? (
                   <>


### PR DESCRIPTION
PR #85 (top10) and #83 (agent-repos) shipped without passing the avatar prop to RankRow. Prod renders 10/41 rows with no logos. Mirror /skills pattern with LetterAvatar.

Verified: prod element grep shows /top10 avatars=0, /agent-repos avatars=0 vs /skills avatars=30. After this fix all three should match.