### PR TITLE
fix(gitignore/AGN-195-followup): allowlist 3 .data/*.jsonl committed by cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ next-env.d.ts
 !/.data/twitter-repo-signals.jsonl
 !/.data/twitter-scans.jsonl
 !/.data/twitter-ingestion-audit.jsonl
+!/.data/trending-dual-write-trace.jsonl
+!/.data/aiso-rescan-queue.jsonl
+!/.data/mcp-usage.jsonl
 
 # local Claude Code workspace (agent prompts, skills, settings)
 /.claude/


### PR DESCRIPTION
﻿## Summary

PR #195 tightened `.gitignore` (`/.data/*` blanket ignore + explicit allowlist), but the allowlist was incomplete — 3 trace/queue files written by cron workflows were omitted. As a result, three workflows now fail at the `git add` step with:

```
The following paths are ignored by one of your .gitignore files:
.data/trending-dual-write-trace.jsonl
```

This PR adds the missing 3 allowlist exceptions.

## Files allowlisted

| File | Producer |
|---|---|
| `.data/trending-dual-write-trace.jsonl` | `.github/workflows/scrape-trending.yml` (line 127) |
| `.data/aiso-rescan-queue.jsonl` | `.github/workflows/cron-agent-commerce.yml` (line 140) |
| `.data/mcp-usage.jsonl` | `.github/workflows/cron-mcp-usage-rotate.yml` (per AGN-861) |

Verified via `git log --all -- <file>`: none of the 3 have ever been committed yet (the workflows have been silently failing the commit step since #195 merged).

## Failure proof

GH Actions run [25473989390](https://github.com/0motionguy/starscreener/actions/runs/25473989390) (`scrape-trending`) shows the exact `git add` failure for `trending-dual-write-trace.jsonl`.

## Test plan

- [x] Diff is exactly 3 lines added to `.gitignore` (no other surface touched)
- [x] Pre-commit guard hooks pass locally
- [ ] Re-trigger `scrape-trending.yml` after merge — confirm the workflow can now `git add` + commit + auto-merge a data PR
