### PR TITLE
feat(feed): repo card hover preview with avatar + 3 commits (AGN-645)

### DIFF
--- a/src/app/api/repos/[owner]/[name]/recent-commits/route.ts
+++ b/src/app/api/repos/[owner]/[name]/recent-commits/route.ts
@@ -1,0 +1,147 @@
+// GET /api/repos/[owner]/[name]/recent-commits
+//
+// Hover-preview helper for RepoCard (AGN-645). Returns the 3 latest
+// commits on the default branch as a slim shape:
+//   { sha, message (first line only), authorLogin, authorAvatarUrl,
+//     committedAt, htmlUrl }
+//
+// Uses the pool-aware githubFetch helper so hover spam doesn't burn
+// quota outside the token-pool accounting. Cached aggressively (s-
+// maxage=300, swr=3600) — three commits don't need second-level
+// freshness, and the client also caches per-session.
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorEnvelope } from "@/lib/api/error-response";
+import { READ_SLOW_HEADERS } from "@/lib/api/cache";
+import { githubFetch } from "@/lib/github-fetch";
+
+export const runtime = "nodejs";
+
+const SLUG_PART_PATTERN = /^[A-Za-z0-9._-]+$/;
+const COMMIT_LIMIT = 3;
+
+interface RawGithubCommit {
+  sha?: string;
+  html_url?: string;
+  commit?: {
+    message?: string;
+    author?: { name?: string; date?: string };
+    committer?: { date?: string };
+  };
+  author?: { login?: string; avatar_url?: string } | null;
+}
+
+export interface RecentCommit {
+  sha: string;
+  shortSha: string;
+  message: string;
+  authorLogin: string | null;
+  authorAvatarUrl: string | null;
+  committedAt: string | null;
+  htmlUrl: string;
+}
+
+function firstLine(message: string): string {
+  const trimmed = message.trim();
+  const newlineIdx = trimmed.indexOf("\n");
+  return newlineIdx === -1 ? trimmed : trimmed.slice(0, newlineIdx);
+}
+
+function normalizeCommit(raw: RawGithubCommit): RecentCommit | null {
+  if (!raw.sha) return null;
+  const message = raw.commit?.message ?? "";
+  return {
+    sha: raw.sha,
+    shortSha: raw.sha.slice(0, 7),
+    message: firstLine(message),
+    authorLogin: raw.author?.login ?? null,
+    authorAvatarUrl: raw.author?.avatar_url ?? null,
+    committedAt:
+      raw.commit?.committer?.date ?? raw.commit?.author?.date ?? null,
+    htmlUrl: raw.html_url ?? `https://github.com/`,
+  };
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ owner: string; name: string }> },
+) {
+  const { owner, name } = await params;
+
+  if (!SLUG_PART_PATTERN.test(owner) || !SLUG_PART_PATTERN.test(name)) {
+    return NextResponse.json(errorEnvelope("Invalid repo slug"), {
+      status: 400,
+    });
+  }
+
+  const result = await githubFetch(
+    `/repos/${owner}/${name}/commits?per_page=${COMMIT_LIMIT}`,
+    {
+      operation: "repos.recent-commits",
+      next: { revalidate: 300 },
+      cache: "default",
+    },
+  );
+
+  if (!result) {
+    return NextResponse.json(errorEnvelope("GitHub upstream unavailable"), {
+      status: 503,
+      headers: READ_SLOW_HEADERS,
+    });
+  }
+
+  if (!result.response.ok) {
+    const status = result.response.status;
+    if (status === 404) {
+      return NextResponse.json(errorEnvelope("Repo not found on GitHub"), {
+        status: 404,
+        headers: READ_SLOW_HEADERS,
+      });
+    }
+    if (status === 403 || status === 429) {
+      return NextResponse.json(errorEnvelope("Rate limited", "RATE_LIMITED"), {
+        status: 503,
+        headers: READ_SLOW_HEADERS,
+      });
+    }
+    return NextResponse.json(errorEnvelope("Upstream error"), {
+      status: 502,
+      headers: READ_SLOW_HEADERS,
+    });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await result.response.json();
+  } catch {
+    return NextResponse.json(errorEnvelope("Upstream parse error"), {
+      status: 502,
+      headers: READ_SLOW_HEADERS,
+    });
+  }
+
+  if (!Array.isArray(raw)) {
+    return NextResponse.json(errorEnvelope("Upstream shape mismatch"), {
+      status: 502,
+      headers: READ_SLOW_HEADERS,
+    });
+  }
+
+  const commits: RecentCommit[] = [];
+  for (const entry of raw) {
+    const normalized = normalizeCommit(entry as RawGithubCommit);
+    if (normalized) commits.push(normalized);
+    if (commits.length >= COMMIT_LIMIT) break;
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      fullName: `${owner}/${name}`,
+      count: commits.length,
+      commits,
+    },
+    { headers: READ_SLOW_HEADERS },
+  );
+}

--- a/src/components/feed/RepoCard.tsx
+++ b/src/components/feed/RepoCard.tsx
@@ -14,6 +14,7 @@ import { NpmBadge } from "@/components/npm/NpmBadge";
 import { getNpmPackagesForRepo } from "@/lib/npm";
 import { EntityLogo } from "@/components/ui/EntityLogo";
 import { repoDisplayLogoUrl } from "@/lib/logos";
+import { RepoCardHoverPreview } from "@/components/feed/RepoCardHoverPreview";
 
 interface RepoCardProps {
   repo: Repo;
@@ -27,6 +28,12 @@ export function RepoCard({ repo, index = 0, showRank = false }: RepoCardProps) {
     repo.stars > 0 ? (repo.starsDelta7d / repo.stars) * 100 : 0;
 
   return (
+    <RepoCardHoverPreview
+      owner={repo.owner}
+      name={repo.name}
+      fullName={repo.fullName}
+      ownerAvatarUrl={repo.ownerAvatarUrl ?? null}
+    >
     <Link
       href={`/repo/${repo.owner}/${repo.name}`}
       className={cn(
@@ -87,5 +94,6 @@ export function RepoCard({ repo, index = 0, showRank = false }: RepoCardProps) {
         </div>
       </div>
     </Link>
+    </RepoCardHoverPreview>
   );
 }

--- a/src/components/feed/RepoCardHoverPreview.tsx
+++ b/src/components/feed/RepoCardHoverPreview.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+// RepoCardHoverPreview (AGN-645)
+//
+// Wraps a RepoCard child in a hover-trigger that shows a popover with
+// the owner avatar + 3 latest commits after a 200ms delay.
+//
+// Caching: per-session module-level Map keyed by fullName. Once a repo's
+// commits load they stay until full reload — avoids re-firing on every
+// hover-out / hover-in cycle. Inflight promises are also memoized so a
+// jittery hover can't double-fetch.
+//
+// API: GET /api/repos/[owner]/[name]/recent-commits → { ok, commits[] }
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+
+import { EntityLogo } from "@/components/ui/EntityLogo";
+
+interface RecentCommit {
+  sha: string;
+  shortSha: string;
+  message: string;
+  authorLogin: string | null;
+  authorAvatarUrl: string | null;
+  committedAt: string | null;
+  htmlUrl: string;
+}
+
+type CacheEntry =
+  | { state: "loaded"; commits: RecentCommit[] }
+  | { state: "error"; error: string };
+
+const sessionCache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<CacheEntry>>();
+
+const HOVER_DELAY_MS = 200;
+
+function fetchRecentCommits(
+  owner: string,
+  name: string,
+): Promise<CacheEntry> {
+  const key = `${owner}/${name}`;
+  const cached = sessionCache.get(key);
+  if (cached) return Promise.resolve(cached);
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<CacheEntry> => {
+    try {
+      const res = await fetch(
+        `/api/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/recent-commits`,
+        { method: "GET", credentials: "same-origin" },
+      );
+      if (!res.ok) {
+        const entry: CacheEntry = {
+          state: "error",
+          error: res.status === 404 ? "Repo not found" : "Couldn't load commits",
+        };
+        // Cache 404s — they won't fix themselves on rehover. Don't cache
+        // transient errors so a retry has a chance.
+        if (res.status === 404) sessionCache.set(key, entry);
+        return entry;
+      }
+      const json = (await res.json()) as {
+        ok?: boolean;
+        commits?: RecentCommit[];
+      };
+      if (!json.ok || !Array.isArray(json.commits)) {
+        return { state: "error", error: "Couldn't load commits" };
+      }
+      const entry: CacheEntry = { state: "loaded", commits: json.commits };
+      sessionCache.set(key, entry);
+      return entry;
+    } catch {
+      return { state: "error", error: "Couldn't load commits" };
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+  const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMo = Math.round(diffDay / 30);
+  if (diffMo < 12) return `${diffMo}mo ago`;
+  const diffYr = Math.round(diffMo / 12);
+  return `${diffYr}y ago`;
+}
+
+interface RepoCardHoverPreviewProps {
+  owner: string;
+  name: string;
+  ownerAvatarUrl: string | null;
+  fullName: string;
+  children: React.ReactNode;
+}
+
+export function RepoCardHoverPreview({
+  owner,
+  name,
+  ownerAvatarUrl,
+  fullName,
+  children,
+}: RepoCardHoverPreviewProps) {
+  const [open, setOpen] = useState(false);
+  const [entry, setEntry] = useState<CacheEntry | null>(() => {
+    return sessionCache.get(`${owner}/${name}`) ?? null;
+  });
+  const delayTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const popoverId = useId();
+
+  const cancelDelay = useCallback(() => {
+    if (delayTimer.current !== null) {
+      clearTimeout(delayTimer.current);
+      delayTimer.current = null;
+    }
+  }, []);
+
+  const onEnter = useCallback(() => {
+    cancelDelay();
+    delayTimer.current = setTimeout(() => {
+      setOpen(true);
+      const cached = sessionCache.get(`${owner}/${name}`);
+      if (cached) {
+        setEntry(cached);
+        return;
+      }
+      void fetchRecentCommits(owner, name).then((next) => {
+        setEntry(next);
+      });
+    }, HOVER_DELAY_MS);
+  }, [owner, name, cancelDelay]);
+
+  const onLeave = useCallback(() => {
+    cancelDelay();
+    setOpen(false);
+  }, [cancelDelay]);
+
+  useEffect(() => {
+    return () => cancelDelay();
+  }, [cancelDelay]);
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      onFocus={onEnter}
+      onBlur={onLeave}
+    >
+      {children}
+      {open && (
+        <div
+          id={popoverId}
+          role="tooltip"
+          aria-label={`${fullName} recent activity`}
+          className="absolute left-0 right-0 top-full z-30 mt-2 rounded-[var(--radius-card)] border border-border-primary bg-bg-card p-3 shadow-[var(--shadow-card-hover)] pointer-events-none"
+        >
+          <div className="flex items-center gap-2 mb-2">
+            <EntityLogo
+              src={ownerAvatarUrl}
+              name={owner}
+              size={20}
+              shape="circle"
+              alt={`${owner} avatar`}
+            />
+            <span className="text-xs font-mono text-text-secondary truncate">
+              {owner}
+            </span>
+            <span className="ml-auto text-[10px] uppercase tracking-wider text-text-tertiary">
+              Latest commits
+            </span>
+          </div>
+          {entry === null && (
+            <div className="text-xs text-text-tertiary py-2">Loading…</div>
+          )}
+          {entry?.state === "error" && (
+            <div className="text-xs text-text-tertiary py-2">{entry.error}</div>
+          )}
+          {entry?.state === "loaded" && entry.commits.length === 0 && (
+            <div className="text-xs text-text-tertiary py-2">
+              No recent commits
+            </div>
+          )}
+          {entry?.state === "loaded" && entry.commits.length > 0 && (
+            <ul className="space-y-1.5">
+              {entry.commits.map((c) => (
+                <li
+                  key={c.sha}
+                  className="flex items-start gap-2 text-xs leading-snug"
+                >
+                  <span className="font-mono text-text-tertiary shrink-0 w-[52px]">
+                    {c.shortSha}
+                  </span>
+                  <span className="text-text-primary truncate flex-1">
+                    {c.message}
+                  </span>
+                  <span className="text-text-tertiary shrink-0 font-mono text-[10px]">
+                    {relativeTime(c.committedAt)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Closes AGN-645 — [QW-8] Repo card hover preview
- Adds `GET /api/repos/[owner]/[name]/recent-commits` using pool-aware `githubFetch` (per_page=3, `s-maxage=300, swr=3600`)
- New `RepoCardHoverPreview` wraps `RepoCard`'s Link: 200ms hover delay, owner avatar + 3 commits (sha + first message line + relative time), closes on `mouseleave`
- Session-level cache (module-level `Map`) keyed by `owner/name` + inflight dedupe so jittery hovers can't refetch or burn GitHub quota

## Files changed
- `src/components/feed/RepoCard.tsx` (wrap Link, +8 LOC)
- `src/components/feed/RepoCardHoverPreview.tsx` (new, ~210 LOC)
- `src/app/api/repos/[owner]/[name]/recent-commits/route.ts` (new, ~140 LOC)

Note: total LOC is over the 50 LOC quick-win advisory because the feature genuinely requires (1) a server route through the pool helper and (2) a client cache primitive — both reusable for future hover-previews. Surgical: no other component touched.

## Verification
- [x] `npm run typecheck` — clean
- [x] `npm run lint:bypass` — pool-bypass guard pass
- [x] `npm run lint:err-envelope` — error envelope guard pass
- [x] `npm run lint:runtime` — runtime guard pass
- [x] `npm run lint:v3-budget` — pass (counts only dropped)
- [x] `npm run lint:img-lazy` — pass

## Test plan
- [ ] Hover any repo card on `/` for ~250ms — popover appears with owner avatar + 3 latest commits + relative timestamps
- [ ] Hover off — popover closes immediately
- [ ] Hover same card again — no refetch (Network tab shows one call total)
- [ ] Hover unknown/deleted repo — popover shows "Repo not found" gracefully (no console errors)
- [ ] Mobile: no accidental taps trigger hover (mouse-only events)

Link: https://github.com/0motionguy/starscreener/issues/AGN-645

🤖 Generated with [Claude Code](https://claude.com/claude-code)