### PR TITLE
feat(observability): add Sprint 1.5 Sentry verification

### DIFF
--- a/docs/forensic/06-SENTRY-VERIFICATION.md
+++ b/docs/forensic/06-SENTRY-VERIFICATION.md
@@ -1,6 +1,6 @@
 # Sentry Verification - Sprint 1 Phase 1.5
 
-Verification timestamp: `2026-05-04T14:13:10.9460284+08:00`
+Verification timestamp: `2026-05-04T14:24:03.0378696+08:00`
 
 ## Status
 
@@ -8,7 +8,7 @@ Sentry delivery is not fully verified yet.
 
 | Surface | Result | Evidence |
 |---|---|---|
-| Vercel production | MISSING | `vercel env list production` for project `starscreener` returned no `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, or `SENTRY_PROJECT` rows. |
+| Vercel production | MISSING | `vercel env ls production` for project `starscreener` returned no `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, or `SENTRY_PROJECT` rows. |
 | Railway production worker | CONFIGURED | `railway variables --json --environment production --service trendingrepo-worker` confirmed `SENTRY_DSN` is present. |
 | Local shell | MISSING | `SENTRY_AUTH_TOKEN`, `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are not present in the local process environment. |
 | Canary event | BLOCKED | The Next.js production runtime has no Vercel Sentry DSN, so `/api/_internal/sentry-canary` cannot produce a real production Sentry event yet. |

--- a/docs/forensic/06-SENTRY-VERIFICATION.md
+++ b/docs/forensic/06-SENTRY-VERIFICATION.md
@@ -25,12 +25,14 @@ Gate: returns `404` unless `SENTRY_CANARY_ENABLED=1`.
 
 Enabled behavior:
 
-1. Creates a deliberate `Error("Sentry canary test error")`.
+1. Throws and catches a typed `SentryCanaryError`.
 2. Captures it to Sentry with tags:
    - `canary=true`
    - `route=api/_internal/sentry-canary`
+   - `source=sentry-canary`
+   - `category=fatal`
 3. Flushes Sentry for up to 2 seconds.
-4. Throws the same error so Next's request-error instrumentation sees a real unhandled route failure.
+4. Returns HTTP `500` JSON with `code=SENTRY_CANARY_FIRED` and `eventId` when the SDK returns one.
 
 Production proof is pending. After Vercel `SENTRY_DSN` is configured, fire:
 
@@ -78,7 +80,7 @@ All subclasses expose:
 | Reddit UA pool | `pool=reddit`, `alert=reddit-ua-pool-exhausted`, `alert=reddit-ua-rate-limit`, `alert=reddit-ua-blocked`, `alert=reddit-ua-5xx`, `alert=reddit-ua-network`. |
 | Twitter fallback | `pool=twitter`, `alert=twitter-degraded`, `source=apify`, `alert=twitter-all-sources-failed`. |
 | Nitter health | `source=nitter-health-check`, `alert=twitter-nitter-health`. |
-| Canary | `canary=true`, `route=api/_internal/sentry-canary`. |
+| Canary | `canary=true`, `route=api/_internal/sentry-canary`, `source=sentry-canary`, `category=fatal`. |
 | Sprint 2 placeholders | No Sentry events emitted yet. Add `source=<EngineError.source>` and `category=<EngineError.category>` when wiring each source. |
 
 ## Adding a New EngineError Subclass

--- a/docs/forensic/06-SENTRY-VERIFICATION.md
+++ b/docs/forensic/06-SENTRY-VERIFICATION.md
@@ -1,6 +1,6 @@
 # Sentry Verification - Sprint 1 Phase 1.5
 
-Verification timestamp: `2026-05-04T14:24:03.0378696+08:00`
+Verification timestamp: `2026-05-04T14:44:00+08:00`
 
 ## Status
 
@@ -11,7 +11,7 @@ Sentry delivery is not fully verified yet.
 | Vercel production | MISSING | `vercel env ls production` for project `starscreener` returned no `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, or `SENTRY_PROJECT` rows. |
 | Railway production worker | CONFIGURED | `railway variables --json --environment production --service trendingrepo-worker` confirmed `SENTRY_DSN` is present. |
 | Local shell | MISSING | `SENTRY_AUTH_TOKEN`, `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are not present in the local process environment. |
-| Local Next startup | VERIFIED | `next dev -p 3024` logged `[STARTUP] SENTRY_DSN not configured - runtime errors will not be reported`. Next compiled the active root `instrumentation.ts`; `src/instrumentation.ts` carries the same startup check for the sprint contract. |
+| Local Next startup | VERIFIED | `next dev -p 3023` logged `[STARTUP] SENTRY_DSN not configured - runtime errors will not be reported`. Next compiled the active root `instrumentation.ts`; `src/instrumentation.ts` carries the same startup check for the sprint contract. |
 | Canary event | BLOCKED | The Next.js production runtime has no Vercel Sentry DSN, so `/api/_internal/sentry-canary` cannot produce a real production Sentry event yet. |
 
 Required operator action: add `SENTRY_DSN` to Vercel production for `starscreener`. Add `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` only if source-map upload and API verification should run from CI/operator shells. Do not paste values in chat.
@@ -26,12 +26,14 @@ Gate: returns `404` unless `SENTRY_CANARY_ENABLED=1`.
 
 Enabled behavior:
 
-1. Creates a deliberate `Error("Sentry canary test error")`.
+1. Creates a deliberate local `SentryCanaryError` typed as an `EngineError`.
 2. Captures it to Sentry with tags:
    - `canary=true`
    - `route=api/_internal/sentry-canary`
+   - `source=sentry-canary`
+   - `category=fatal`
 3. Flushes Sentry for up to 2 seconds.
-4. Throws the same error so Next's request-error instrumentation sees a real unhandled route failure.
+4. Throws the same typed error so Next's request-error instrumentation sees a real unhandled route failure.
 
 Production proof is pending. After Vercel `SENTRY_DSN` is configured, fire:
 
@@ -79,7 +81,7 @@ All subclasses expose:
 | Reddit UA pool | `pool=reddit`, `alert=reddit-ua-pool-exhausted`, `alert=reddit-ua-rate-limit`, `alert=reddit-ua-blocked`, `alert=reddit-ua-5xx`, `alert=reddit-ua-network`. |
 | Twitter fallback | `pool=twitter`, `alert=twitter-degraded`, `source=apify`, `alert=twitter-all-sources-failed`. |
 | Nitter health | `source=nitter-health-check`, `alert=twitter-nitter-health`. |
-| Canary | `canary=true`, `route=api/_internal/sentry-canary`. |
+| Canary | `canary=true`, `route=api/_internal/sentry-canary`, `source=sentry-canary`, `category=fatal`. |
 | Sprint 2 placeholders | No Sentry events emitted yet. Add `source=<EngineError.source>` and `category=<EngineError.category>` when wiring each source. |
 
 ## Adding a New EngineError Subclass

--- a/docs/forensic/06-SENTRY-VERIFICATION.md
+++ b/docs/forensic/06-SENTRY-VERIFICATION.md
@@ -11,6 +11,7 @@ Sentry delivery is not fully verified yet.
 | Vercel production | MISSING | `vercel env ls production` for project `starscreener` returned no `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, or `SENTRY_PROJECT` rows. |
 | Railway production worker | CONFIGURED | `railway variables --json --environment production --service trendingrepo-worker` confirmed `SENTRY_DSN` is present. |
 | Local shell | MISSING | `SENTRY_AUTH_TOKEN`, `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are not present in the local process environment. |
+| Local Next startup | VERIFIED | `next dev -p 3024` logged `[STARTUP] SENTRY_DSN not configured - runtime errors will not be reported`. Next compiled the active root `instrumentation.ts`; `src/instrumentation.ts` carries the same startup check for the sprint contract. |
 | Canary event | BLOCKED | The Next.js production runtime has no Vercel Sentry DSN, so `/api/_internal/sentry-canary` cannot produce a real production Sentry event yet. |
 
 Required operator action: add `SENTRY_DSN` to Vercel production for `starscreener`. Add `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` only if source-map upload and API verification should run from CI/operator shells. Do not paste values in chat.

--- a/docs/forensic/06-SENTRY-VERIFICATION.md
+++ b/docs/forensic/06-SENTRY-VERIFICATION.md
@@ -1,0 +1,94 @@
+# Sentry Verification - Sprint 1 Phase 1.5
+
+Verification timestamp: `2026-05-04T14:13:10.9460284+08:00`
+
+## Status
+
+Sentry delivery is not fully verified yet.
+
+| Surface | Result | Evidence |
+|---|---|---|
+| Vercel production | MISSING | `vercel env list production` for project `starscreener` returned no `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, or `SENTRY_PROJECT` rows. |
+| Railway production worker | CONFIGURED | `railway variables --json --environment production --service trendingrepo-worker` confirmed `SENTRY_DSN` is present. |
+| Local shell | MISSING | `SENTRY_AUTH_TOKEN`, `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are not present in the local process environment. |
+| Canary event | BLOCKED | The Next.js production runtime has no Vercel Sentry DSN, so `/api/_internal/sentry-canary` cannot produce a real production Sentry event yet. |
+
+Required operator action: add `SENTRY_DSN` to Vercel production for `starscreener`. Add `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` only if source-map upload and API verification should run from CI/operator shells. Do not paste values in chat.
+
+## Canary Endpoint
+
+Endpoint: `GET /api/_internal/sentry-canary`
+
+Auth: `Authorization: Bearer <CRON_SECRET>`
+
+Gate: returns `404` unless `SENTRY_CANARY_ENABLED=1`.
+
+Enabled behavior:
+
+1. Throws and catches a typed `SentryCanaryError`.
+2. Captures it to Sentry with tags:
+   - `canary=true`
+   - `route=api/_internal/sentry-canary`
+   - `source=sentry-canary`
+   - `category=fatal`
+3. Flushes Sentry for up to 2 seconds.
+4. Returns HTTP `500` JSON with `code=SENTRY_CANARY_FIRED` and `eventId` when the SDK returns one.
+
+Production proof is pending. After Vercel `SENTRY_DSN` is configured, fire:
+
+```powershell
+curl.exe -i -H "Authorization: Bearer $env:CRON_SECRET" https://trendingrepo.com/api/_internal/sentry-canary
+```
+
+Expected proof fields to add here:
+
+| Field | Value |
+|---|---|
+| Sentry event ID | BLOCKED - Vercel `SENTRY_DSN` missing |
+| Sentry event URL | BLOCKED - Vercel `SENTRY_DSN` missing |
+
+## EngineError Hierarchy
+
+`src/lib/errors.ts` now has 38 classes:
+
+| Group | Classes |
+|---|---|
+| Base | `EngineError` |
+| GitHub | `GithubRateLimitError`, `GithubInvalidTokenError`, `GithubPoolExhaustedError`, `GithubRecoverableError` |
+| Reddit | `RedditRateLimitError`, `RedditBlockedError`, `RedditPoolExhaustedError`, `RedditRecoverableError` |
+| Twitter/Apify/Nitter | `ApifyQuotaError`, `ApifyTokenInvalidError`, `NitterInstanceDownError`, `NitterAllInstancesDownError`, `TwitterAllSourcesFailedError` |
+| Hacker News | `HackerNewsRecoverableError`, `HackerNewsQuarantineError`, `HackerNewsFatalError` |
+| Bluesky | `BlueskyRecoverableError`, `BlueskyQuarantineError`, `BlueskyFatalError` |
+| Dev.to | `DevtoRecoverableError`, `DevtoQuarantineError`, `DevtoFatalError` |
+| Lobsters | `LobstersRecoverableError`, `LobstersQuarantineError`, `LobstersFatalError` |
+| Product Hunt | `ProductHuntRecoverableError`, `ProductHuntQuarantineError`, `ProductHuntFatalError` |
+| Hugging Face | `HuggingFaceRecoverableError`, `HuggingFaceQuarantineError`, `HuggingFaceFatalError` |
+| npm | `NpmRecoverableError`, `NpmQuarantineError`, `NpmFatalError` |
+| arXiv | `ArxivRecoverableError`, `ArxivQuarantineError`, `ArxivFatalError` |
+
+All subclasses expose:
+
+- `category`: `recoverable`, `quarantine`, or `fatal`
+- `source`: typed `EngineErrorSource`
+- `metadata`: structured context safe for Sentry `extra`/context fields
+
+## Sentry Tags
+
+| Source | Current tags |
+|---|---|
+| GitHub pool/runtime | `pool=github`, `alert=github-pool-exhausted`, `alert=github-pool-network`, `alert=github-pool-key-invalid`, `alert=github-pool-rate-limit`, `alert=github-pool-5xx`, plus low-quota tags `token` and `remaining` with token redaction. |
+| Reddit UA pool | `pool=reddit`, `alert=reddit-ua-pool-exhausted`, `alert=reddit-ua-rate-limit`, `alert=reddit-ua-blocked`, `alert=reddit-ua-5xx`, `alert=reddit-ua-network`. |
+| Twitter fallback | `pool=twitter`, `alert=twitter-degraded`, `source=apify`, `alert=twitter-all-sources-failed`. |
+| Nitter health | `source=nitter-health-check`, `alert=twitter-nitter-health`. |
+| Canary | `canary=true`, `route=api/_internal/sentry-canary`, `source=sentry-canary`, `category=fatal`. |
+| Sprint 2 placeholders | No Sentry events emitted yet. Add `source=<EngineError.source>` and `category=<EngineError.category>` when wiring each source. |
+
+## Adding a New EngineError Subclass
+
+1. Add the source slug to `EngineErrorSource`.
+2. Add one or more concrete subclasses extending `EngineError`.
+3. Use exact literal `category` and `source` fields with `as const`.
+4. Throw the subclass at the failure boundary with structured metadata.
+5. Capture with Sentry tags `source`, `category`, and a source-specific `alert`.
+6. Add retry/quarantine behavior before fatal escalation.
+7. Update this document with the emitted tags and verification proof.

--- a/docs/forensic/06-SENTRY-VERIFICATION.md
+++ b/docs/forensic/06-SENTRY-VERIFICATION.md
@@ -25,14 +25,12 @@ Gate: returns `404` unless `SENTRY_CANARY_ENABLED=1`.
 
 Enabled behavior:
 
-1. Throws and catches a typed `SentryCanaryError`.
+1. Creates a deliberate `Error("Sentry canary test error")`.
 2. Captures it to Sentry with tags:
    - `canary=true`
    - `route=api/_internal/sentry-canary`
-   - `source=sentry-canary`
-   - `category=fatal`
 3. Flushes Sentry for up to 2 seconds.
-4. Returns HTTP `500` JSON with `code=SENTRY_CANARY_FIRED` and `eventId` when the SDK returns one.
+4. Throws the same error so Next's request-error instrumentation sees a real unhandled route failure.
 
 Production proof is pending. After Vercel `SENTRY_DSN` is configured, fire:
 
@@ -80,7 +78,7 @@ All subclasses expose:
 | Reddit UA pool | `pool=reddit`, `alert=reddit-ua-pool-exhausted`, `alert=reddit-ua-rate-limit`, `alert=reddit-ua-blocked`, `alert=reddit-ua-5xx`, `alert=reddit-ua-network`. |
 | Twitter fallback | `pool=twitter`, `alert=twitter-degraded`, `source=apify`, `alert=twitter-all-sources-failed`. |
 | Nitter health | `source=nitter-health-check`, `alert=twitter-nitter-health`. |
-| Canary | `canary=true`, `route=api/_internal/sentry-canary`, `source=sentry-canary`, `category=fatal`. |
+| Canary | `canary=true`, `route=api/_internal/sentry-canary`. |
 | Sprint 2 placeholders | No Sentry events emitted yet. Add `source=<EngineError.source>` and `category=<EngineError.category>` when wiring each source. |
 
 ## Adding a New EngineError Subclass

--- a/docs/forensic/06-SENTRY-VERIFICATION.md
+++ b/docs/forensic/06-SENTRY-VERIFICATION.md
@@ -26,14 +26,12 @@ Gate: returns `404` unless `SENTRY_CANARY_ENABLED=1`.
 
 Enabled behavior:
 
-1. Throws and catches a typed `SentryCanaryError`.
+1. Creates a deliberate `Error("Sentry canary test error")`.
 2. Captures it to Sentry with tags:
    - `canary=true`
    - `route=api/_internal/sentry-canary`
-   - `source=sentry-canary`
-   - `category=fatal`
 3. Flushes Sentry for up to 2 seconds.
-4. Returns HTTP `500` JSON with `code=SENTRY_CANARY_FIRED` and `eventId` when the SDK returns one.
+4. Throws the same error so Next's request-error instrumentation sees a real unhandled route failure.
 
 Production proof is pending. After Vercel `SENTRY_DSN` is configured, fire:
 
@@ -81,7 +79,7 @@ All subclasses expose:
 | Reddit UA pool | `pool=reddit`, `alert=reddit-ua-pool-exhausted`, `alert=reddit-ua-rate-limit`, `alert=reddit-ua-blocked`, `alert=reddit-ua-5xx`, `alert=reddit-ua-network`. |
 | Twitter fallback | `pool=twitter`, `alert=twitter-degraded`, `source=apify`, `alert=twitter-all-sources-failed`. |
 | Nitter health | `source=nitter-health-check`, `alert=twitter-nitter-health`. |
-| Canary | `canary=true`, `route=api/_internal/sentry-canary`, `source=sentry-canary`, `category=fatal`. |
+| Canary | `canary=true`, `route=api/_internal/sentry-canary`. |
 | Sprint 2 placeholders | No Sentry events emitted yet. Add `source=<EngineError.source>` and `category=<EngineError.category>` when wiring each source. |
 
 ## Adding a New EngineError Subclass

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -9,6 +9,19 @@ import * as Sentry from "@sentry/nextjs";
 
 export const onRequestError = Sentry.captureRequestError;
 
+let startupLogged = false;
+
 export function register() {
-  // intentionally empty
+  if (startupLogged) return;
+  startupLogged = true;
+
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn || dsn.length === 0) {
+    console.error(
+      "[STARTUP] SENTRY_DSN not configured - runtime errors will not be reported",
+    );
+    return;
+  }
+
+  console.log("[STARTUP] Sentry DSN present (length:", dsn.length, ")");
 }

--- a/scripts/check-freshness.mts
+++ b/scripts/check-freshness.mts
@@ -3,6 +3,7 @@
 import "./_load-env.mjs";
 
 type Status = "GREEN" | "YELLOW" | "RED" | "DEAD";
+type SentryStatus = "CONFIGURED" | "MISSING" | "TEST_FIRED";
 
 interface FreshnessSource {
   name: string;
@@ -31,10 +32,25 @@ interface HealthState {
   computedAt?: string | null;
 }
 
+interface SentryState {
+  status: SentryStatus;
+  detail: string;
+  eventId?: string;
+}
+
+interface SentryCanaryResponse {
+  ok?: false;
+  error?: string;
+  reason?: string;
+  code?: string;
+  eventId?: string;
+}
+
 interface Options {
   baseUrl: string;
   json: boolean;
   timeoutMs: number;
+  sentryCanary: boolean;
 }
 
 const DEFAULT_BASE_URL = "http://localhost:3023";
@@ -44,9 +60,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 function usage(): string {
   return [
-    "usage: npm run freshness:check -- [--prod] [--base-url <url>] [--json]",
+    "usage: npm run freshness:check -- [--prod] [--base-url <url>] [--json] [--sentry-canary]",
     "",
     "Checks /api/health and /api/cron/freshness/state.",
+    "--sentry-canary additionally calls /api/_internal/sentry-canary.",
     "Default target is http://localhost:3023. --prod targets https://trendingrepo.com.",
   ].join("\n");
 }
@@ -56,6 +73,7 @@ function parseArgs(argv: string[]): Options {
   let baseUrl: string | null = null;
   let json = false;
   let timeoutMs = DEFAULT_TIMEOUT_MS;
+  let sentryCanary = false;
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -63,6 +81,8 @@ function parseArgs(argv: string[]): Options {
       prod = true;
     } else if (arg === "--json") {
       json = true;
+    } else if (arg === "--sentry-canary") {
+      sentryCanary = true;
     } else if (arg === "--help" || arg === "-h") {
       console.log(usage());
       process.exit(0);
@@ -90,6 +110,7 @@ function parseArgs(argv: string[]): Options {
     baseUrl: normalizeBaseUrl(baseUrl ?? (prod ? PROD_BASE_URL : DEFAULT_BASE_URL)),
     json,
     timeoutMs,
+    sentryCanary,
   };
 }
 
@@ -178,6 +199,78 @@ async function fetchJson<T>(url: string, timeoutMs: number, auth: boolean): Prom
   }
 }
 
+async function fetchSentryCanary(opts: Options): Promise<SentryState | null> {
+  if (!opts.sentryCanary) return null;
+
+  const url = endpoint(opts.baseUrl, "/api/_internal/sentry-canary");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+
+  if (process.env.CRON_SECRET) {
+    assertSafeAuthDestination(url);
+    headers.Authorization = `Bearer ${process.env.CRON_SECRET}`;
+  }
+
+  try {
+    const response = await fetch(url, { headers, signal: controller.signal });
+    const text = await response.text();
+    let body: SentryCanaryResponse | null = null;
+    try {
+      body = text ? JSON.parse(text) as SentryCanaryResponse : null;
+    } catch {
+      body = null;
+    }
+
+    if (response.status >= 500) {
+      return {
+        status: "TEST_FIRED",
+        detail: `canary endpoint returned HTTP ${response.status}`,
+        ...(body.eventId ? { eventId: body.eventId } : {}),
+      };
+    }
+
+    return {
+      status: sentryDsnConfigured() ? "CONFIGURED" : "MISSING",
+      detail: `canary probe returned HTTP ${response.status}`,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error && error.name === "AbortError"
+        ? `canary probe timed out after ${opts.timeoutMs}ms`
+        : `canary probe failed: ${error instanceof Error ? error.message : String(error)}`;
+    return {
+      status: sentryDsnConfigured() ? "CONFIGURED" : "MISSING",
+      detail: redactSecret(message),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function sentryDsnConfigured(): boolean {
+  return Boolean((process.env.SENTRY_DSN ?? "").trim());
+}
+
+async function checkSentryStatus(opts: Options): Promise<SentryState> {
+  const canary = await fetchSentryCanary(opts);
+  if (canary) return canary;
+
+  if (sentryDsnConfigured()) {
+    return {
+      status: "CONFIGURED",
+      detail: "SENTRY_DSN present in this runtime",
+    };
+  }
+
+  return {
+    status: "MISSING",
+    detail: "SENTRY_DSN missing in this runtime",
+  };
+}
+
 function sanitizeUrl(raw: string): string {
   const url = new URL(raw);
   url.username = "";
@@ -256,7 +349,12 @@ function exitCodeFor(state: FreshnessState): number {
   return 0;
 }
 
-function printReport(opts: Options, health: HealthState, state: FreshnessState): void {
+function printReport(
+  opts: Options,
+  health: HealthState,
+  state: FreshnessState,
+  sentry: SentryState,
+): void {
   console.log(
     `freshness-check target=${opts.baseUrl} health=${health.status ?? "unknown"} sourceStatus=${health.sourceStatus ?? "unknown"} checkedAt=${state.checkedAt}`,
   );
@@ -278,6 +376,9 @@ function printReport(opts: Options, health: HealthState, state: FreshnessState):
   console.log(
     `summary: green=${state.summary.green} yellow=${state.summary.yellow} red=${state.summary.red} dead=${state.summary.dead} blocking_non_green=${blockingNonGreen} advisory_non_green=${advisoryNonGreen}`,
   );
+  console.log(
+    `Sentry: ${sentry.status}${sentry.eventId ? ` eventId=${sentry.eventId}` : ""}`,
+  );
 }
 
 async function main(): Promise<void> {
@@ -285,18 +386,19 @@ async function main(): Promise<void> {
   const healthUrl = endpoint(opts.baseUrl, "/api/health?soft=1");
   const stateUrl = endpoint(opts.baseUrl, "/api/cron/freshness/state");
 
-  const [health, state] = await Promise.all([
+  const [health, state, sentry] = await Promise.all([
     fetchJson<HealthState>(healthUrl, opts.timeoutMs, false),
     fetchJson<FreshnessState>(stateUrl, opts.timeoutMs, true),
+    checkSentryStatus(opts),
   ]);
 
   validateFreshnessState(state);
   const code = exitCodeFor(state);
 
   if (opts.json) {
-    console.log(JSON.stringify({ target: opts.baseUrl, health, freshness: state, exitCode: code }, null, 2));
+    console.log(JSON.stringify({ target: opts.baseUrl, health, freshness: state, sentry, exitCode: code }, null, 2));
   } else {
-    printReport(opts, health, state);
+    printReport(opts, health, state, sentry);
     if (code === 0) {
       const advisoryNonGreen = state.sources.filter(
         (source) => source.blocking === false && source.status !== "GREEN",

--- a/src/app/api/_internal/sentry-canary/route.ts
+++ b/src/app/api/_internal/sentry-canary/route.ts
@@ -1,46 +1,31 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 
-import { timingSafeEqualStr } from "@/lib/api/auth";
+import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { EngineError } from "@/lib/errors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function authFailure(request: NextRequest): NextResponse | null {
-  const secret = process.env.CRON_SECRET?.trim();
-  if (!secret) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: "CRON_SECRET not configured",
-        code: "AUTH_NOT_CONFIGURED",
-      },
-      { status: 503 },
-    );
-  }
-
-  const header = request.headers.get("authorization")?.trim() ?? "";
-  if (!header.startsWith("Bearer ")) {
-    return NextResponse.json(
-      { ok: false, error: "unauthorized", code: "UNAUTHORIZED" },
-      { status: 401 },
-    );
-  }
-
-  const candidate = header.slice("Bearer ".length).trim();
-  if (!timingSafeEqualStr(candidate, secret)) {
-    return NextResponse.json(
-      { ok: false, error: "unauthorized", code: "UNAUTHORIZED" },
-      { status: 401 },
-    );
-  }
-
-  return null;
+class SentryCanaryError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "sentry-canary" as const;
 }
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-  const deny = authFailure(request);
-  if (deny) return deny;
+interface SentryCanaryResponse {
+  ok: false;
+  error: string;
+  code: "NOT_FOUND" | "SENTRY_CANARY_FIRED";
+  eventId?: string;
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<SentryCanaryResponse | { ok: false; reason: string }>> {
+  const deny = authFailureResponse(verifyCronAuth(request));
+  if (deny) {
+    return deny as NextResponse<{ ok: false; reason: string }>;
+  }
 
   if (process.env.SENTRY_CANARY_ENABLED !== "1") {
     return NextResponse.json(
@@ -49,20 +34,40 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const error = new Error("Sentry canary test error");
+  let error: SentryCanaryError;
+  try {
+    throw new SentryCanaryError("Sentry canary test error", {
+      canary: true,
+      route: "api/_internal/sentry-canary",
+    });
+  } catch (caught) {
+    error = caught as SentryCanaryError;
+  }
+
   let eventId: string | undefined;
 
   Sentry.withScope((scope) => {
     scope.setTag("canary", "true");
     scope.setTag("route", "api/_internal/sentry-canary");
+    scope.setTag("source", error.source);
+    scope.setTag("category", error.category);
     scope.setContext("sentry_canary", {
       firedAt: new Date().toISOString(),
       enabled: true,
+      metadata: error.metadata,
     });
     eventId = Sentry.captureException(error);
   });
 
   await Sentry.flush(2000);
   console.error("[sentry-canary] fired", eventId ?? "event-id-unavailable");
-  throw error;
+  return NextResponse.json(
+    {
+      ok: false,
+      error: "sentry canary fired",
+      code: "SENTRY_CANARY_FIRED",
+      ...(eventId ? { eventId } : {}),
+    },
+    { status: 500 },
+  );
 }

--- a/src/app/api/_internal/sentry-canary/route.ts
+++ b/src/app/api/_internal/sentry-canary/route.ts
@@ -1,45 +1,19 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 
-import { timingSafeEqualStr } from "@/lib/api/auth";
+import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { EngineError, engineErrorTags } from "@/lib/errors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function authFailure(request: NextRequest): NextResponse | null {
-  const secret = process.env.CRON_SECRET?.trim();
-  if (!secret) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: "CRON_SECRET not configured",
-        code: "AUTH_NOT_CONFIGURED",
-      },
-      { status: 503 },
-    );
-  }
-
-  const header = request.headers.get("authorization")?.trim() ?? "";
-  if (!header.startsWith("Bearer ")) {
-    return NextResponse.json(
-      { ok: false, error: "unauthorized", code: "UNAUTHORIZED" },
-      { status: 401 },
-    );
-  }
-
-  const candidate = header.slice("Bearer ".length).trim();
-  if (!timingSafeEqualStr(candidate, secret)) {
-    return NextResponse.json(
-      { ok: false, error: "unauthorized", code: "UNAUTHORIZED" },
-      { status: 401 },
-    );
-  }
-
-  return null;
+class SentryCanaryError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "sentry-canary" as const;
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const deny = authFailure(request);
+  const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
 
   if (process.env.SENTRY_CANARY_ENABLED !== "1") {
@@ -49,15 +23,22 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const error = new Error("Sentry canary test error");
+  const error = new SentryCanaryError("Sentry canary test error", {
+    route: "api/_internal/sentry-canary",
+    canary: true,
+  });
   let eventId: string | undefined;
 
   Sentry.withScope((scope) => {
     scope.setTag("canary", "true");
     scope.setTag("route", "api/_internal/sentry-canary");
+    for (const [key, value] of Object.entries(engineErrorTags(error))) {
+      scope.setTag(key, value);
+    }
     scope.setContext("sentry_canary", {
       firedAt: new Date().toISOString(),
       enabled: true,
+      errorName: error.name,
     });
     eventId = Sentry.captureException(error);
   });

--- a/src/app/api/_internal/sentry-canary/route.ts
+++ b/src/app/api/_internal/sentry-canary/route.ts
@@ -1,31 +1,46 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 
-import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
-import { EngineError } from "@/lib/errors";
+import { timingSafeEqualStr } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-class SentryCanaryError extends EngineError {
-  readonly category = "fatal" as const;
-  readonly source = "sentry-canary" as const;
-}
-
-interface SentryCanaryResponse {
-  ok: false;
-  error: string;
-  code: "NOT_FOUND" | "SENTRY_CANARY_FIRED";
-  eventId?: string;
-}
-
-export async function GET(
-  request: NextRequest,
-): Promise<NextResponse<SentryCanaryResponse | { ok: false; reason: string }>> {
-  const deny = authFailureResponse(verifyCronAuth(request));
-  if (deny) {
-    return deny as NextResponse<{ ok: false; reason: string }>;
+function authFailure(request: NextRequest): NextResponse | null {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "CRON_SECRET not configured",
+        code: "AUTH_NOT_CONFIGURED",
+      },
+      { status: 503 },
+    );
   }
+
+  const header = request.headers.get("authorization")?.trim() ?? "";
+  if (!header.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { ok: false, error: "unauthorized", code: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+
+  const candidate = header.slice("Bearer ".length).trim();
+  if (!timingSafeEqualStr(candidate, secret)) {
+    return NextResponse.json(
+      { ok: false, error: "unauthorized", code: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+
+  return null;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const deny = authFailure(request);
+  if (deny) return deny;
 
   if (process.env.SENTRY_CANARY_ENABLED !== "1") {
     return NextResponse.json(
@@ -34,40 +49,20 @@ export async function GET(
     );
   }
 
-  let error: SentryCanaryError;
-  try {
-    throw new SentryCanaryError("Sentry canary test error", {
-      canary: true,
-      route: "api/_internal/sentry-canary",
-    });
-  } catch (caught) {
-    error = caught as SentryCanaryError;
-  }
-
+  const error = new Error("Sentry canary test error");
   let eventId: string | undefined;
 
   Sentry.withScope((scope) => {
     scope.setTag("canary", "true");
     scope.setTag("route", "api/_internal/sentry-canary");
-    scope.setTag("source", error.source);
-    scope.setTag("category", error.category);
     scope.setContext("sentry_canary", {
       firedAt: new Date().toISOString(),
       enabled: true,
-      metadata: error.metadata,
     });
     eventId = Sentry.captureException(error);
   });
 
   await Sentry.flush(2000);
   console.error("[sentry-canary] fired", eventId ?? "event-id-unavailable");
-  return NextResponse.json(
-    {
-      ok: false,
-      error: "sentry canary fired",
-      code: "SENTRY_CANARY_FIRED",
-      ...(eventId ? { eventId } : {}),
-    },
-    { status: 500 },
-  );
+  throw error;
 }

--- a/src/app/api/_internal/sentry-canary/route.ts
+++ b/src/app/api/_internal/sentry-canary/route.ts
@@ -1,0 +1,73 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+
+import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { EngineError } from "@/lib/errors";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+class SentryCanaryError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "sentry-canary" as const;
+}
+
+interface SentryCanaryResponse {
+  ok: false;
+  error: string;
+  code: "NOT_FOUND" | "SENTRY_CANARY_FIRED";
+  eventId?: string;
+}
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<SentryCanaryResponse | { ok: false; reason: string }>> {
+  const deny = authFailureResponse(verifyCronAuth(request));
+  if (deny) {
+    return deny as NextResponse<{ ok: false; reason: string }>;
+  }
+
+  if (process.env.SENTRY_CANARY_ENABLED !== "1") {
+    return NextResponse.json(
+      { ok: false, error: "not found", code: "NOT_FOUND" },
+      { status: 404 },
+    );
+  }
+
+  let error: SentryCanaryError;
+  try {
+    throw new SentryCanaryError("Sentry canary test error", {
+      canary: true,
+      route: "api/_internal/sentry-canary",
+    });
+  } catch (caught) {
+    error = caught as SentryCanaryError;
+  }
+
+  let eventId: string | undefined;
+
+  Sentry.withScope((scope) => {
+    scope.setTag("canary", "true");
+    scope.setTag("route", "api/_internal/sentry-canary");
+    scope.setTag("source", error.source);
+    scope.setTag("category", error.category);
+    scope.setContext("sentry_canary", {
+      firedAt: new Date().toISOString(),
+      enabled: true,
+      metadata: error.metadata,
+    });
+    eventId = Sentry.captureException(error);
+  });
+
+  await Sentry.flush(2000);
+  console.error("[sentry-canary] fired", eventId ?? "event-id-unavailable");
+  return NextResponse.json(
+    {
+      ok: false,
+      error: "sentry canary fired",
+      code: "SENTRY_CANARY_FIRED",
+      ...(eventId ? { eventId } : {}),
+    },
+    { status: 500 },
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,20 @@
+import * as Sentry from "@sentry/nextjs";
+
+let startupLogged = false;
+
+export const onRequestError = Sentry.captureRequestError;
+
+export function register() {
+  if (startupLogged) return;
+  startupLogged = true;
+
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn || dsn.length === 0) {
+    console.error(
+      "[STARTUP] SENTRY_DSN not configured - runtime errors will not be reported",
+    );
+    return;
+  }
+
+  console.log("[STARTUP] Sentry DSN present (length:", dsn.length, ")");
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -26,7 +26,8 @@ export type EngineErrorSource =
   | "producthunt"
   | "huggingface"
   | "npm"
-  | "arxiv";
+  | "arxiv"
+  | "sentry-canary";
 
 export class GithubRateLimitError extends EngineError {
   readonly category = "quarantine" as const;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -19,6 +19,7 @@ export type EngineErrorSource =
   | "twitter"
   | "twitter-apify"
   | "twitter-nitter"
+  | "sentry-canary"
   | "hackernews"
   | "bluesky"
   | "devto"

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,6 +1,6 @@
 export abstract class EngineError extends Error {
-  abstract readonly category: "recoverable" | "quarantine" | "fatal";
-  abstract readonly source: string;
+  abstract readonly category: EngineErrorCategory;
+  abstract readonly source: EngineErrorSource;
 
   constructor(
     message: string,
@@ -10,6 +10,24 @@ export abstract class EngineError extends Error {
     this.name = new.target.name;
   }
 }
+
+export type EngineErrorCategory = "recoverable" | "quarantine" | "fatal";
+
+export type EngineErrorSource =
+  | "github"
+  | "reddit"
+  | "twitter"
+  | "twitter-apify"
+  | "twitter-nitter"
+  | "sentry-canary"
+  | "hackernews"
+  | "bluesky"
+  | "devto"
+  | "lobsters"
+  | "producthunt"
+  | "huggingface"
+  | "npm"
+  | "arxiv";
 
 export class GithubRateLimitError extends EngineError {
   readonly category = "quarantine" as const;
@@ -74,6 +92,126 @@ export class NitterAllInstancesDownError extends EngineError {
 export class TwitterAllSourcesFailedError extends EngineError {
   readonly category = "fatal" as const;
   readonly source = "twitter";
+}
+
+export class HackerNewsRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "hackernews" as const;
+}
+
+export class HackerNewsQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "hackernews" as const;
+}
+
+export class HackerNewsFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "hackernews" as const;
+}
+
+export class BlueskyRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "bluesky" as const;
+}
+
+export class BlueskyQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "bluesky" as const;
+}
+
+export class BlueskyFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "bluesky" as const;
+}
+
+export class DevtoRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "devto" as const;
+}
+
+export class DevtoQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "devto" as const;
+}
+
+export class DevtoFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "devto" as const;
+}
+
+export class LobstersRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "lobsters" as const;
+}
+
+export class LobstersQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "lobsters" as const;
+}
+
+export class LobstersFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "lobsters" as const;
+}
+
+export class ProductHuntRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "producthunt" as const;
+}
+
+export class ProductHuntQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "producthunt" as const;
+}
+
+export class ProductHuntFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "producthunt" as const;
+}
+
+export class HuggingFaceRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "huggingface" as const;
+}
+
+export class HuggingFaceQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "huggingface" as const;
+}
+
+export class HuggingFaceFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "huggingface" as const;
+}
+
+export class NpmRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "npm" as const;
+}
+
+export class NpmQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "npm" as const;
+}
+
+export class NpmFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "npm" as const;
+}
+
+export class ArxivRecoverableError extends EngineError {
+  readonly category = "recoverable" as const;
+  readonly source = "arxiv" as const;
+}
+
+export class ArxivQuarantineError extends EngineError {
+  readonly category = "quarantine" as const;
+  readonly source = "arxiv" as const;
+}
+
+export class ArxivFatalError extends EngineError {
+  readonly category = "fatal" as const;
+  readonly source = "arxiv" as const;
 }
 
 export function engineErrorTags(error: unknown): Record<string, string> {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -19,7 +19,6 @@ export type EngineErrorSource =
   | "twitter"
   | "twitter-apify"
   | "twitter-nitter"
-  | "sentry-canary"
   | "hackernews"
   | "bluesky"
   | "devto"

--- a/tasks/CURRENT-SPRINT.md
+++ b/tasks/CURRENT-SPRINT.md
@@ -96,7 +96,8 @@ See individual phase prompts.
   `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run build`
   passed. Local auth probe returned API/page HTTP 200 with pool rows populated.
 - 2026-05-04 Phase 1.5 partial: `EngineError` hierarchy expanded to the
-  38-class target, `src/instrumentation.ts` logs `SENTRY_DSN` startup status,
+  38-class target, active root `instrumentation.ts` plus
+  `src/instrumentation.ts` log `SENTRY_DSN` startup status,
   `/api/_internal/sentry-canary` exists behind `CRON_SECRET` and
   `SENTRY_CANARY_ENABLED=1`, and `scripts/check-freshness.mts` reports a
   Sentry readiness row. Verification is blocked because Vercel production is

--- a/tasks/CURRENT-SPRINT.md
+++ b/tasks/CURRENT-SPRINT.md
@@ -1,6 +1,6 @@
 # CURRENT SPRINT — Sprint 1: Pool Verification + Source Activation
 
-Status: IN PROGRESS - Phase 1.4 /admin/keys dashboard ready for review
+Status: IN PROGRESS - Phase 1.5 blocked on Vercel Sentry DSN
 Started: 2026-05-03
 Target completion: 2026-05-10
 
@@ -95,3 +95,11 @@ See individual phase prompts.
   freshness:check -- --timeout-ms 30000` passed with blocking_non_green=0;
   `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run build`
   passed. Local auth probe returned API/page HTTP 200 with pool rows populated.
+- 2026-05-04 Phase 1.5 partial: `EngineError` hierarchy expanded to the
+  38-class target, `src/instrumentation.ts` logs `SENTRY_DSN` startup status,
+  `/api/_internal/sentry-canary` exists behind `CRON_SECRET` and
+  `SENTRY_CANARY_ENABLED=1`, and `scripts/check-freshness.mts` reports a
+  Sentry readiness row. Verification is blocked because Vercel production is
+  missing `SENTRY_DSN`, and the local shell is missing `SENTRY_AUTH_TOKEN` /
+  Sentry org/project values for dashboard API proof. Railway production worker
+  does have `SENTRY_DSN` configured.


### PR DESCRIPTION
## Summary
- Consolidates and extends EngineError hierarchy for Sprint 1.5
- Adds Sentry DSN startup checks and internal Sentry canary endpoint
- Extends freshness check with Sentry status and documents verification state

## Verification
- freshness:check blocking sources green in local operator checkout on 2026-05-04
- Branch validation previously passed typecheck, lint, test, and build before push

## Known external blocker
- Production Sentry canary proof is still blocked until Vercel production has SENTRY_DSN configured. The endpoint is gated by CRON_SECRET and SENTRY_CANARY_ENABLED=1.