### PR TITLE
feat(seo): add full metadata (canonical+OG+Twitter+JSON-LD) to /githubrepo (AGN-912)

### DIFF
--- a/src/app/githubrepo/__tests__/metadata.test.ts
+++ b/src/app/githubrepo/__tests__/metadata.test.ts
@@ -1,0 +1,98 @@
+// AGN-912 snapshot — locks the /githubrepo metadata head block so a future
+// edit can't silently drop canonical / OG / Twitter / robots fields. The
+// SEO audit (AGN-790) flagged this surface as the most critical zero-meta
+// page; AGN-791 added partial values; AGN-912 finished the head and added
+// this guardrail.
+//
+// SITE_URL is module-load-time resolved from NEXT_PUBLIC_APP_URL — pin it
+// before importing the page so the canonical / OG URL assertions stay
+// deterministic regardless of the local host env.
+
+import { describe, it, expect, beforeAll } from "vitest";
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_APP_URL = "https://trendingrepo.com";
+});
+
+async function loadMetadata() {
+  const mod = await import("../page");
+  return mod.metadata;
+}
+
+describe("GET /githubrepo metadata", () => {
+  it("matches the locked SEO head snapshot", async () => {
+    const metadata = await loadMetadata();
+    expect(metadata).toMatchInlineSnapshot(`
+      {
+        "alternates": {
+          "canonical": "https://trendingrepo.com/githubrepo",
+        },
+        "description": "Live momentum-ranked list of the top 50 trending GitHub repositories with cross-source mention chips (Hacker News, Reddit, Bluesky, dev.to, Lobsters, npm, Hugging Face, arXiv, X). Refreshes every minute.",
+        "openGraph": {
+          "description": "Live momentum-ranked list of the top 50 trending GitHub repositories with cross-source mention chips (Hacker News, Reddit, Bluesky, dev.to, Lobsters, npm, Hugging Face, arXiv, X). Refreshes every minute.",
+          "images": [
+            {
+              "alt": "TrendingRepo — top 50 trending GitHub repositories, live",
+              "height": 630,
+              "url": "/og-card.png",
+              "width": 1200,
+            },
+          ],
+          "locale": "en_US",
+          "siteName": "TrendingRepo",
+          "title": "Top 50 trending GitHub repos — live — TrendingRepo",
+          "type": "website",
+          "url": "https://trendingrepo.com/githubrepo",
+        },
+        "robots": {
+          "follow": true,
+          "googleBot": {
+            "follow": true,
+            "index": true,
+            "max-image-preview": "large",
+            "max-snippet": -1,
+            "max-video-preview": -1,
+          },
+          "index": true,
+        },
+        "title": "Top 50 trending GitHub repos — live",
+        "twitter": {
+          "card": "summary_large_image",
+          "creator": "@0motionguy",
+          "description": "Live momentum-ranked list of the top 50 trending GitHub repositories with cross-source mention chips (Hacker News, Reddit, Bluesky, dev.to, Lobsters, npm, Hugging Face, arXiv, X). Refreshes every minute.",
+          "images": [
+            "/og-card.png",
+          ],
+          "site": "@0motionguy",
+          "title": "Top 50 trending GitHub repos — live — TrendingRepo",
+        },
+      }
+    `);
+  });
+
+  it("exposes an absolute canonical URL", async () => {
+    const metadata = await loadMetadata();
+    expect(metadata.alternates?.canonical).toBe(
+      "https://trendingrepo.com/githubrepo",
+    );
+  });
+
+  it("declares OG image dimensions and alt text", async () => {
+    const metadata = await loadMetadata();
+    const images = metadata.openGraph?.images;
+    expect(Array.isArray(images)).toBe(true);
+    const first = (images as Array<{ width?: number; height?: number; alt?: string }>)[0];
+    expect(first?.width).toBe(1200);
+    expect(first?.height).toBe(630);
+    expect(first?.alt).toMatch(/TrendingRepo/);
+  });
+
+  it("opts the page in to indexing with an explicit robots block", async () => {
+    const metadata = await loadMetadata();
+    expect(metadata.robots).toMatchObject({
+      index: true,
+      follow: true,
+      googleBot: { index: true, follow: true },
+    });
+  });
+});

--- a/src/app/githubrepo/page.tsx
+++ b/src/app/githubrepo/page.tsx
@@ -2,9 +2,15 @@
 //
 // Strips the home page down to its three load-bearing pieces: the page-head
 // (title + refreshed clock), the 6-up MetricGrid stats, and the LiveTopTable
-// with category tabs. No consensus / breakout / featured / bubble map / FAQ /
-// JSON-LD — just the list. Same data wiring as `/` so cards stay consistent.
+// with category tabs. No consensus / breakout / featured / bubble map / FAQ —
+// just the list. Same data wiring as `/` so cards stay consistent.
+//
+// Inline JSON-LD (CollectionPage + ItemList + BreadcrumbList) anchors this
+// surface in structured data so crawlers don't fall back to the parent
+// homepage feed, plus an explicit per-page Metadata export with canonical /
+// OG / Twitter / robots so rich-result tooling has a complete head block.
 
+import type { Metadata } from "next";
 import { getDerivedRepos } from "@/lib/derived-repos";
 import { lastFetchedAt, refreshTrendingFromStore } from "@/lib/trending";
 import { refreshRedditMentionsFromStore } from "@/lib/reddit-data";
@@ -26,9 +32,62 @@ import {
   type LiveRow,
 } from "@/components/home/LiveTopTable";
 import { CATEGORIES } from "@/lib/constants";
+import {
+  SITE_NAME,
+  SITE_URL,
+  absoluteUrl,
+  safeJsonLd,
+} from "@/lib/seo";
 import type { Repo } from "@/lib/types";
 
 export const revalidate = 60;
+
+const PAGE_PATH = "/githubrepo";
+const PAGE_TITLE = "Top 50 trending GitHub repos — live";
+const PAGE_DESCRIPTION =
+  "Live momentum-ranked list of the top 50 trending GitHub repositories with cross-source mention chips (Hacker News, Reddit, Bluesky, dev.to, Lobsters, npm, Hugging Face, arXiv, X). Refreshes every minute.";
+const PAGE_OG_TITLE = `${PAGE_TITLE} — ${SITE_NAME}`;
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: absoluteUrl(PAGE_PATH) },
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    title: PAGE_OG_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    locale: "en_US",
+    images: [
+      {
+        url: "/og-card.png",
+        width: 1200,
+        height: 630,
+        alt: `${SITE_NAME} — top 50 trending GitHub repositories, live`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@0motionguy",
+    creator: "@0motionguy",
+    title: PAGE_OG_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: ["/og-card.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-snippet": -1,
+      "max-image-preview": "large",
+      "max-video-preview": -1,
+    },
+  },
+};
 
 const compactNumber = new Intl.NumberFormat("en-US", {
   notation: "compact",
@@ -141,9 +200,73 @@ export default async function GithubRepoPage() {
       .reduce((sum, repo) => sum + Math.max(0, repo.starsDelta24h), 0),
   })).sort((a, b) => b.delta - a.delta)[0];
 
+  // Top 20 of the visible 50 — keeps the structured-data payload bounded
+  // while still giving crawlers a meaningful ItemList to anchor against.
+  const itemListTop = liveRows.slice(0, 20);
+  const pageUrl = absoluteUrl(PAGE_PATH);
+
   return (
     <>
       <MarkVisited routeKey="trendingRepos" count={repos.length} />
+      {/* CollectionPage + ItemList JSON-LD — declares this page is a
+          curated list of trending GitHub repos and enumerates the top 20
+          so structured-data rich results can pick them up. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: safeJsonLd({
+            "@context": "https://schema.org",
+            "@type": "CollectionPage",
+            "@id": `${SITE_URL}${PAGE_PATH}#page`,
+            name: PAGE_OG_TITLE,
+            description: PAGE_DESCRIPTION,
+            url: pageUrl,
+            inLanguage: "en-US",
+            isPartOf: {
+              "@type": "WebSite",
+              name: SITE_NAME,
+              url: SITE_URL,
+            },
+            dateModified: new Date(lastFetchedAt).toISOString(),
+            mainEntity: {
+              "@type": "ItemList",
+              numberOfItems: itemListTop.length,
+              itemListOrder: "https://schema.org/ItemListOrderDescending",
+              itemListElement: itemListTop.map((repo, i) => ({
+                "@type": "ListItem",
+                position: i + 1,
+                url: absoluteUrl(`/repo/${repo.owner}/${repo.name}`),
+                name: repo.fullName,
+              })),
+            },
+          }),
+        }}
+      />
+      {/* BreadcrumbList JSON-LD — Home -> GitHub repos so crawlers can
+          attach this surface to the canonical home anchor. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: safeJsonLd({
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            itemListElement: [
+              {
+                "@type": "ListItem",
+                position: 1,
+                name: "Home",
+                item: absoluteUrl("/"),
+              },
+              {
+                "@type": "ListItem",
+                position: 2,
+                name: "GitHub repos",
+                item: pageUrl,
+              },
+            ],
+          }),
+        }}
+      />
       <div className="home-surface">
         <section className="page-head">
           <div>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,9 @@ export default defineConfig({
       "src/app/api/oembed/__tests__/**/*.test.{ts,tsx}",
       // E6: x402 manifest stub route — same rationale as E5.
       "src/app/x402/__tests__/**/*.test.{ts,tsx}",
+      // AGN-912: /githubrepo Metadata snapshot — node:test can't load
+      // page.tsx (JSX + next/server-aware imports), vitest can.
+      "src/app/githubrepo/__tests__/**/*.test.{ts,tsx}",
     ],
     // src/lib/__tests__/* and src/lib/pipeline/__tests__/* run under
     // node:test via `npm test` — vitest can't read those (no


### PR DESCRIPTION
AGN-790 audit flagged /githubrepo as the most critical zero-meta surface.
This wires the full head block:

- Per-page Metadata export with explicit absolute canonical URL
- Open Graph (type/siteName/title/desc/url/locale/image) with image
  width/height/alt set against the existing /og-card.png
- Twitter card (summary_large_image) with site/creator handles
- Explicit robots block (index/follow + googleBot max-* directives)
  so the policy is no longer implicit
- CollectionPage + ItemList JSON-LD enumerating the visible top 20
  trending repos (anchored to lastFetchedAt for dateModified)
- BreadcrumbList JSON-LD (Home -> GitHub repos)
- Vitest snapshot test locking the metadata object so future edits
  can't silently regress the head block

Co-Authored-By: Paperclip <noreply@paperclip.ing>
