### PR TITLE
chore(gitignore): catch non-dot-prefixed scratch + generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,21 @@ awesome-codex-skills/
 
 # storybook static build output (built artifact, not source)
 /storybook-static/
+
+# operator scratch — non-dot-prefixed shapes (existing .tmp_* / .tmp-* patterns miss these)
+/tmp_*.json
+/tmp-*.log
+/tmp-*.err.log
+/tmp-*.out.log
+
+# QA freshness probe run dumps
+/qa-freshness-*.json
+
+# Stryker mutation HTML reports (config stays committed)
+/reports/
+
+# generated Storybook static output rendered into docs
+/docs/storybook/
+
+# local agent vector DB (per-machine runtime state, regenerated automatically)
+/ruvector.db


### PR DESCRIPTION
Existing `.tmp_*` / `.tmp-*` only match dot-prefixed names; actual scratch shapes from collector and agent runs miss the dot. Adds patterns for `tmp_wake.json`, `tmp-*.log/err.log/out.log`, `qa-freshness-*.json`, `/reports/` (Stryker HTML), `/docs/storybook/` (generated build), and `/ruvector.db` (1.6 MB local agent DB).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>