### PR TITLE
feat(brand): replace generic stars with TrendingRepo mark site-wide (AGN-560)

### DIFF
--- a/src/app/agent-commerce/page.tsx
+++ b/src/app/agent-commerce/page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 
 import { Card, CardBody, CardHeader } from "@/components/ui/Card";
 import { Metric, MetricGrid } from "@/components/ui/Metric";
+import { BrandStar } from "@/components/shared/BrandStar";
 import { AgentCommerceCard } from "@/components/agent-commerce/AgentCommerceCard";
 import { AgentCommerceFilterBar } from "@/components/agent-commerce/AgentCommerceFilterBar";
 import { AgentCommerceTabs } from "@/components/agent-commerce/AgentCommerceTabs";
@@ -842,9 +843,13 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
                             marginLeft: 8,
                             color: "#fbbf24",
                             fontWeight: 700,
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 4,
                           }}
                         >
-                          ★{item.live.stars.toLocaleString("en-US")}
+                          <BrandStar size={12} />
+                          {item.live.stars.toLocaleString("en-US")}
                         </span>
                       ) : null}
                       {item.live?.pushedAt ? (

--- a/src/app/repo/[owner]/[name]/page.tsx
+++ b/src/app/repo/[owner]/[name]/page.tsx
@@ -23,6 +23,7 @@ import type { Metadata } from "next";
 import { getDerivedRepoByFullName } from "@/lib/derived-repos";
 import { formatNumber, getRelativeTime } from "@/lib/utils";
 import { absoluteUrl, SITE_NAME, safeJsonLd } from "@/lib/seo";
+import { BrandStar } from "@/components/shared/BrandStar";
 import { buildRepoPageSchemas } from "@/lib/seo-repo-schemas";
 import { buildCanonicalRepoProfile } from "@/lib/api/repo-profile";
 // Data-store refresh hooks. The repo detail page consumes signal data from
@@ -289,7 +290,7 @@ export default async function RepoDetailPage({ params }: PageProps) {
                 </span>
               ))}
               <span className="stat">
-                <span className="lbl">★</span>
+                <span className="lbl"><BrandStar size={11} /></span>
                 <b>{formatNumber(repo.stars)}</b>
               </span>
               <span className="stat">

--- a/src/components/cross-signal/CrossSignalBreakouts.tsx
+++ b/src/components/cross-signal/CrossSignalBreakouts.tsx
@@ -11,7 +11,6 @@
 // and surfaces stars + 24h delta for context.
 
 import Link from "next/link";
-import { Star } from "lucide-react";
 import type { Repo } from "@/lib/types";
 import { formatNumber } from "@/lib/utils";
 import { ChannelDots } from "./ChannelDots";
@@ -19,6 +18,7 @@ import { HnBadge } from "@/components/hackernews/HnBadge";
 import { getHnMentions } from "@/lib/hackernews";
 import { EntityLogo } from "@/components/ui/EntityLogo";
 import { repoDisplayLogoUrl } from "@/lib/logos";
+import { BrandStar } from "@/components/shared/BrandStar";
 
 interface CrossSignalBreakoutsProps {
   repos: Repo[];
@@ -133,7 +133,7 @@ export function CrossSignalBreakouts({
                     overflowing. The 24h delta is the load-bearing signal. */}
                 <span className="hidden md:inline-flex"><HnBadge mention={hnMention} size="sm" /></span>
                 <span className="hidden md:inline-flex items-center gap-1 font-mono text-[11px] text-text-secondary tabular-nums">
-                  <Star size={11} className="text-[var(--v4-amber)] shrink-0" fill="currentColor" />
+                  <BrandStar size={11} className="text-[var(--v4-amber)] shrink-0" />
                   {formatNumber(repo.stars)}
                 </span>
                 <span

--- a/src/components/feed/RepoCard.tsx
+++ b/src/components/feed/RepoCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { Star } from "lucide-react";
 import type { Repo } from "@/lib/types";
 import { cn, formatNumber } from "@/lib/utils";
 import { Sparkline } from "@/components/shared/Sparkline";
@@ -9,6 +8,7 @@ import { DeltaBadge } from "@/components/shared/DeltaBadge";
 import { CategoryPill } from "@/components/shared/CategoryPill";
 import { MomentumBadge } from "@/components/shared/MomentumBadge";
 import { RankBadge } from "@/components/shared/RankBadge";
+import { BrandStar } from "@/components/shared/BrandStar";
 import { RepoMentionBadges } from "@/components/repo-signals/RepoMentionBadges";
 import { NpmBadge } from "@/components/npm/NpmBadge";
 import { getNpmPackagesForRepo } from "@/lib/npm";
@@ -68,7 +68,7 @@ export function RepoCard({ repo, index = 0, showRank = false }: RepoCardProps) {
       {/* Row 3: Stars | Delta | Sparkline | Momentum */}
       <div className="mt-2.5 flex items-center gap-3">
         <span className="inline-flex items-center gap-1 font-mono text-xs text-text-secondary shrink-0">
-          <Star size={12} className="text-[var(--v4-amber)]" />
+          <BrandStar size={12} className="text-[var(--v4-amber)]" />
           {formatNumber(repo.stars)}
         </span>
 

--- a/src/components/home/LiveTopTable.tsx
+++ b/src/components/home/LiveTopTable.tsx
@@ -7,11 +7,11 @@ import {
   ArrowUp,
   ArrowDown,
   ArrowUpDown,
-  Star,
   Brain,
   FileText,
   Package,
 } from "lucide-react";
+import { BrandStar } from "@/components/shared/BrandStar";
 
 import {
   GithubIcon,
@@ -467,7 +467,7 @@ export function LiveTopTable({ rows, categories }: LiveTopTableProps) {
                   </td>
                   <td className="num metric-num stars-num">
                     <span className="stars-main">
-                      <Star size={12} strokeWidth={2.1} fill="currentColor" />
+                      <BrandStar size={12} />
                       {formatCompact(row.stars)}
                     </span>
                   </td>

--- a/src/components/home/__tests__/v4-home-repo.test.tsx
+++ b/src/components/home/__tests__/v4-home-repo.test.tsx
@@ -191,9 +191,9 @@ describe("RelatedRepoCard", () => {
       />,
     );
     expect(getByText("TYPESCRIPT").className).toBe("v4-related-card__lang");
-    expect(container.querySelector(".v4-related-card__stars")?.textContent).toBe(
-      "★ 22.2K",
-    );
+    const starsCell = container.querySelector(".v4-related-card__stars");
+    expect(starsCell?.querySelector("svg")).not.toBeNull();
+    expect(starsCell?.textContent?.trim()).toBe("22.2K");
     expect(getByText("SIM 0.86").className).toBe("v4-related-card__why");
   });
 

--- a/src/components/repo-detail/RelatedRepoCard.tsx
+++ b/src/components/repo-detail/RelatedRepoCard.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
+import { BrandStar } from "@/components/shared/BrandStar";
 
 export interface RelatedRepoCardProps {
   /** Repo full name e.g. "abhigyanpatwari/GitNexus". */
@@ -53,7 +54,7 @@ export function RelatedRepoCard({
         ) : null}
         {stars ? (
           <span className="v4-related-card__stars">
-            {"★ "}
+            <BrandStar size={11} className="text-[var(--v4-amber)]" />{" "}
             {stars}
           </span>
         ) : null}

--- a/src/components/watchlist/WatchlistManager.tsx
+++ b/src/components/watchlist/WatchlistManager.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Eye, Star, Trash2, ArrowRight } from "lucide-react";
+import { Eye, Trash2, ArrowRight } from "lucide-react";
+import { BrandStar } from "@/components/shared/BrandStar";
 import { useWatchlistStore } from "@/lib/store";
 import { cn, formatNumber, getRelativeTime } from "@/lib/utils";
 import { Sparkline } from "@/components/shared/Sparkline";
@@ -52,7 +53,7 @@ function WatchedRepoCard({
           {/* Stats row */}
           <div className="flex items-center gap-3 mt-2 flex-wrap">
             <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
-              <Star size={13} className="text-accent-amber shrink-0" />
+              <BrandStar size={13} className="text-accent-amber shrink-0" />
               <span className="font-mono text-text-primary">
                 {formatNumber(repo.stars)}
               </span>


### PR DESCRIPTION
## Summary
- AGN-560 — [P0 brand] Replace generic-star icons with TrendingRepo mark site-wide.
- Header logo already uses the official `/brand/trendingrepo-mark.svg` asset (verified byte-identical to source folder), so the `Header.tsx` render path is unchanged.
- Swept the codebase for `<Star>` from `lucide-react` (4 visible usages) and Unicode `★` rendered in JSX (2 highest-prominence usages). All replaced with the existing `<BrandStar>` component that renders the TrendingRepo brand-mark shape.

## Files changed (7)
- `src/components/cross-signal/CrossSignalBreakouts.tsx` — homepage cross-signal row star count
- `src/components/feed/RepoCard.tsx` — repo card star count
- `src/components/home/LiveTopTable.tsx` — homepage Live Top table star column
- `src/components/watchlist/WatchlistManager.tsx` — watched-repo card star count
- `src/components/repo-detail/RelatedRepoCard.tsx` — related-repo footer star
- `src/app/repo/[owner]/[name]/page.tsx` — repo detail header stat strip star label
- `src/app/agent-commerce/page.tsx` — agent commerce card amber star prefix

## Intentionally NOT changed
Per K3 (surgical changes) — out of scope for AGN-560:
- `FeaturedCard.tsx` — unit tests anchor on the literal `★` glyph; would expand scope to tests.
- `SkillsTopTable.tsx` — `SortHeader.label` is typed `string`, would require widening the prop type.
- `watchlist/page.tsx` — `★` is inline inside a sentence-form expression.
- Ticker text strings, `og-primitives.tsx` font-fallback comment, OG image route, `top10/types.ts` data property — text labels not visual icons.
- `RankStarMark` component (already on-brand — uses `/brand/trendingrepo-mark.svg`).

## Test plan
- [x] `npm run typecheck` (tsc --noEmit) — passes clean
- [x] All pre-commit lint hooks (legacy tokens, error envelope, route runtime, token budget, pool bypass) — pass
- [ ] Visual smoke — cannot browser-check from CLI environment. Reviewer should verify:
  - homepage Live Top table renders brand-mark glyph in stars column
  - homepage cross-signal breakouts row shows brand mark next to star counts
  - `/repo/{owner}/{name}` detail page header stat strip uses brand mark
  - `/agent-commerce` cards show brand mark before star count
  - watchlist + RepoCard star indicators are on-brand

## Note on header
The spec text says "Replace with the official logo asset". The Header already imports `/brand/trendingrepo-mark.svg`. Confirmed the file in `public/brand/` is byte-identical to the source asset folder `Trending Repo  Logo/`. No render change needed for the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)