### PR TITLE
fix(sidebar): consolidate HF Models/Datasets/Spaces into one entry with internal Tabs (AGN-365)

### DIFF
--- a/src/app/huggingface/trending/page.tsx
+++ b/src/app/huggingface/trending/page.tsx
@@ -96,7 +96,7 @@ export default async function HuggingFaceTrendingPage() {
           }
           title="Hugging Face · trending"
           lede="Top models ranked by domain-scored momentum (weeklyDownloads + recency). Snapshot pulled from the public trending feed and re-scored against the cross-domain percentile."
-          tabBar={<HfNavTabs activeHref="/huggingface/models" />}
+          tabBar={<HfNavTabs activeHref="/huggingface/trending" />}
         />
         <ColdState />
       </main>
@@ -166,7 +166,7 @@ export default async function HuggingFaceTrendingPage() {
             ]}
           />
         }
-        tabBar={<HfNavTabs activeHref="/huggingface/models" />}
+        tabBar={<HfNavTabs activeHref="/huggingface/trending" />}
         listEyebrow="Model feed · top 100 by momentum"
         list={<HfModelFeed models={models} />}
       />

--- a/src/components/huggingface/HfNavTabs.tsx
+++ b/src/components/huggingface/HfNavTabs.tsx
@@ -1,8 +1,11 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 
+// AGN-365: tabs live on the HF Models host page (/huggingface/trending). The
+// Models tab points to that canonical path so sidebar + tab active states
+// align (sidebar links to /huggingface/trending; Models tab is active there).
 const HF_TABS = [
-  { href: "/huggingface/models", label: "Models" },
+  { href: "/huggingface/trending", label: "Models" },
   { href: "/huggingface/datasets", label: "Datasets" },
   { href: "/huggingface/spaces", label: "Spaces" },
 ] as const;

--- a/src/components/layout/SidebarContent.tsx
+++ b/src/components/layout/SidebarContent.tsx
@@ -522,12 +522,15 @@ export function SidebarContent({
             badgeTone="default"
             active={pathname === "/npm" || pathname.startsWith("/npm/")}
           />
+          {/* AGN-365: single HF entry. Datasets/Spaces are tabs on the host page,
+              not separate sidebar items. Pathname startsWith /huggingface still
+              keeps the row active across all three tabs. */}
           <FreshCountNavRow
             routeKey="hfModels"
             currentCount={sourceCounts?.hfModels ?? 0}
-            href="/huggingface"
+            href="/huggingface/trending"
             icon={Brain}
-            label="HUGGINGFACE"
+            label="HF Models"
             active={pathname.startsWith("/huggingface")}
           />
         </V2Section>


### PR DESCRIPTION
Sidebar now has a single 'HF Models' entry pointing to /huggingface/trending
(the canonical host page). HfNavTabs (Models/Datasets/Spaces) lives on the
host page and switches between the three views — Datasets and Spaces are no
longer separate sidebar items, so the duplicated rows the user reported are
gone. Models tab now links to /huggingface/trending so sidebar + tab active
states agree.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
