### PR TITLE
fix(actions/AGN-861-followup): allow data-bot action to use PAT for CI triggering

### DIFF
--- a/.github/actions/git-commit-data/action.yml
+++ b/.github/actions/git-commit-data/action.yml
@@ -53,6 +53,20 @@ inputs:
       output every run). Default false: missing paths fail loud.
     required: false
     default: "false"
+  gh-token:
+    description: |
+      Token used for `git push` and `gh pr create` / `gh pr merge`.
+      Defaults to the workflow-provided GITHUB_TOKEN. To allow the
+      auto-generated PR to trigger required status checks
+      (workflow_run / pull_request), pass a fine-grained PAT or
+      GitHub App token via a repo secret — GitHub deliberately
+      suppresses workflow triggers for actions performed by
+      GITHUB_TOKEN to prevent infinite loops, which leaves data
+      PRs stuck waiting for branch-protection checks that will
+      never run. Empty string falls back to GITHUB_TOKEN.
+      See docs/DATA-BOT-PAT-SETUP.md.
+    required: false
+    default: ${{ github.token }}
 
 outputs:
   committed:
@@ -84,7 +98,11 @@ runs:
         RUN_ATTEMPT: ${{ github.run_attempt }}
         # `gh` reads GH_TOKEN automatically; the calling workflow MUST
         # declare permissions: { contents: write, pull-requests: write }.
-        GH_TOKEN: ${{ github.token }}
+        # The `|| github.token` fallback handles a workflow that wires
+        # `gh-token: ${{ secrets.DATA_BOT_TOKEN }}` while the secret is
+        # unset on a fork or pre-rollout repo — empty string would
+        # otherwise unauthenticate `gh` entirely.
+        GH_TOKEN: ${{ inputs.gh-token != '' && inputs.gh-token || github.token }}
       run: |
         set -euo pipefail
         git config user.name  "$INPUT_ACTOR_NAME"
@@ -127,7 +145,20 @@ runs:
         # Push the commit to the data-bot branch (force-with-lease in case
         # of a rerun colliding on the same name — should not happen given
         # run-attempt suffix, but cheap insurance).
-        git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
+        #
+        # Push to an explicit token-embedded URL rather than reusing the
+        # remote configured by actions/checkout (which is bound to
+        # GITHUB_TOKEN via http.extraheader). When GH_TOKEN is a PAT or
+        # GitHub App token, the resulting push is attributed to that
+        # identity, which lets workflow_run / pull_request triggers fire
+        # on the auto-generated data PR — GITHUB_TOKEN-authored events
+        # are deliberately suppressed by GitHub to prevent infinite
+        # loops, which leaves data PRs stuck waiting for required status
+        # checks that never run. (AGN-861 follow-up: 30+ data PRs stalled.)
+        # The `-c http.extraheader=` empties the checkout-configured
+        # header so the URL credential is the one git actually sends.
+        PUSH_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git -c http.extraheader= push --force-with-lease "$PUSH_URL" "HEAD:refs/heads/${BRANCH}"
 
         # Open the PR. Body intentionally minimal — automation noise stays
         # out of the activity feed but operators can click through to the

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -108,6 +108,12 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          # Pass DATA_BOT_TOKEN so the auto-PR triggers required status
+          # checks (workflow_run / pull_request). GITHUB_TOKEN-authored
+          # PRs are suppressed by GitHub, which strands them at branch
+          # protection. Empty/unset secret falls back to GITHUB_TOKEN
+          # inside the action — see docs/DATA-BOT-PAT-SETUP.md.
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh fast discovery snapshots ${{ steps.ts.outputs.value }}"
           paths: |
             data/trending.json

--- a/docs/DATA-BOT-PAT-SETUP.md
+++ b/docs/DATA-BOT-PAT-SETUP.md
@@ -1,0 +1,88 @@
+# Data-bot PAT setup (`DATA_BOT_TOKEN`)
+
+## Why this exists
+
+GitHub deliberately suppresses `workflow_run` and `pull_request` triggers
+when an action is performed by `GITHUB_TOKEN` — anti-infinite-loop
+protection. The 26 cron data-collection workflows in this repo all push
+a "data" branch and open a PR via `.github/actions/git-commit-data`.
+With the default token, those PRs sit forever waiting for the required
+`Typecheck, guards, tests, build, e2e` status check, which never runs
+because the PR's `pull_request` event is suppressed. Branch protection
+then blocks the merge. Result before this fix: 30+ stuck open data PRs.
+
+The action now accepts an optional `gh-token` input. Passing a PAT or
+GitHub App installation token attributes the push to a non-Actions
+identity, which lets CI fire normally.
+
+## Mint the token (pick one)
+
+### Option A — fine-grained PAT (faster, expires)
+
+1. github.com → Settings → Developer settings → Personal access tokens →
+   Fine-grained tokens → **Generate new token**
+2. Resource owner: `0motionguy`. Repository access: `0motionguy/starscreener`.
+3. Repository permissions:
+   - **Contents:** Read and write
+   - **Pull requests:** Read and write
+   - **Actions:** Read
+   - **Metadata:** Read (auto-required)
+4. Expiration: 90 days max (set a calendar reminder to rotate).
+5. Generate and copy the token.
+
+### Option B — GitHub App (preferred, no expiry)
+
+1. Settings → Developer settings → GitHub Apps → **New GitHub App**.
+2. Permissions: `contents:write`, `pull_requests:write`, `actions:read`.
+3. Install on `0motionguy/starscreener`.
+4. Generate an installation token via your existing app-token action
+   (e.g. `actions/create-github-app-token@v1`) inside each workflow.
+   Pass the resulting token as `gh-token`.
+
+Option B is the long-term answer (no rotation). Option A unblocks the
+current backlog today.
+
+## Store as a repo secret
+
+`gh secret set DATA_BOT_TOKEN --repo 0motionguy/starscreener --body "<token>"`
+
+Or via the UI: Settings → Secrets and variables → Actions →
+**New repository secret** → name `DATA_BOT_TOKEN`.
+
+## Roll out to workflows
+
+The action defaults `gh-token` to `${{ github.token }}`, so workflows
+that don't pass `gh-token` keep working with the legacy (broken)
+behavior. Migration is per-workflow, additive:
+
+```yaml
+- uses: ./.github/actions/git-commit-data
+  with:
+    gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+    message: "..."
+    paths: |
+      ...
+```
+
+If `DATA_BOT_TOKEN` is unset on a fork or before rollout, the action
+falls back to `GITHUB_TOKEN` automatically — empty-secret-safe.
+
+## Rollout order (recommended)
+
+`scrape-trending.yml` is wired as the reference example in this PR.
+After verifying CI fires on its next data PR, bulk-update the remaining
+25 callers via grep:
+
+```bash
+grep -rl 'git-commit-data' .github/workflows/
+```
+
+Drain the stuck PR backlog by re-running each workflow once the secret
+is in place — the next data PR from each will trigger CI and merge.
+
+## Rotation
+
+Fine-grained PATs expire. When `gh-token` 401s, the push step fails
+loud (no silent fallback to GITHUB_TOKEN once a value is passed). Mint
+a replacement and update the secret. GitHub App tokens (Option B) are
+minted per-run by the app-token action and don't need rotation.


### PR DESCRIPTION
## Root cause

`.github/actions/git-commit-data` uses `GITHUB_TOKEN` for both `git push` and `gh pr create` / `gh pr merge`. GitHub deliberately suppresses `workflow_run` and `pull_request` triggers when the actor is `GITHUB_TOKEN` (anti-infinite-loop). The required status check `Typecheck, guards, tests, build, e2e` therefore never runs on data PRs, branch protection blocks the merge, and 30+ data PRs are stranded open.

## Fix

Add an optional `gh-token` input to the action (defaults to `${{ github.token }}`, falls back if empty). Calling workflows can now pass a fine-grained PAT or GitHub App token via `secrets.DATA_BOT_TOKEN` to attribute the push to a non-Actions identity, which lets CI fire normally.

The token is wired into both:
- **`git push`** — uses a token-embedded URL that overrides the `http.extraheader` configured by `actions/checkout`.
- **`gh pr create` / `gh pr merge`** — the existing `GH_TOKEN` env var, now sourced from the input.

Empty/unset secret falls back to `GITHUB_TOKEN`, so all 26 existing callers keep working unchanged. Migration is per-workflow and additive.

## Files changed

- `.github/actions/git-commit-data/action.yml` (~25 line diff: new input + token wiring)
- `.github/workflows/scrape-trending.yml` (+7 lines: reference example for the pattern)
- `docs/DATA-BOT-PAT-SETUP.md` (NEW, ~70 lines: PAT vs GitHub App, secret setup, rollout order, rotation)

## Follow-ups (separate PRs)

1. Mint `DATA_BOT_TOKEN` secret on `0motionguy/starscreener`.
2. Verify CI fires on `scrape-trending`'s next data PR (single-workflow soak).
3. Bulk-update the remaining 25 callers to pass `gh-token`. High-priority candidates are the highest-volume cron workflows (Twitter, Reddit, GitHub-trending) since they generate the most stuck PRs.
4. Drain the stuck data-PR backlog by re-running each workflow once the secret is in place.

## Test plan

- [ ] Mint `DATA_BOT_TOKEN` per `docs/DATA-BOT-PAT-SETUP.md`.
- [ ] Trigger `Refresh fast discovery` manually (`gh workflow run scrape-trending.yml`).
- [ ] Confirm the resulting `data/refresh-fast-discovery-*` PR shows the `Typecheck, guards, tests, build, e2e` check running (not stuck pending).
- [ ] Confirm auto-merge fires once the check passes.
- [ ] Without the secret set, confirm the action still works (falls back to `GITHUB_TOKEN`, PR still created, CI still suppressed — same as today).
