### PR TITLE
fix(a11y): WCAG AA on top routes — sampled text (AGN-696)

### DIFF
--- a/src/app/mcp/_components/McpCells.tsx
+++ b/src/app/mcp/_components/McpCells.tsx
@@ -107,7 +107,7 @@ export function TerminalCellTitle({ item }: { item: EcosystemLeaderboardItem }) 
 
 export function TerminalCellPackage({ mcp }: { mcp: McpDisplayFields | undefined }) {
   if (!mcp || !mcp.packageName) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   const reg = mcp.packageRegistry;
   const regColor =
@@ -155,7 +155,7 @@ export function TerminalCellWeeklyDownloads({
   mcp: McpDisplayFields | undefined;
 }) {
   if (!mcp) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
 
   // Primary path: combined 7d downloads available.
@@ -207,7 +207,7 @@ export function TerminalCellWeeklyDownloads({
         {fmtCompact(sum)}
         <span
           className="ml-1 text-[9px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--v3-ink-500)" }}
+          style={{ color: "var(--v3-ink-400)" }}
         >
           abs
         </span>
@@ -229,7 +229,7 @@ export function TerminalCellWeeklyDownloads({
         {fmtCompact(mcp.npmDependents)}
         <span
           className="ml-1 text-[9px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--v3-ink-500)" }}
+          style={{ color: "var(--v3-ink-400)" }}
         >
           abs
         </span>
@@ -254,7 +254,7 @@ export function TerminalCellWeeklyDownloads({
         {fmtCompact(mcp.installsTotal)}
         <span
           className="ml-1 text-[9px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--v3-ink-500)" }}
+          style={{ color: "var(--v3-ink-400)" }}
           title="lifetime installs (cold-start fallback)"
         >
           abs
@@ -278,7 +278,7 @@ export function TerminalCellWeeklyDownloads({
         {fmtCompact(mcp.starsTotal)}
         <span
           className="ml-1 text-[9px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--v3-ink-500)" }}
+          style={{ color: "var(--v3-ink-400)" }}
           title="GitHub stars (final fallback)"
         >
           stars
@@ -287,7 +287,7 @@ export function TerminalCellWeeklyDownloads({
     );
   }
 
-  return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+  return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
 }
 
 // ---------------------------------------------------------------------------
@@ -301,7 +301,7 @@ export function TerminalCellWeeklyDownloads({
 
 function renderInstallWindow(value: number | null | undefined) {
   if (value === null || value === undefined || !Number.isFinite(value)) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   return (
     <span
@@ -343,7 +343,7 @@ export function TerminalCellToolCount({
   mcp: McpDisplayFields | undefined;
 }) {
   if (!mcp || mcp.toolCount === null) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   return (
     <span
@@ -365,7 +365,7 @@ export function TerminalCellTransports({
 }: {
   mcp: McpDisplayFields | undefined;
 }) {
-  if (!mcp) return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+  if (!mcp) return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   const transports: Array<{ label: string; tone: string }> = [];
   if (mcp.isStdio) {
     transports.push({ label: "stdio", tone: "var(--v3-ink-300)" });
@@ -377,7 +377,7 @@ export function TerminalCellTransports({
     transports.push({ label: "stream", tone: "var(--v3-acc)" });
   }
   if (transports.length === 0) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   return (
     <div className="flex flex-wrap gap-1">
@@ -428,7 +428,7 @@ export function TerminalCellLastRelease({
   mcp: McpDisplayFields | undefined;
 }) {
   if (!mcp || !mcp.lastReleaseAt) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   return (
     <span
@@ -525,7 +525,7 @@ export function TerminalCellHotness({
   const value =
     typeof item.hotness === "number" ? item.hotness : item.signalScore;
   if (value === null || value === undefined || !Number.isFinite(value)) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   return (
     <span
@@ -545,7 +545,7 @@ export function TerminalCellLinkedRepo({
   item: EcosystemLeaderboardItem;
 }) {
   if (!item.linkedRepo) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   return (
     <Link

--- a/src/components/home/CrossSourceTriBoxes.tsx
+++ b/src/components/home/CrossSourceTriBoxes.tsx
@@ -228,7 +228,7 @@ function Box({
       {rows.length === 0 ? (
         <div
           className="v2-mono py-6 px-3 text-center text-[10px] tracking-[0.18em]"
-          style={{ color: "var(--v3-ink-500)" }}
+          style={{ color: "var(--v3-ink-400)" }}
         >
           {`// ${emptyHint}`}
         </div>

--- a/src/components/signal/SignalTable.tsx
+++ b/src/components/signal/SignalTable.tsx
@@ -325,7 +325,7 @@ export function SignalTable({
                             {row.topic}
                           </span>
                         ) : (
-                          <span style={{ color: "var(--v3-ink-500)" }}>—</span>
+                          <span style={{ color: "var(--v3-ink-400)" }}>—</span>
                         )}
                       </td>
                     );
@@ -343,7 +343,7 @@ export function SignalTable({
                             <span className="truncate">{row.linkedRepo}</span>
                           </Link>
                         ) : (
-                          <span style={{ color: "var(--v3-ink-500)" }}>—</span>
+                          <span style={{ color: "var(--v3-ink-400)" }}>—</span>
                         )}
                       </td>
                     );

--- a/src/components/skills/SkillsTerminalTable.tsx
+++ b/src/components/skills/SkillsTerminalTable.tsx
@@ -191,7 +191,7 @@ function CollectionSummaryRow({
         {row.siblings.length > 30 ? (
           <li
             className="font-mono italic"
-            style={{ color: "var(--v3-ink-500)" }}
+            style={{ color: "var(--v3-ink-400)" }}
           >
             +{row.siblings.length - 30} more not shown
           </li>
@@ -349,7 +349,7 @@ function TerminalCellSkillNumber({
   signed?: boolean;
 }) {
   if (value === undefined || value === null || !Number.isFinite(value)) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   const formatted = formatCompactNumber(Math.abs(value));
   const sign = signed ? (value > 0 ? "+" : value < 0 ? "−" : "") : "";
@@ -380,14 +380,14 @@ function TerminalCellForksWithFallback({ row }: { row: EcosystemLeaderboardItem 
         {formatCompactNumber(row.forks)}
         <span
           className="ml-1 text-[9px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--v3-ink-500)" }}
+          style={{ color: "var(--v3-ink-400)" }}
         >
           abs
         </span>
       </span>
     );
   }
-  return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+  return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
 }
 
 function TerminalCellInstallsWithFallback({ row }: { row: EcosystemLeaderboardItem }) {
@@ -400,19 +400,19 @@ function TerminalCellInstallsWithFallback({ row }: { row: EcosystemLeaderboardIt
         {formatCompactNumber(row.installs7d)}
         <span
           className="ml-1 text-[9px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--v3-ink-500)" }}
+          style={{ color: "var(--v3-ink-400)" }}
         >
           abs
         </span>
       </span>
     );
   }
-  return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+  return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
 }
 
 function TerminalCellSkillDerivative({ row }: { row: EcosystemLeaderboardItem }) {
   if (row.derivativeRepoCount === undefined || row.derivativeRepoCount === null) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   // E3: tooltip surfaces sample sources (registry the count was derived from)
   // when present. Today's payload carries roster keys ("trending-skill",
@@ -452,7 +452,7 @@ export function TerminalCellHotness({
 }) {
   const value = rawScore ?? signalScore;
   if (value === undefined || value === null || !Number.isFinite(value)) {
-    return <span style={{ color: "var(--v3-ink-500)" }}>—</span>;
+    return <span style={{ color: "var(--v3-ink-400)" }}>—</span>;
   }
   const pct = Math.max(0, Math.min(100, value));
   return (

--- a/src/components/top10/Top10Page.tsx
+++ b/src/components/top10/Top10Page.tsx
@@ -417,7 +417,7 @@ function CategoryTabs({ active, counts, meta, onPick }: CategoryTabsProps) {
               className="tabular-nums"
               style={{
                 fontSize: 9,
-                color: on ? "rgba(0,0,0,0.45)" : "var(--v3-ink-500, #3c444d)",
+                color: on ? "rgba(0,0,0,0.45)" : "var(--v3-ink-400, #909caa)",
                 background: on ? "rgba(0,0,0,0.18)" : "var(--v3-bg-100, #151a20)",
                 padding: "2px 7px",
               }}
@@ -689,7 +689,7 @@ function Chip({
         color: on
           ? "#08090a"
           : disabled
-            ? "var(--v3-ink-500, #3c444d)"
+            ? "var(--v3-ink-400, #909caa)"
             : "var(--v3-ink-300, #84909b)",
         fontSize: 9.5,
         letterSpacing: "0.14em",
@@ -786,7 +786,7 @@ function RankRow({
       <Delta delta={item.deltaPct} sparkline={item.sparkline} />
       <span
         className="text-center"
-        style={{ color: "var(--v3-ink-500, #3c444d)" }}
+        style={{ color: "var(--v3-ink-400, #909caa)" }}
       >
         →
       </span>
@@ -838,7 +838,7 @@ function Body({ item, category }: { item: Top10Item; category: Top10Category }) 
             <span style={{ color: "var(--v3-ink-300, #84909b)", fontWeight: 400 }}>
               {item.owner}
             </span>
-            <span style={{ color: "var(--v3-ink-500, #3c444d)" }}>/</span>
+            <span style={{ color: "var(--v3-ink-400, #909caa)" }}>/</span>
           </>
         ) : null}
         <span>{item.title}</span>


### PR DESCRIPTION
## AGN-696 — Contrast AA failures on top routes (sampled text half)

Sidebar version text was already fixed in 87eb9ec0. This PR closes the **sampled text** half of AGN-696.

## Root cause

`--v3-ink-500` / `--v4-ink-500` resolves to `--color-text-disabled` = `#3c444d`. Audit table:

| Surface | Ratio | WCAG AA |
|---|---|---|
| --color-bg-canvas (#070809) | 2.03:1 | FAIL |
| --color-bg-shell (#0b0d0f) | 1.97:1 | FAIL |
| --color-bg-raised (#101418) | 1.87:1 | FAIL |
| --color-bg-muted (#151a20) | 1.77:1 | FAIL |
| --color-bg-fill (#1d242b) | 1.59:1 | FAIL |
| --color-bg-strong (#2a323a) | 1.32:1 | FAIL |

`#3c444d` is meant for genuinely disabled controls (WCAG 1.4.3 incidental exemption applies). The bug: several leaderboard cells used it as **visible body text** for em-dash placeholders and filter-pill counts on the top routes the spec calls out.

## Fix

Retag those visible uses to `--v3-ink-400` / `--v4-ink-400` = `#909caa` (passes AA 4.66 - 7.18:1 across every dark surface).

## Files

- `src/app/mcp/_components/McpCells.tsx` — 14 em-dash placeholders (/mcp)
- `src/components/skills/SkillsTerminalTable.tsx` — 8 em-dash placeholders (/skills)
- `src/components/signal/SignalTable.tsx` — 2 em-dash placeholders (/signals)
- `src/components/top10/Top10Page.tsx` — 4 filter pill counts + separator (/top10)
- `src/components/home/CrossSourceTriBoxes.tsx` — 1 placeholder (/)

Net diff: 29 line replacements. No design-token changes — disabled-control rendering (Sidebar nav with `aria-disabled`, `opacity-60`) is left alone since 1.4.3 exempts it.

## Verification

- `npm run typecheck` clean.
- All pre-commit token-budget / Zod / runtime / error-envelope hooks passed.
- Audit script `.audit/contrast-check.mjs` confirms 0 failures on the sidebar/version cluster (already-landed prior fix). Extended audit confirms ink-400 passes AA on every dark surface in the system.

**Visual contrast must be re-verified by Mirko on the Vercel preview** for /, /skills, /mcp, /signals, /top10.

## Spec

`/PAP/issues/AGN-696` — parent AGN-583. Done when route-level audits show >= 4.5:1 across these top routes.

Co-Authored-By: Paperclip <noreply@paperclip.ing>