### PR TITLE
audit-2026-05-04 wave 4: 4 new test files + agent-commerce retry + admin/roi fixes

### DIFF
--- a/.audit/2026-05-04-swarm/AUDIT-FINAL.md
+++ b/.audit/2026-05-04-swarm/AUDIT-FINAL.md
@@ -1,0 +1,103 @@
+# STARSCREENER audit-2026-05-04 — FINAL STATUS
+
+**Author:** agent E8 (final consolidation)
+**Branch read:** `origin/main`
+**Window:** `c4f02c27..origin/main` = **29 commits**
+**Source artefacts:** `MAP.md`, `REPORT.md`, `AUDIT-RESPONSE.md`, `phase-logs/{A1,A2,A3,A4,A10,A14,A32,A33,A34,C5}.md`
+
+---
+
+## TL;DR
+
+Four audit-driven PRs landed on `main` in the 2026-05-04 window — **#96** (9-commit swarm closing the bulk of P0/P1 findings + admin keys dashboard), **#97** (operator-page follow-up: `/about`, `/x402`, `/api/oembed`, Footer, llms-full, FreshnessBadge), **#99** (snapshot timeouts + secret-rotation runbook + arxiv ownership), and **#101** (D1 workflow Node 22 alignment + agentic.market 429 retry). Across the window: **29 commits**, **~25 sub-agents dispatched** across 5 waves (A-series + C-wave + layer2 + layer3 + wave4), **swarm/Ax-tagged commits = 4** (A6/A7/A8/A13) plus a Sprint 1.5 Sentry-verification chain (~13 commits) cherry-picked into the same window. Net audit findings closed: **~22 of ~30** catalogued; remainder are operator-only (Apify dashboard, Sentry org access, Vercel function timeouts, Supabase write-path triage). No source files were touched in this E8 finalize step — single Write is this report.
+
+## PRs merged today
+
+| PR   | SHA        | Summary                                                                                  | Files |
+|------|------------|------------------------------------------------------------------------------------------|------:|
+| #96  | `2f937dfa` | 9-commit swarm closes P0/P1 findings + admin/keys dashboard sprint                       |    42 |
+| #97  | `1ddca17a` | `/about`, `/x402`, `/api/oembed` + Footer + llms-full + FreshnessBadge follow-up         |     6 |
+| #99  | `1901fe1c` | Snapshot timeouts + secret rotation runbook + arxiv ownership                            |     7 |
+| #101 | `23bccfb8` | `cron-agent-commerce.yml` retry + continue-on-error on agentic.market 429s; Node 22 align |    1 |
+
+Aggregate: **56 files** across the four merged PRs (`git show --stat` per merge SHA).
+
+## Findings shipped (per area)
+
+### security/headers
+- `pricing/page.tsx` JSON-LD safe-escape via `safeJsonLd()` — A8 (`9b7a17a6`), in PR #96. Closes A4-triage §"defense-in-depth".
+- GET `/api/admin/scan` gated behind `verifyAdminAuth` (`82accffe`) — closes audit "unauth admin scan" finding.
+- Token masking + EngineError Sentry tags wired across `github-token-pool.ts`, `github-fetch.ts`, `pool/twitter-fallback.ts` (`e548ea0a`). Reinforced by `a1073b4f feat(errors): consolidate + extend EngineError hierarchy`.
+- Sentry DSN startup verification (`9ff3d3f7`) + canary endpoint `/api/_internal/sentry-canary` (`ad04e262`, scoped fix `cc322398`, typed throw `600a9227`/`6d242fc3`/`d9f21717`/`18f22309`/`2ea006a9`/`fd04ea5f`) — Sprint 1.5 observability landed in audit window.
+- Secret-rotation runbook `docs/RUNBOOK-secret-rotation.md` (370 lines) added in PR #99 — closes the "no rotation runbook anywhere in repo" deferred finding.
+
+### frontend/UI
+- FeaturedCard star-rendering DOM split fix + `RelatedRepoCard` `★ 22.2K` rendering — A7 (`aae6b9c8`) in PR #96. Resolves 4 stable + 1 flaky vitest cases catalogued in `phase-logs/A10-test-baseline.md`.
+- Sidebar `/githubrepo` 404 retargeted to `/` per WIREMAP §3a — A7 (`aae6b9c8`).
+- Operator-only pages shipped in PR #97: `/about` (200), `/x402` (402 paywall hint), `/api/oembed` (200), Footer revamp, `llms-full.txt`, `FreshnessBadge` component.
+- `home-page-honesty` consensus panel ≥8 slice preserved at `src/app/page.tsx:736` (verified by AUDIT-RESPONSE).
+
+### worker/data
+- Worker GitHub token-pool wiring — A6 (`be477069`) at `apps/trendingrepo-worker/src/lib/util/github-token-pool.ts`. Closes ENGINE Tier-2 #5 (PAT double-billing). Caller migration across `apps/trendingrepo-worker/src/fetchers/**` is **flagged for follow-up** in REPORT.md (the new module may be partially dead until callers are migrated).
+- `arxiv` worker fetcher ownership decision documented in PR #99 — script remains primary writer; worker fetcher stays unregistered with explicit doc.
+- Funding-fetcher freshness registration (`b741ddd9`) — pre-swarm, in window.
+
+### workflows/CI
+- Freshness-gate advisory-vs-blocking distinction at `/api/cron/freshness/state` — A8 (`9b7a17a6`).
+- Snapshot workflows hardened with `timeout-minutes` caps (was 6.1h hangs) in PR #99.
+- `cron-agent-commerce.yml` retry+continue-on-error for agentic.market 429s and Node 22 pin (PR #101).
+- D1 workflows aligned to Node 22 in same PR.
+- Shared `.github/actions/git-commit-data/action.yml` with 6-attempt rebase backoff (cherry-pick `13cced72`/`d303c666`/`4140acfc` already on branch) — fixes Twitter/Devto/collection-rankings/fast-discovery push-race failures.
+- `check-freshness` extended to include Sentry status (`17d39f7a`).
+
+### docs
+- Cadence claim drift consolidation to "20m" in user-facing surfaces (`llms.txt`, `llms-full.txt`, home page) — A13 (`6ebcb4b0`) in PR #96. Note: `docs/ARCHITECTURE.md`/`INGESTION.md`/`DEPLOY.md` themselves were **not** touched (REPORT.md §A1).
+- Sentry verification proof + alignment notes (`c13f8c7e`, `1ac66690`, `57507e69`).
+- `docs/RUNBOOK-secret-rotation.md` new — quarterly cadence for `GH_TOKEN_POOL`, `APIFY_API_TOKEN`, `CRON_SECRET`, Bluesky, ProductHunt, Reddit (PR #99).
+- `tasks/CURRENT-SPRINT.md` updated (`294d3d99`).
+- 5 doc contradictions (DEPLOY.md, ENGINE.md, SITE-WIREMAP.md cadence) addressed via `cf3b2a95 docs(A25)` + `c308ad6f docs(A25)` + A13 + workflow-side `8da042c0 chore(workflows/A20)` (cherry-picked from sprint branch into PR #96).
+
+## Findings still deferred (operator-only)
+
+1. **`/api/pipeline/ingest` 504 timeouts (Vercel)** — production runtime issue; not fixable from this workspace under the no-`vercel --prod` rule. Operator must investigate Vercel function timeout, chunk the route, or migrate ingest to the Railway worker.
+2. **Apify Twitter actor cost / dataset metrics** — no `APIFY_API_TOKEN` in workspace. Operator must check `apidojo~tweet-scraper` actor in Apify dashboard for runs/day, dataset rows, $/run vs $8/day budget.
+3. **Sentry event-flow verification on `agnt-pf` (de.sentry.io)** — Sentry MCP not authorised for the EU org in this session. Operator must verify last 5 events for `trendingrepo` (app) and `trendingrepo-worker` (project id 4511285393686608); confirm DSNs in Vercel + Railway env.
+4. **`trending-mcp` / `mcp-dependents` / `mcp-smithery-rank` Redis null metadata** — writers exist and recent workflow runs reported success, but live Redis probe is needed (no token in session). Operator runs `npm run verify:data-store` against prod.
+5. **Supabase `last_seen_at` lag** — domain-level lag of 2-4 days behind worker `updated_at`. Investigation requires Supabase write to confirm fix won't break ranking. Operator-owned.
+6. **`Refresh agent-commerce pipeline` repeated failures (since 2026-05-03T12:51Z)** — multi-script orchestration; failure mode invisible from `gh run view --log-failed`. Needs targeted follow-up swarm or operator deep-dive. (Mitigated partially by PR #101 retry/Node 22 pin; needs end-to-end verification.)
+7. **Frontend external-image blocks** (`dev.to` ORB, ProductHunt unavatar.io block, `hackernews/trending` 404 resources, `bluesky/trending` 22 console errors, `compare`/`skills` 503) — runtime image-host issues; require browser-replicated debug per route.
+8. **No unified `cross-mentions:{repo}` aggregator key** — product decision, not a bug. Needs Phase-2 design in `tasks/` before any worker change.
+9. **Complexity hotspot `src/app/agent-commerce/...`** at cyclo 45 / cogni 111 / **2238 LOC** — 3× next-worst LOC. No refactor agent assigned; needs operator-owned scope + plan.
+10. **11 MEDIUM dependency CVEs** (`@sentry/nextjs`, `@vitest/mocker`, `esbuild`, `next`, `postcss`, `resend`, `svix`, `uuid`, `vite`, `vite-node`, `vitest`) — `npm audit --json` was never run cleanly. Half are dev-only and bumpable in isolation; `next` + `@sentry/nextjs` carry framework-bump risk.
+11. **Worker fetcher caller migration** to the new `github-token-pool` module — `be477069` adds the module but diff shows no caller migration in `apps/trendingrepo-worker/src/fetchers/**`. If callers still read `process.env.GITHUB_TOKEN` directly, ENGINE Tier-2 #5 remains effectively open.
+12. **Pre-existing dirty workspace tree** — 30+ paths modified (`.gitignore`, `data/*.json`, `.data/**`, etc.) belonging to another agent / in-flight branch. Hard rule: don't touch. Operator commits/stashes/reverts intentionally.
+
+## Final swarm metrics
+
+- **Agents dispatched:** ~25 across 5 waves (A1-A14 audit, C-wave deps follow-up, layer2 layer3 wave4 dispatch shells in `.audit/2026-05-04-swarm/`).
+- **Agent-commits with `swarm/Ax` tag landed:** 4 (A6 `be477069`, A7 `aae6b9c8`, A8 `9b7a17a6`, A13 `6ebcb4b0`).
+- **Total commits in audit window** (`c4f02c27..origin/main`): **29** — including 4 PR merges, 13 Sentry observability fixes, 5 `chore(data)` data refreshes, 2 Sentry doc updates, 1 sprint update, 4 ops/health.
+- **Audit deliverables produced:** `MAP.md`, `REPORT.md`, `AUDIT-RESPONSE.md`, 17 phase-logs (`A1-A14`, `A32-A34`, `C5`), 5 dispatch shells, `wave2-pr-body.md`, `audit-queen-objective.txt`, `orchestration.log`, this `AUDIT-FINAL.md`.
+- **Swarm runtime:** initialised `2026-05-04T05:37Z` (Phase 0 MAP), this E8 finalize step `2026-05-04T07:50Z`.
+
+## Production verify (curl spot-checks)
+
+Recommended (operator to execute against `https://trending.report` or current canonical prod URL):
+
+```
+curl -sI https://<prod>/about              # expect HTTP/2 200
+curl -sI https://<prod>/x402               # expect 402 (paywall hint, PR #97)
+curl -sI https://<prod>/api/oembed         # expect 200 (PR #97 oembed responder)
+curl -sI https://<prod>/api/health         # expect 200 + freshness JSON
+curl -sI https://<prod>/api/_internal/sentry-canary  # expect 200 + Sentry event captured
+curl -sI https://<prod>/twitter            # expect 200; client hydrates fresh ts
+curl -sI https://<prod>/githubrepo         # expect 308/redirect to / (sidebar fix)
+curl -sI https://<prod>/llms.txt           # expect 200, "20m" cadence (A13)
+curl -sI https://<prod>/llms-full.txt      # expect 200, full surface map (PR #97)
+```
+
+Spot-checks not run from this E8 step (no network egress in finalize). REPORT.md notes A14 `npm run typecheck && npm run lint:guards && npm test && npm run test:hooks && npm run freshness:check -- --timeout-ms 30000` should be the gating pre-merge sequence; AUDIT-RESPONSE confirmed `npx vitest run` against `FeaturedCard.test.tsx` + `v4-home-repo.test.tsx` + `home-page-honesty.test.ts` = **30/30 passing** locally on the resolved branch state.
+
+---
+
+**Status:** audit-2026-05-04 wave **closed for code work** on `origin/main`. Remaining items are operator/runtime/infra-owned and explicitly out of swarm scope. Next operator action: execute the curl spot-checks above and tick off deferred items #1–#6 in priority order.

--- a/.github/workflows/cron-agent-commerce.yml
+++ b/.github/workflows/cron-agent-commerce.yml
@@ -24,19 +24,40 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Fetch Agentic Market services
+        continue-on-error: true
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
-        run: node scripts/fetch-agentic-market.mjs
+        run: |
+          set +e
+          attempt=1
+          max_attempts=3
+          while [ "$attempt" -le "$max_attempts" ]; do
+            echo "[agent-commerce] agentic.market attempt=$attempt/$max_attempts"
+            node scripts/fetch-agentic-market.mjs
+            rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "[agent-commerce] agentic.market fetch succeeded"
+              exit 0
+            fi
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "::warning::agentic.market fetch failed after $max_attempts attempts (last_rc=$rc); continuing with stale cached payload"
+              exit 0
+            fi
+            sleep_seconds=$((attempt * 30))
+            echo "[agent-commerce] retrying in ${sleep_seconds}s"
+            sleep "$sleep_seconds"
+            attempt=$((attempt + 1))
+          done
 
       - name: Fetch OpenRouter models
         env:

--- a/docs/REPO-OVERVIEW.md
+++ b/docs/REPO-OVERVIEW.md
@@ -1,0 +1,102 @@
+# STARSCREENER — Repo Overview
+
+Onboarding for a new contributor. One page. Read this first, then dive into the deep docs linked at the bottom.
+
+## What this is
+
+Real-time trend-discovery scanner. Aggregates GitHub stars, Twitter buzz, Reddit / HN / Bluesky / ProductHunt / DevTo / Lobsters / arXiv / npm / Product-Hunt signals, scores + classifies repos, and surfaces breakout candidates before they go mainstream.
+
+Two deployable surfaces live in this monorepo:
+
+1. **Next.js app** (`src/app/`) — operator UI + public read-only routes. Vercel main = production.
+2. **trendingrepo-worker** (`apps/trendingrepo-worker/`) — sister Railway service hosting ~37 background fetchers (MCP registries, funding sources, scoring, consensus analyst). Independent build / deploy. See its own README in that subdir.
+
+## Tech stack
+
+- **Framework:** Next.js 15 (App Router, Turbopack, RSC + client islands)
+- **Language:** TypeScript 5 strict
+- **UI:** React 19, Tailwind 4, Recharts, Framer Motion, Zustand
+- **Data store:** Redis (Railway `redis://` via `ioredis` OR Upstash REST) — source of truth for ~30 cron-driven payloads. Three-tier read in [src/lib/data-store.ts](../src/lib/data-store.ts): Redis → bundled JSON → in-memory last-known-good.
+- **Validation:** Zod on all API boundaries (enforced by `npm run lint:guards`)
+- **Auth:** cookie-based admin session
+- **Payments:** Stripe configured (not billed yet)
+- **Deploy:** Vercel (main → prod) + GitHub Actions cron (3h default) + Railway (worker)
+- **Node:** 22.x (pinned via `engines`)
+
+## Repo layout
+
+```
+src/
+  app/                 App Router routes (/twitter, /ideas, /funding, /admin, /reddit, /hackernews, /bluesky, /devto, /lobsters, /producthunt, ...)
+  components/          UI components grouped by domain (ideas/, reactions/, news/, submissions/, ...)
+  lib/                 Server libs — data-store, scoring, freshness, twitter service, env guards
+bin/ cli/ scripts/     Collector entrypoints (collect-twitter, collect-funding, scrape-* per source)
+.data/                 git-tracked JSONL scan output (whitelisted in .gitignore)
+data/                  bundled JSON snapshots seeding cold starts (writes happen via Redis, NOT here)
+apps/
+  trendingrepo-worker/ Railway sister service — fetchers, consensus analyst, scoring jobs
+mcp/                   MCP server source for code-review-graph integration
+docs/                  ARCHITECTURE / DATABASE / DEPLOY / INGESTION / TWITTER_SIGNAL_LAYER / SOURCE_DISCOVERY / OPERATOR / ENGINE / SITE-WIREMAP, plus protocols/ and review/ subdirs
+.github/workflows/     ~62 GitHub Actions workflows — scheduled scrapers, health-watch, sentry verify, refresh jobs
+tasks/                 BACKLOG.md, CURRENT-SPRINT.md, data-api.md (data-layer plan)
+```
+
+## Data flow (one paragraph)
+
+GitHub Actions cron jobs run collectors (`scripts/scrape-*`, `scripts/collect-*`) on a staggered hourly+minute rotation. Each collector runs in **direct mode**: it writes append-only JSONL to `.data/*.jsonl`, dual-writes the latest payload to Redis via [scripts/_data-store-write.mjs](../scripts/_data-store-write.mjs), and `git push`es the JSONL change. The Next.js app reads via `refreshXxxFromStore()` hooks (Redis → bundled JSON → memory fallback). Public pages render from the in-memory cache; ISR = 30 min on `/`. **Never** `readFileSync(process.cwd(), "data", ...)` for new sources — always go through the data-store. **Never** switch Twitter back to API mode (Vercel filesystem is ephemeral; writes vanish).
+
+## Run dev
+
+```bash
+npm install                    # Node 22.x required
+cp .env.example .env.local     # then fill GITHUB_TOKEN, CRON_SECRET; pick ONE Redis pair (REDIS_URL OR UPSTASH_*)
+npm run dev                    # Turbopack on port 3023
+```
+
+OneDrive gotcha: `next.config.ts:12-25` has a `.next` junction workaround. CSS edits can be silently reverted by OneDrive sync — see memory note `project_onedrive_dev_server_block`.
+
+## Common scripts
+
+```bash
+npm run dev                    # Turbopack, port 3023
+npm run build && npm start     # production path
+npm run lint                   # eslint
+npm run lint:guards            # meta-lint: Zod on mutating routes, error envelopes, runtime drift
+npm run typecheck              # strict tsc — run before EVERY commit
+npm test                       # node:test + tsx + vitest in serial
+npm run test:hooks             # vitest only
+npm run test:e2e               # Playwright
+npm run collect:twitter        # Apify apidojo~tweet-scraper
+npm run scrape:reddit          # also :hn :bsky :ph :devto :lobsters :arxiv :npm
+npm run verify:data-store      # sanity-check Redis connectivity
+```
+
+## Tests
+
+- **vitest** — colocated under `src/**/__vitest__/*.test.ts` and `src/**/__tests__/*.test.tsx`. Fast unit + component tests. Entry: `npm run test:hooks`.
+- **node:test + tsx** — older suite for collector / scoring logic. Entry: included in `npm test`.
+- **Playwright** — end-to-end against running dev server. Entry: `npm run test:e2e` (or `:e2e:ui`).
+
+`npm test` runs all three in serial. CI runs the same.
+
+## Where to look first
+
+- **Operator situational-awareness** → [docs/OPERATOR.md](OPERATOR.md) — TL;DR, current prod state, what shipped vs open
+- **Engine map (62 workflows × keys × cron × pools)** → [docs/ENGINE.md](ENGINE.md)
+- **Site wire map (route → data → collector → external API)** → [docs/SITE-WIREMAP.md](SITE-WIREMAP.md)
+- New here on architecture? [docs/ARCHITECTURE.md](ARCHITECTURE.md)
+- Data layer plan? [tasks/data-api.md](../tasks/data-api.md)
+- Ingest pipeline? [docs/INGESTION.md](INGESTION.md) + [docs/TWITTER_SIGNAL_LAYER.md](TWITTER_SIGNAL_LAYER.md)
+- Adding a signal source? [docs/SOURCE_DISCOVERY.md](SOURCE_DISCOVERY.md)
+- Deploy issues? [docs/DEPLOY.md](DEPLOY.md)
+
+## Conventions that bite
+
+- **Direct mode only** for collectors. API mode silently fails on Vercel.
+- **`git add <specific-file>`** only — never `-A` or `.` (parallel-session merge anti-pattern).
+- **Mutating API routes need Zod** — `lint:guards` enforces.
+- **Data reads via data-store**, not `readFileSync`.
+- **Append-only JSONL** for scans. Aggregator dedupes downstream.
+- **Run `npm run typecheck` before every commit.** If red, revert.
+
+Full anti-patterns list: [CLAUDE.md](../CLAUDE.md) → "Anti-Patterns Already Burned".

--- a/src/app/api/admin/pool-state/route.ts
+++ b/src/app/api/admin/pool-state/route.ts
@@ -4,7 +4,11 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { adminAuthFailureResponse, verifyAdminAuth } from "@/lib/api/auth";
 import { getDataStore } from "@/lib/data-store";
-import { getGitHubTokenPool } from "@/lib/github-token-pool";
+import {
+  getGitHubTokenPool,
+  redactToken,
+  type PublishedTokenState,
+} from "@/lib/github-token-pool";
 import { githubKeyFingerprint } from "@/lib/pool/github-telemetry";
 import { redditUserAgentFingerprint } from "@/lib/pool/reddit-ua-pool";
 import { redis } from "@/lib/redis";
@@ -21,6 +25,8 @@ export interface UsageSummary {
   requests24h: number;
   success24h: number;
   fail24h: number;
+  rateLimited24h?: number;
+  last429At?: string | null;
   lastCallAt: string | null;
   lastOperation: string | null;
   lastStatusCode: number | null;
@@ -115,6 +121,12 @@ interface MetaFile {
   writtenAt?: string;
 }
 
+interface GithubKeyDescriptor {
+  label: string;
+  usageFingerprints: string[];
+  publishedState: PublishedTokenState | null;
+}
+
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const IDLE_KEY_MS = 12 * HOUR_MS;
@@ -169,15 +181,29 @@ function classifyByAge(iso: string | null, budgetMs: number): PoolStatus {
 
 async function readUsage(
   prefix: "github" | "reddit" | "twitter",
-  fingerprint: string,
+  fingerprintOrAliases: string | string[],
   buckets: string[],
 ): Promise<UsageSummary & { lastRateLimitRemaining: number | null; lastRateLimitReset: string | null }> {
+  const fingerprints = Array.from(
+    new Set(
+      (Array.isArray(fingerprintOrAliases)
+        ? fingerprintOrAliases
+        : [fingerprintOrAliases]
+      ).filter(Boolean),
+    ),
+  );
   const hashes = await Promise.all(
-    buckets.map((bucket) => redis.hgetall(`pool:${prefix}:usage:${fingerprint}:${bucket}`)),
+    buckets.flatMap((bucket) =>
+      fingerprints.map((fingerprint) =>
+        redis.hgetall(`pool:${prefix}:usage:${fingerprint}:${bucket}`),
+      ),
+    ),
   );
   let requests24h = 0;
   let success24h = 0;
   let fail24h = 0;
+  let rateLimited24h = 0;
+  let last429At: string | null = null;
   let lastCallAt: string | null = null;
   let lastOperation: string | null = null;
   let lastStatusCode: number | null = null;
@@ -189,6 +215,7 @@ async function readUsage(
     requests24h += parseNumber(hash.requests) ?? 0;
     success24h += parseNumber(hash.success) ?? 0;
     fail24h += parseNumber(hash.fail) ?? 0;
+    rateLimited24h += parseNumber(hash.rateLimited) ?? 0;
 
     const callAt = parseIso(hash.lastCallAt);
     if (callAt && (!lastCallAt || Date.parse(callAt) > Date.parse(lastCallAt))) {
@@ -202,12 +229,21 @@ async function readUsage(
         ? new Date(resetUnix * 1000).toISOString()
         : null;
     }
+    const rateLimitedAt = parseIso(hash.last429At);
+    if (
+      rateLimitedAt &&
+      (!last429At || Date.parse(rateLimitedAt) > Date.parse(last429At))
+    ) {
+      last429At = rateLimitedAt;
+    }
   }
 
   return {
     requests24h,
     success24h,
     fail24h,
+    rateLimited24h,
+    last429At,
     lastCallAt,
     lastOperation,
     lastStatusCode,
@@ -219,34 +255,108 @@ async function readUsage(
 
 async function readQuarantine(
   prefix: "github" | "reddit",
-  fingerprint: string,
+  fingerprintOrAliases: string | string[],
 ): Promise<QuarantineState> {
-  const raw = await redis.get(`pool:${prefix}:quarantine:${fingerprint}`);
-  if (!raw) return { active: false, reason: null, until: null };
-  try {
-    const parsed = JSON.parse(raw) as { reason?: string; untilTimestamp?: number };
-    const untilMs =
-      typeof parsed.untilTimestamp === "number"
-        ? parsed.untilTimestamp * 1000
-        : null;
-    return {
-      active: untilMs !== null && untilMs > Date.now(),
-      reason: parsed.reason ?? null,
-      until: untilMs ? new Date(untilMs).toISOString() : null,
-    };
-  } catch {
-    return { active: true, reason: "unknown", until: null };
-  }
-}
-
-function configuredGithubFingerprints(): string[] {
-  return Array.from(
+  const fingerprints = Array.from(
     new Set(
-      getGitHubTokenPool()
-        .snapshot()
-        .map((state) => githubKeyFingerprint(state.token)),
+      (Array.isArray(fingerprintOrAliases)
+        ? fingerprintOrAliases
+        : [fingerprintOrAliases]
+      ).filter(Boolean),
     ),
   );
+  const raws = await Promise.all(
+    fingerprints.map((fingerprint) =>
+      redis.get(`pool:${prefix}:quarantine:${fingerprint}`),
+    ),
+  );
+  let latestInactive: QuarantineState = { active: false, reason: null, until: null };
+  for (const raw of raws) {
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw) as { reason?: string; untilTimestamp?: number };
+      const untilMs =
+        typeof parsed.untilTimestamp === "number"
+          ? parsed.untilTimestamp * 1000
+          : null;
+      const state: QuarantineState = {
+        active: untilMs !== null && untilMs > Date.now(),
+        reason: parsed.reason ?? null,
+        until: untilMs ? new Date(untilMs).toISOString() : null,
+      };
+      if (state.active) return state;
+      if (
+        state.until &&
+        (!latestInactive.until ||
+          Date.parse(state.until) > Date.parse(latestInactive.until))
+      ) {
+        latestInactive = state;
+      }
+    } catch {
+      return { active: true, reason: "unknown", until: null };
+    }
+  }
+  return latestInactive;
+}
+
+function githubLegacyFingerprint(token: string | null | undefined): string {
+  const trimmed = token?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed.slice(-4) : "none";
+}
+
+function quarantineFromPublishedState(
+  state: PublishedTokenState | null,
+): QuarantineState {
+  if (!state?.quarantinedUntilMs) {
+    return { active: false, reason: null, until: null };
+  }
+  return {
+    active: state.quarantinedUntilMs > Date.now(),
+    reason: "published",
+    until: new Date(state.quarantinedUntilMs).toISOString(),
+  };
+}
+
+function configuredGithubKeys(): GithubKeyDescriptor[] {
+  const states = getGitHubTokenPool().snapshot();
+  const legacyCounts = new Map<string, number>();
+  const labelCounts = new Map<string, number>();
+  const labelIndexes = new Map<string, number>();
+
+  for (const state of states) {
+    const legacy = githubLegacyFingerprint(state.token);
+    legacyCounts.set(legacy, (legacyCounts.get(legacy) ?? 0) + 1);
+    const label = redactToken(state.token);
+    labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+  }
+
+  return states.map((state): GithubKeyDescriptor => {
+    const label = redactToken(state.token);
+    const labelIndex = (labelIndexes.get(label) ?? 0) + 1;
+    labelIndexes.set(label, labelIndex);
+    const safeLabel =
+      (labelCounts.get(label) ?? 0) > 1 ? `${label}#${labelIndex}` : label;
+    const legacy = githubLegacyFingerprint(state.token);
+    const usageFingerprints = [githubKeyFingerprint(state.token)];
+    if ((legacyCounts.get(legacy) ?? 0) === 1) {
+      usageFingerprints.push(legacy);
+    }
+    return {
+      label: safeLabel,
+      usageFingerprints,
+      publishedState: {
+        tokenLabel: label,
+        remaining: state.remaining,
+        resetUnixSec: state.resetUnixSec,
+        lastObservedMs: state.lastObservedMs,
+        quarantinedUntilMs: state.quarantinedUntilMs,
+        lambdaId: "local",
+        writtenAt: state.lastObservedMs
+          ? new Date(state.lastObservedMs).toISOString()
+          : "",
+      },
+    };
+  });
 }
 
 function stddev(values: number[]): number {
@@ -269,22 +379,45 @@ function poolHealth(rows: Array<{ status: PoolStatus; requests24h: number }>): P
 }
 
 async function githubState(buckets: string[]): Promise<AdminPoolStateResponse["github"]> {
-  const fingerprints = configuredGithubFingerprints();
+  const keys = configuredGithubKeys();
   const rows = await Promise.all(
-    fingerprints.map(async (fingerprint): Promise<GithubPoolRow> => {
-      const usage = await readUsage("github", fingerprint, buckets);
-      const quarantine = await readQuarantine("github", fingerprint);
+    keys.map(async (key): Promise<GithubPoolRow> => {
+      const usage = await readUsage("github", key.usageFingerprints, buckets);
+      const telemetryQuarantine = await readQuarantine("github", key.usageFingerprints);
+      const publishedQuarantine = quarantineFromPublishedState(key.publishedState);
+      const quarantine = telemetryQuarantine.active
+        ? telemetryQuarantine
+        : publishedQuarantine.active
+          ? publishedQuarantine
+          : telemetryQuarantine.until
+            ? telemetryQuarantine
+            : publishedQuarantine;
+      const publishedLastObserved = key.publishedState?.lastObservedMs
+        ? new Date(key.publishedState.lastObservedMs).toISOString()
+        : null;
+      const lastCallAt =
+        usage.lastCallAt ??
+        publishedLastObserved ??
+        parseIso(key.publishedState?.writtenAt);
       const idle =
-        !usage.lastCallAt ||
-        Date.now() - Date.parse(usage.lastCallAt) > IDLE_KEY_MS;
+        !lastCallAt ||
+        Date.now() - Date.parse(lastCallAt) > IDLE_KEY_MS;
       const status: PoolStatus = quarantine.active
         ? "RED"
         : idle
-          ? "YELLOW"
+          ? "RED"
           : "GREEN";
       return {
-        fingerprint,
+        fingerprint: key.label,
         ...usage,
+        lastCallAt,
+        lastRateLimitRemaining:
+          usage.lastRateLimitRemaining ?? key.publishedState?.remaining ?? null,
+        lastRateLimitReset:
+          usage.lastRateLimitReset ??
+          (key.publishedState?.resetUnixSec
+            ? new Date(key.publishedState.resetUnixSec * 1000).toISOString()
+            : null),
         quarantine,
         idle,
         status,
@@ -292,7 +425,7 @@ async function githubState(buckets: string[]): Promise<AdminPoolStateResponse["g
     }),
   );
   return {
-    totalConfigured: fingerprints.length,
+    totalConfigured: keys.length,
     health: poolHealth(rows),
     rows,
   };
@@ -307,11 +440,14 @@ async function redditState(buckets: string[]): Promise<AdminPoolStateResponse["r
       const fingerprint = redditUserAgentFingerprint(userAgent);
       const usage = await readUsage("reddit", fingerprint, buckets);
       const quarantine = await readQuarantine("reddit", fingerprint);
-      const last429At = usage.lastStatusCode === 429 ? usage.lastCallAt : null;
+      const last429At =
+        usage.last429At ?? (usage.lastStatusCode === 429 ? usage.lastCallAt : null);
       const status: PoolStatus = quarantine.active
         ? "RED"
-        : last429At
+        : usage.rateLimited24h && usage.rateLimited24h > 0
           ? "YELLOW"
+          : usage.fail24h > usage.success24h && usage.fail24h > 0
+            ? "YELLOW"
           : "GREEN";
       return {
         fingerprint,
@@ -328,7 +464,7 @@ async function redditState(buckets: string[]): Promise<AdminPoolStateResponse["r
     rows.map((row) => redis.hgetall(`pool:reddit:usage:${row.fingerprint}:${currentBucket}`)),
   );
   const rateLimitedLastHour = lastHourHashes.reduce((sum, hash) => {
-    return sum + (parseNumber(hash.lastStatusCode) === 429 ? (parseNumber(hash.requests) ?? 1) : 0);
+    return sum + (parseNumber(hash.rateLimited) ?? 0);
   }, 0);
   return {
     totalConfigured: agents.length,

--- a/src/app/api/admin/scan/__tests__/rate-limit.test.ts
+++ b/src/app/api/admin/scan/__tests__/rate-limit.test.ts
@@ -1,0 +1,95 @@
+// StarScreener — POST /api/admin/scan rate-limit envelope test.
+//
+// The route advertises 8 requests per 60s window. When the bucket is
+// saturated, POST must return 429 with a numeric Retry-After header
+// (seconds) and the standard { ok: false, error: "rate limited" } body.
+//
+// Auth runs BEFORE the limiter, so we set ADMIN_TOKEN and pass a matching
+// Authorization header — otherwise the request 401s and never reaches the
+// rate-limit branch under test.
+//
+// Pattern follows src/lib/pipeline/__tests__/rate-limit-routes.test.ts:
+// inject a MemoryRateLimitStore primed past max, then invoke POST directly.
+//
+// Run:
+//   npx tsx --test src/app/api/admin/scan/__tests__/rate-limit.test.ts
+
+import { beforeEach, after, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { _setStoreForTests } from "../../../../../lib/api/rate-limit";
+import {
+  MemoryRateLimitStore,
+  _resetFallbackWarningForTests,
+} from "../../../../../lib/api/rate-limit-store";
+
+const ADMIN_SCAN_WINDOW_MS = 60_000;
+const ADMIN_SCAN_MAX = 8;
+const ADMIN_TOKEN = "test-admin-token-rate-limit-fixture-32chars";
+
+const previousAdminToken = process.env.ADMIN_TOKEN;
+process.env.ADMIN_TOKEN = ADMIN_TOKEN;
+
+async function primeSaturatedStore(
+  ip: string,
+  windowMs: number,
+  maxRequests: number,
+): Promise<MemoryRateLimitStore> {
+  const store = new MemoryRateLimitStore();
+  const ttlSec = Math.max(1, Math.ceil(windowMs / 1000));
+  const key = `rl:${ip}:${windowMs}:${maxRequests}`;
+  for (let i = 0; i < maxRequests; i += 1) {
+    await store.incrementWithTtl(key, ttlSec);
+  }
+  _setStoreForTests(store);
+  return store;
+}
+
+beforeEach(() => {
+  _setStoreForTests(null);
+  _resetFallbackWarningForTests();
+});
+
+after(() => {
+  if (previousAdminToken === undefined) {
+    delete process.env.ADMIN_TOKEN;
+  } else {
+    process.env.ADMIN_TOKEN = previousAdminToken;
+  }
+  _setStoreForTests(null);
+});
+
+test("POST /api/admin/scan: returns 429 with Retry-After when rate-limit bucket is saturated", async () => {
+  const ip = "198.51.100.50";
+  await primeSaturatedStore(ip, ADMIN_SCAN_WINDOW_MS, ADMIN_SCAN_MAX);
+
+  const { POST } = await import("../route");
+  const { NextRequest } = await import("next/server");
+
+  const req = new Request("http://localhost/api/admin/scan", {
+    method: "POST",
+    headers: {
+      "x-forwarded-for": ip,
+      authorization: `Bearer ${ADMIN_TOKEN}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ source: "reddit" }),
+  });
+  const res = await POST(new NextRequest(req) as never);
+
+  assert.equal(res.status, 429, "expected 429 when bucket saturated");
+
+  const retryAfter = res.headers.get("retry-after");
+  assert.ok(
+    retryAfter !== null && /^\d+$/.test(retryAfter),
+    `Retry-After must be integer seconds, got: ${retryAfter}`,
+  );
+  assert.ok(
+    Number(retryAfter) >= 1,
+    `Retry-After should be >= 1 second, got: ${retryAfter}`,
+  );
+
+  const body = (await res.json()) as { ok: boolean; error: string };
+  assert.equal(body.ok, false, "envelope must be { ok: false, ... }");
+  assert.match(body.error, /rate limited/, "error string must mention rate limited");
+});

--- a/src/app/api/cron/freshness/state/__tests__/health-states.test.ts
+++ b/src/app/api/cron/freshness/state/__tests__/health-states.test.ts
@@ -1,0 +1,113 @@
+// F7 — Cover the freshness `health` discriminator added in 9b7a17a6.
+//
+// Rules per freshness-health.ts:deriveHealth:
+//   - "stale"    : at least one BLOCKING source is non-GREEN
+//   - "advisory" : every blocking source is GREEN, but at least one
+//                  non-blocking source is non-GREEN
+//   - "ok"       : every source is GREEN
+//
+// We invoke deriveHealth() directly with synthetic SourceState[] arrays so
+// nothing in the route file (Redis, fs, network) needs mocking.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  deriveHealth,
+  type FreshnessSourceState,
+  type FreshnessSourceStatus,
+} from "../../../../../../lib/freshness-health";
+
+type SourceState = FreshnessSourceState & {
+  name: string;
+  lastUpdate: string | null;
+  freshnessBudget: string;
+  ageMs: number | null;
+};
+
+function source(
+  name: string,
+  status: FreshnessSourceStatus,
+  blocking: boolean,
+): SourceState {
+  return {
+    name,
+    lastUpdate: status === "DEAD" ? null : "2026-05-04T00:00:00.000Z",
+    freshnessBudget: "6h",
+    ageMs: status === "DEAD" ? null : 1000,
+    status,
+    blocking,
+  };
+}
+
+test("deriveHealth: all GREEN → ok", () => {
+  const sources: SourceState[] = [
+    source("trending-repos", "GREEN", true),
+    source("mcp-dependents", "GREEN", false),
+    source("mcp-smithery-rank", "GREEN", false),
+  ];
+  assert.equal(deriveHealth(sources), "ok");
+});
+
+test("deriveHealth: empty list → ok", () => {
+  assert.equal(deriveHealth([]), "ok");
+});
+
+test("deriveHealth: only non-blocking degraded → advisory", () => {
+  const sources: SourceState[] = [
+    source("trending-repos", "GREEN", true),
+    source("mcp-dependents", "YELLOW", false),
+  ];
+  assert.equal(deriveHealth(sources), "advisory");
+});
+
+test("deriveHealth: non-blocking RED still advisory (not stale)", () => {
+  const sources: SourceState[] = [
+    source("trending-repos", "GREEN", true),
+    source("mcp-smithery-rank", "RED", false),
+  ];
+  assert.equal(deriveHealth(sources), "advisory");
+});
+
+test("deriveHealth: non-blocking DEAD still advisory (not stale)", () => {
+  const sources: SourceState[] = [
+    source("trending-repos", "GREEN", true),
+    source("mcp-dependents", "DEAD", false),
+  ];
+  assert.equal(deriveHealth(sources), "advisory");
+});
+
+test("deriveHealth: blocking YELLOW → stale", () => {
+  const sources: SourceState[] = [
+    source("trending-repos", "YELLOW", true),
+    source("mcp-dependents", "GREEN", false),
+  ];
+  assert.equal(deriveHealth(sources), "stale");
+});
+
+test("deriveHealth: blocking RED → stale", () => {
+  const sources: SourceState[] = [source("trending-repos", "RED", true)];
+  assert.equal(deriveHealth(sources), "stale");
+});
+
+test("deriveHealth: blocking DEAD → stale", () => {
+  const sources: SourceState[] = [source("trending-repos", "DEAD", true)];
+  assert.equal(deriveHealth(sources), "stale");
+});
+
+test("deriveHealth: blocking degraded wins over non-blocking GREEN", () => {
+  const sources: SourceState[] = [
+    source("mcp-dependents", "GREEN", false),
+    source("mcp-smithery-rank", "GREEN", false),
+    source("trending-repos", "RED", true),
+  ];
+  assert.equal(deriveHealth(sources), "stale");
+});
+
+test("deriveHealth: blocking degraded wins over non-blocking degraded", () => {
+  const sources: SourceState[] = [
+    source("mcp-dependents", "RED", false),
+    source("trending-repos", "YELLOW", true),
+  ];
+  assert.equal(deriveHealth(sources), "stale");
+});

--- a/src/app/api/cron/freshness/state/route.ts
+++ b/src/app/api/cron/freshness/state/route.ts
@@ -10,6 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
 import { getDataStore } from "@/lib/data-store";
+import { deriveHealth, type FreshnessHealth } from "@/lib/freshness-health";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -37,14 +38,6 @@ interface SourceState {
   status: SourceStatus;
   blocking: boolean;
 }
-
-// `health` distinguishes the three operator-meaningful states the gate can be
-// in: `ok` (everything GREEN), `advisory` (only non-blocking sources have
-// degraded — operator can ship), `stale` (at least one blocking source has
-// degraded — gate must not pass). Without this third value, a real Redis
-// outage on a blocking source looks identical to steady-state advisory
-// yellow on `mcp-dependents` / `mcp-smithery-rank`.
-type FreshnessHealth = "ok" | "advisory" | "stale";
 
 interface FreshnessStateResponse {
   checkedAt: string;
@@ -561,16 +554,6 @@ function summarize(sources: SourceState[]): FreshnessStateResponse["summary"] {
     red: sources.filter((source) => source.status === "RED").length,
     dead: sources.filter((source) => source.status === "DEAD").length,
   };
-}
-
-function deriveHealth(sources: SourceState[]): FreshnessHealth {
-  let advisoryDegraded = false;
-  for (const source of sources) {
-    if (source.status === "GREEN") continue;
-    if (source.blocking) return "stale";
-    advisoryDegraded = true;
-  }
-  return advisoryDegraded ? "advisory" : "ok";
 }
 
 export async function GET(

--- a/src/app/api/oembed/__tests__/route.test.ts
+++ b/src/app/api/oembed/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+// E5 — coverage for /api/oembed.
+//
+// Behaviour matrix from src/app/api/oembed/route.ts:
+//   - format != "json"          → 501 UNSUPPORTED_FORMAT
+//   - url missing               → 404 UNSUPPORTED_URL
+//   - url off-domain (SSRF)     → 404 UNSUPPORTED_URL
+//   - url path !== /repo/o/n    → 404 UNSUPPORTED_URL
+//   - valid /repo/owner/name    → 200 + full oEmbed rich JSON
+//
+// SITE_URL is resolved at module-load time from NEXT_PUBLIC_APP_URL (default
+// https://trendingrepo.com). We pin it explicitly so the on-domain assertion
+// is deterministic regardless of host env.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { NextRequest } from "next/server";
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_APP_URL = "https://trendingrepo.com";
+});
+
+async function callGet(rawUrl: string): Promise<Response> {
+  const { GET } = await import("../route");
+  const req = new NextRequest(rawUrl);
+  return GET(req);
+}
+
+describe("GET /api/oembed", () => {
+  it("returns 501 when format is not json", async () => {
+    const res = await callGet(
+      "https://trendingrepo.com/api/oembed?format=xml&url=https://trendingrepo.com/repo/vercel/next.js",
+    );
+    expect(res.status).toBe(501);
+    const body = (await res.json()) as { ok: boolean; code?: string };
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe("UNSUPPORTED_FORMAT");
+  });
+
+  it("returns 404 when url query param is missing", async () => {
+    const res = await callGet("https://trendingrepo.com/api/oembed");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { ok: boolean; code?: string };
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe("UNSUPPORTED_URL");
+  });
+
+  it("returns 404 when url host is off-domain (SSRF guard)", async () => {
+    const res = await callGet(
+      "https://trendingrepo.com/api/oembed?url=https://attacker.example.com/repo/vercel/next.js",
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { ok: boolean; code?: string };
+    expect(body.code).toBe("UNSUPPORTED_URL");
+  });
+
+  it("returns 404 when url path is not /repo/owner/name", async () => {
+    const res = await callGet(
+      "https://trendingrepo.com/api/oembed?url=https://trendingrepo.com/funding",
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { ok: boolean; code?: string };
+    expect(body.code).toBe("UNSUPPORTED_URL");
+  });
+
+  it("returns 200 with the full oEmbed rich payload for a valid repo url", async () => {
+    const res = await callGet(
+      "https://trendingrepo.com/api/oembed?url=https://trendingrepo.com/repo/vercel/next.js",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/json\+oembed/);
+    const cc = res.headers.get("cache-control") ?? "";
+    expect(cc).toContain("public");
+    expect(cc).toContain("s-maxage=86400");
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.version).toBe("1.0");
+    expect(body.type).toBe("rich");
+    expect(body.title).toBe("vercel/next.js — TrendingRepo");
+    expect(body.author_name).toBe("vercel");
+    expect(body.author_url).toBe("https://github.com/vercel");
+    expect(body.provider_name).toBe("TrendingRepo");
+    expect(body.provider_url).toBe("https://trendingrepo.com");
+    expect(body.thumbnail_url).toBe(
+      "https://avatars.githubusercontent.com/vercel?s=80&v=4",
+    );
+    expect(body.thumbnail_width).toBe(80);
+    expect(body.thumbnail_height).toBe(80);
+    expect(body.width).toBe(600);
+    expect(body.height).toBe(280);
+    expect(body.cache_age).toBe("86400");
+    expect(typeof body.html).toBe("string");
+    expect(body.html).toContain(
+      "https://trendingrepo.com/repo/vercel/next.js",
+    );
+    expect(body.html).toContain('sandbox="allow-scripts allow-same-origin"');
+  });
+
+  it("returns 200 for a valid url with a trailing slash", async () => {
+    const res = await callGet(
+      "https://trendingrepo.com/api/oembed?url=https://trendingrepo.com/repo/vercel/next.js/",
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { author_name: string };
+    expect(body.author_name).toBe("vercel");
+  });
+});

--- a/src/app/bluesky/trending/page.tsx
+++ b/src/app/bluesky/trending/page.tsx
@@ -20,7 +20,7 @@ import {
 import { TerminalFeedTable, type FeedColumn } from "@/components/feed/TerminalFeedTable";
 import { WindowedFeedTable } from "@/components/feed/WindowedFeedTable";
 import { EntityLogo } from "@/components/ui/EntityLogo";
-import { repoLogoUrl, userLogoUrl, resolveLogoUrl } from "@/lib/logos";
+import { repoLogoUrl, userLogoUrl } from "@/lib/logos";
 
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
@@ -214,16 +214,12 @@ function BskyPostFeed({ posts }: { posts: BskyPost[] }) {
             ?.avatar ??
           (p.author as { avatarUrl?: string | null } | null)?.avatarUrl ??
           null;
-        const handleFavicon = p.author?.handle
-          ? resolveLogoUrl(p.author.handle, null, 64)
-          : null;
         return (
           <div className="flex min-w-0 items-start gap-2">
             <EntityLogo
               src={
                 repoLogoUrl(linkedRepo) ??
-                userLogoUrl(authorAvatar) ??
-                handleFavicon
+                userLogoUrl(authorAvatar)
               }
               name={linkedRepo ?? p.author?.handle ?? p.text}
               size={20}

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -198,11 +198,13 @@ export default async function FundingPage() {
       .slice(0, 10)
       .map((signal, index) => {
         // AUDIT-2026-05-04: closes the funding-page no-images gap.
-        // Prefer the extractor's pre-resolved logoUrl when populated,
-        // otherwise derive a Google Favicons URL from companyWebsite.
-        const explicit = signal.extracted?.companyLogoUrl ?? null;
-        const logoUrl =
-          explicit ?? companyLogoUrl(signal.extracted?.companyWebsite ?? null);
+        // Route extractor logo inputs through the shared sanitizer so legacy
+        // Clearbit URLs do not leak direct third-party image failures into UI.
+        const explicit =
+          signal.extracted?.companyLogoUrl ??
+          signal.extracted?.companyWebsite ??
+          null;
+        const logoUrl = companyLogoUrl(explicit);
         return (
           <MoverRow
             key={signal.id}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+@source not "../../.audit";
+@source not "../../.claude-flow";
+@source not "../../.hive-mind";
+@source not "../../.tmp";
+@source not "../../dogfood-output";
+@source not "../../test-results";
+
 /* V4 (CORPUS) primitives — loaded after Tailwind so utility classes keep
    precedence but V4 component selectors take over inside their blocks. */
 @import "../components/ui/v4.css";

--- a/src/app/hackernews/trending/page.tsx
+++ b/src/app/hackernews/trending/page.tsx
@@ -20,7 +20,7 @@ import {
 import { TerminalFeedTable, type FeedColumn } from "@/components/feed/TerminalFeedTable";
 import { WindowedFeedTable } from "@/components/feed/WindowedFeedTable";
 import { EntityLogo } from "@/components/ui/EntityLogo";
-import { repoLogoUrl, resolveLogoUrl } from "@/lib/logos";
+import { repoLogoUrl } from "@/lib/logos";
 
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
@@ -206,11 +206,10 @@ function HnStoryFeed({ stories }: { stories: HnStory[] }) {
       header: "Title",
       render: (s) => {
         const linkedRepo = s.linkedRepos?.[0]?.fullName;
-        const fallbackLogo = resolveLogoUrl(s.url ?? null, s.title, 64);
         return (
           <div className="flex min-w-0 items-center gap-2">
             <EntityLogo
-              src={repoLogoUrl(linkedRepo) ?? fallbackLogo}
+              src={repoLogoUrl(linkedRepo)}
               name={linkedRepo ?? s.by ?? s.title}
               size={20}
               shape="square"

--- a/src/app/lobsters/page.tsx
+++ b/src/app/lobsters/page.tsx
@@ -20,7 +20,7 @@ import {
 import { TerminalFeedTable, type FeedColumn } from "@/components/feed/TerminalFeedTable";
 import { WindowedFeedTable } from "@/components/feed/WindowedFeedTable";
 import { EntityLogo } from "@/components/ui/EntityLogo";
-import { repoLogoUrl, resolveLogoUrl } from "@/lib/logos";
+import { repoLogoUrl } from "@/lib/logos";
 
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
@@ -207,11 +207,10 @@ function StoryFeed({ stories }: { stories: LobstersStory[] }) {
       render: (story) => {
         const commentsHref = story.commentsUrl || lobstersStoryHref(story.shortId);
         const linkedRepo = story.linkedRepos?.[0]?.fullName;
-        const fallbackLogo = resolveLogoUrl(story.url ?? null, story.title, 64);
         return (
           <div className="flex min-w-0 items-center gap-2">
             <EntityLogo
-              src={repoLogoUrl(linkedRepo) ?? fallbackLogo}
+              src={repoLogoUrl(linkedRepo)}
               name={linkedRepo ?? story.title}
               size={20}
               shape="square"

--- a/src/app/x402/__tests__/route.test.ts
+++ b/src/app/x402/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+// E6 — coverage for the x402 HTTP 402 manifest stub.
+//
+// The route only re-exports method handlers (GET/HEAD/POST/OPTIONS) — no
+// data-store, no auth, no env. Tests construct a plain Request, invoke the
+// handler directly, and assert on status + headers + body shape.
+
+import { describe, it, expect } from "vitest";
+
+import { GET, HEAD, POST, OPTIONS } from "../route";
+
+import type { NextRequest } from "next/server";
+
+function makeReq(method: string): NextRequest {
+  return new Request("http://localhost/x402", { method }) as unknown as NextRequest;
+}
+
+describe("x402 route — HTTP 402 manifest stub", () => {
+  it("GET returns 402 with x402 JSON body", async () => {
+    const res = GET(makeReq("GET"));
+    expect(res.status).toBe(402);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+    expect(res.headers.get("X-Payment-Required")).toBe("x402");
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("type", "x402-payment-required");
+    expect(body).toHaveProperty("version");
+    expect(body).toHaveProperty("accepts");
+    expect(body).toHaveProperty("networks");
+    expect(body).toHaveProperty("description");
+    expect(body).toHaveProperty("docs");
+    expect(Array.isArray(body.accepts)).toBe(true);
+    expect(Array.isArray(body.networks)).toBe(true);
+  });
+
+  it("HEAD returns 402 with X-Payment-Required header and no body", async () => {
+    const res = HEAD(makeReq("HEAD"));
+    expect(res.status).toBe(402);
+    expect(res.headers.get("X-Payment-Required")).toBe("x402");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const text = await res.text();
+    expect(text).toBe("");
+  });
+
+  it("POST returns 402 with x402 JSON body", async () => {
+    const res = POST(makeReq("POST"));
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("type", "x402-payment-required");
+    expect(body).toHaveProperty("accepts");
+    expect(body).toHaveProperty("networks");
+  });
+
+  it("OPTIONS returns 204 with Allow header listing supported methods", async () => {
+    const res = OPTIONS();
+    expect(res.status).toBe(204);
+    const allow = res.headers.get("Allow") ?? "";
+    expect(allow).toMatch(/GET/);
+    expect(allow).toMatch(/HEAD/);
+    expect(allow).toMatch(/POST/);
+    expect(allow).toMatch(/OPTIONS/);
+    expect(res.headers.get("Access-Control-Allow-Methods")).toMatch(/GET/);
+  });
+
+  it("does not export handlers for unsupported methods (Next.js will 405)", async () => {
+    const mod = await import("../route");
+    const exported = Object.keys(mod);
+    expect(exported).not.toContain("DELETE");
+    expect(exported).not.toContain("PUT");
+    expect(exported).not.toContain("PATCH");
+    expect(exported).toContain("GET");
+    expect(exported).toContain("HEAD");
+    expect(exported).toContain("POST");
+    expect(exported).toContain("OPTIONS");
+  });
+});

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Footer } from "@/components/layout/Footer";
+
+afterEach(() => {
+  cleanup();
+});
+
+const SOCIAL_HREFS = {
+  LinkedIn: "https://www.linkedin.com/company/trendingrepo",
+  YouTube: "https://www.youtube.com/@trendingrepo",
+  Reddit: "https://www.reddit.com/r/trendingrepo",
+  G2: "https://www.g2.com/products/trendingrepo",
+} as const;
+
+describe("Footer social anchors", () => {
+  it("renders all 4 social anchors with their expected hrefs", () => {
+    const { getByText } = render(<Footer />);
+
+    for (const [label, expectedHref] of Object.entries(SOCIAL_HREFS)) {
+      const anchor = getByText(label).closest("a");
+      expect(anchor, `${label} anchor should exist`).not.toBeNull();
+      expect(anchor?.getAttribute("href")).toBe(expectedHref);
+    }
+  });
+
+  it("marks each social anchor as external with rel containing noreferrer", () => {
+    const { getByText } = render(<Footer />);
+
+    for (const label of Object.keys(SOCIAL_HREFS)) {
+      const anchor = getByText(label).closest("a");
+      expect(anchor?.getAttribute("target")).toBe("_blank");
+      const rel = anchor?.getAttribute("rel") ?? "";
+      expect(rel).toContain("noreferrer");
+    }
+  });
+});

--- a/src/components/news/newsTopMetrics.ts
+++ b/src/components/news/newsTopMetrics.ts
@@ -551,8 +551,7 @@ export function buildHackerNewsHeader(
       byline: s.by ? `@${s.by}` : undefined,
       scoreLabel: `${compactNumber(s.score ?? 0)} pts · ${compactNumber(s.descendants ?? 0)} cmts`,
       ageHours: s.ageHours ?? null,
-      logoUrl:
-        repoLogoUrl(linkedRepo) ?? resolveLogoUrl(s.url ?? null, s.title, 64),
+      logoUrl: repoLogoUrl(linkedRepo),
       logoName: linkedRepo ?? s.by ?? s.title,
     };
   });
@@ -627,10 +626,7 @@ export function buildBlueskyHeader(
       ageHours: p.ageHours ?? null,
       logoUrl:
         repoLogoUrl(linkedRepo) ??
-        userLogoUrl(authorAvatar) ??
-        (p.author?.handle
-          ? resolveLogoUrl(p.author.handle, null, 64)
-          : null),
+        userLogoUrl(authorAvatar),
       logoName: linkedRepo ?? p.author?.handle ?? p.text,
     };
   });
@@ -972,8 +968,7 @@ export function buildLobstersHeader(
       byline: s.by ? `@${s.by}` : undefined,
       scoreLabel: `${compactNumber(s.score ?? 0)} pts · ${compactNumber(s.commentCount ?? 0)} cmts`,
       ageHours: s.ageHours ?? null,
-      logoUrl:
-        repoLogoUrl(linkedRepo) ?? resolveLogoUrl(s.url ?? null, s.title, 64),
+      logoUrl: repoLogoUrl(linkedRepo),
       logoName: linkedRepo ?? s.by ?? s.title,
     };
   });

--- a/src/components/shared/__tests__/FreshnessBadge.test.tsx
+++ b/src/components/shared/__tests__/FreshnessBadge.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+// Anchor "now" so the relative-time math is deterministic regardless of
+// when the suite runs. classifyFreshness reads Date.now() by default.
+const NOW = new Date("2026-05-04T12:00:00.000Z").getTime();
+
+function setNow(ms: number) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(ms));
+}
+
+describe("FreshnessBadge", () => {
+  it("renders 'live' for an age under one minute", () => {
+    setNow(NOW);
+    const fetchedAt = new Date(NOW - 30 * 1000).toISOString();
+    const { container } = render(
+      <FreshnessBadge lastUpdatedAt={fetchedAt} source="reddit" />,
+    );
+    // Badge content is "<TONE> · <ageLabel>". formatScrapeAge returns "live"
+    // when the age is < 60s (see src/lib/news/freshness.ts).
+    expect(container.textContent).toContain("· live");
+    expect(container.textContent).toContain("FRESH");
+  });
+
+  it("renders '{m}m' for a sub-hour age", () => {
+    setNow(NOW);
+    const fetchedAt = new Date(NOW - 2 * 60 * 1000).toISOString();
+    const { container } = render(
+      <FreshnessBadge lastUpdatedAt={fetchedAt} source="reddit" />,
+    );
+    expect(container.textContent).toContain("· 2m");
+  });
+
+  it("renders '{h}h' for a sub-day age", () => {
+    setNow(NOW);
+    // 4h is past reddit's stale threshold (cold), but the ageLabel formatter
+    // only cares about magnitude, not status. Pick the slow-cron `npm`
+    // source so the badge is still warn-leaning instead of cold.
+    const fetchedAt = new Date(NOW - 4 * 60 * 60 * 1000).toISOString();
+    const { container } = render(
+      <FreshnessBadge lastUpdatedAt={fetchedAt} source="npm" />,
+    );
+    expect(container.textContent).toContain("· 4h");
+  });
+
+  it("renders '—' when lastUpdatedAt is missing", () => {
+    setNow(NOW);
+    const { container } = render(
+      <FreshnessBadge lastUpdatedAt={null} source="reddit" />,
+    );
+    expect(container.textContent).toContain("· —");
+    // No fetchedAt → classifyFreshness returns status:"cold" → COLD label.
+    expect(container.textContent).toContain("COLD");
+  });
+});

--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -208,8 +208,8 @@ export function DropRepoPage() {
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
-        <section className="v2-card p-5 sm:p-6">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+        <section className="v2-card p-5 sm:p-6 lg:min-w-0 lg:flex-1">
           <div className="flex flex-wrap items-center gap-3">
             <span className="inline-flex items-center gap-2 rounded-full border border-border-primary bg-bg-secondary px-3 py-1 text-[11px] font-mono uppercase tracking-[0.14em] text-text-tertiary">
               <Send className="h-3.5 w-3.5" />
@@ -246,8 +246,8 @@ export function DropRepoPage() {
             </Link>
           </div>
 
-          <form className="mt-6 grid gap-4" onSubmit={handleSubmit}>
-            <label className="grid gap-2">
+          <form className="mt-6 flex flex-col gap-4" onSubmit={handleSubmit}>
+            <label className="flex flex-col gap-2">
               <span className="text-sm font-medium text-text-primary">
                 GitHub repo
               </span>
@@ -260,7 +260,7 @@ export function DropRepoPage() {
               />
             </label>
 
-            <label className="grid gap-2">
+            <label className="flex flex-col gap-2">
               <span className="text-sm font-medium text-text-primary">
                 Why now
               </span>
@@ -273,8 +273,8 @@ export function DropRepoPage() {
               />
             </label>
 
-            <div className="grid gap-4 md:grid-cols-2">
-              <label className="grid gap-2">
+            <div className="flex flex-col gap-4 md:flex-row">
+              <label className="flex flex-1 flex-col gap-2">
                 <span className="text-sm font-medium text-text-primary">
                   Contact
                 </span>
@@ -287,7 +287,7 @@ export function DropRepoPage() {
                 />
               </label>
 
-              <label className="grid gap-2">
+              <label className="flex flex-1 flex-col gap-2">
                 <span className="text-sm font-medium text-text-primary">
                   X share link
                 </span>
@@ -333,7 +333,7 @@ export function DropRepoPage() {
           {result && (
             <div className="mt-4 rounded-card border border-border-primary bg-bg-secondary px-4 py-4">
               {result.kind === "created" && result.submission && (
-                <div className="grid gap-2">
+                <div className="flex flex-col gap-2">
                   <p className="text-sm font-medium text-text-primary">
                     Added to queue: {result.submission.fullName}
                   </p>
@@ -345,7 +345,7 @@ export function DropRepoPage() {
               )}
 
               {result.kind === "duplicate" && result.submission && (
-                <div className="grid gap-2">
+                <div className="flex flex-col gap-2">
                   <p className="text-sm font-medium text-text-primary">
                     Already in queue: {result.submission.fullName}
                   </p>
@@ -356,7 +356,7 @@ export function DropRepoPage() {
               )}
 
               {result.kind === "already_tracked" && result.repo && (
-                <div className="grid gap-2">
+                <div className="flex flex-col gap-2">
                   <p className="text-sm font-medium text-text-primary">
                     Already tracked: {result.repo.fullName}
                   </p>
@@ -373,7 +373,7 @@ export function DropRepoPage() {
           )}
         </section>
 
-        <aside className="grid gap-6">
+        <aside className="flex flex-col gap-6 lg:w-[360px] lg:max-w-[38%] lg:shrink-0">
           <section className="v2-card p-5 sm:p-6">
             <div className="flex items-center gap-2 text-text-primary">
               <Sparkles className="h-4 w-4 text-brand" />
@@ -381,7 +381,7 @@ export function DropRepoPage() {
                 Queue signals
               </h2>
             </div>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:flex-col">
               <MetricCard
                 label="Active"
                 value={loading ? "..." : String(queue.pending)}
@@ -418,7 +418,7 @@ export function DropRepoPage() {
               </h2>
             </div>
 
-            <div className="mt-4 grid gap-3">
+            <div className="mt-4 flex flex-col gap-3">
               {submissions.length === 0 && !loading && (
                 <p className="text-sm text-text-secondary">
                   No queued submissions yet.

--- a/src/lib/__tests__/github-telemetry.test.ts
+++ b/src/lib/__tests__/github-telemetry.test.ts
@@ -3,6 +3,7 @@ import { afterEach, test } from "node:test";
 
 import { _setRedisForTests } from "../redis";
 import {
+  githubKeyFingerprint,
   isKeyQuarantined,
   quarantineKey,
   recordGithubCall,
@@ -76,10 +77,11 @@ class FakePool implements GitHubTokenPool {
   }
 
   recordRateLimit(_token: string, remaining: number, resetUnixSec: number): void {
+    void _token;
     this.rateLimitRecords.push({ remaining, resetUnixSec });
   }
 
-  quarantine(_token: string): void {
+  quarantine(): void {
     this.quarantineCalls += 1;
   }
 
@@ -148,6 +150,15 @@ test("recordGithubCall increments fail counter when the call is not successful",
   assert.equal(hash.lastRateLimitRemaining, undefined);
 });
 
+test("githubKeyFingerprint distinguishes different tokens with the same suffix", () => {
+  const first = githubKeyFingerprint("tok-a-aaaaaaaaaaaaaaaaabcd");
+  const second = githubKeyFingerprint("tok-b-bbbbbbbbbbbbbbbbabcd");
+
+  assert.notEqual(first, second);
+  assert.match(first, /^abcd-[0-9a-f]{8}$/);
+  assert.match(second, /^abcd-[0-9a-f]{8}$/);
+});
+
 test("quarantineKey stores fingerprint quarantine until an absolute unix timestamp", async () => {
   const fake = new FakeRedis();
   _setRedisForTests(fake);
@@ -191,7 +202,8 @@ test("githubFetch records usage telemetry for a successful response", async () =
     { remaining: 4998, resetUnixSec: 1_800_000_000 },
   ]);
   const hourBucket = new Date().toISOString().slice(0, 13).replace("T", "-");
-  const hash = await fake.hgetall(`pool:github:usage:abcd:${hourBucket}`);
+  const fingerprint = githubKeyFingerprint(pool.token);
+  const hash = await fake.hgetall(`pool:github:usage:${fingerprint}:${hourBucket}`);
   assert.equal(hash.requests, "1");
   assert.equal(hash.success, "1");
   assert.equal(hash.lastOperation, "rate_limit");
@@ -217,6 +229,10 @@ test("githubFetch quarantines invalid tokens by fingerprint after 401", async ()
 
   assert.equal(result?.response.status, 401);
   assert.equal(pool.quarantineCalls, 4);
-  assert.equal(await isKeyQuarantined("abcd"), true);
-  assert.match(fake.strings.get("pool:github:quarantine:abcd") ?? "", /invalid_token/);
+  const fingerprint = githubKeyFingerprint(pool.token);
+  assert.equal(await isKeyQuarantined(fingerprint), true);
+  assert.match(
+    fake.strings.get(`pool:github:quarantine:${fingerprint}`) ?? "",
+    /invalid_token/,
+  );
 });

--- a/src/lib/__tests__/logos.test.ts
+++ b/src/lib/__tests__/logos.test.ts
@@ -6,6 +6,7 @@ import {
   mcpEntityLogoUrl,
   profileLogoUrl,
   repoDisplayLogoUrl,
+  repoLogoUrl,
 } from "../logos";
 
 test("repoDisplayLogoUrl prefers a captured repo avatar", () => {
@@ -60,6 +61,40 @@ test("mcpEntityLogoUrl falls back to registry favicons for MCP rows", () => {
     ),
     "https://www.google.com/s2/favicons?domain=mcp.so&sz=64",
   );
+});
+
+test("repoLogoUrl composes the GitHub owner avatar URL with the requested size", () => {
+  assert.equal(
+    repoLogoUrl("vercel/next.js", 64),
+    "https://github.com/vercel.png?size=64",
+  );
+});
+
+test("repoLogoUrl defaults to size=40 when no size is provided", () => {
+  assert.equal(repoLogoUrl("vercel/next.js"), "https://github.com/vercel.png?size=40");
+});
+
+test("repoLogoUrl encodes owner segments to keep the URL well-formed", () => {
+  assert.equal(
+    repoLogoUrl("my org/repo", 40),
+    "https://github.com/my%20org.png?size=40",
+  );
+});
+
+test("repoLogoUrl returns null for empty, whitespace, or nullish input", () => {
+  assert.equal(repoLogoUrl(""), null);
+  assert.equal(repoLogoUrl(null), null);
+  assert.equal(repoLogoUrl(undefined), null);
+  assert.equal(repoLogoUrl("   "), null);
+});
+
+test("repoLogoUrl gracefully falls back when the owner half is missing", () => {
+  // Malformed: leading slash means the split owner is empty → null, not a broken URL.
+  assert.equal(repoLogoUrl("/orphan-repo"), null);
+});
+
+test("repoLogoUrl tolerates a bare owner with no `/name` half", () => {
+  assert.equal(repoLogoUrl("vercel", 40), "https://github.com/vercel.png?size=40");
 });
 
 test("mcpEntityLogoUrl ignores invalid registry logo URLs", () => {

--- a/src/lib/__tests__/reddit-ua-pool.test.ts
+++ b/src/lib/__tests__/reddit-ua-pool.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { redditUserAgentFingerprint } from "../pool/reddit-ua-pool";
+
+test("redditUserAgentFingerprint keeps configured user-agents distinct", () => {
+  const userAgents = [
+    "trendingrepo-scanner/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-discovery/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-signals/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-aggregator/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-mentions/1.0 (+https://trendingrepo.com)",
+  ];
+
+  const fingerprints = userAgents.map(redditUserAgentFingerprint);
+
+  assert.equal(new Set(fingerprints).size, userAgents.length);
+  assert.ok(
+    fingerprints.every((fingerprint) =>
+      /^trendingrepo-[a-z0-9-]+-[0-9a-f]{8}$/.test(fingerprint),
+    ),
+  );
+});

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { safeJsonLd } from "../seo";
+
+test("safeJsonLd escapes < > & in top-level string values", () => {
+  const out = safeJsonLd({ x: "</script><img src=x onerror=alert(1)> & co" });
+  assert.ok(!out.includes("<"), "raw < must not appear");
+  assert.ok(!out.includes(">"), "raw > must not appear");
+  assert.ok(!/&(?!#|amp;|lt;|gt;|quot;|apos;)/.test(out.replace(/\\u0026/g, "")),
+    "raw & must be escaped to \\u0026");
+  assert.match(out, /\\u003c/);
+  assert.match(out, /\\u003e/);
+  assert.match(out, /\\u0026/);
+});
+
+test("safeJsonLd escapes < > & inside nested objects and arrays", () => {
+  const payload = {
+    name: "ok",
+    nested: {
+      deeper: {
+        bad: "<script>alert('x')</script>",
+        amp: "a & b",
+      },
+      list: [
+        "</script>",
+        { evil: "<svg/onload=1>" },
+        ["a > b", "c & d"],
+      ],
+    },
+  };
+
+  const out = safeJsonLd(payload);
+  // After escaping, no raw <, >, or & should remain anywhere in the output.
+  assert.ok(!out.includes("<"), "no raw < in nested output");
+  assert.ok(!out.includes(">"), "no raw > in nested output");
+  assert.ok(!out.includes("&") || /\\u0026/.test(out),
+    "& only allowed as part of \\u0026 escape");
+  // Strip escapes and confirm the unescaped form contained the markers.
+  assert.match(out, /\\u003cscript\\u003e/);
+  assert.match(out, /\\u003c\/script\\u003e/);
+  assert.match(out, /a \\u0026 b/);
+});
+
+test("safeJsonLd escapes U+2028 and U+2029 line/paragraph separators", () => {
+  const payload = {
+    line: `before\u2028after`,
+    paragraph: `before\u2029after`,
+    nested: {
+      both: `\u2028middle\u2029end`,
+    },
+  };
+
+  const out = safeJsonLd(payload);
+  assert.ok(!out.includes("\u2028"), "raw U+2028 must not survive");
+  assert.ok(!out.includes("\u2029"), "raw U+2029 must not survive");
+  assert.match(out, /\\u2028/);
+  assert.match(out, /\\u2029/);
+  // Both occurrences in `nested.both` must be escaped, not just the first.
+  const u2028Hits = (out.match(/\\u2028/g) ?? []).length;
+  const u2029Hits = (out.match(/\\u2029/g) ?? []).length;
+  assert.equal(u2028Hits, 2, "every U+2028 instance escaped");
+  assert.equal(u2029Hits, 2, "every U+2029 instance escaped");
+});
+
+test("safeJsonLd round-trips back to the original value via JSON.parse", () => {
+  const payload = {
+    xss: "</script><b>&\u2028\u2029</b>",
+    nested: { deep: ["<", ">", "&", "\u2028", "\u2029"] },
+  };
+  const out = safeJsonLd(payload);
+  // JSON.parse interprets \uXXXX escapes — the round-trip should equal input.
+  assert.deepEqual(JSON.parse(out), payload);
+});

--- a/src/lib/api/__tests__/auth.test.ts
+++ b/src/lib/api/__tests__/auth.test.ts
@@ -1,0 +1,176 @@
+// Coverage for verifyAdminAuth + verifyCronAuth happy/sad paths.
+//
+// Exercises:
+//   - verifyCronAuth      → ok / unauthorized / not_configured
+//   - verifyAdminAuth     → ok via cookie, ok via bearer, unauthorized,
+//                            not_configured
+//
+// node:test + assert/strict — same pattern as repo-profile.test.ts.
+//
+// Run:
+//   npx tsx --test src/lib/api/__tests__/auth.test.ts
+
+import { afterEach, beforeEach, test } from "node:test";
+import assert from "node:assert/strict";
+import { NextRequest } from "next/server";
+
+import {
+  verifyAdminAuth,
+  verifyCronAuth,
+  __resetAuthWarningsForTests,
+} from "../auth";
+import { signAdminSession } from "../admin-session";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(
+    new Request("http://localhost/api/test", { headers }),
+  );
+}
+
+function mutableEnv(): Record<string, string | undefined> {
+  return process.env as Record<string, string | undefined>;
+}
+
+beforeEach(() => {
+  // Wipe the auth-related env so each test starts from a known floor.
+  delete process.env.CRON_SECRET;
+  delete process.env.ADMIN_TOKEN;
+  delete process.env.SESSION_SECRET;
+  delete mutableEnv().NODE_ENV;
+  __resetAuthWarningsForTests();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  __resetAuthWarningsForTests();
+});
+
+// ---------------------------------------------------------------------------
+// verifyCronAuth
+// ---------------------------------------------------------------------------
+
+test("verifyCronAuth: not_configured when CRON_SECRET unset in production", () => {
+  mutableEnv().NODE_ENV = "production";
+  const verdict = verifyCronAuth(makeRequest());
+  assert.equal(verdict.kind, "not_configured");
+});
+
+test("verifyCronAuth: ok in dev when CRON_SECRET unset (developer fallback)", () => {
+  mutableEnv().NODE_ENV = "development";
+  const verdict = verifyCronAuth(makeRequest());
+  assert.equal(verdict.kind, "ok");
+});
+
+test("verifyCronAuth: ok with raw Authorization secret", () => {
+  process.env.CRON_SECRET = "supersecret-123";
+  const verdict = verifyCronAuth(
+    makeRequest({ authorization: "supersecret-123" }),
+  );
+  assert.equal(verdict.kind, "ok");
+});
+
+test("verifyCronAuth: ok with Bearer-prefixed Authorization secret", () => {
+  process.env.CRON_SECRET = "supersecret-123";
+  const verdict = verifyCronAuth(
+    makeRequest({ authorization: "Bearer supersecret-123" }),
+  );
+  assert.equal(verdict.kind, "ok");
+});
+
+test("verifyCronAuth: unauthorized when Authorization missing", () => {
+  process.env.CRON_SECRET = "supersecret-123";
+  const verdict = verifyCronAuth(makeRequest());
+  assert.equal(verdict.kind, "unauthorized");
+});
+
+test("verifyCronAuth: unauthorized on wrong secret (raw)", () => {
+  process.env.CRON_SECRET = "supersecret-123";
+  const verdict = verifyCronAuth(
+    makeRequest({ authorization: "wrong-token" }),
+  );
+  assert.equal(verdict.kind, "unauthorized");
+});
+
+test("verifyCronAuth: unauthorized on wrong secret (Bearer)", () => {
+  process.env.CRON_SECRET = "supersecret-123";
+  const verdict = verifyCronAuth(
+    makeRequest({ authorization: "Bearer wrong-token" }),
+  );
+  assert.equal(verdict.kind, "unauthorized");
+});
+
+// ---------------------------------------------------------------------------
+// verifyAdminAuth
+// ---------------------------------------------------------------------------
+
+test("verifyAdminAuth: not_configured when ADMIN_TOKEN unset and no valid cookie", () => {
+  const verdict = verifyAdminAuth(makeRequest());
+  assert.equal(verdict.kind, "not_configured");
+});
+
+test("verifyAdminAuth: unauthorized when ADMIN_TOKEN set but no Authorization header", () => {
+  process.env.ADMIN_TOKEN = "admin-secret-xyz";
+  const verdict = verifyAdminAuth(makeRequest());
+  assert.equal(verdict.kind, "unauthorized");
+});
+
+test("verifyAdminAuth: ok with raw Authorization admin token", () => {
+  process.env.ADMIN_TOKEN = "admin-secret-xyz";
+  const verdict = verifyAdminAuth(
+    makeRequest({ authorization: "admin-secret-xyz" }),
+  );
+  assert.equal(verdict.kind, "ok");
+});
+
+test("verifyAdminAuth: ok with Bearer-prefixed admin token", () => {
+  process.env.ADMIN_TOKEN = "admin-secret-xyz";
+  const verdict = verifyAdminAuth(
+    makeRequest({ authorization: "Bearer admin-secret-xyz" }),
+  );
+  assert.equal(verdict.kind, "ok");
+});
+
+test("verifyAdminAuth: unauthorized on wrong admin token", () => {
+  process.env.ADMIN_TOKEN = "admin-secret-xyz";
+  const verdict = verifyAdminAuth(
+    makeRequest({ authorization: "Bearer not-the-token" }),
+  );
+  assert.equal(verdict.kind, "unauthorized");
+});
+
+test("verifyAdminAuth: ok via valid ss_admin signed cookie (no bearer needed)", () => {
+  process.env.SESSION_SECRET = "session-secret-abc";
+  process.env.ADMIN_TOKEN = "admin-secret-xyz";
+  const cookie = signAdminSession({
+    issuedAt: Date.now(),
+    username: "operator",
+  });
+  const verdict = verifyAdminAuth(
+    makeRequest({ cookie: `ss_admin=${cookie}` }),
+  );
+  assert.equal(verdict.kind, "ok");
+});
+
+test("verifyAdminAuth: cookie path falls through to bearer when signature invalid", () => {
+  process.env.SESSION_SECRET = "session-secret-abc";
+  process.env.ADMIN_TOKEN = "admin-secret-xyz";
+  // Tampered cookie value — verifyAdminSession returns null, falls through.
+  const verdict = verifyAdminAuth(
+    makeRequest({
+      cookie: "ss_admin=garbage.value",
+      authorization: "Bearer admin-secret-xyz",
+    }),
+  );
+  assert.equal(verdict.kind, "ok");
+});
+
+test("verifyAdminAuth: tampered cookie with no bearer → unauthorized", () => {
+  process.env.SESSION_SECRET = "session-secret-abc";
+  process.env.ADMIN_TOKEN = "admin-secret-xyz";
+  const verdict = verifyAdminAuth(
+    makeRequest({ cookie: "ss_admin=garbage.value" }),
+  );
+  assert.equal(verdict.kind, "unauthorized");
+});

--- a/src/lib/api/__tests__/error-response.test.ts
+++ b/src/lib/api/__tests__/error-response.test.ts
@@ -1,0 +1,37 @@
+// Contract test for the canonical API error envelope.
+//
+// errorEnvelope() returns { ok:false, error, code? }. The `code`
+// field MUST be omitted (not undefined) when no code is passed —
+// downstream JSON serialization + type-narrowing relies on absence.
+//
+// Run with:
+//   npx tsx --test src/lib/api/__tests__/error-response.test.ts
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { errorEnvelope } from "../error-response";
+
+test("errorEnvelope returns {ok:false, error} with no code key when code omitted", () => {
+  const env = errorEnvelope("bad thing");
+  assert.deepEqual(env, { ok: false, error: "bad thing" });
+  assert.equal(Object.prototype.hasOwnProperty.call(env, "code"), false);
+  assert.equal(JSON.stringify(env), '{"ok":false,"error":"bad thing"}');
+});
+
+test("errorEnvelope includes code when provided", () => {
+  const env = errorEnvelope("rate limited", "RATE_LIMITED");
+  assert.deepEqual(env, { ok: false, error: "rate limited", code: "RATE_LIMITED" });
+  assert.equal(env.code, "RATE_LIMITED");
+});
+
+test("errorEnvelope drops code when explicitly undefined", () => {
+  const env = errorEnvelope("nope", undefined);
+  assert.deepEqual(env, { ok: false, error: "nope" });
+  assert.equal(Object.prototype.hasOwnProperty.call(env, "code"), false);
+});
+
+test("errorEnvelope preserves ok:false discriminator", () => {
+  const env = errorEnvelope("x");
+  assert.equal(env.ok, false);
+});

--- a/src/lib/derived-repos/decorators/__tests__/twitter.test.ts
+++ b/src/lib/derived-repos/decorators/__tests__/twitter.test.ts
@@ -1,0 +1,123 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { decorateWithTwitter } from "../twitter";
+import type { Repo } from "../../../types";
+import type { TwitterRepoSignal } from "../../../twitter/types";
+
+// Hand-rolled minimal Repo used for shape + immutability assertions. We only
+// need fields the decorator passes through (`fullName`) plus a small payload
+// to verify deep equality after the call.
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  const base: Repo = {
+    id: "test--repo",
+    fullName: "test/repo",
+    name: "repo",
+    owner: "test",
+    ownerAvatarUrl: "",
+    description: "",
+    url: "https://github.com/test/repo",
+    language: null,
+    topics: ["a", "b"],
+    categoryId: "uncategorized",
+    stars: 0,
+    forks: 0,
+    contributors: 0,
+    openIssues: 0,
+    lastCommitAt: "2026-01-01T00:00:00.000Z",
+    lastReleaseAt: null,
+    lastReleaseTag: null,
+    createdAt: "2025-01-01T00:00:00.000Z",
+    starsDelta24h: 0,
+    starsDelta7d: 0,
+    starsDelta30d: 0,
+    forksDelta7d: 0,
+    contributorsDelta30d: 0,
+    momentumScore: 0,
+    movementStatus: "stable",
+    rank: 0,
+    categoryRank: 0,
+    sparklineData: [],
+    socialBuzzScore: 0,
+    mentionCount24h: 0,
+  };
+  return { ...base, ...overrides };
+}
+
+const SIGNALS_PATH = resolve(
+  process.cwd(),
+  ".data",
+  "twitter-repo-signals.jsonl",
+);
+
+function readFirstSignal(): TwitterRepoSignal | null {
+  if (!existsSync(SIGNALS_PATH)) return null;
+  const raw = readFileSync(SIGNALS_PATH, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as TwitterRepoSignal;
+      if (parsed.githubFullName) return parsed;
+    } catch {
+      // skip malformed line
+    }
+  }
+  return null;
+}
+
+test("decorateWithTwitter assigns twitter:null for repos with no signal", () => {
+  const repo = makeRepo({
+    fullName: "no-such-owner-xyz/no-such-repo-zzz-12345",
+  });
+  const [out] = decorateWithTwitter([repo]);
+  assert.equal(out.twitter, null);
+});
+
+test("decorateWithTwitter does not mutate the input repos or array", () => {
+  const repo = makeRepo({ fullName: "no-such-owner-xyz/no-such-repo-zzz" });
+  const before = structuredClone(repo);
+  const input = [repo];
+  const inputBefore = structuredClone(input);
+
+  const out = decorateWithTwitter(input);
+
+  // Input array reference is preserved by caller; element identity should be
+  // untouched and contents deep-equal to the pre-call snapshot.
+  assert.deepEqual(input, inputBefore);
+  assert.deepEqual(repo, before);
+  assert.notEqual(out, input, "output array must be a new array");
+  assert.notEqual(out[0], repo, "output repo must be a new object (spread)");
+});
+
+test("decorateWithTwitter maps signal metrics/score/badge fields onto the repo", () => {
+  const signal = readFirstSignal();
+  if (!signal) {
+    // No fixture available — this assertion path only exercises the mapping
+    // contract when a real signal is on disk; skip cleanly otherwise.
+    return;
+  }
+
+  const repo = makeRepo({ fullName: signal.githubFullName });
+  const [out] = decorateWithTwitter([repo]);
+
+  assert.ok(out.twitter, "expected twitter rollup to be attached");
+  if (!out.twitter) return; // narrow
+
+  assert.equal(out.twitter.mentionCount24h, signal.metrics.mentionCount24h);
+  assert.equal(out.twitter.uniqueAuthors24h, signal.metrics.uniqueAuthors24h);
+  assert.equal(
+    out.twitter.finalTwitterScore,
+    signal.score.finalTwitterScore,
+  );
+  assert.equal(out.twitter.badgeState, signal.badge.state);
+  assert.equal(out.twitter.topPostUrl, signal.metrics.topPostUrl);
+  assert.equal(out.twitter.lastScannedAt, signal.updatedAt);
+
+  // Mapping must not leak any other top-level field changes.
+  const { twitter: _t, ...rest } = out;
+  const { twitter: _orig, ...repoRest } = repo;
+  assert.deepEqual(rest, repoRest);
+});

--- a/src/lib/freshness-health.ts
+++ b/src/lib/freshness-health.ts
@@ -1,0 +1,23 @@
+export type FreshnessHealth = "ok" | "advisory" | "stale";
+
+export type FreshnessSourceStatus = "GREEN" | "YELLOW" | "RED" | "DEAD";
+
+export interface FreshnessSourceState {
+  status: FreshnessSourceStatus;
+  blocking: boolean;
+}
+
+// `health` distinguishes the three operator-meaningful states the gate can be
+// in: `ok` (everything GREEN), `advisory` (only non-blocking sources have
+// degraded), and `stale` (at least one blocking source has degraded).
+export function deriveHealth(
+  sources: ReadonlyArray<FreshnessSourceState>,
+): FreshnessHealth {
+  let advisoryDegraded = false;
+  for (const source of sources) {
+    if (source.status === "GREEN") continue;
+    if (source.blocking) return "stale";
+    advisoryDegraded = true;
+  }
+  return advisoryDegraded ? "advisory" : "ok";
+}

--- a/src/lib/pool/github-telemetry.ts
+++ b/src/lib/pool/github-telemetry.ts
@@ -1,4 +1,5 @@
 import { redis } from "@/lib/redis";
+import { createHash } from "node:crypto";
 
 export type GithubQuarantineReason =
   | "rate_limit"
@@ -18,7 +19,9 @@ export interface GithubCallTelemetry {
 
 export function githubKeyFingerprint(token: string | null | undefined): string {
   const trimmed = token?.trim() ?? "";
-  return trimmed.length > 0 ? trimmed.slice(-4) : "none";
+  if (trimmed.length === 0) return "none";
+  const hash = createHash("sha256").update(trimmed).digest("hex").slice(0, 8);
+  return `${trimmed.slice(-4)}-${hash}`;
 }
 
 export async function recordGithubCall(

--- a/src/lib/pool/reddit-ua-pool.ts
+++ b/src/lib/pool/reddit-ua-pool.ts
@@ -4,6 +4,7 @@ import {
   type RedditQuarantineParams,
 } from "@/lib/pool/reddit-telemetry";
 import configuredUserAgents from "@/../config/reddit-user-agents.json";
+import { createHash } from "node:crypto";
 
 const DEFAULT_USER_AGENTS = [
   "trendingrepo-scanner/1.0 (+https://trendingrepo.com)",
@@ -24,7 +25,8 @@ export function redditUserAgentFingerprint(userAgent: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   if (!cleaned) return "reddit-ua-unknown";
-  return cleaned.slice(-24);
+  const hash = createHash("sha256").update(userAgent).digest("hex").slice(0, 8);
+  return `${cleaned.slice(0, 24)}-${hash}`;
 }
 
 export async function selectUserAgent(): Promise<string> {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,11 @@ export default defineConfig({
       // level, no nesting) so funding/__tests__/ doesn't double-run
       // under tsx --test.
       "src/lib/funding/__tests__/**/*.test.{ts,tsx}",
+      // E5: oEmbed route uses NextRequest + vitest API; node:test runner
+      // can't import next/server cleanly, so it lives under vitest.
+      "src/app/api/oembed/__tests__/**/*.test.{ts,tsx}",
+      // E6: x402 manifest stub route — same rationale as E5.
+      "src/app/x402/__tests__/**/*.test.{ts,tsx}",
     ],
     // src/lib/__tests__/* and src/lib/pipeline/__tests__/* run under
     // node:test via `npm test` — vitest can't read those (no


### PR DESCRIPTION
## Summary
Continuation of the audit-2026-05-04 swarm. 7 commits — mix of test coverage from the 15-agent F-series + 2 fixes from agents that took longer + 1 carryover from PR #101's squash.

## Commits
- `58ffcaba` **F14** — test(derived-repos): twitter decorator immutability + mapping
- `ba594d0c` **E5** — test(api): oEmbed SSRF guard + url matrix
- `90ec33b5` **F2** — test(api): admin/scan 10 req/min rate-limit envelope
- `22d25330` **F13** — test(api): error-envelope shape contract
- `23da3214` — fix(roi): harden source logos and submit layout
- `77551445` — fix(admin): disambiguate key pool telemetry
- `6c30774a` D1 (already merged via #101 squash; harmless duplicate)

## Operator deliverables landed in `.audit/2026-05-04-swarm/`
- ✅ `AUDIT-FINAL.md` (E8) — consolidated end-of-day report

## Test plan
- [ ] CI green
- [ ] Vercel preview OK
- [ ] New tests run as part of `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code) — ruflo 15-agent swarm wave 4