### PR TITLE
feat(analytics): PostHog funnel events on key user flows (AGN-848)

### DIFF
--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -1,0 +1,107 @@
+# PostHog Funnels
+
+**Owner:** Frontend Polish · **Issue:** AGN-848 · **Status:** events shipping (visualisation lives in PostHog)
+
+This doc enumerates every named PostHog funnel event the web app emits.
+The events are stable API contracts — PostHog dashboards key on them.
+Rename or remove only with a coordinated dashboard update.
+
+The PostHog client SDK (`posthog-js`) is initialised in
+`src/components/providers/PostHogProvider.tsx`. Funnel call sites use
+the helper at `src/lib/analytics/funnel.ts`, which exposes a single
+`captureFunnelStep({ step, flow, ...properties })` function. Two
+ergonomic wrappers ride on top of the helper:
+
+- `<FunnelMount step flow properties? />` —
+  `src/components/analytics/FunnelMount.tsx`. Fires once on mount. Use
+  from server components that just need to record a page view.
+- `<TrackedExternalLink step flow trackProps? ... />` —
+  `src/components/analytics/TrackedExternalLink.tsx`. Drop-in
+  replacement for `<a target="_blank">` when the parent is a server
+  component but the click should still emit a funnel step.
+
+If `NEXT_PUBLIC_POSTHOG_KEY` is unset (preview / local dev without
+analytics provisioned), the helper is a silent no-op.
+
+All funnel events share the same PostHog event name (`funnel_step`) and
+are differentiated by the `step` and `flow` properties — this lets the
+PostHog UI build funnels from a single event series filtered by `flow`,
+which is much simpler to maintain than one named event per step.
+
+---
+
+## Flows
+
+### `discover-repo` — home → search → repo → GitHub click
+
+| # | Step | Fired from | Notable extra properties |
+| - | ---- | ---------- | ------------------------ |
+| 1 | `home_view` | `<FunnelMount>` in `src/app/page.tsx` | — |
+| 2 | `search_query` | `src/components/shared/SearchBar.tsx` (Enter + "See all results" footer) | `query_length`, `source` (`enter_key` \| `see_all_results`) |
+| 2′ | `search_result_select` | `src/components/shared/SearchBar.tsx` autocomplete row click — short-cut into the funnel that bypasses `/search` | `repo` |
+| 3 | `repo_view` | `<FunnelMount>` in `src/app/repo/[owner]/[name]/page.tsx` | `repo` |
+| 4 | `github_click` | `<TrackedExternalLink>` (header `↗`, id-actions "GitHub ↗") + `RepoActionRow` "OPEN ON GITHUB" | `repo`, `position` (`header` \| `id_actions` \| `repo_detail`) |
+
+Either `search_query` *or* `search_result_select` advances the funnel
+from step 2 — PostHog funnels can express "any of these events" via
+the union UI.
+
+### `top10-discover` — home → /top10 → repo → GitHub click
+
+| # | Step | Fired from | Notable extra properties |
+| - | ---- | ---------- | ------------------------ |
+| 1 | `home_view` | shared with `discover-repo` | — |
+| 2 | `top10_view` | `<FunnelMount>` in `src/app/top10/page.tsx` | — |
+| 3 | `repo_view` | shared with `discover-repo` | `repo` |
+| 4 | `github_click` | shared with `discover-repo` | `repo`, `position` |
+
+### `watchlist-add` — repo → save
+
+| # | Step | Fired from | Notable extra properties |
+| - | ---- | ---------- | ------------------------ |
+| 1 | `repo_view` | shared with `discover-repo` | `repo` |
+| 2 | `watchlist_add` | `RepoActionRow.handleWatch` — only counts adds, not removes | `repo`, `source` (`repo_detail`) |
+
+### `submit-repo` — open form → fill → submit
+
+Lives on `/submit` (`src/components/submissions/DropRepoPage.tsx`).
+
+| # | Step | Trigger | Notable extra properties |
+| - | ---- | ------- | ------------------------ |
+| 1 | `submit_open` | DropRepoPage mount | — |
+| 2 | `submit_fill` | First non-empty change to the repo input on the current mount | — |
+| 3 | `submit_success` | API responded `ok: true` | `kind` (`created` \| `duplicate` \| `already_tracked`) |
+
+`submit_fill` fires **once per mount** — clearing the form after a
+successful "created" submission also resets the latch so a follow-up
+submission is captured cleanly. There's no explicit `submit_failure`
+event today: validation failures keep the operator on the form, which
+the dashboard can spot as `submit_fill` without a downstream
+`submit_success`.
+
+---
+
+## Adding a new flow
+
+1. Add the flow id to the `FunnelFlow` union and any new step ids to
+   `FunnelStep` in `src/lib/analytics/funnel.ts`. The TypeScript union
+   is the single source of truth — a typo at the call site becomes a
+   compile error.
+2. Wire `captureFunnelStep`, `<FunnelMount>`, or `<TrackedExternalLink>`
+   into the relevant component(s).
+3. Document the flow in this file in the same shape (table per flow).
+4. Ping whoever maintains the PostHog dashboards so they can build the
+   funnel insight in PostHog → Insights → New funnel, filtered on
+   `flow=<your-flow-id>`.
+
+## Verifying locally
+
+- Set `NEXT_PUBLIC_POSTHOG_KEY` in `.env.local`. With
+  `NODE_ENV=development` the client SDK runs in debug mode and logs
+  every capture to the console.
+- PostHog "Live events" tab shows the events as they land. Filter on
+  `event = funnel_step` to see only the funnel surface; group by
+  `properties.flow` to slice per-funnel.
+- Funnel charts: PostHog → Insights → New funnel → pick `funnel_step`
+  multiple times, fix `flow` to the chosen flow id and `step` to the
+  step you want for that position.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/ecosystem-leaderboards";
 import { BubbleMap } from "@/components/terminal/BubbleMap";
 import { HomeEmptyState } from "@/components/home/HomeEmptyState";
+import { FunnelMount } from "@/components/analytics/FunnelMount";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { ChartStat, ChartStats } from "@/components/ui/ChartShell";
 import { Metric, MetricGrid } from "@/components/ui/Metric";
@@ -813,6 +814,7 @@ export default async function HomePage() {
 
   return (
     <>
+      <FunnelMount step="home_view" flow="discover-repo" />
       <div className="home-surface">
         <section className="page-head">
           <div>

--- a/src/app/repo/[owner]/[name]/page.tsx
+++ b/src/app/repo/[owner]/[name]/page.tsx
@@ -67,6 +67,8 @@ import { ProjectSurfaceMap } from "@/components/repo-detail/ProjectSurfaceMap";
 import { NpmAdoptionPanel } from "@/components/repo-detail/NpmAdoptionPanel";
 import { RepoActionRow } from "@/components/repo-detail/RepoActionRow";
 import { MarkRepoViewed } from "@/components/repo-detail/MarkRepoViewed";
+import { FunnelMount } from "@/components/analytics/FunnelMount";
+import { TrackedExternalLink } from "@/components/analytics/TrackedExternalLink";
 import { ObjectReactions } from "@/components/reactions/ObjectReactions";
 import {
   countReactions,
@@ -279,15 +281,16 @@ export default async function RepoDetailPage({ params }: PageProps) {
             </div>
             <h1>
               <span className="owner">{repo.owner} /</span> {repo.name}
-              <a
+              <TrackedExternalLink
+                step="github_click"
+                flow="discover-repo"
+                trackProps={{ repo: repo.fullName, position: "header" }}
                 href={repo.url || `https://github.com/${repo.fullName}`}
-                target="_blank"
-                rel="noopener noreferrer"
                 className="ext"
                 aria-label={`Open ${repo.fullName} on GitHub`}
               >
                 ↗
-              </a>
+              </TrackedExternalLink>
             </h1>
             {repo.description ? <p className="desc">{repo.description}</p> : null}
             <div className="row">
@@ -316,14 +319,15 @@ export default async function RepoDetailPage({ params }: PageProps) {
             <Link href={`/repo/${repo.owner}/${repo.name}/star-activity`} className="btn">
               Star activity
             </Link>
-            <a
+            <TrackedExternalLink
+              step="github_click"
+              flow="discover-repo"
+              trackProps={{ repo: repo.fullName, position: "id_actions" }}
               href={repo.url || `https://github.com/${repo.fullName}`}
-              target="_blank"
-              rel="noopener noreferrer"
               className="btn gh"
             >
               GitHub ↗
-            </a>
+            </TrackedExternalLink>
           </div>
         </section>
 
@@ -378,6 +382,11 @@ export default async function RepoDetailPage({ params }: PageProps) {
               nothing exists. */}
           {/* <CompletenessStrip> WIP — re-enable once merged from stash. */}
           <MarkRepoViewed owner={repo.owner} name={repo.name} />
+          <FunnelMount
+            step="repo_view"
+            flow="discover-repo"
+            properties={{ repo: repo.fullName }}
+          />
           <RepoActionRow repo={repo} />
           <ObjectReactions
             objectType="repo"

--- a/src/app/top10/page.tsx
+++ b/src/app/top10/page.tsx
@@ -37,6 +37,7 @@ import { LetterAvatar } from "@/components/shared/LetterAvatar";
 import { Sparkline } from "@/components/shared/Sparkline";
 import { WhyBadge } from "@/components/repo/WhyBadge";
 import { getWhyNarrative, type WhyNarrative } from "@/lib/why-narrative";
+import { FunnelMount } from "@/components/analytics/FunnelMount";
 
 // ISR — 10-minute cadence matches the V4 leaderboard surfaces. Underlying
 // readers refresh every 6 hours via cron; tighter cache wastes work
@@ -173,6 +174,7 @@ export default async function Top10RootPage() {
 
   return (
     <main className="home-surface">
+      <FunnelMount step="top10_view" flow="top10-discover" />
       <PageHead
         crumb={
           <>

--- a/src/components/analytics/FunnelMount.tsx
+++ b/src/components/analytics/FunnelMount.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+// AGN-848 — Tiny client component that fires a single `funnel_step` event
+// on mount. Lets server components (home, /top10, /repo/[owner]/[name],
+// /submit) participate in PostHog funnels without converting to client.
+//
+// Renders nothing. The capture is wrapped in `captureFunnelStep` so it
+// no-ops when PostHog isn't loaded.
+
+import { useEffect } from "react";
+
+import {
+  captureFunnelStep,
+  type FunnelFlow,
+  type FunnelStep,
+} from "@/lib/analytics/funnel";
+
+interface FunnelMountProps {
+  step: FunnelStep;
+  flow: FunnelFlow;
+  /** Optional flat properties — e.g. repo full name on the detail page. */
+  properties?: Record<string, string | number | boolean | undefined>;
+}
+
+export function FunnelMount({ step, flow, properties }: FunnelMountProps) {
+  useEffect(() => {
+    captureFunnelStep({ step, flow, ...(properties ?? {}) });
+    // We deliberately fire-once-per-mount. A page navigating to itself
+    // with different props (e.g. different repo) re-mounts the component,
+    // so the dependency array can stay empty without dropping events.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}

--- a/src/components/analytics/TrackedExternalLink.tsx
+++ b/src/components/analytics/TrackedExternalLink.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+// AGN-848 — Thin <a> wrapper that fires a `funnel_step` capture before
+// the browser opens the new tab. Used by the server-rendered repo-detail
+// surfaces that link out to GitHub but don't already own a client
+// onClick handler. The render result is identical to a plain anchor —
+// only behaviour difference is the side-effect.
+
+import { captureFunnelStep, type FunnelFlow, type FunnelStep } from "@/lib/analytics/funnel";
+
+interface TrackedExternalLinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  step: FunnelStep;
+  flow: FunnelFlow;
+  /** Flat properties the dashboard can break down on. */
+  trackProps?: Record<string, string | number | boolean | undefined>;
+  href: string;
+  children: React.ReactNode;
+}
+
+export function TrackedExternalLink({
+  step,
+  flow,
+  trackProps,
+  onClick,
+  href,
+  children,
+  target = "_blank",
+  rel = "noopener noreferrer",
+  ...rest
+}: TrackedExternalLinkProps) {
+  return (
+    <a
+      {...rest}
+      href={href}
+      target={target}
+      rel={rel}
+      onClick={(event) => {
+        captureFunnelStep({ step, flow, ...(trackProps ?? {}) });
+        onClick?.(event);
+      }}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/repo-detail/RepoActionRow.tsx
+++ b/src/components/repo-detail/RepoActionRow.tsx
@@ -20,6 +20,7 @@ import {
   toastWatchRemoved,
 } from "@/lib/toast";
 import { cn } from "@/lib/utils";
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 
 interface RepoActionRowProps {
   repo: Repo;
@@ -37,9 +38,30 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
   const handleWatch = useCallback(() => {
     const wasWatched = isWatched;
     toggleWatch(repo.id, repo.stars);
-    if (wasWatched) toastWatchRemoved(repo.fullName);
-    else toastWatchAdded(repo.fullName);
+    if (wasWatched) {
+      toastWatchRemoved(repo.fullName);
+    } else {
+      toastWatchAdded(repo.fullName);
+      // AGN-848 — only track ADDs as the funnel step. Removals don't
+      // progress the discovery → save funnel; counting them would
+      // inflate conversion artificially.
+      captureFunnelStep({
+        step: "watchlist_add",
+        flow: "watchlist-add",
+        repo: repo.fullName,
+        source: "repo_detail",
+      });
+    }
   }, [isWatched, toggleWatch, repo.id, repo.stars, repo.fullName]);
+
+  const handleGithubClick = useCallback(() => {
+    captureFunnelStep({
+      step: "github_click",
+      flow: "discover-repo",
+      repo: repo.fullName,
+      position: "action_row",
+    });
+  }, [repo.fullName]);
 
   const handleCompare = useCallback(() => {
     if (isComparing) {
@@ -106,6 +128,7 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
         href={repo.url || `https://github.com/${repo.fullName}`}
         target="_blank"
         rel="noopener noreferrer"
+        onClick={handleGithubClick}
         className="v2-btn v2-btn-ghost ml-auto min-h-[44px]"
       >
         <ExternalLink size={14} aria-hidden style={{ marginRight: 8 }} />

--- a/src/components/repo-detail/RepoActionRow.tsx
+++ b/src/components/repo-detail/RepoActionRow.tsx
@@ -55,11 +55,14 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
   }, [isWatched, toggleWatch, repo.id, repo.stars, repo.fullName]);
 
   const handleGithubClick = useCallback(() => {
+    // Position label aligns with `docs/POSTHOG-FUNNELS.md` so the
+    // dashboard can break down the github_click step by which surface
+    // emitted it.
     captureFunnelStep({
       step: "github_click",
       flow: "discover-repo",
       repo: repo.fullName,
-      position: "action_row",
+      position: "repo_detail",
     });
   }, [repo.fullName]);
 

--- a/src/components/shared/SearchBar.tsx
+++ b/src/components/shared/SearchBar.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Search, X } from "lucide-react";
 import { cn, formatNumber } from "@/lib/utils";
 import { ROUTES } from "@/lib/constants";
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 import type { Repo } from "@/lib/types";
 import { EntityLogo } from "@/components/ui/EntityLogo";
 import { BrandStar } from "@/components/shared/BrandStar";
@@ -166,6 +167,14 @@ export function SearchBar({
 
   const gotoRepo = useCallback(
     (repo: Repo) => {
+      // AGN-848 — funnel "search_result_select" step. Operator picked a
+      // repo from the autocomplete dropdown instead of submitting to
+      // /search; record the conversion for the discover-repo funnel.
+      captureFunnelStep({
+        step: "search_result_select",
+        flow: "discover-repo",
+        repo: repo.fullName,
+      });
       router.push(`/repo/${repo.owner}/${repo.name}`);
       setPreviewOpen(false);
       setValue("");
@@ -202,6 +211,15 @@ export function SearchBar({
       if (e.key === "Enter") {
         const q = value.trim();
         if (q) {
+          // AGN-848 — funnel step "search_query". Fired on the explicit
+          // submit (Enter), not on every keystroke, so the count maps 1:1
+          // to "operator decided to search this term".
+          captureFunnelStep({
+            step: "search_query",
+            flow: "discover-repo",
+            query_length: q.length,
+            source: "enter_key",
+          });
           router.push(`${ROUTES.SEARCH}?q=${encodeURIComponent(q)}`);
           setPreviewOpen(false);
         }
@@ -344,6 +362,14 @@ export function SearchBar({
                 onClick={() => {
                   const q = value.trim();
                   if (q) {
+                    // AGN-848 — funnel step "search_query" (alternate
+                    // trigger via the autocomplete footer button).
+                    captureFunnelStep({
+                      step: "search_query",
+                      flow: "discover-repo",
+                      query_length: q.length,
+                      source: "see_all_results",
+                    });
                     router.push(`${ROUTES.SEARCH}?q=${encodeURIComponent(q)}`);
                     setPreviewOpen(false);
                   }

--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 
 import { ROUTES } from "@/lib/constants";
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 
 interface QueueSummary {
   pending: number;
@@ -122,6 +123,10 @@ export function DropRepoPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<SubmissionResult | null>(null);
+  // AGN-848 — funnel step "submit_fill" fires only the first time the
+  // operator types into the repo input on this mount. Without the latch
+  // every keystroke would inflate the metric.
+  const [fillFired, setFillFired] = useState(false);
 
   async function loadQueue(): Promise<void> {
     setLoading(true);
@@ -145,6 +150,8 @@ export function DropRepoPage() {
 
   useEffect(() => {
     void loadQueue();
+    // AGN-848 — funnel step "submit_open". Once on mount.
+    captureFunnelStep({ step: "submit_open", flow: "submit-repo" });
   }, []);
 
   useEffect(() => {
@@ -193,11 +200,22 @@ export function DropRepoPage() {
       setQueue(data.result.queue);
       await loadQueue();
 
+      // AGN-848 — funnel step "submit_success". Tag with `kind` so the
+      // dashboard can split created vs duplicate vs already_tracked
+      // without requiring per-call event names.
+      captureFunnelStep({
+        step: "submit_success",
+        flow: "submit-repo",
+        kind: data.result.kind,
+      });
+
       if (data.result.kind === "created") {
         setRepo("");
         setWhyNow("");
         setContact("");
         setShareUrl("");
+        // Allow `submit_fill` to fire again on the cleared form.
+        setFillFired(false);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -253,7 +271,18 @@ export function DropRepoPage() {
               </span>
               <input
                 value={repo}
-                onChange={(event) => setRepo(event.target.value)}
+                onChange={(event) => {
+                  const next = event.target.value;
+                  setRepo(next);
+                  // AGN-848 — funnel step "submit_fill" once per mount.
+                  if (!fillFired && next.trim().length > 0) {
+                    setFillFired(true);
+                    captureFunnelStep({
+                      step: "submit_fill",
+                      flow: "submit-repo",
+                    });
+                  }
+                }}
                 placeholder="openai/openai-agents-python or https://github.com/openai/openai-agents-python"
                 className="h-11 rounded-card border border-border-primary bg-bg-secondary px-3 text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-brand/50"
                 autoComplete="off"

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -1,0 +1,85 @@
+// AGN-848 — Client-side PostHog funnel helper.
+//
+// Wraps `posthog-js` so call sites emit a single event shape
+// (`funnel_step`) without reaching for the SDK directly. PostHog is
+// initialised by `<PostHogProvider>` (src/components/providers); when
+// `NEXT_PUBLIC_POSTHOG_KEY` is unset the SDK never loads and every
+// capture here becomes a no-op.
+//
+// All funnels documented in `docs/POSTHOG-FUNNELS.md`. Add a new flow
+// there before adding capture calls so the dashboard side stays in sync
+// with what the client emits.
+//
+// Contract:
+//   - Pure side-effect, fire-and-forget. Never throws.
+//   - Server-rendered code paths are guarded via the `typeof window`
+//     check so accidental imports from a Server Component do not blow
+//     up the build.
+//   - Properties are flat key/value pairs — PostHog funnels filter on
+//     property equality, so nested objects defeat the dashboard.
+
+"use client";
+
+import posthog from "posthog-js";
+
+/**
+ * Canonical funnel identifiers. Keep this list authoritative — the
+ * PostHog dashboard funnels filter on `flow=...` exact match, and a
+ * stray string here means a funnel quietly stops counting.
+ *
+ * 1. `discover-repo`     home -> search -> repo-detail -> github click
+ * 2. `top10-discover`    home -> /top10 -> repo-detail -> github click
+ * 3. `watchlist-add`     repo-detail -> watchlist add
+ * 4. `submit-repo`       /submit open -> form fill -> submit success
+ */
+export type FunnelFlow =
+  | "discover-repo"
+  | "top10-discover"
+  | "watchlist-add"
+  | "submit-repo";
+
+/**
+ * Canonical step identifiers. Listed centrally so any regression in
+ * call-site naming surfaces as a TypeScript error rather than silently
+ * fragmenting the dashboard counts.
+ */
+export type FunnelStep =
+  // entry / discovery
+  | "home_view"
+  | "search_query"
+  | "search_result_select"
+  | "top10_view"
+  | "repo_view"
+  | "github_click"
+  // watchlist
+  | "watchlist_add"
+  // submit
+  | "submit_open"
+  | "submit_fill"
+  | "submit_success";
+
+interface FunnelStepProps {
+  step: FunnelStep;
+  flow: FunnelFlow;
+  /** Optional flat properties — repo full name, query length, etc. */
+  [key: string]: string | number | boolean | undefined;
+}
+
+/**
+ * Emit a single funnel step. Safe to call from any client component.
+ * No-ops when:
+ *   - running on the server (typeof window === "undefined")
+ *   - PostHog SDK was never initialised (NEXT_PUBLIC_POSTHOG_KEY unset)
+ */
+export function captureFunnelStep(props: FunnelStepProps): void {
+  if (typeof window === "undefined") return;
+  try {
+    // posthog.__loaded is set by posthog-js once init() resolves.
+    // Skipping when the SDK is dormant avoids accidental queueing in
+    // preview / local-dev builds without analytics provisioned.
+    if (!posthog.__loaded) return;
+    posthog.capture("funnel_step", props);
+  } catch {
+    // Analytics must never throw upstream.
+  }
+}


### PR DESCRIPTION
## Summary

- Defines four PostHog funnels via a single stable `funnel_step` event keyed on `flow` + `step` properties: `discover-repo` (home → search → repo → GitHub click), `top10-discover` (home → /top10 → repo → GitHub click), `watchlist-add` (repo → save), `submit-repo` (open → fill → submit).
- Adds `src/lib/analytics/funnel.ts` (typed `captureFunnelStep`, `FunnelStep` / `FunnelFlow` unions) plus two ergonomic wrappers: `<FunnelMount>` for server pages that just need a mount-time view event, and `<TrackedExternalLink>` so server-rendered `<a target="_blank">` GitHub links can still emit a click event without going client.
- Wires the events from `app/page.tsx`, `app/top10/page.tsx`, `app/repo/[owner]/[name]/page.tsx`, `SearchBar` (Enter, autocomplete row, "see all results" footer), `RepoActionRow` (watchlist add + GitHub click), and `DropRepoPage` (open / fill / success). Documents every event in `docs/POSTHOG-FUNNELS.md`.
- Funnel visualisation lives in PostHog (Insights → New funnel → filter on `flow=...`). No frontend chart work shipped — that's the spec.

## Test plan

- [ ] `npm run typecheck` passes (verified locally — clean).
- [ ] With `NEXT_PUBLIC_POSTHOG_KEY` set in `.env.local`, walk the discover-repo funnel and confirm `funnel_step` events with the expected `flow`/`step` pairs land in PostHog Live events.
- [ ] Repeat for the submit-repo funnel (open `/submit`, type into the repo input, submit a known-tracked repo to hit `kind=already_tracked`, then a fresh URL to hit `kind=created`).
- [ ] Confirm helper is a no-op when `NEXT_PUBLIC_POSTHOG_KEY` is unset (preview env without analytics provisioned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)