### PR TITLE
feat(privacy): add GDPR cookie consent banner (AGN-840)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,7 @@ import {
 import { MobileDrawerLazy } from "@/components/layout/MobileDrawerLazy";
 import { MobileNav } from "@/components/layout/MobileNav";
 import { BrowserAlertBridge } from "@/components/alerts/BrowserAlertBridge";
+import { CookieConsentBanner } from "@/components/consent/CookieConsentBanner";
 import { DesignSystemProvider } from "@/components/v3";
 import { SITE_URL, SITE_NAME, SITE_TAGLINE, SITE_DESCRIPTION } from "@/lib/seo";
 import "./globals.css";
@@ -230,6 +231,7 @@ export default async function RootLayout({
               <MobileNav />
               <BrowserAlertBridge />
               <ToasterLazy />
+              <CookieConsentBanner />
               </DesignSystemProvider>
             </StoreProvider>
           </PostHogProvider>

--- a/src/components/consent/CookieConsentBanner.tsx
+++ b/src/components/consent/CookieConsentBanner.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+// GDPR cookie consent banner (AGN-840). Klaro-style UX:
+//   - First visit: banner appears, analytics blocked by default
+//   - User picks Accept (analytics on) or Decline (analytics stays off)
+//   - Choice persists in localStorage; banner does not re-show next visit
+//   - PostHogProvider listens for the consent-changed event and only
+//     initialises posthog-js after `accepted`
+//
+// We hand-roll this rather than embed Klaro because (a) the only
+// non-essential vendor today is PostHog and (b) Klaro's runtime is
+// ~30 KB plus a separate CSS layer that fights our v3 token system.
+// If we ever need a multi-vendor catalogue UI, swap-in is a one-file
+// move (consent.ts is the only persistence surface).
+
+import { useEffect, useState } from "react";
+import { CONSENT_CHANGED_EVENT, readConsent, writeConsent } from "@/lib/consent";
+
+export function CookieConsentBanner() {
+  // Keep the banner mounted server-side as null so it can't cause
+  // hydration mismatches on the chosen state. We only flip `visible`
+  // after the first effect once we've read localStorage.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const existing = readConsent();
+    if (!existing) setVisible(true);
+
+    // If a different surface (e.g. a future "Manage cookies" link in
+    // the footer) wipes the stored choice, reopen the banner.
+    function onChange() {
+      const next = readConsent();
+      setVisible(next == null);
+    }
+    window.addEventListener(CONSENT_CHANGED_EVENT, onChange);
+    return () => window.removeEventListener(CONSENT_CHANGED_EVENT, onChange);
+  }, []);
+
+  if (!visible) return null;
+
+  function handle(choice: "accepted" | "declined") {
+    writeConsent(choice);
+    setVisible(false);
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="cookie-consent-title"
+      aria-describedby="cookie-consent-body"
+      className="fixed bottom-3 left-3 right-3 z-[90] mx-auto max-w-xl rounded-[2px] border p-4 shadow-[var(--shadow-popover)] sm:left-4 sm:right-auto sm:bottom-4"
+      style={{
+        background: "var(--v3-bg-050)",
+        borderColor: "var(--v3-line-200)",
+        color: "var(--v3-ink-100)",
+      }}
+    >
+      <p
+        id="cookie-consent-title"
+        className="text-[13px] font-medium tracking-[-0.005em]"
+        style={{ color: "var(--v3-ink-000)" }}
+      >
+        Cookies & analytics
+      </p>
+      <p
+        id="cookie-consent-body"
+        className="mt-1 text-[12px] leading-snug"
+        style={{ color: "var(--v3-ink-300)" }}
+      >
+        We use a few necessary cookies to remember your theme and watchlist.
+        With your consent we also load PostHog to understand which trending
+        signals matter. Decline and only the essentials run.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => handle("accepted")}
+          className="rounded-[2px] px-3 py-1.5 text-[12px] font-medium transition-colors"
+          style={{
+            background: "var(--v3-acc)",
+            color: "var(--v3-bg-025)",
+          }}
+        >
+          Accept analytics
+        </button>
+        <button
+          type="button"
+          onClick={() => handle("declined")}
+          className="rounded-[2px] border px-3 py-1.5 text-[12px] font-medium transition-colors"
+          style={{
+            borderColor: "var(--v3-line-200)",
+            color: "var(--v3-ink-100)",
+            background: "transparent",
+          }}
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -1,11 +1,29 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { CONSENT_CHANGED_EVENT, readConsent } from "@/lib/consent";
 
+// Lazily initialise posthog-js only after the user has accepted
+// analytics via the consent banner (AGN-840). Before consent we
+// never call posthog.init, so no network calls or cookies are set.
+// Re-runs on the consent-changed event so accepting the banner
+// fires the SDK without a page reload.
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  const [hasConsent, setHasConsent] = useState(false);
+
   useEffect(() => {
+    function syncConsent() {
+      setHasConsent(readConsent()?.analytics === true);
+    }
+    syncConsent();
+    window.addEventListener(CONSENT_CHANGED_EVENT, syncConsent);
+    return () => window.removeEventListener(CONSENT_CHANGED_EVENT, syncConsent);
+  }, []);
+
+  useEffect(() => {
+    if (!hasConsent) return;
     const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
     if (!key) return;
     if (posthog.__loaded) return;
@@ -26,7 +44,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         if (process.env.NODE_ENV === "development") ph.debug();
       },
     });
-  }, []);
+  }, [hasConsent]);
 
   return <PHProvider client={posthog}>{children}</PHProvider>;
 }

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,68 @@
+// Cookie consent helpers (AGN-840). Klaro-style API: a single boolean
+// for the "analytics" service, persisted in localStorage. Necessary
+// cookies (theme, watchlist, etc.) are always allowed and never gated.
+//
+// We deliberately ship a hand-rolled banner instead of pulling in
+// Klaro (~30 KB + its own CSS layer) because the only non-essential
+// integration we need to gate today is PostHog. If we ever need
+// per-vendor toggles or a Cookie Information service catalogue,
+// swapping in Klaro is a one-file move (this module is the only
+// place reading the key).
+
+export const CONSENT_STORAGE_KEY = "trendingrepo-consent-v1";
+
+export type ConsentChoice = "accepted" | "declined";
+
+export type ConsentState = {
+  analytics: boolean;
+  // ISO timestamp the user made the choice. Useful for re-prompting
+  // after a policy change (not wired today; reserved for future use).
+  decidedAt: string;
+  choice: ConsentChoice;
+};
+
+// Custom event fired on the window when consent changes. PostHogProvider
+// listens for this so it can init/opt-in immediately after Accept
+// without waiting for a page navigation.
+export const CONSENT_CHANGED_EVENT = "trendingrepo:consent-changed";
+
+export function readConsent(): ConsentState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ConsentState>;
+    if (
+      parsed &&
+      typeof parsed.analytics === "boolean" &&
+      typeof parsed.decidedAt === "string" &&
+      (parsed.choice === "accepted" || parsed.choice === "declined")
+    ) {
+      return parsed as ConsentState;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeConsent(choice: ConsentChoice): ConsentState {
+  const state: ConsentState = {
+    analytics: choice === "accepted",
+    decidedAt: new Date().toISOString(),
+    choice,
+  };
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(state));
+      window.dispatchEvent(
+        new CustomEvent<ConsentState>(CONSENT_CHANGED_EVENT, { detail: state }),
+      );
+    } catch {
+      // localStorage can throw in private mode / disabled storage. The
+      // banner will simply re-show next visit, which is the correct
+      // behaviour — we never silently treat the user as opted-in.
+    }
+  }
+  return state;
+}


### PR DESCRIPTION
## Summary
- Adds a first-visit cookie consent banner that gates PostHog analytics behind explicit user consent (AGN-840 / [BIZ-3]).
- Necessary cookies (theme, watchlist, sidebar state, etc.) continue to work out of the box; PostHog only initialises after the user clicks **Accept analytics**.
- Choice persists in `localStorage` under `trendingrepo-consent-v1`; banner does not re-show on subsequent visits.

## Cookiebot vs Klaro — choice + reason
The spec listed both. **Picked Klaro-style (free, embedded) over Cookiebot (paid SaaS)** because Klaro is OSS / self-hosted and we already control all the analytics surfaces.

Then, given the only non-essential vendor today is PostHog, I wrote a **hand-rolled banner with a Klaro-equivalent UX** rather than pulling in the full `klaro` package (~30 KB runtime + its own CSS layer that fights our v3 token system). The persistence module (`src/lib/consent.ts`) is the single source of truth — if we ever need a multi-vendor catalogue UI we can swap-in actual Klaro by replacing only `CookieConsentBanner.tsx` and keeping the same key.

## Files
- **NEW** `src/lib/consent.ts` — read/write helpers + custom event for live updates
- **NEW** `src/components/consent/CookieConsentBanner.tsx` — bottom-left dialog with Accept / Decline, v3-token styled
- **MODIFIED** `src/components/providers/PostHogProvider.tsx` — only calls `posthog.init` after consent; reacts to consent-changed event so accepting fires SDK without page reload
- **MODIFIED** `src/app/layout.tsx` — mounts `<CookieConsentBanner />` inside the existing provider tree

## Acceptance
- [x] Banner shows on first visit (no `trendingrepo-consent-v1` key in localStorage)
- [x] PostHog only fires after consent — `posthog.init` is gated by `hasConsent` state
- [x] Necessary cookies always allowed (theme migration script in `<head>` is untouched)
- [x] Choice persists across reloads
- [x] `npm run typecheck` clean

## Test plan
- [ ] Visit site fresh (incognito) → banner appears bottom-left
- [ ] Click **Decline** → banner disappears, no PostHog network calls in DevTools, `localStorage.trendingrepo-consent-v1` stored with `analytics:false`
- [ ] Click **Accept analytics** → banner disappears, PostHog `/decide` request fires, `analytics:true` persisted
- [ ] Reload → banner stays hidden, PostHog only fires when previously accepted
- [ ] Manually clear `localStorage.trendingrepo-consent-v1` → banner re-appears