### PR TITLE
chore(swarm): set up 2x2 worktree topology + relocate docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Real-time trend-discovery scanner. Aggregates GitHub stars, Twitter buzz, Reddit
 - Verify Redis data-store: `npm run verify:data-store` (requires `REDIS_URL` for Railway, OR `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` for Upstash)
 
 ## Where to Look First
+- **2x2 swarm operating contract (read on every swarm session start)** → [docs/SWARM-2x2.md](docs/SWARM-2x2.md) — worktree-per-agent topology, 8-rule contract, port assignments, ship runbook. Loaded by every Claude / Codex agent in the parallel topology.
 - **Operator situational-awareness doc (start here)** → [docs/OPERATOR.md](docs/OPERATOR.md) — TL;DR for a fresh session, current production state, audit-2026-05-04 followup status, hourly+minute workflow rotation, image-coverage map, what-shipped-vs-open. Operator-only — never linked from any public route. Refreshed at the end of every "go" wave.
 - **Engine map (62 workflows + every API key + every cron + pool architecture)** → [docs/ENGINE.md](docs/ENGINE.md) — read FIRST when you need to know what runs where, on what cadence, with which keys. Refreshed 2026-05-02.
 - **Site wire map (every route → its data → collector → external API)** → [docs/SITE-WIREMAP.md](docs/SITE-WIREMAP.md) — top-down menu walk. Use when a page is broken to trace it back to the failing collector. Refreshed 2026-05-02.
@@ -84,6 +85,13 @@ Real-time trend-discovery scanner. Aggregates GitHub stars, Twitter buzz, Reddit
 - **Parallel-session merges silently steal staged work.** When 4 agents work the same workspace concurrently, `git add` + `git commit` interleave: agent A's `git add file-a` lands in agent B's `git commit` and vice versa. Survival pattern: always `git add <SPECIFIC-FILE>` (NEVER `git add -A` or `git add .`), and `git commit -m "wip(...)"` IMMEDIATELY after each Write so the commit boundary is durable. Staging is shared mutable state; commits are durable history. Learned 2026-05-02 across 4 parallel agent dispatch.
 - **Audit premises must be verified before believing.** The 2026-05-01 ultra audit claimed 3 P0s lived on `feat/v4-alert-rules`; verification (`grep ThemeToggle src/components/layout/Header.tsx` etc.) showed they were never on any branch — they had to be implemented fresh. M6: memory is suspect — recalled facts are hypotheses until verified. Cherry-pick plans built on un-verified branch state will fail; always grep `main` for the markers BEFORE planning the cherry-pick.
 
+## Multi-Agent Setup (2x2 swarm)
+- Repo lives at `C:\dev\trendingrepo` (off OneDrive — CSS edits and `.next` cache are no longer at risk of silent revert).
+- 4 swarm worktrees under `C:\dev\trendingrepo-wt\{tl,tr,bl,br}` map to branches `bot/swarm-{tl,tr}-claude` and `bot/swarm-{bl,br}-codex`. Ports 3023/3024/3025/3026.
+- Every push from a swarm branch creates a Vercel Preview at `starscreener-git-bot-swarm-<slug>.vercel.app` — that's the visual-proof surface.
+- Full operating contract: [docs/SWARM-2x2.md](docs/SWARM-2x2.md). Read it before doing anything in a swarm worktree.
+
 ## References
 - Plans: `~/.claude/plans/`
-- Memory: `~/.claude/projects/c--Users-mirko-OneDrive-Desktop-STARSCREENER/memory/MEMORY.md`
+- Memory: `~/.claude/projects/c--dev-trendingrepo/memory/MEMORY.md` (post-2026-05-06 cutover; the historical key `c--Users-mirko-OneDrive-Desktop-STARSCREENER` retains pre-move notes)
+- Windows perf hardening (deferred sprint): [tasks/perf-windows-tuning.md](tasks/perf-windows-tuning.md)

--- a/docs/SWARM-2x2.md
+++ b/docs/SWARM-2x2.md
@@ -1,0 +1,173 @@
+# Swarm 2x2 — Operating Contract
+
+Authoritative spec for the four-agent parallel topology. Every swarm session reads this on start. CLAUDE.md links here.
+
+---
+
+## Topology
+
+Two Claude Code sessions + two Codex CLI sessions, each in a dedicated git worktree on a dedicated branch. Same `.git` directory, isolated working trees and indexes.
+
+```
+                    github.com/0motionguy/starscreener
+                              (remote)
+                                  |
+                          C:\dev\trendingrepo
+                          (main checkout — human review only)
+                                  |
+        +-------------------------+-------------------------+
+        |              |                       |            |
+     tl (3023)      tr (3024)              bl (3025)     br (3026)
+   Claude #1       Claude #2              Codex #1      Codex #2
+        |              |                       |            |
+  bot/swarm-tl-   bot/swarm-tr-          bot/swarm-bl-  bot/swarm-br-
+     claude         claude                  codex         codex
+        |              |                       |            |
+        +----- each push -> Vercel Preview per branch -----+
+                                  |
+                                main -> production
+```
+
+Worktree paths:
+
+- `C:\dev\trendingrepo-wt\tl` -> `bot/swarm-tl-claude` (Claude #1, port 3023)
+- `C:\dev\trendingrepo-wt\tr` -> `bot/swarm-tr-claude` (Claude #2, port 3024)
+- `C:\dev\trendingrepo-wt\bl` -> `bot/swarm-bl-codex` (Codex #1, port 3025)
+- `C:\dev\trendingrepo-wt\br` -> `bot/swarm-br-codex` (Codex #2, port 3026)
+
+The legacy `C:\Users\mirko\Worktrees\AGN-*` worktrees belong to prior tickets and are untouched by the swarm.
+
+---
+
+## Port Assignments
+
+| Slot | Worktree | Branch                | Dev Port |
+|------|----------|-----------------------|----------|
+| tl   | `…\tl`   | `bot/swarm-tl-claude` | 3023     |
+| tr   | `…\tr`   | `bot/swarm-tr-claude` | 3024     |
+| bl   | `…\bl`   | `bot/swarm-bl-codex`  | 3025     |
+| br   | `…\br`   | `bot/swarm-br-codex`  | 3026     |
+
+`PORT` is set in each worktree's `.env.local`. Never hardcode in `package.json` — the value must travel with the worktree.
+
+---
+
+## The 8-Rule Contract
+
+Every agent in the swarm follows these rules. No exceptions.
+
+1. **One worktree, one branch, one agent.** Never `cd` into another agent's worktree, even to "just check something."
+2. **Stage by exact path only.** Always `git add <SPECIFIC-FILE>`. Never `git add -A`, `git add .`, or repo-spanning pathspec wildcards.
+3. **Commit immediately after each Write.** Small commits are durable boundaries; staged files are shared mutable state.
+4. **Push after every commit.** The matching Vercel Preview must reflect current branch state.
+5. **Never `git checkout` a branch another agent owns** — even from your own worktree. Each branch has exactly one writer.
+6. **Resolve conflicts inside your own worktree via `git pull --rebase`.** Don't switch branches to escape a conflict.
+7. **Cross-agent dependencies route through `main`.** Upstream agent ships first via its draft PR; downstream agent rebases onto the new `main`. No direct branch-to-branch merges.
+8. **Long-running commands run inside the owning worktree only.** `npm run build`, `npm test`, `npm run dev` from the main checkout while agents work corrupts the Next.js `.next` cache — race condition guaranteed.
+
+---
+
+## Runbook — Start a Session
+
+From inside your assigned worktree (PowerShell):
+
+```powershell
+# Verify you are in the right worktree on the right branch
+cd C:\dev\trendingrepo-wt\tl       # example for slot tl
+git rev-parse --show-toplevel       # must match the worktree path
+git branch --show-current           # must be bot/swarm-tl-claude
+
+# Sync to remote tip of your branch
+git fetch origin
+git pull --rebase origin bot/swarm-tl-claude
+
+# Read mandatory session-opening docs (CLAUDE.md step 1-7)
+# - CLAUDE.md, docs/ENGINE.md, docs/SITE-WIREMAP.md
+# - docs/AUDIT-2026-05-04.md, docs/forensic/00-INDEX.md
+# - tasks/CURRENT-SPRINT.md, tasks/BACKLOG.md
+# - npm run freshness:check
+
+# Start dev server on this slot's port
+npm run dev -- -p $env:PORT         # PORT is sourced from .env.local
+```
+
+Confirm the port and worktree match the slot before doing any work. If the port is wrong, the Vercel Preview screenshot will not match what the agent verifies locally.
+
+---
+
+## Runbook — Ship a Change
+
+From inside your worktree only:
+
+```powershell
+# 1. Stage exact files (one git add per path)
+git add src/components/Foo.tsx
+git add src/components/Foo.test.tsx
+
+# 2. Commit immediately — do not let staging linger
+git commit -m "feat(foo/AGN-1234): explicit summary"
+
+# 3. Push to your branch
+git push origin bot/swarm-tl-claude
+
+# 4. Open the draft PR (first push only)
+gh pr create --draft --base main --head bot/swarm-tl-claude `
+  --title "AGN-1234: explicit summary" `
+  --body "Summary + test plan"
+
+# 5. Wait for Vercel Preview check (~3 min). Capture URL from PR checks panel.
+gh pr checks --watch
+
+# 6. Verify visual changes against the Preview URL (M4: visual fix needs visual proof).
+
+# 7. Mark PR ready and merge via the main checkout (human or CI).
+gh pr ready
+```
+
+Repeat steps 1-3 for every Write. Do not batch.
+
+---
+
+## Vercel Previews
+
+- Each push to `bot/swarm-{tl,tr,bl,br}-{claude,codex}` creates a Preview at:
+  ```
+  https://starscreener-git-bot-swarm-<slug>-<vercel-org>.vercel.app
+  ```
+- The Preview URL appears in the PR's GitHub checks panel within ~3 min.
+- The Preview is the canonical visual proof surface. `tsc`, `npm run build`, `curl 200` are not visual proof.
+- If the Preview does not reflect your latest commit, you forgot to push (rule 4).
+
+---
+
+## Anti-Patterns
+
+### Staged-file theft (already burned, 2026-05-02)
+
+**Symptom:** Agent A writes `file-a.ts` and runs `git add -A`. Agent B, working concurrently in the same checkout, writes `file-b.ts` and runs `git commit -m "wip(b)"`. Agent B's commit contains both `file-a.ts` and `file-b.ts`. Agent A's later `git commit` is empty or carries someone else's work.
+
+**Why it happens:** Staging (`.git/index`) is per-checkout, not per-process. `git add` mutates a shared file. `git commit` snapshots whatever is staged at that instant — author identity does not enter into it.
+
+**Why worktrees fix it:** Each worktree has its own `index` file. `C:\dev\trendingrepo-wt\tl\.git` (a pointer file) resolves to a worktree-specific index under the main `.git/worktrees/tl/index`. Two worktrees cannot stomp each other's stage.
+
+**Why worktrees only fix it if the contract is followed:** If an agent `cd`s into another agent's worktree (rule 1) or runs `git add -A` from a path that resolves to the wrong worktree, the isolation collapses. Rules 1 and 2 are the load-bearing ones.
+
+### `.next` cache race
+
+Running `npm run dev` or `npm run build` from `C:\dev\trendingrepo` while the four worktree agents are also building corrupts the `.next` cache. Symptoms: phantom 500s, missing chunk graph, `ENOENT` loops on Windows + OneDrive (see memory `project_onedrive_dev_server_block`). The main checkout is read-only during swarm operation.
+
+### Cross-branch merges
+
+`git merge bot/swarm-tr-claude` from a `bot/swarm-tl-claude` worktree imports unreviewed code, defeats branch protection, and produces a Preview that does not match either agent's PR. Cross-agent dependencies go through `main` (rule 7).
+
+---
+
+## Coordination
+
+- The user (Basil) assigns tasks in chat per session ("tl: AGN-1234, br: AGN-1500"). No shared task list across sessions.
+- Each session may use its own `TaskCreate` to break its task into subtasks. The harness scopes these per-session — they do not leak across agents.
+- Shared schema or shared module changes: upstream agent ships first to `main`, downstream agent rebases. Announce in chat once the upstream PR is merged so the downstream knows to rebase.
+
+---
+
+*Authoritative spec — agents must read this on session start. CLAUDE.md links here.*

--- a/tasks/perf-windows-tuning.md
+++ b/tasks/perf-windows-tuning.md
@@ -1,0 +1,254 @@
+# Windows Performance Tuning — Deferred Sprint
+
+Owner: Basil. Single 30-min admin PowerShell session. Queued from the 2026-05-06 "move repo off OneDrive + 2x2 swarm" plan; perf hardening was deferred so the swarm could start sooner.
+
+Run every step in an **elevated PowerShell** (Run as Administrator). Do not skip the verify line — if it doesn't print the expected output, stop and diagnose before moving on.
+
+---
+
+## 1. Windows Defender exclusions
+
+WHY: `Antimalware Service Executable` pegs CPU during long Claude Code sessions, `npm install`, `tsc`, and `next build` because Defender scans every one of the ~50,000 file events a Node toolchain emits. Path + process exclusions remove that scan cost without weakening Defender for the rest of the system.
+
+```powershell
+# Paths
+Add-MpPreference -ExclusionPath "C:\dev"
+Add-MpPreference -ExclusionPath "$env:USERPROFILE\.claude"
+Add-MpPreference -ExclusionPath "$env:APPDATA\npm"
+Add-MpPreference -ExclusionPath "$env:APPDATA\npm-cache"
+Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\npm-cache"
+Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\pnpm"
+Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\Yarn"
+Add-MpPreference -ExclusionPath "$env:USERPROFILE\AppData\Roaming\Anthropic"
+
+# Processes
+Add-MpPreference -ExclusionProcess "node.exe"
+Add-MpPreference -ExclusionProcess "npm.exe"
+Add-MpPreference -ExclusionProcess "pnpm.exe"
+Add-MpPreference -ExclusionProcess "yarn.exe"
+Add-MpPreference -ExclusionProcess "git.exe"
+Add-MpPreference -ExclusionProcess "claude.exe"
+Add-MpPreference -ExclusionProcess "Code.exe"
+Add-MpPreference -ExclusionProcess "WindowsTerminal.exe"
+Add-MpPreference -ExclusionProcess "powershell.exe"
+Add-MpPreference -ExclusionProcess "pwsh.exe"
+```
+
+Verify:
+```powershell
+Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
+Get-MpPreference | Select-Object -ExpandProperty ExclusionProcess
+```
+
+Caveat: do NOT disable Defender entirely. Exclusions only.
+
+---
+
+## 2. Ultimate Performance power plan
+
+WHY: Default Balanced throttles CPU during sustained loads (long builds, swarm runs). Ultimate Performance removes the throttle.
+
+```powershell
+powercfg -duplicatescheme e9a42b02-d5df-448d-aa00-03f14749eb61
+powercfg -setactive e9a42b02-d5df-448d-aa00-03f14749eb61
+powercfg -getactivescheme
+```
+
+Verify: `getactivescheme` prints the Ultimate Performance GUID (`e9a42b02-d5df-448d-aa00-03f14749eb61`).
+
+---
+
+## 3. Long path support
+
+WHY: Required for deep `node_modules` trees. Without it, paths over 260 chars fail and break installs/builds non-deterministically.
+
+```powershell
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+git config --global core.longpaths true
+```
+
+Verify:
+```powershell
+(Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem").LongPathsEnabled  # -> 1
+git config --global core.longpaths                                                              # -> true
+```
+
+---
+
+## 4. Git performance config
+
+WHY: fscache + preloadindex + manyFiles cut `git status` from seconds to milliseconds on large trees. `gc.auto 256` keeps repacks cheap.
+
+```powershell
+git config --global core.fscache true
+git config --global core.preloadindex true
+git config --global gc.auto 256
+git config --global core.autocrlf input
+git config --global feature.manyFiles true
+```
+
+NOTE: `core.autocrlf input` (NOT `true`). `true` rewrites LF->CRLF on checkout and breaks Linux line endings on Vercel.
+
+Verify:
+```powershell
+git config --global --get-regexp '^(core|gc|feature)\.'
+```
+
+---
+
+## 5. Node memory ceiling
+
+WHY: Large Next.js builds OOM at the default 1.5–4 GB Node heap.
+
+Add to `$PROFILE`:
+```powershell
+$env:NODE_OPTIONS = "--max-old-space-size=8192"
+```
+
+Bump to `12288` if the machine has 32+ GB RAM.
+
+Verify: open a new shell, then:
+```powershell
+$env:NODE_OPTIONS   # -> --max-old-space-size=8192
+```
+
+---
+
+## 6. Disable Windows Search indexing for C:\dev
+
+WHY: Search indexer re-reads every file change in `C:\dev`, doubling disk IO during builds. There is no clean PowerShell equivalent for the per-folder index attribute on Windows 11 — this is a manual GUI step.
+
+Steps:
+1. File Explorer -> right-click `C:\dev` -> **Properties**
+2. **Advanced…** -> uncheck **"Allow files in this folder to have contents indexed in addition to file properties"**
+3. OK -> **Apply changes to this folder, subfolders and files**
+4. If prompted on access-denied items: **Ignore All**
+
+Verify: re-open Properties -> Advanced -> checkbox is unchecked.
+
+---
+
+## 7. Claude Code effort defaults
+
+WHY: `xhigh` is the right daily default for senior-engineer-grade work. `max` is prone to overthinking per Anthropic's own guidance — reach for it via `/effort max` per-task only on architecture or hard debugging.
+
+```powershell
+[Environment]::SetEnvironmentVariable("CLAUDE_CODE_EFFORT_LEVEL", "xhigh", "User")
+[Environment]::SetEnvironmentVariable("ANTHROPIC_MODEL", "claude-opus-4-7", "User")
+[Environment]::SetEnvironmentVariable("NODE_OPTIONS", "--max-old-space-size=8192", "User")
+```
+
+Verify: open a new terminal, run `claude`, confirm the status bar shows `xhigh · /effort` and `opus 4.7`.
+
+---
+
+## 8. Proactivity Protocol — addition to CLAUDE.md
+
+WHY: The repo's CLAUDE.md sets behavioral defaults for every session. The current rules cover *what* to investigate (M1–M6) but not the *cadence* of acting vs asking. Add the Proactivity Protocol as a new section at the bottom of `CLAUDE.md` (root of repo).
+
+Append verbatim:
+
+```markdown
+## Proactivity Protocol
+
+You are the [LEAD] CTO operating a live production system. Default to action,
+not deference. Specifically:
+
+- Investigate before asking. If a question can be answered by reading 3 or
+  fewer files or running one command, do it instead of asking.
+- Verify, don't assume. Memory is a hint, not proof. Check with grep, Glob,
+  Bash, browser, logs, or API responses. Cite the evidence.
+- Surface findings, don't bury them. When you discover something the user
+  didn't ask about but should know — broken cron, drifting Redis schema,
+  missing auth header — flag it explicitly with "HEADS UP:" before
+  continuing the original task.
+- Propose next steps. End substantive responses with "Next, I recommend X
+  because Y" or "Open questions: ...". Never end with passive "Let me know
+  what you'd like."
+- Plan, then execute. For changes touching >2 files: enter plan mode,
+  produce a numbered plan, wait for approval, execute. For <=2 files: edit
+  directly and report what you did.
+- Escalate when blocked. After 2 failed approaches, stop and write a short
+  diagnostic ("here's what I tried, here's what I saw, here are 3 options")
+  rather than thrashing on a third.
+- Use subagents proactively. For tasks touching >=10 files or >=3 independent
+  domains, spawn parallel research subagents and synthesize. Do not ask
+  permission first.
+- Run validators automatically. After any code edit: npm run typecheck and
+  the relevant npm test <file>. Report pass/fail without being asked.
+- Don't perform false modesty. If you're confident, say so. If uncertain,
+  say what would resolve the uncertainty.
+
+When in doubt about whether to act or ask: ACT. The user can always tell
+you to back off. The user cannot recover wasted turns.
+```
+
+Verify: `git diff CLAUDE.md` shows the new section appended; commit with message `docs(claude): add Proactivity Protocol`.
+
+---
+
+## 9. Optional but high-impact: Windows Terminal + PowerShell 7
+
+WHY: PowerShell 7 (`pwsh.exe`) starts ~3x faster than Windows PowerShell 5.1 and has materially better JSON handling (`ConvertFrom-Json -AsHashtable`, `??`, `?.`, ternary).
+
+Install if missing:
+```powershell
+winget install --id Microsoft.PowerShell -e
+```
+
+Then in **Windows Terminal -> Settings -> Startup -> Default profile** select **PowerShell** (the 7.x entry, not "Windows PowerShell").
+
+Verify: open a new tab, run `$PSVersionTable.PSVersion` -> major version 7+.
+
+---
+
+## 10. NOT recommended this sprint
+
+- **WSL2 migration.** Real wins available but a 2–4 hour project on its own. Native Windows + the above recovers most of the lost performance.
+- **Disabling Defender entirely.** Exclusions only.
+- **`bypassPermissions` mode in Claude Code on production code.** Stay in default permissions on this repo.
+
+---
+
+## Verification harness
+
+Run end-to-end after all steps. Paste the output into the next session so the next agent can confirm the box is hardened.
+
+```powershell
+Write-Host "=== Defender exclusions ===" -ForegroundColor Cyan
+Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
+Write-Host ""
+Get-MpPreference | Select-Object -ExpandProperty ExclusionProcess
+
+Write-Host "`n=== Power plan ===" -ForegroundColor Cyan
+powercfg -getactivescheme
+
+Write-Host "`n=== Long paths ===" -ForegroundColor Cyan
+"LongPathsEnabled = $((Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem').LongPathsEnabled)"
+"git core.longpaths = $(git config --global core.longpaths)"
+
+Write-Host "`n=== Git config ===" -ForegroundColor Cyan
+git config --global --get-regexp '^(core|gc|feature)\.'
+
+Write-Host "`n=== Node + Claude env ===" -ForegroundColor Cyan
+"NODE_OPTIONS = $([Environment]::GetEnvironmentVariable('NODE_OPTIONS','User'))"
+"CLAUDE_CODE_EFFORT_LEVEL = $([Environment]::GetEnvironmentVariable('CLAUDE_CODE_EFFORT_LEVEL','User'))"
+"ANTHROPIC_MODEL = $([Environment]::GetEnvironmentVariable('ANTHROPIC_MODEL','User'))"
+
+Write-Host "`n=== PowerShell version ===" -ForegroundColor Cyan
+$PSVersionTable.PSVersion
+```
+
+Expected: every section non-empty, GUID matches Ultimate Performance, `LongPathsEnabled = 1`, env vars set, PSVersion 7+.
+
+---
+
+## Reboot
+
+Final step. Env vars and Defender prefs need a fresh process tree — without reboot, half the changes don't take effect.
+
+```powershell
+Restart-Computer
+```
+
+After reboot, re-run the verification harness once more and confirm the Claude Code status bar shows `xhigh · /effort` and `opus 4.7`. Then this sprint is closed.


### PR DESCRIPTION
Adds `docs/SWARM-2x2.md` (the swarm operating contract — worktree-per-agent topology, 8-rule contract, port assignments, ship runbook) and `tasks/perf-windows-tuning.md` (deferred Windows perf sprint). Updates `CLAUDE.md` with reference to the contract, adds the Multi-Agent Setup section, and updates the memory path post-OneDrive cutover.

Cherry-picked from `bot/frontend/AGN-522` commit `e213cd76`. The original commit also touched `.gitignore`; that hunk is intentionally excluded here and lives in PR #195 (chore/gitignore-scratch) so each concern lands independently.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>