### PR TITLE
feat(ux): reset/clear filter button on filtered lists (AGN-609)

### DIFF
--- a/src/components/agent-commerce/AgentCommerceFilterBar.tsx
+++ b/src/components/agent-commerce/AgentCommerceFilterBar.tsx
@@ -75,7 +75,24 @@ function toggleProtocol(
 }
 
 export function AgentCommerceFilterBar(props: FilterBarProps) {
-  const { category, protocols, pricing, portalReady, baseQuery } = props;
+  const { category, protocols, pricing, portalReady, query, baseQuery } = props;
+
+  // AGN-609 — show a "Clear filters" chip when any narrowing param is set.
+  // Preserve the search `q` (search is its own input, not part of the
+  // filter chip set) but drop every category/protocol/pricing/portal toggle
+  // in one click.
+  const hasActiveFilter =
+    category !== null ||
+    protocols.size > 0 ||
+    pricing !== null ||
+    portalReady;
+
+  const clearHref = (() => {
+    const next = new URLSearchParams();
+    if (query) next.set("q", query);
+    const qs = next.toString();
+    return qs ? `/agent-commerce?${qs}` : "/agent-commerce";
+  })();
 
   return (
     <div className="ac-filterbar">
@@ -138,6 +155,19 @@ export function AgentCommerceFilterBar(props: FilterBarProps) {
           Portal Ready
         </Link>
       </div>
+
+      {hasActiveFilter && (
+        <div className="ac-fb-group" style={{ marginLeft: "auto" }}>
+          <Link
+            className="ac-chip ac-chip-clear is-on"
+            href={clearHref}
+            aria-label="Clear all filters"
+            title="Clear all filters"
+          >
+            ✕ Clear
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/signals-terminal/SourceFilterBar.tsx
+++ b/src/components/signals-terminal/SourceFilterBar.tsx
@@ -226,6 +226,12 @@ export function SourceFilterBar({
   const isAllOn = active.size === ALL_KEYS.size;
   const topics = allTopics();
 
+  // AGN-609 — show a "Clear filters" chip when any of source/window/topic
+  // has been narrowed away from defaults. Click → /signals (drops every
+  // query param at once). Cheaper for the user than tapping each chip.
+  const hasActiveFilter =
+    !isAllOn || timeWindow !== DEFAULT_WINDOW || topic !== null;
+
   return (
     <div
       style={{
@@ -383,9 +389,26 @@ export function SourceFilterBar({
         );
       })}
 
+      {hasActiveFilter && (
+        <Link
+          href="/signals"
+          prefetch={false}
+          className="signals-chip signals-chip-clear"
+          aria-label="Clear all filters"
+          title="Clear all filters"
+          style={{
+            marginLeft: "auto",
+            color: "var(--color-text-default)",
+            borderColor: "var(--color-border-strong, var(--color-border-default))",
+          }}
+        >
+          ✕ CLEAR
+        </Link>
+      )}
+
       <span
         style={{
-          marginLeft: "auto",
+          marginLeft: hasActiveFilter ? 0 : "auto",
           fontSize: 9.5,
           letterSpacing: "0.16em",
           color: "var(--color-text-subtle)",

--- a/src/components/terminal/FilterBar.tsx
+++ b/src/components/terminal/FilterBar.tsx
@@ -8,6 +8,9 @@
 // re-renders the interactive sub-bars.
 
 import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { useFilterStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
 import type { FilterBarVariant, MetaCounts } from "@/lib/types";
 
 import { StatsBarClient, type StatsBarStats } from "./StatsBarClient";
@@ -45,6 +48,32 @@ export function FilterBar({ variant = "full" }: FilterBarProps) {
   const [counts, setCounts] = useState<MetaCounts>(EMPTY_COUNTS);
   const [stats, setStats] = useState<StatsBarStats | null>(null);
 
+  // AGN-609 — surface a "Clear filters" chip whenever any transient
+  // narrative filter diverges from defaults. Only the bits that actually
+  // shape the visible list are tracked here; layout prefs (density, view
+  // mode, columns) are user preferences, not "filters".
+  const timeRange = useFilterStore((s) => s.timeRange);
+  const activeMetaFilter = useFilterStore((s) => s.activeMetaFilter);
+  const activeTag = useFilterStore((s) => s.activeTag);
+  const activeTab = useFilterStore((s) => s.activeTab);
+  const category = useFilterStore((s) => s.category);
+  const languages = useFilterStore((s) => s.languages);
+  const starsRange = useFilterStore((s) => s.starsRange);
+  const minMomentum = useFilterStore((s) => s.minMomentum);
+  const onlyWatched = useFilterStore((s) => s.onlyWatched);
+  const resetFilters = useFilterStore((s) => s.resetFilters);
+
+  const hasActiveFilter =
+    timeRange !== "7d" ||
+    activeMetaFilter !== null ||
+    activeTag !== null ||
+    activeTab !== "trending" ||
+    category !== null ||
+    languages.length > 0 ||
+    starsRange !== null ||
+    minMomentum > 0 ||
+    onlyWatched;
+
   useEffect(() => {
     if (cfg.showMetas) {
       fetch("/api/pipeline/meta-counts")
@@ -79,6 +108,29 @@ export function FilterBar({ variant = "full" }: FilterBarProps) {
           {cfg.showStats && stats && <StatsBarClient stats={stats} />}
 
           <div className="ml-auto flex items-center gap-3 shrink-0">
+            {hasActiveFilter && (
+              <button
+                type="button"
+                onClick={() => resetFilters()}
+                aria-label="Clear all filters"
+                title="Clear all filters"
+                className={cn(
+                  "v2-mono inline-flex items-center gap-1.5 px-2.5 py-1",
+                  "transition-colors duration-150 focus-visible:outline-none",
+                )}
+                style={{
+                  fontSize: 10,
+                  borderRadius: 2,
+                  border: "1px solid var(--v2-acc)",
+                  background: "var(--v2-acc-soft)",
+                  color: "var(--v2-acc)",
+                }}
+              >
+                <X size={11} aria-hidden="true" strokeWidth={2} />
+                CLEAR
+              </button>
+            )}
+
             {cfg.showTabs && <TabBar />}
 
             {cfg.showTime && (


### PR DESCRIPTION
## AGN-609 — Reset/Clear filter button on every filtered list

Adds a "Clear filters" affordance to the three primary filter bars in the app. When any filter is active, a high-contrast accent-colored chip appears next to the filter controls. Clicking it resets every transient filter to default while preserving user layout preferences (density, view mode, columns).

## Files changed

- `src/components/terminal/FilterBar.tsx` — adds a `CLEAR` chip when any of `timeRange`, `activeMetaFilter`, `activeTag`, `activeTab`, `category`, `languages`, `starsRange`, `minMomentum`, or `onlyWatched` diverges from defaults. Wires to existing `useFilterStore.resetFilters()` (already separated from layout prefs by design — `resetFilters` is the right surface, `resetAll` would also nuke columns/density which are user prefs).
- `src/components/signals-terminal/SourceFilterBar.tsx` — adds a `✕ CLEAR` link that navigates to bare `/signals` when source/window/topic params diverge from defaults.
- `src/components/agent-commerce/AgentCommerceFilterBar.tsx` — adds a `✕ Clear` chip that drops `cat`, `protocol`, `pricing`, and `portalready` params while preserving `q` (search input).

## Routes covered

The 3 filter-bar components above power: `/top`, `/search`, `/collections/[slug]`, `/categories/[slug]`, `/watchlist` (FilterBar) + `/signals` (SourceFilterBar) + `/agent-commerce` (AgentCommerceFilterBar). Roughly 7 routes.

## Scope (per spec — top routes)

- `/` (home): does NOT use FilterBar — it's a server-derived BubbleMap dashboard with no per-list filter UI. **Not in scope** (no filters to clear).
- `/trending`: does not exist as a top-level route — trending lives inside the FilterBar's TabBar on the Terminal-Layout pages, which IS covered.
- `/signals`: covered (SourceFilterBar).
- `/skills`, `/top10`: V4 leaderboard pages with no per-list interactive filters — display-only ranked lists. **Not in scope** (no filters to clear).

## Verification

- `npm run typecheck`: clean (only pre-existing playwright/vitest type errors unrelated to this change)
- Pre-commit hooks: all 8 invariant checks passed (no legacy tokens, no error-message echoes, zod on mutating routes, runtime declared, error envelope, v3 token budget, no pool bypass, img lazy)
- Visual review pending Mirko's screen (mobile + desktop)
- Keyboard tab order: chip is a normal `<button>` / `<Link>`, slots into existing focus order at the start of the right-side cluster

## Design notes

- Chip uses existing accent-glow styling (`var(--v2-acc)` + `var(--v2-acc-soft)`) on the Terminal FilterBar — matches the active TabBar/TimeRangePills pill styling
- SourceFilterBar uses the existing `signals-chip` class to stay consistent with the rest of the bar
- AgentCommerceFilterBar uses the existing `ac-chip is-on` styling
- Hidden when no filter is active — no visual noise on the default state
- Aria-labels + titles on every variant for screen-reader / hover affordance

Link: /PAP/issues/AGN-609

Co-Authored-By: Paperclip <noreply@paperclip.ing>