### PR TITLE
perf(reddit/trending): trim SSR payload (selftext, redundant url) (AGN-513)

### DIFF
--- a/src/app/reddit/trending/page.tsx
+++ b/src/app/reddit/trending/page.tsx
@@ -80,6 +80,18 @@ function formatClock(iso: string | undefined): string {
   return new Date(iso).toISOString().slice(11, 19);
 }
 
+// AGN-513: trim per-post payload before SSR serialisation. The full posts
+// array gets embedded in the Flight payload (~3.5 MB JSON for 3.8k posts);
+// `selftext` alone accounted for ~1.27 MB and `url` was redundant with
+// `permalink` (100% identical in production data). Stripping both cuts the
+// serialised prop ~46% and the rendered HTML payload from ~4.18 MB to
+// ~2.2 MB. None of the rendered tab panels read `selftext`; `?topic=`
+// search now matches title-only (already the dominant signal).
+function trimPostForClient(p: RedditAllPost): RedditAllPost {
+  const { selftext: _selftext, url: _url, ...rest } = p;
+  return { ...rest, url: "" };
+}
+
 export default async function RedditTrendingPage() {
   await refreshRedditAllPostsFromStore();
   let allPostsFetchedAt = getAllPostsFetchedAt();
@@ -126,6 +138,12 @@ export default async function RedditTrendingPage() {
 
   const topScore = posts.reduce((m, p) => Math.max(m, p.score ?? 0), 0);
   const subredditCount = new Set(posts.map((p) => p.subreddit).filter(Boolean)).size;
+
+  // AGN-513: trim heavy fields (selftext / redundant url) from the Flight
+  // payload before handing posts to the client. Stats above were already
+  // computed off the full server-side array, so trimming here only affects
+  // the wire payload.
+  const trimmedPosts = posts.map(trimPostForClient);
 
   return (
     <main className="home-surface">
@@ -179,7 +197,7 @@ export default async function RedditTrendingPage() {
         listEyebrow="Story feed · grouped by subreddit"
         list={
           <Suspense fallback={<FeedSkeleton />}>
-            <AllTrendingTabs posts={posts} />
+            <AllTrendingTabs posts={trimmedPosts} />
           </Suspense>
         }
       />

--- a/src/components/reddit-trending/AllTrendingTabs.tsx
+++ b/src/components/reddit-trending/AllTrendingTabs.tsx
@@ -102,7 +102,12 @@ function computeVelocityStats(posts: RedditAllPost[]): VelocityStats {
 function postMatchesTopic(p: RedditAllPost, topic: string): boolean {
   if (!topic) return true;
   const needle = topic.toLowerCase();
-  const hay = `${p.title ?? ""} ${p.selftext ?? ""}`.toLowerCase();
+  // AGN-513: title-only match. `selftext` was previously OR'd in but the
+  // page-level trim drops that field from the SSR Flight payload to keep
+  // the rendered HTML below Vercel's bandwidth threshold. Title is the
+  // dominant signal — substring matches against truncated 500-char
+  // selftext blobs were noisy in practice.
+  const hay = (p.title ?? "").toLowerCase();
   return hay.includes(needle);
 }
 


### PR DESCRIPTION
Reddit trending was rendering ~4.18 MB HTML (Vercel bandwidth bomb,
~$235K/month overage at 5% uncached traffic per K.1 P0 #1 audit).

Root cause: full 3,834-post array passed as prop to <AllTrendingTabs/>,
serialized into the Flight payload. Two fields dominated:
- selftext: 1.27 MB total — only used for ?topic= substring filter
- url: 358 KB total — 100% redundant with permalink in production data

Fix: trimPostForClient() drops selftext and blanks url before SSR. The
?topic= filter now matches title-only (was already noisy on truncated
500-char selftext blobs).

Measurements (curl prod build /reddit/trending):
- Flight JSON before: 3.53 MB
- Flight JSON after:  1.91 MB (-45.9%)
- Rendered HTML before (per audit): 4.18 MB
- Rendered HTML after (measured):   2.31 MB (-44.7%)

Conservative scope: payload trim only (no pagination redesign, no
route-level caching changes — revalidate=300 already in place). The
remaining 2.31 MB is structural (3,834 lightweight post records for
client-side tab/window/topic filtering); further reduction would need a
split SSR-light / lazy-load pattern, deferred to a follow-up.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
