### PR TITLE
fix(workflows/AGN-861): port check-nitter to PR + auto-merge action

### DIFF
--- a/.github/workflows/check-nitter.yml
+++ b/.github/workflows/check-nitter.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,8 +23,8 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       - name: Commit nitter status update
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add config/nitter-instances.json
-          git diff --cached --quiet || (git commit -m "chore: nitter health update" && git push)
+        uses: ./.github/actions/git-commit-data
+        with:
+          message: "chore: nitter health update"
+          paths: |
+            config/nitter-instances.json


### PR DESCRIPTION
Last remaining direct-pusher fixed. Daily nitter health check has been failing GH006 since the branch protection went on. Pattern matches PR #190 (the 26-workflow migration).