### PR TITLE
fix(ci): set fetch-depth: 0 on check-nitter and collect-funding workflows

### DIFF
--- a/.github/workflows/check-nitter.yml
+++ b/.github/workflows/check-nitter.yml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"

--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: '22'


### PR DESCRIPTION
Both workflows do `git diff --cached/staged && git commit` after `actions/checkout`. Default fetch-depth=1 makes those operations fragile (same class of failure as gitleaks pre-#162). 23 sibling data-refresh workflows already specify `fetch-depth: 0`; this brings these two in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)