### PR TITLE
perf(og): add Cache-Control + revalidate to opengraph-image routes (AGN-442)

### DIFF
--- a/src/app/breakouts/opengraph-image.tsx
+++ b/src/app/breakouts/opengraph-image.tsx
@@ -11,7 +11,7 @@ import { ImageResponse } from "next/og";
 import { getDerivedRepos } from "@/lib/derived-repos";
 import { getChannelStatus } from "@/lib/pipeline/cross-signal";
 import type { Repo } from "@/lib/types";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import {
   CardFrame,
   StarMark,
@@ -244,6 +244,6 @@ export default async function BreakoutsOGImage() {
         </div>
       </CardFrame>
     ),
-    size,
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }

--- a/src/app/categories/[slug]/opengraph-image.tsx
+++ b/src/app/categories/[slug]/opengraph-image.tsx
@@ -7,7 +7,7 @@
 import { ImageResponse } from "next/og";
 import { getDerivedRepos } from "@/lib/derived-repos";
 import { CATEGORIES } from "@/lib/constants";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import { StarMark } from "@/lib/og-primitives";
 
 export const runtime = "nodejs";
@@ -59,7 +59,7 @@ export default async function CategoryOGImage({ params }: RouteParams) {
           </div>
         </div>
       ),
-      size,
+      { ...size, headers: OG_CACHE_HEADERS },
     );
   }
 
@@ -307,7 +307,7 @@ export default async function CategoryOGImage({ params }: RouteParams) {
         />
       </div>
     ),
-    size,
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }
 

--- a/src/app/collections/[slug]/opengraph-image.tsx
+++ b/src/app/collections/[slug]/opengraph-image.tsx
@@ -16,7 +16,7 @@ import {
   isCuratedQuietStub,
 } from "@/lib/collections";
 import { getDerivedRepos } from "@/lib/derived-repos";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import {
   CardFrame,
   NotFoundCard,
@@ -52,7 +52,7 @@ export default async function CollectionOGImage({ params }: RouteParams) {
           hint={`/collections/${slug}`}
         />
       ),
-      size,
+      { ...size, headers: OG_CACHE_HEADERS },
     );
   }
 
@@ -258,7 +258,7 @@ export default async function CollectionOGImage({ params }: RouteParams) {
         </div>
       </CardFrame>
     ),
-    size,
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }
 

--- a/src/app/compare/opengraph-image.tsx
+++ b/src/app/compare/opengraph-image.tsx
@@ -18,7 +18,7 @@ import {
   getDerivedRepoById,
   getDerivedRepos,
 } from "@/lib/derived-repos";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import { StarMark } from "@/lib/og-primitives";
 import type { Repo } from "@/lib/types";
 
@@ -158,7 +158,7 @@ export default async function CompareOGImage() {
           />
         </div>
       ),
-      size,
+      { ...size, headers: OG_CACHE_HEADERS },
     );
   }
 
@@ -340,7 +340,7 @@ export default async function CompareOGImage() {
         />
       </div>
     ),
-    size,
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }
 

--- a/src/app/ideas/[id]/opengraph-image.tsx
+++ b/src/app/ideas/[id]/opengraph-image.tsx
@@ -16,7 +16,7 @@ import { ImageResponse } from "next/og";
 
 import { getIdeaById, toPublicIdea } from "@/lib/ideas";
 import { countReactions, listReactionsForObject } from "@/lib/reactions";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import { StarMark } from "@/lib/og-primitives";
 
 export const runtime = "nodejs";
@@ -42,7 +42,10 @@ export default async function IdeaOGImage({ params }: RouteParams) {
     (record.status === "published" || record.status === "shipped");
 
   if (!visible) {
-    return new ImageResponse(<NotFoundCard />, { ...size });
+    return new ImageResponse(<NotFoundCard />, {
+      ...size,
+      headers: OG_CACHE_HEADERS,
+    });
   }
 
   const idea = toPublicIdea(record);
@@ -184,7 +187,7 @@ export default async function IdeaOGImage({ params }: RouteParams) {
         </div>
       </div>
     ),
-    { ...size },
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -8,7 +8,7 @@
 import { ImageResponse } from "next/og";
 import { getTopMoversByDelta24h } from "@/lib/trending";
 import { getDerivedRepoCount } from "@/lib/derived-repos";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import { Dot, StarMark } from "@/lib/og-primitives";
 
 export const runtime = "nodejs";
@@ -199,7 +199,7 @@ export default async function HomeOGImage() {
         />
       </div>
     ),
-    size,
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }
 

--- a/src/app/repo/[owner]/[name]/opengraph-image.tsx
+++ b/src/app/repo/[owner]/[name]/opengraph-image.tsx
@@ -14,7 +14,7 @@
 import { ImageResponse } from "next/og";
 import { CATEGORIES } from "@/lib/constants";
 import { getDerivedRepoByFullName } from "@/lib/derived-repos";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import { StarMark } from "@/lib/og-primitives";
 
 export const runtime = "nodejs";
@@ -90,7 +90,7 @@ export default async function RepoOGImage({ params }: RouteParams) {
           </div>
         </div>
       ),
-      size,
+      { ...size, headers: OG_CACHE_HEADERS },
     );
   }
 
@@ -299,7 +299,7 @@ export default async function RepoOGImage({ params }: RouteParams) {
         />
       </div>
     ),
-    size,
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }
 

--- a/src/app/u/[handle]/opengraph-image.tsx
+++ b/src/app/u/[handle]/opengraph-image.tsx
@@ -9,7 +9,7 @@
 import { ImageResponse } from "next/og";
 
 import { getProfile } from "@/lib/profile";
-import { OG_COLORS } from "@/lib/seo";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
 import {
   CardFrame,
   NotFoundCard,
@@ -43,7 +43,7 @@ export default async function UserProfileOGImage({ params }: RouteParams) {
           hint={`/u/${handle}`}
         />
       ),
-      size,
+      { ...size, headers: OG_CACHE_HEADERS },
     );
   }
 
@@ -118,7 +118,7 @@ export default async function UserProfileOGImage({ params }: RouteParams) {
           </div>
         </CardFrame>
       ),
-      size,
+      { ...size, headers: OG_CACHE_HEADERS },
     );
   }
 
@@ -283,7 +283,7 @@ export default async function UserProfileOGImage({ params }: RouteParams) {
         </div>
       </CardFrame>
     ),
-    size,
+    { ...size, headers: OG_CACHE_HEADERS },
   );
 }
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -16,6 +16,19 @@ export const SITE_URL: string = (
 
 export const SITE_NAME = "TrendingRepo";
 export const SITE_TAGLINE = "The trend map for open source";
+
+// Cache-Control headers for opengraph-image.tsx ImageResponse returns.
+//
+// Crawlers (Twitter, LinkedIn, Slack, Discord, Telegram) hit OG endpoints
+// on every share. Without this header, every unfurl triggers a fresh
+// ImageResponse render against the Lambda fleet. Mirroring the existing
+// /api/og/<route>/route.tsx policy: 5-minute edge cache, 1-hour SWR
+// window so crawlers get a near-instant response while content stays fresh.
+//
+// AGN-442 — patches the 8 force-dynamic OG metadata files.
+export const OG_CACHE_HEADERS = {
+  "cache-control": "public, s-maxage=300, stale-while-revalidate=3600",
+} as const;
 export const SITE_DESCRIPTION =
   "The trend map for open source. See what's heating up on GitHub, Reddit, Hacker News, ProductHunt, Bluesky, and dev.to — one live terminal for every signal.";
 


### PR DESCRIPTION
8 force-dynamic opengraph-image.tsx routes had no cache-control header, so every Twitter/LinkedIn/Slack/Discord/Telegram unfurl triggered a fresh ImageResponse render against the Lambda fleet. Mirror the existing /api/og/<route>/route.tsx policy (s-maxage=300, swr=3600) by adding a shared OG_CACHE_HEADERS constant and wiring it into every ImageResponse return for: / · /repo/[owner]/[name] · /u/[handle] · /breakouts · /compare · /categories/[slug] · /collections/[slug] · /ideas/[id].

Co-Authored-By: Paperclip <noreply@paperclip.ing>
