### PR TITLE
feat(brief): /brief/[owner]/[name] route + RepoHero (from AGN-799)

### DIFF
--- a/data/briefs/vercel-next.js.md
+++ b/data/briefs/vercel-next.js.md
@@ -1,0 +1,14 @@
+---
+hook: React framework that turned full-stack defaults into deploy-time leverage.
+what: Next.js is a production React framework for routing, rendering, and server-side data workflows. Teams use it to ship app experiences with an opinionated runtime and hosting-friendly primitives.
+why_now: The project keeps shipping high-visibility releases and ecosystem updates, which sustains attention from both maintainers and adopters. Ongoing release velocity is visible in GitHub release activity: https://github.com/vercel/next.js/releases
+who_built_it: Next.js is maintained by Vercel, the company behind a broad frontend deployment platform and multiple OSS web tooling projects.
+who_its_for: Product teams that need fast iteration on React applications with built-in server rendering patterns.
+whats_different: Compared with plain React + custom tooling, Next.js bundles routing, rendering modes, and server actions in one framework path. Compared with Remix, it prioritizes convention-heavy defaults and tight platform integration.
+sources:
+- https://github.com/vercel/next.js/releases
+- https://github.com/vercel/next.js
+- https://nextjs.org/blog
+written_at: 2026-05-04T21:46:42.494Z
+---
+Next.js has become the default choice for teams that want React plus production architecture in one package.\n\nIt combines routing, server rendering, and data workflows with a stable release cadence and a large maintainer ecosystem.\n\nRecent release activity and ecosystem updates continue to reinforce adoption momentum for both startups and enterprise frontend teams.

--- a/src/app/brief/[owner]/[name]/error.tsx
+++ b/src/app/brief/[owner]/[name]/error.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+export default function BriefError({ reset }: { reset: () => void }) {
+  return (
+    <main className="home-surface" style={{ paddingTop: 24, paddingBottom: 32 }}>
+      <section className="panel" style={{ padding: 24 }}>
+        <h1 style={{ marginTop: 0, fontSize: 22 }}>Brief unavailable</h1>
+        <p style={{ color: "var(--v4-ink-300)" }}>
+          The editorial brief failed to load. Try again.
+        </p>
+        <button type="button" onClick={reset} className="btn">
+          Retry
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/src/app/brief/[owner]/[name]/loading.tsx
+++ b/src/app/brief/[owner]/[name]/loading.tsx
@@ -1,0 +1,15 @@
+export default function BriefLoading() {
+  return (
+    <main className="home-surface" style={{ paddingTop: 24, paddingBottom: 32 }}>
+      <section className="panel" style={{ padding: 24 }}>
+        <div className="skeleton-shimmer h-3 w-32 rounded-[2px]" />
+        <div className="mt-3 skeleton-shimmer h-8 w-[260px] max-w-full rounded-[2px]" />
+        <div className="mt-6 grid gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="skeleton-shimmer h-4 w-full rounded-[2px]" />
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/brief/[owner]/[name]/opengraph-image.tsx
+++ b/src/app/brief/[owner]/[name]/opengraph-image.tsx
@@ -1,0 +1,72 @@
+import { ImageResponse } from "next/og";
+
+import { getBrief } from "@/lib/briefs";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+export const alt = "TrendingRepo editorial brief";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface RouteParams {
+  params: Promise<{ owner: string; name: string }>;
+}
+
+export default async function BriefOGImage({ params }: RouteParams) {
+  const { owner, name } = await params;
+  const brief = await getBrief(owner, name);
+
+  if (!brief) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "#0f172a",
+            color: "#e2e8f0",
+            fontSize: 48,
+            fontFamily: "sans-serif",
+            fontWeight: 700,
+          }}
+        >
+          Brief not found
+        </div>
+      ),
+      size,
+    );
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "linear-gradient(140deg, #0f172a 0%, #111827 60%, #1f2937 100%)",
+          color: "#f8fafc",
+          padding: "48px 60px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: "flex", fontSize: 20, opacity: 0.9 }}>{brief.owner}/{brief.name}</div>
+          <div style={{ display: "flex", fontSize: 62, lineHeight: 1.06, fontWeight: 800 }}>{brief.hook}</div>
+          <div style={{ display: "flex", fontSize: 28, lineHeight: 1.35, opacity: 0.92 }}>{brief.what}</div>
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "space-between", fontSize: 22, opacity: 0.82 }}>
+          <span>TrendingRepo Editorial Brief</span>
+          <span>{brief.written_at.slice(0, 10)}</span>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/src/app/brief/[owner]/[name]/page.tsx
+++ b/src/app/brief/[owner]/[name]/page.tsx
@@ -1,0 +1,124 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { getBrief } from "@/lib/briefs";
+import { SITE_NAME, absoluteUrl, safeJsonLd } from "@/lib/seo";
+
+interface BriefPageProps {
+  params: Promise<{ owner: string; name: string }>;
+}
+
+export const revalidate = 300;
+
+function bodyParagraphs(markdown: string): string[] {
+  return markdown
+    .split(/\n{2,}/)
+    .map((chunk) => chunk.trim())
+    .filter(Boolean);
+}
+
+export async function generateMetadata({ params }: BriefPageProps): Promise<Metadata> {
+  const { owner, name } = await params;
+  const brief = await getBrief(owner, name);
+
+  if (!brief) {
+    return {
+      title: `Brief Not Found - ${SITE_NAME}`,
+      robots: { index: false, follow: true },
+      alternates: { canonical: absoluteUrl(`/brief/${owner}/${name}`) },
+    };
+  }
+
+  const title = `${brief.name}: ${brief.hook}`;
+  const description = brief.what;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: absoluteUrl(`/brief/${owner}/${name}`) },
+    openGraph: {
+      type: "article",
+      title,
+      description,
+      url: absoluteUrl(`/brief/${owner}/${name}`),
+      siteName: SITE_NAME,
+      images: [absoluteUrl(`/brief/${owner}/${name}/opengraph-image`)],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [absoluteUrl(`/brief/${owner}/${name}/opengraph-image`)],
+    },
+  };
+}
+
+export default async function BriefPage({ params }: BriefPageProps) {
+  const { owner, name } = await params;
+  const brief = await getBrief(owner, name);
+
+  if (!brief) {
+    notFound();
+  }
+
+  // TypeScript cannot narrow through notFound() — brief is guaranteed non-null here.
+  const resolvedBrief = brief!;
+
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: `${resolvedBrief.name}: ${resolvedBrief.hook}`,
+    description: resolvedBrief.what,
+    author: {
+      "@type": "Person",
+      name: "TrendingRepo Editorial",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+    },
+    datePublished: resolvedBrief.written_at,
+    dateModified: resolvedBrief.written_at,
+    mainEntityOfPage: absoluteUrl(`/brief/${resolvedBrief.owner}/${resolvedBrief.name}`),
+    url: absoluteUrl(`/brief/${resolvedBrief.owner}/${resolvedBrief.name}`),
+  };
+
+  return (
+    <main className="home-surface" style={{ paddingTop: 24, paddingBottom: 32 }}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(articleJsonLd) }} />
+      <article className="panel" style={{ padding: 24 }}>
+        <header style={{ marginBottom: 20 }}>
+          <p style={{ fontFamily: "var(--v4-mono)", fontSize: 12, color: "var(--v4-ink-400)", margin: 0 }}>
+            {resolvedBrief.owner}/{resolvedBrief.name}
+          </p>
+          <h1 style={{ margin: "8px 0 0", fontSize: 30, lineHeight: 1.2 }}>{resolvedBrief.hook}</h1>
+        </header>
+
+        <div style={{ display: "grid", gap: 20, gridTemplateColumns: "minmax(0,1fr) minmax(220px,300px)" }}>
+          <section>
+            {bodyParagraphs(resolvedBrief.body).map((paragraph, idx) => (
+              <p key={`${paragraph.slice(0, 16)}-${idx}`} style={{ marginTop: idx === 0 ? 0 : 14, lineHeight: 1.7 }}>
+                {paragraph}
+              </p>
+            ))}
+          </section>
+
+          <aside>
+            <h2 style={{ margin: "0 0 10px", fontSize: 14, letterSpacing: "0.08em", textTransform: "uppercase" }}>Sources</h2>
+            <ul style={{ margin: 0, paddingLeft: 18, display: "grid", gap: 8 }}>
+              {resolvedBrief.sources.map((source) => (
+                <li key={source}>
+                  <Link href={source} target="_blank" rel="noopener noreferrer">
+                    {source}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+            <p style={{ marginTop: 16, fontSize: 12, color: "var(--v4-ink-400)" }}>Written at: {resolvedBrief.written_at}</p>
+          </aside>
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/src/app/brief/sitemap.xml/route.ts
+++ b/src/app/brief/sitemap.xml/route.ts
@@ -1,0 +1,25 @@
+import { listRepoBriefRefs } from "@/lib/briefs";
+import { absoluteUrl } from "@/lib/seo";
+import { renderUrlset, type UrlEntry, xmlResponse } from "@/lib/sitemap-xml";
+
+export const revalidate = 3600;
+export const dynamic = "force-static";
+
+export function GET(): Response {
+  const entries: UrlEntry[] = listRepoBriefRefs().map((brief) => {
+    const writtenAt = brief.writtenAt ? new Date(brief.writtenAt) : null;
+    const lastmod =
+      writtenAt && !Number.isNaN(writtenAt.getTime())
+        ? writtenAt
+        : brief.updatedAt;
+
+    return {
+      loc: absoluteUrl(`/brief/${brief.owner}/${brief.name}`),
+      lastmod,
+      changefreq: "weekly",
+      priority: 0.7,
+    };
+  });
+
+  return xmlResponse(renderUrlset(entries), 3600);
+}

--- a/src/components/repo/RepoBrief.tsx
+++ b/src/components/repo/RepoBrief.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import type { JSX } from "react";
+
+import type { RepoBrief } from "@/lib/briefs";
+
+interface RepoBriefProps {
+  brief: RepoBrief;
+}
+
+interface RepoBriefHeroProps {
+  owner: string;
+  name: string;
+  hook: string;
+}
+
+function renderParagraphs(text: string): JSX.Element[] {
+  return text
+    .split(/\n{2,}/)
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .map((chunk, idx) => (
+      <p key={`${chunk.slice(0, 16)}-${idx}`} style={{ marginTop: idx === 0 ? 0 : 8 }}>
+        {chunk}
+      </p>
+    ));
+}
+
+export function RepoBriefHero({ owner, name, hook }: RepoBriefHeroProps) {
+  return (
+    <section className="v2-card p-3" aria-label="Editorial brief highlight">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-text-tertiary">{"// BRIEF"}</span>
+        <span className="badge badge--info">editorial</span>
+      </div>
+      <p className="mt-2 text-sm leading-relaxed text-text-primary">{hook}</p>
+      <Link href={`/brief/${owner}/${name}`} className="mt-2 inline-block text-xs font-mono uppercase tracking-[0.1em] text-accent hover:underline">
+        Read full brief -&gt;
+      </Link>
+    </section>
+  );
+}
+
+export function RepoBriefView({ brief }: RepoBriefProps) {
+  return (
+    <article className="panel" style={{ padding: 24, display: "grid", gap: 16 }}>
+      <header style={{ display: "grid", gap: 8 }}>
+        <p style={{ fontFamily: "var(--v4-mono)", fontSize: 12, color: "var(--v4-ink-400)", margin: 0 }}>
+          {brief.owner}/{brief.name}
+        </p>
+        <h1 style={{ margin: 0, fontSize: 28, lineHeight: 1.2 }}>{brief.hook}</h1>
+      </header>
+
+      <section>
+        <h2 style={{ marginBottom: 8, fontSize: 16 }}>What</h2>
+        {renderParagraphs(brief.what)}
+      </section>
+      <section>
+        <h2 style={{ marginBottom: 8, fontSize: 16 }}>Why now</h2>
+        {renderParagraphs(brief.why_now)}
+      </section>
+      <section>
+        <h2 style={{ marginBottom: 8, fontSize: 16 }}>Who built it</h2>
+        {renderParagraphs(brief.who_built_it)}
+      </section>
+      <section>
+        <h2 style={{ marginBottom: 8, fontSize: 16 }}>Who it&apos;s for</h2>
+        {renderParagraphs(brief.who_its_for)}
+      </section>
+      <section>
+        <h2 style={{ marginBottom: 8, fontSize: 16 }}>What&apos;s different</h2>
+        {renderParagraphs(brief.whats_different)}
+      </section>
+
+      <section>
+        <h2 style={{ marginBottom: 8, fontSize: 16 }}>Sources</h2>
+        <ul style={{ margin: 0, paddingLeft: 18, display: "grid", gap: 6 }}>
+          {brief.sources.map((source) => (
+            <li key={source}>
+              <Link href={source} target="_blank" rel="noopener noreferrer">
+                {source}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <footer style={{ color: "var(--v4-ink-400)", fontSize: 12 }}>
+        Written at: {brief.written_at || "unknown"}
+      </footer>
+    </article>
+  );
+}
+
+export default RepoBriefView;

--- a/src/lib/briefs.ts
+++ b/src/lib/briefs.ts
@@ -1,0 +1,346 @@
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { getDataStore } from "@/lib/data-store";
+
+export interface RepoBriefFaqItem {
+  q: string;
+  a: string;
+}
+
+export interface RepoBrief {
+  owner: string;
+  name: string;
+  hook: string;
+  what: string;
+  why_now: string;
+  who_built_it: string;
+  who_its_for: string;
+  whats_different: string;
+  sources: string[];
+  written_at: string;
+  body: string;
+  faq?: RepoBriefFaqItem[];
+}
+
+export interface RepoBriefRef {
+  owner: string;
+  name: string;
+  writtenAt: string;
+  updatedAt: Date;
+}
+
+const SLUG_PART_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+interface ParsedFrontmatter {
+  [key: string]: string | string[];
+}
+
+function isValidSlugPart(value: string): boolean {
+  return SLUG_PART_PATTERN.test(value);
+}
+
+function isLikelyIsoTimestamp(value: string): boolean {
+  if (!value) return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed);
+}
+
+function briefPath(owner: string, name: string): string {
+  return resolve(process.cwd(), "data", "briefs", `${owner}-${name}.md`);
+}
+
+function briefDir(): string {
+  return resolve(process.cwd(), "data", "briefs");
+}
+
+function briefStoreKey(owner: string, name: string): string {
+  return `brief:${owner}:${name}`;
+}
+
+function splitFrontmatter(raw: string): { frontmatter: string; body: string } {
+  if (!raw.startsWith("---\n") && !raw.startsWith("---\r\n")) {
+    return { frontmatter: "", body: raw };
+  }
+
+  const normalized = raw.replace(/\r\n/g, "\n");
+  const closeIndex = normalized.indexOf("\n---\n", 4);
+  if (closeIndex === -1) {
+    return { frontmatter: "", body: raw };
+  }
+
+  const frontmatter = normalized.slice(4, closeIndex);
+  const body = normalized.slice(closeIndex + 5).trim();
+  return { frontmatter, body };
+}
+
+function parseFrontmatter(frontmatter: string): ParsedFrontmatter {
+  const lines = frontmatter.split("\n");
+  const parsed: ParsedFrontmatter = {};
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]?.trimEnd() ?? "";
+    if (!line || line.startsWith("#")) continue;
+
+    if (line.startsWith("sources:")) {
+      const sources: string[] = [];
+      for (let j = i + 1; j < lines.length; j += 1) {
+        const item = lines[j]?.trim() ?? "";
+        if (item.startsWith("- ")) {
+          sources.push(item.slice(2).trim());
+          i = j;
+          continue;
+        }
+        break;
+      }
+      parsed.sources = sources;
+      continue;
+    }
+
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim().replace(/^"|"$/g, "");
+    parsed[key] = value;
+  }
+
+  return parsed;
+}
+
+function strField(parsed: ParsedFrontmatter, key: string): string {
+  const value = parsed[key];
+  return typeof value === "string" ? value : "";
+}
+
+function normalizeSources(sources: string[]): string[] {
+  return Array.from(new Set(sources.map((source) => source.trim()).filter(Boolean)));
+}
+
+function isValidSourceUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function parseMarkdownBrief(owner: string, name: string, raw: string): RepoBrief | null {
+  const { frontmatter, body } = splitFrontmatter(raw);
+  if (!frontmatter) return null;
+
+  const parsed = parseFrontmatter(frontmatter);
+  const sources = normalizeSources(
+    Array.isArray(parsed.sources)
+      ? parsed.sources.filter((source) => typeof source === "string" && source.trim().length > 0)
+      : [],
+  );
+
+  const brief: RepoBrief = {
+    owner,
+    name,
+    hook: strField(parsed, "hook"),
+    what: strField(parsed, "what"),
+    why_now: strField(parsed, "why_now"),
+    who_built_it: strField(parsed, "who_built_it"),
+    who_its_for: strField(parsed, "who_its_for"),
+    whats_different: strField(parsed, "whats_different"),
+    sources,
+    written_at: strField(parsed, "written_at"),
+    body,
+  };
+
+  return normalizeBrief(brief);
+}
+
+function normalizeBrief(input: RepoBrief | null): RepoBrief | null {
+  if (!input) return null;
+  if (!isValidSlugPart(input.owner) || !isValidSlugPart(input.name)) return null;
+
+  const brief: RepoBrief = {
+    ...input,
+    hook: input.hook?.trim() ?? "",
+    what: input.what?.trim() ?? "",
+    why_now: input.why_now?.trim() ?? "",
+    who_built_it: input.who_built_it?.trim() ?? "",
+    who_its_for: input.who_its_for?.trim() ?? "",
+    whats_different: input.whats_different?.trim() ?? "",
+    body: input.body?.trim() ?? "",
+    written_at: input.written_at?.trim() ?? "",
+    sources: normalizeSources(input.sources ?? []),
+  };
+
+  if (!brief.hook || !brief.what || !brief.why_now || !brief.who_built_it || !brief.who_its_for || !brief.whats_different) {
+    return null;
+  }
+
+  if (!brief.body) {
+    brief.body = [brief.what, brief.why_now, brief.who_built_it, brief.who_its_for, brief.whats_different].join("\n\n");
+  }
+
+  if (!isLikelyIsoTimestamp(brief.written_at)) return null;
+  if (brief.sources.length < 3 || !brief.sources.every(isValidSourceUrl)) return null;
+
+  return brief;
+}
+
+function toMarkdown(brief: RepoBrief): string {
+  const lines = [
+    "---",
+    `hook: ${brief.hook}`,
+    `what: ${brief.what}`,
+    `why_now: ${brief.why_now}`,
+    `who_built_it: ${brief.who_built_it}`,
+    `who_its_for: ${brief.who_its_for}`,
+    `whats_different: ${brief.whats_different}`,
+    "sources:",
+    ...brief.sources.map((source) => `- ${source}`),
+    `written_at: ${brief.written_at}`,
+    "---",
+    brief.body,
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function parseStoredBrief(data: unknown, owner: string, name: string): RepoBrief | null {
+  if (!data || typeof data !== "object") return null;
+  const record = data as Partial<RepoBrief>;
+
+  return normalizeBrief({
+    owner,
+    name,
+    hook: typeof record.hook === "string" ? record.hook : "",
+    what: typeof record.what === "string" ? record.what : "",
+    why_now: typeof record.why_now === "string" ? record.why_now : "",
+    who_built_it: typeof record.who_built_it === "string" ? record.who_built_it : "",
+    who_its_for: typeof record.who_its_for === "string" ? record.who_its_for : "",
+    whats_different: typeof record.whats_different === "string" ? record.whats_different : "",
+    sources: Array.isArray(record.sources) ? record.sources.filter((v): v is string => typeof v === "string") : [],
+    written_at: typeof record.written_at === "string" ? record.written_at : "",
+    body: typeof record.body === "string" ? record.body : "",
+    faq: Array.isArray(record.faq)
+      ? record.faq.filter((entry): entry is RepoBriefFaqItem => Boolean(entry && typeof entry === "object" && typeof (entry as RepoBriefFaqItem).q === "string" && typeof (entry as RepoBriefFaqItem).a === "string"))
+      : [],
+  });
+}
+
+function parseRepoBriefFromFile(owner: string, name: string): RepoBrief | null {
+  const filePath = briefPath(owner, name);
+  if (!existsSync(filePath)) return null;
+
+  const raw = readFileSync(filePath, "utf8");
+  return parseMarkdownBrief(owner, name, raw);
+}
+
+export function getBriefFromFile(owner: string, name: string): RepoBrief | null {
+  if (!isValidSlugPart(owner) || !isValidSlugPart(name)) return null;
+  return parseRepoBriefFromFile(owner, name);
+}
+
+export async function getBrief(owner: string, name: string): Promise<RepoBrief | null> {
+  if (!isValidSlugPart(owner) || !isValidSlugPart(name)) return null;
+
+  const store = getDataStore();
+  const result = await store.read<unknown>(briefStoreKey(owner, name));
+  const fromStore = parseStoredBrief(result.data, owner, name);
+  if (fromStore) return fromStore;
+
+  return parseRepoBriefFromFile(owner, name);
+}
+
+export async function setBrief(owner: string, name: string, body: RepoBrief): Promise<void> {
+  if (!isValidSlugPart(owner) || !isValidSlugPart(name)) {
+    throw new Error("Invalid brief slug");
+  }
+
+  const normalized = normalizeBrief({ ...body, owner, name });
+  if (!normalized) {
+    throw new Error("Invalid brief payload");
+  }
+
+  const store = getDataStore();
+  await store.write<RepoBrief>(briefStoreKey(owner, name), normalized, { ttlSeconds: 2_592_000 });
+
+  // Keep markdown artifact for local indexing and durability.
+  writeFileSync(briefPath(owner, name), toMarkdown(normalized), "utf8");
+}
+
+export async function listRecentBriefs(limit = 7): Promise<RepoBriefRef[]> {
+  const dir = briefDir();
+  if (!existsSync(dir)) return [];
+
+  const refs: RepoBriefRef[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === ".gitkeep") continue;
+
+    const stem = entry.name.slice(0, -3);
+    const sep = stem.indexOf("-");
+    if (sep <= 0 || sep >= stem.length - 1) continue;
+
+    const owner = stem.slice(0, sep);
+    const name = stem.slice(sep + 1);
+    if (!isValidSlugPart(owner) || !isValidSlugPart(name)) continue;
+
+    const brief = await getBrief(owner, name);
+    if (!brief) continue;
+
+    const filePath = briefPath(owner, name);
+    const stat = statSync(filePath);
+    refs.push({
+      owner,
+      name,
+      writtenAt: brief.written_at,
+      updatedAt: stat.mtime,
+    });
+  }
+
+  return refs
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+    .slice(0, Math.max(1, Math.floor(limit)));
+}
+
+export function listRepoBriefRefs(): RepoBriefRef[] {
+  const dir = briefDir();
+  if (!existsSync(dir)) return [];
+
+  const refs: RepoBriefRef[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === ".gitkeep") {
+      continue;
+    }
+
+    const stem = entry.name.slice(0, -3);
+    const sep = stem.indexOf("-");
+    if (sep <= 0 || sep >= stem.length - 1) {
+      continue;
+    }
+
+    const owner = stem.slice(0, sep);
+    const name = stem.slice(sep + 1);
+    if (!isValidSlugPart(owner) || !isValidSlugPart(name)) {
+      continue;
+    }
+
+    const brief = parseRepoBriefFromFile(owner, name);
+    if (!brief) {
+      continue;
+    }
+
+    const filePath = briefPath(owner, name);
+    const stat = statSync(filePath);
+    refs.push({
+      owner,
+      name,
+      writtenAt: brief.written_at,
+      updatedAt: stat.mtime,
+    });
+  }
+
+  return refs.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+}
+
+// Back-compat alias for in-flight branches.
+export const getRepoBrief = getBrief;


### PR DESCRIPTION
Carves brief-route + repo-hero work from closed #112. Skips drift.

Co-Authored-By: Paperclip <noreply@paperclip.ing>