### PR TITLE
fix(huggingface): repair avatar/logo loading on models/datasets/spaces pages (AGN-789)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -60,6 +60,11 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "unavatar.io" },
       { protocol: "https", hostname: "www.google.com" },
       { protocol: "https", hostname: "ph-files.imgix.net" },
+      // Hugging Face — platform mark + author/org avatars (CDN). Used by
+      // /huggingface/{models,datasets,spaces} via EntityLogo (raw <img>),
+      // listed here so any future migration to next/image doesn't break.
+      { protocol: "https", hostname: "huggingface.co" },
+      { protocol: "https", hostname: "cdn-avatars.huggingface.co" },
     ],
   },
   // Uncomment for Docker/Railway/Fly deployments that need a self-contained

--- a/src/lib/logos.ts
+++ b/src/lib/logos.ts
@@ -174,13 +174,21 @@ function normalizeHfAuthor(author: string | null | undefined): string {
 
 /**
  * Project-specific logo for a HuggingFace org/user. Returns the favicon URL
- * for a mapped domain (NVIDIA, Google, Meta, DeepSeek, etc.) or null when
- * the author isn't recognised — null lets EntityLogo render its monogram
- * tile (colored initial), which looks intentional and consistent. We
- * deliberately do NOT slug-guess random author names into `{slug}.com`
- * favicons because Google's service serves a generic globe for unknown
- * domains, not a 404 — so misses look like "broken globe icons" rather
- * than letting the monogram fallback kick in.
+ * for a mapped domain (NVIDIA, Google, Meta, DeepSeek, etc.) when the author
+ * is in HF_AUTHOR_DOMAIN_MAP; otherwise falls back to the stable HF platform
+ * mark so every HF row carries a recognisable logo.
+ *
+ * History: this used to return null for unmapped authors and let EntityLogo
+ * render a monogram tile. In practice the long-tail (Jackrong, cyankiwi,
+ * etc.) made all 3 HF feed pages look broken — users reported every row as
+ * a missing logo (AGN-789). Slug-guessing `{slug}.com` favicons via Google
+ * s2 still serves a generic globe for unknown domains (looks like a broken
+ * icon), so the safe default is the HF mark itself: stable URL, on-brand,
+ * and unmistakably "this is a Hugging Face entity".
+ *
+ * Returns null only when `author` is empty/whitespace — there's nothing
+ * meaningful to render in that case, EntityLogo will fall back to its
+ * monogram tile.
  */
 export function huggingFaceAuthorLogoUrl(
   author: string | null | undefined,
@@ -189,9 +197,12 @@ export function huggingFaceAuthorLogoUrl(
   const slug = normalizeHfAuthor(author);
   if (!slug) return null;
   const mapped = HF_AUTHOR_DOMAIN_MAP.get(slug);
-  if (!mapped) return null;
-  const sz = Math.max(16, Math.min(256, Math.round(size)));
-  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(mapped)}&sz=${sz}`;
+  if (mapped) {
+    const sz = Math.max(16, Math.min(256, Math.round(size)));
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(mapped)}&sz=${sz}`;
+  }
+  // Unmapped author → HF platform mark. Stable, on-brand, no broken icon.
+  return huggingFaceLogoUrl();
 }
 
 export interface McpLogoInput {


### PR DESCRIPTION
Two-part fix for user-reported broken logos across all 3 HF feed pages:

1. huggingFaceAuthorLogoUrl now falls back to the stable HF platform mark
   for authors not in HF_AUTHOR_DOMAIN_MAP (was returning null → monogram
   tile). The long-tail of HF authors (Jackrong, cyankiwi, etc.) was
   leaving every row looking 'broken' to users — slug-guessing favicons
   was rejected because Google s2 serves a generic globe for unknowns,
   which looks worse than a real logo. The HF mark is on-brand, stable,
   and unmistakably says 'this is a Hugging Face entity'.

2. next.config.ts images.remotePatterns adds huggingface.co and
   cdn-avatars.huggingface.co. EntityLogo currently uses raw <img> so
   this is defensive — any future migration to next/image (post AGN-438
   pattern) will work without revisiting the HF feeds.

Existing logos.test.ts (13 tests) still pass — the huggingFaceLogoUrl
contract is unchanged.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
