### PR TITLE
fix(admin): disambiguate key pool telemetry

### DIFF
--- a/src/app/api/admin/pool-state/route.ts
+++ b/src/app/api/admin/pool-state/route.ts
@@ -4,7 +4,11 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { adminAuthFailureResponse, verifyAdminAuth } from "@/lib/api/auth";
 import { getDataStore } from "@/lib/data-store";
-import { getGitHubTokenPool } from "@/lib/github-token-pool";
+import {
+  getGitHubTokenPool,
+  redactToken,
+  type PublishedTokenState,
+} from "@/lib/github-token-pool";
 import { githubKeyFingerprint } from "@/lib/pool/github-telemetry";
 import { redditUserAgentFingerprint } from "@/lib/pool/reddit-ua-pool";
 import { redis } from "@/lib/redis";
@@ -21,6 +25,8 @@ export interface UsageSummary {
   requests24h: number;
   success24h: number;
   fail24h: number;
+  rateLimited24h?: number;
+  last429At?: string | null;
   lastCallAt: string | null;
   lastOperation: string | null;
   lastStatusCode: number | null;
@@ -115,6 +121,12 @@ interface MetaFile {
   writtenAt?: string;
 }
 
+interface GithubKeyDescriptor {
+  label: string;
+  usageFingerprints: string[];
+  publishedState: PublishedTokenState | null;
+}
+
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const IDLE_KEY_MS = 12 * HOUR_MS;
@@ -169,15 +181,29 @@ function classifyByAge(iso: string | null, budgetMs: number): PoolStatus {
 
 async function readUsage(
   prefix: "github" | "reddit" | "twitter",
-  fingerprint: string,
+  fingerprintOrAliases: string | string[],
   buckets: string[],
 ): Promise<UsageSummary & { lastRateLimitRemaining: number | null; lastRateLimitReset: string | null }> {
+  const fingerprints = Array.from(
+    new Set(
+      (Array.isArray(fingerprintOrAliases)
+        ? fingerprintOrAliases
+        : [fingerprintOrAliases]
+      ).filter(Boolean),
+    ),
+  );
   const hashes = await Promise.all(
-    buckets.map((bucket) => redis.hgetall(`pool:${prefix}:usage:${fingerprint}:${bucket}`)),
+    buckets.flatMap((bucket) =>
+      fingerprints.map((fingerprint) =>
+        redis.hgetall(`pool:${prefix}:usage:${fingerprint}:${bucket}`),
+      ),
+    ),
   );
   let requests24h = 0;
   let success24h = 0;
   let fail24h = 0;
+  let rateLimited24h = 0;
+  let last429At: string | null = null;
   let lastCallAt: string | null = null;
   let lastOperation: string | null = null;
   let lastStatusCode: number | null = null;
@@ -189,6 +215,7 @@ async function readUsage(
     requests24h += parseNumber(hash.requests) ?? 0;
     success24h += parseNumber(hash.success) ?? 0;
     fail24h += parseNumber(hash.fail) ?? 0;
+    rateLimited24h += parseNumber(hash.rateLimited) ?? 0;
 
     const callAt = parseIso(hash.lastCallAt);
     if (callAt && (!lastCallAt || Date.parse(callAt) > Date.parse(lastCallAt))) {
@@ -202,12 +229,21 @@ async function readUsage(
         ? new Date(resetUnix * 1000).toISOString()
         : null;
     }
+    const rateLimitedAt = parseIso(hash.last429At);
+    if (
+      rateLimitedAt &&
+      (!last429At || Date.parse(rateLimitedAt) > Date.parse(last429At))
+    ) {
+      last429At = rateLimitedAt;
+    }
   }
 
   return {
     requests24h,
     success24h,
     fail24h,
+    rateLimited24h,
+    last429At,
     lastCallAt,
     lastOperation,
     lastStatusCode,
@@ -219,34 +255,108 @@ async function readUsage(
 
 async function readQuarantine(
   prefix: "github" | "reddit",
-  fingerprint: string,
+  fingerprintOrAliases: string | string[],
 ): Promise<QuarantineState> {
-  const raw = await redis.get(`pool:${prefix}:quarantine:${fingerprint}`);
-  if (!raw) return { active: false, reason: null, until: null };
-  try {
-    const parsed = JSON.parse(raw) as { reason?: string; untilTimestamp?: number };
-    const untilMs =
-      typeof parsed.untilTimestamp === "number"
-        ? parsed.untilTimestamp * 1000
-        : null;
-    return {
-      active: untilMs !== null && untilMs > Date.now(),
-      reason: parsed.reason ?? null,
-      until: untilMs ? new Date(untilMs).toISOString() : null,
-    };
-  } catch {
-    return { active: true, reason: "unknown", until: null };
-  }
-}
-
-function configuredGithubFingerprints(): string[] {
-  return Array.from(
+  const fingerprints = Array.from(
     new Set(
-      getGitHubTokenPool()
-        .snapshot()
-        .map((state) => githubKeyFingerprint(state.token)),
+      (Array.isArray(fingerprintOrAliases)
+        ? fingerprintOrAliases
+        : [fingerprintOrAliases]
+      ).filter(Boolean),
     ),
   );
+  const raws = await Promise.all(
+    fingerprints.map((fingerprint) =>
+      redis.get(`pool:${prefix}:quarantine:${fingerprint}`),
+    ),
+  );
+  let latestInactive: QuarantineState = { active: false, reason: null, until: null };
+  for (const raw of raws) {
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw) as { reason?: string; untilTimestamp?: number };
+      const untilMs =
+        typeof parsed.untilTimestamp === "number"
+          ? parsed.untilTimestamp * 1000
+          : null;
+      const state: QuarantineState = {
+        active: untilMs !== null && untilMs > Date.now(),
+        reason: parsed.reason ?? null,
+        until: untilMs ? new Date(untilMs).toISOString() : null,
+      };
+      if (state.active) return state;
+      if (
+        state.until &&
+        (!latestInactive.until ||
+          Date.parse(state.until) > Date.parse(latestInactive.until))
+      ) {
+        latestInactive = state;
+      }
+    } catch {
+      return { active: true, reason: "unknown", until: null };
+    }
+  }
+  return latestInactive;
+}
+
+function githubLegacyFingerprint(token: string | null | undefined): string {
+  const trimmed = token?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed.slice(-4) : "none";
+}
+
+function quarantineFromPublishedState(
+  state: PublishedTokenState | null,
+): QuarantineState {
+  if (!state?.quarantinedUntilMs) {
+    return { active: false, reason: null, until: null };
+  }
+  return {
+    active: state.quarantinedUntilMs > Date.now(),
+    reason: "published",
+    until: new Date(state.quarantinedUntilMs).toISOString(),
+  };
+}
+
+function configuredGithubKeys(): GithubKeyDescriptor[] {
+  const states = getGitHubTokenPool().snapshot();
+  const legacyCounts = new Map<string, number>();
+  const labelCounts = new Map<string, number>();
+  const labelIndexes = new Map<string, number>();
+
+  for (const state of states) {
+    const legacy = githubLegacyFingerprint(state.token);
+    legacyCounts.set(legacy, (legacyCounts.get(legacy) ?? 0) + 1);
+    const label = redactToken(state.token);
+    labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+  }
+
+  return states.map((state): GithubKeyDescriptor => {
+    const label = redactToken(state.token);
+    const labelIndex = (labelIndexes.get(label) ?? 0) + 1;
+    labelIndexes.set(label, labelIndex);
+    const safeLabel =
+      (labelCounts.get(label) ?? 0) > 1 ? `${label}#${labelIndex}` : label;
+    const legacy = githubLegacyFingerprint(state.token);
+    const usageFingerprints = [githubKeyFingerprint(state.token)];
+    if ((legacyCounts.get(legacy) ?? 0) === 1) {
+      usageFingerprints.push(legacy);
+    }
+    return {
+      label: safeLabel,
+      usageFingerprints,
+      publishedState: {
+        tokenLabel: label,
+        remaining: state.remaining,
+        resetUnixSec: state.resetUnixSec,
+        lastObservedMs: state.lastObservedMs,
+        quarantinedUntilMs: state.quarantinedUntilMs,
+        lambdaId: "local",
+        writtenAt: state.lastObservedMs
+          ? new Date(state.lastObservedMs).toISOString()
+          : "",
+      },
+    };
+  });
 }
 
 function stddev(values: number[]): number {
@@ -269,22 +379,45 @@ function poolHealth(rows: Array<{ status: PoolStatus; requests24h: number }>): P
 }
 
 async function githubState(buckets: string[]): Promise<AdminPoolStateResponse["github"]> {
-  const fingerprints = configuredGithubFingerprints();
+  const keys = configuredGithubKeys();
   const rows = await Promise.all(
-    fingerprints.map(async (fingerprint): Promise<GithubPoolRow> => {
-      const usage = await readUsage("github", fingerprint, buckets);
-      const quarantine = await readQuarantine("github", fingerprint);
+    keys.map(async (key): Promise<GithubPoolRow> => {
+      const usage = await readUsage("github", key.usageFingerprints, buckets);
+      const telemetryQuarantine = await readQuarantine("github", key.usageFingerprints);
+      const publishedQuarantine = quarantineFromPublishedState(key.publishedState);
+      const quarantine = telemetryQuarantine.active
+        ? telemetryQuarantine
+        : publishedQuarantine.active
+          ? publishedQuarantine
+          : telemetryQuarantine.until
+            ? telemetryQuarantine
+            : publishedQuarantine;
+      const publishedLastObserved = key.publishedState?.lastObservedMs
+        ? new Date(key.publishedState.lastObservedMs).toISOString()
+        : null;
+      const lastCallAt =
+        usage.lastCallAt ??
+        publishedLastObserved ??
+        parseIso(key.publishedState?.writtenAt);
       const idle =
-        !usage.lastCallAt ||
-        Date.now() - Date.parse(usage.lastCallAt) > IDLE_KEY_MS;
+        !lastCallAt ||
+        Date.now() - Date.parse(lastCallAt) > IDLE_KEY_MS;
       const status: PoolStatus = quarantine.active
         ? "RED"
         : idle
-          ? "YELLOW"
+          ? "RED"
           : "GREEN";
       return {
-        fingerprint,
+        fingerprint: key.label,
         ...usage,
+        lastCallAt,
+        lastRateLimitRemaining:
+          usage.lastRateLimitRemaining ?? key.publishedState?.remaining ?? null,
+        lastRateLimitReset:
+          usage.lastRateLimitReset ??
+          (key.publishedState?.resetUnixSec
+            ? new Date(key.publishedState.resetUnixSec * 1000).toISOString()
+            : null),
         quarantine,
         idle,
         status,
@@ -292,7 +425,7 @@ async function githubState(buckets: string[]): Promise<AdminPoolStateResponse["g
     }),
   );
   return {
-    totalConfigured: fingerprints.length,
+    totalConfigured: keys.length,
     health: poolHealth(rows),
     rows,
   };
@@ -307,11 +440,14 @@ async function redditState(buckets: string[]): Promise<AdminPoolStateResponse["r
       const fingerprint = redditUserAgentFingerprint(userAgent);
       const usage = await readUsage("reddit", fingerprint, buckets);
       const quarantine = await readQuarantine("reddit", fingerprint);
-      const last429At = usage.lastStatusCode === 429 ? usage.lastCallAt : null;
+      const last429At =
+        usage.last429At ?? (usage.lastStatusCode === 429 ? usage.lastCallAt : null);
       const status: PoolStatus = quarantine.active
         ? "RED"
-        : last429At
+        : usage.rateLimited24h && usage.rateLimited24h > 0
           ? "YELLOW"
+          : usage.fail24h > usage.success24h && usage.fail24h > 0
+            ? "YELLOW"
           : "GREEN";
       return {
         fingerprint,
@@ -328,7 +464,7 @@ async function redditState(buckets: string[]): Promise<AdminPoolStateResponse["r
     rows.map((row) => redis.hgetall(`pool:reddit:usage:${row.fingerprint}:${currentBucket}`)),
   );
   const rateLimitedLastHour = lastHourHashes.reduce((sum, hash) => {
-    return sum + (parseNumber(hash.lastStatusCode) === 429 ? (parseNumber(hash.requests) ?? 1) : 0);
+    return sum + (parseNumber(hash.rateLimited) ?? 0);
   }, 0);
   return {
     totalConfigured: agents.length,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+@source not "../../.audit";
+@source not "../../.claude-flow";
+@source not "../../.hive-mind";
+@source not "../../.tmp";
+@source not "../../dogfood-output";
+@source not "../../test-results";
+
 /* V4 (CORPUS) primitives — loaded after Tailwind so utility classes keep
    precedence but V4 component selectors take over inside their blocks. */
 @import "../components/ui/v4.css";

--- a/src/lib/__tests__/github-telemetry.test.ts
+++ b/src/lib/__tests__/github-telemetry.test.ts
@@ -3,6 +3,7 @@ import { afterEach, test } from "node:test";
 
 import { _setRedisForTests } from "../redis";
 import {
+  githubKeyFingerprint,
   isKeyQuarantined,
   quarantineKey,
   recordGithubCall,
@@ -76,10 +77,11 @@ class FakePool implements GitHubTokenPool {
   }
 
   recordRateLimit(_token: string, remaining: number, resetUnixSec: number): void {
+    void _token;
     this.rateLimitRecords.push({ remaining, resetUnixSec });
   }
 
-  quarantine(_token: string): void {
+  quarantine(): void {
     this.quarantineCalls += 1;
   }
 
@@ -148,6 +150,15 @@ test("recordGithubCall increments fail counter when the call is not successful",
   assert.equal(hash.lastRateLimitRemaining, undefined);
 });
 
+test("githubKeyFingerprint distinguishes different tokens with the same suffix", () => {
+  const first = githubKeyFingerprint("tok-a-aaaaaaaaaaaaaaaaabcd");
+  const second = githubKeyFingerprint("tok-b-bbbbbbbbbbbbbbbbabcd");
+
+  assert.notEqual(first, second);
+  assert.match(first, /^abcd-[0-9a-f]{8}$/);
+  assert.match(second, /^abcd-[0-9a-f]{8}$/);
+});
+
 test("quarantineKey stores fingerprint quarantine until an absolute unix timestamp", async () => {
   const fake = new FakeRedis();
   _setRedisForTests(fake);
@@ -191,7 +202,8 @@ test("githubFetch records usage telemetry for a successful response", async () =
     { remaining: 4998, resetUnixSec: 1_800_000_000 },
   ]);
   const hourBucket = new Date().toISOString().slice(0, 13).replace("T", "-");
-  const hash = await fake.hgetall(`pool:github:usage:abcd:${hourBucket}`);
+  const fingerprint = githubKeyFingerprint(pool.token);
+  const hash = await fake.hgetall(`pool:github:usage:${fingerprint}:${hourBucket}`);
   assert.equal(hash.requests, "1");
   assert.equal(hash.success, "1");
   assert.equal(hash.lastOperation, "rate_limit");
@@ -217,6 +229,10 @@ test("githubFetch quarantines invalid tokens by fingerprint after 401", async ()
 
   assert.equal(result?.response.status, 401);
   assert.equal(pool.quarantineCalls, 4);
-  assert.equal(await isKeyQuarantined("abcd"), true);
-  assert.match(fake.strings.get("pool:github:quarantine:abcd") ?? "", /invalid_token/);
+  const fingerprint = githubKeyFingerprint(pool.token);
+  assert.equal(await isKeyQuarantined(fingerprint), true);
+  assert.match(
+    fake.strings.get(`pool:github:quarantine:${fingerprint}`) ?? "",
+    /invalid_token/,
+  );
 });

--- a/src/lib/__tests__/reddit-ua-pool.test.ts
+++ b/src/lib/__tests__/reddit-ua-pool.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { redditUserAgentFingerprint } from "../pool/reddit-ua-pool";
+
+test("redditUserAgentFingerprint keeps configured user-agents distinct", () => {
+  const userAgents = [
+    "trendingrepo-scanner/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-discovery/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-signals/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-aggregator/1.0 (+https://trendingrepo.com)",
+    "trendingrepo-mentions/1.0 (+https://trendingrepo.com)",
+  ];
+
+  const fingerprints = userAgents.map(redditUserAgentFingerprint);
+
+  assert.equal(new Set(fingerprints).size, userAgents.length);
+  assert.ok(
+    fingerprints.every((fingerprint) =>
+      /^trendingrepo-[a-z0-9-]+-[0-9a-f]{8}$/.test(fingerprint),
+    ),
+  );
+});

--- a/src/lib/pool/github-telemetry.ts
+++ b/src/lib/pool/github-telemetry.ts
@@ -1,4 +1,5 @@
 import { redis } from "@/lib/redis";
+import { createHash } from "node:crypto";
 
 export type GithubQuarantineReason =
   | "rate_limit"
@@ -18,7 +19,9 @@ export interface GithubCallTelemetry {
 
 export function githubKeyFingerprint(token: string | null | undefined): string {
   const trimmed = token?.trim() ?? "";
-  return trimmed.length > 0 ? trimmed.slice(-4) : "none";
+  if (trimmed.length === 0) return "none";
+  const hash = createHash("sha256").update(trimmed).digest("hex").slice(0, 8);
+  return `${trimmed.slice(-4)}-${hash}`;
 }
 
 export async function recordGithubCall(

--- a/src/lib/pool/reddit-ua-pool.ts
+++ b/src/lib/pool/reddit-ua-pool.ts
@@ -4,6 +4,7 @@ import {
   type RedditQuarantineParams,
 } from "@/lib/pool/reddit-telemetry";
 import configuredUserAgents from "@/../config/reddit-user-agents.json";
+import { createHash } from "node:crypto";
 
 const DEFAULT_USER_AGENTS = [
   "trendingrepo-scanner/1.0 (+https://trendingrepo.com)",
@@ -24,7 +25,8 @@ export function redditUserAgentFingerprint(userAgent: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   if (!cleaned) return "reddit-ua-unknown";
-  return cleaned.slice(-24);
+  const hash = createHash("sha256").update(userAgent).digest("hex").slice(0, 8);
+  return `${cleaned.slice(0, 24)}-${hash}`;
 }
 
 export async function selectUserAgent(): Promise<string> {


### PR DESCRIPTION
## Summary
- make GitHub/Reddit pool telemetry fingerprints collision-resistant
- keep configured GitHub rows from collapsing while preserving legacy telemetry aliases
- add regression coverage for GitHub same-suffix tokens and configured Reddit UA uniqueness

## Verification
- npm run freshness:check: PASS all green after mcp-registry-official refresh
- npm run typecheck: PASS
- npm run lint: PASS (warnings only)
- npx tsx --test src/lib/__tests__/github-telemetry.test.ts src/lib/__tests__/reddit-ua-pool.test.ts: PASS 7/7
- npm run build: PASS on clean branch before final rebase; post-rebase typecheck/focused tests passed
- Render smoke on 127.0.0.1:3041: /admin/keys sections visible, 11 GitHub rows, 5 Reddit rows, unauth redirect, no overflow