### PR TITLE
chore(workflows/AGN-861-followup): roll out DATA_BOT_TOKEN to remaining 25 data workflows

### DIFF
--- a/.github/workflows/check-nitter.yml
+++ b/.github/workflows/check-nitter.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Commit nitter status update
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore: nitter health update"
           paths: |
             config/nitter-instances.json

--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -34,6 +34,7 @@ jobs:
         name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-name: "github-actions[bot]"
           actor-email: "github-actions[bot]@users.noreply.github.com"
           message: "chore: auto-update funding signals [skip ci]"

--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -91,6 +91,7 @@ jobs:
           HUSKY: "0"
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh twitter signals ${{ steps.ts.outputs.value }}"
           paths: |
             .data/twitter-repo-signals.jsonl

--- a/.github/workflows/cron-agent-commerce.yml
+++ b/.github/workflows/cron-agent-commerce.yml
@@ -127,6 +127,7 @@ jobs:
         id: commit-step
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "data(agent-commerce): refresh pipeline ${{ steps.ts.outputs.value }}"
           ignore-missing: "true"
           paths: |

--- a/.github/workflows/cron-freshness-check.yml
+++ b/.github/workflows/cron-freshness-check.yml
@@ -151,6 +151,7 @@ jobs:
         # empty-commit per cycle.
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(ops): cron health ${{ steps.probe.outputs.status }}"
           paths: |

--- a/.github/workflows/enrich-arxiv.yml
+++ b/.github/workflows/enrich-arxiv.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh arxiv enrichment ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/enrich-repo-profiles.yml
+++ b/.github/workflows/enrich-repo-profiles.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh repo profiles ${{ steps.ts.outputs.value }}"
           paths: |
             data/repo-profiles.json

--- a/.github/workflows/ping-mcp-liveness.yml
+++ b/.github/workflows/ping-mcp-liveness.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh mcp liveness ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/promote-unknown-mentions.yml
+++ b/.github/workflows/promote-unknown-mentions.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): promote unknown mentions ${{ steps.ts.outputs.value }}"
           paths: |
             data/unknown-mentions-promoted.json

--- a/.github/workflows/refresh-collection-rankings.yml
+++ b/.github/workflows/refresh-collection-rankings.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh collection rankings ${{ steps.ts.outputs.value }}"
           paths: |
             data/collection-rankings.json

--- a/.github/workflows/refresh-reddit-baselines.yml
+++ b/.github/workflows/refresh-reddit-baselines.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh reddit baselines ${{ steps.ts.outputs.value }}"
           paths: |
             data/reddit-baselines.json

--- a/.github/workflows/run-shadow-scoring.yml
+++ b/.github/workflows/run-shadow-scoring.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Commit report if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh scoring shadow report ${{ steps.ts.outputs.value }}"
           paths: |
             data/scoring-shadow-report.json

--- a/.github/workflows/scrape-arxiv.yml
+++ b/.github/workflows/scrape-arxiv.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh arxiv signals ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/scrape-awesome-skills.yml
+++ b/.github/workflows/scrape-awesome-skills.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh awesome-skills index ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/scrape-bluesky.yml
+++ b/.github/workflows/scrape-bluesky.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh bluesky signals ${{ steps.ts.outputs.value }}"
           paths: |
             data/bluesky-mentions.json

--- a/.github/workflows/scrape-claude-rss.yml
+++ b/.github/workflows/scrape-claude-rss.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh Claude (Anthropic) news ${{ steps.ts.outputs.value }}"
           paths: |
             data/claude-rss.json

--- a/.github/workflows/scrape-devto.yml
+++ b/.github/workflows/scrape-devto.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh dev.to signals ${{ steps.ts.outputs.value }}"
           paths: |
             data/devto-mentions.json

--- a/.github/workflows/scrape-huggingface-datasets.yml
+++ b/.github/workflows/scrape-huggingface-datasets.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh huggingface dataset signals ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/scrape-huggingface-spaces.yml
+++ b/.github/workflows/scrape-huggingface-spaces.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh huggingface space signals ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/scrape-huggingface.yml
+++ b/.github/workflows/scrape-huggingface.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh huggingface signals ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/scrape-lobsters.yml
+++ b/.github/workflows/scrape-lobsters.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh lobsters signals ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/scrape-npm.yml
+++ b/.github/workflows/scrape-npm.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh npm package telemetry ${{ steps.ts.outputs.value }}"
           paths: |
             data/npm-packages.json

--- a/.github/workflows/scrape-openai-rss.yml
+++ b/.github/workflows/scrape-openai-rss.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh OpenAI news ${{ steps.ts.outputs.value }}"
           paths: |
             data/openai-rss.json

--- a/.github/workflows/scrape-producthunt.yml
+++ b/.github/workflows/scrape-producthunt.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh ProductHunt launches ${{ steps.ts.outputs.value }}"
           paths: |
             data/producthunt-launches.json

--- a/.github/workflows/sweep-staleness.yml
+++ b/.github/workflows/sweep-staleness.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           actor-email: "bot@trendingrepo.com"
           message: "chore(data): refresh staleness report ${{ steps.ts.outputs.value }}"
           paths: |

--- a/.github/workflows/sync-trustmrr.yml
+++ b/.github/workflows/sync-trustmrr.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Commit if changed
         uses: ./.github/actions/git-commit-data
         with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "chore(data): refresh trustmrr overlays ${{ steps.ts.outputs.value }}"
           paths: |
             data/trustmrr-startups.json


### PR DESCRIPTION
Follow-up to #307. After #307 + DATA_BOT_TOKEN secret are in place, the remaining 25 workflows need the gh-token input passed too. Draft until #307 merges.

## What

Adds `gh-token: ${{ secrets.DATA_BOT_TOKEN }}` as the first `with:` input to the `./.github/actions/git-commit-data` invocation in 26 workflows. Mirrors the pattern PR #307 wired into `scrape-trending.yml`.

## Why

PR #307 added the `gh-token` input to the action and used it in `scrape-trending.yml` only. Without this PR, the other 26 callers fall back to `GITHUB_TOKEN`, which suppresses `pull_request` / `workflow_run` triggers — required CI checks never run, branch protection blocks the merge, data PRs stack up.

## Files changed (26)

- check-nitter.yml
- collect-funding.yml
- collect-twitter.yml
- cron-agent-commerce.yml
- cron-freshness-check.yml
- enrich-arxiv.yml
- enrich-repo-profiles.yml
- ping-mcp-liveness.yml
- promote-unknown-mentions.yml
- refresh-collection-rankings.yml
- refresh-reddit-baselines.yml
- run-shadow-scoring.yml
- scrape-arxiv.yml
- scrape-awesome-skills.yml
- scrape-bluesky.yml
- scrape-claude-rss.yml
- scrape-devto.yml
- scrape-huggingface-datasets.yml
- scrape-huggingface-spaces.yml
- scrape-huggingface.yml
- scrape-lobsters.yml
- scrape-npm.yml
- scrape-openai-rss.yml
- scrape-producthunt.yml
- sweep-staleness.yml
- sync-trustmrr.yml

## Test plan

- [ ] Confirm `DATA_BOT_TOKEN` secret is set on `0motionguy/starscreener` (per docs/DATA-BOT-PAT-SETUP.md).
- [ ] Confirm `scrape-trending.yml`'s next data PR triggers the required `Typecheck, guards, tests, build, e2e` check (single-workflow soak from #307).
- [ ] Mark this PR ready, merge.
- [ ] Trigger one of the rolled-out workflows manually (e.g. `gh workflow run scrape-bluesky.yml`) and confirm the resulting data PR runs CI and auto-merges.
- [ ] Drain the 30+ stuck data-PR backlog by re-running each workflow once.