### PR TITLE
fix(home,githubrepo/AGN-723,AGN-725): clip mobile route-shell horizontal overflow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2747,6 +2747,22 @@ body::before {
   max-width: 100%;
 }
 
+/* AGN-723/725 mobile overflow guard. The .table-scroll clamp above keeps
+   the leaderboard contained, but sub-pixel rounding + nested flex children
+   on home-surface still produced a ~11px page overshoot at 375/390 widths.
+   Clip horizontal overflow on the route-shell containers so scrollWidth ≤
+   innerWidth. `clip` is preferred over `hidden`: it does not establish a
+   new scroll container, so internal .table-scroll panes still scroll
+   horizontally as intended. Desktop (>=768px) is unaffected. */
+@media (max-width: 767px) {
+  html,
+  body,
+  .v3-root,
+  .app-shell {
+    overflow-x: clip;
+  }
+}
+
 .tbl {
   width: 100%;
   border-collapse: collapse;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2742,6 +2742,9 @@ body::before {
 
 .table-scroll {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .tbl {


### PR DESCRIPTION
Cherry-pick of 84028b60 + d10d4984 from #156 to ship the mobile-overflow fix independently of the failing preview build there.

Closes AGN-723 (homepage / overflow at 375/390).
Closes AGN-725 (/githubrepo overflow at 375/390).

Verification: scrollWidth <= innerWidth at 375/390/768 once preview lands.
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>