### PR TITLE
fix(AGN-469): clarify scraper cadence copy on HomeEmptyState

### DIFF
--- a/src/components/home/HomeEmptyState.tsx
+++ b/src/components/home/HomeEmptyState.tsx
@@ -40,7 +40,7 @@ export function HomeEmptyState() {
           className="mx-auto mt-5 max-w-[52ch] v2-mono text-[10px] leading-relaxed text-[color:var(--v2-ink-400)]"
         >
           <span aria-hidden="true">{"// "}</span>
-          SCRAPER RUNS EVERY 20 MIN · DATA HYDRATES ON NEXT BUILD ·
+          SCRAPER RUNS EVERY 20 MIN (:07, :27, :47 UTC) · DATA HYDRATES ON NEXT BUILD ·
           SUBMITTED REPOS ARE PICKED UP ON THE NEXT INGEST.
         </p>
 


### PR DESCRIPTION
## Summary
- Appends exact cron offset times (`(:07, :27, :47 UTC)`) to the HomeEmptyState banner so operators see the precise schedule from `cron-pipeline-ingest.yml` instead of an ambiguous "every 20 min"

## Test plan
- [ ] HomeEmptyState renders with updated copy including UTC offsets
- [ ] No visual regressions on home page empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)