### PR TITLE
perf(ci/AGN-861-followup): split data-PR validator from full e2e suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # Data-only PRs (cron-driven auto-bot) skip the full e2e suite and run
+    # the lightweight `data-pr-validate` workflow instead. Code PRs still
+    # run this gate. See .github/workflows/data-pr-validate.yml.
+    paths-ignore:
+      - 'data/**'
+      - '.data/**'
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/data-pr-validate.yml
+++ b/.github/workflows/data-pr-validate.yml
@@ -1,0 +1,112 @@
+name: data-pr-validate
+
+# Lightweight gate for data-only PRs (cron-driven auto-bot writes under
+# data/** and .data/**). The full e2e suite in ci.yml is skipped for these
+# paths via paths-ignore; this workflow takes its place as the required
+# status check on data PRs. Two real validations:
+#   1. Every changed JSON / JSONL file parses cleanly.
+#   2. PR touches ONLY data/** or .data/** — rejects any attempt to
+#      smuggle code changes through the data path filter.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'data/**'
+      - '.data/**'
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same PR ref to avoid burning minutes.
+concurrency:
+  group: data-pr-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate data PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need history so `git diff origin/main...HEAD` works.
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate every changed JSON parses
+        shell: bash
+        run: |
+          set -euo pipefail
+          # NUL-delimited so paths with spaces / unusual chars stay intact.
+          mapfile -d '' changed < <(git diff -z --name-only --diff-filter=AM origin/main...HEAD -- 'data/**/*.json' '.data/**/*.json' '.data/**/*.jsonl' || true)
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No JSON / JSONL changes in data paths -- skipping validation"
+            exit 0
+          fi
+          echo "Validating ${#changed[@]} changed file(s)"
+          fail=0
+          for f in "${changed[@]}"; do
+            [ -z "$f" ] && continue
+            if [ ! -f "$f" ]; then
+              # Renamed / deleted in HEAD — skip.
+              continue
+            fi
+            case "$f" in
+              *.jsonl)
+                # JSONL: each non-blank line must parse as JSON. Stream the
+                # whole file into node once (cheaper than node-per-line).
+                if ! node -e '
+                  const fs = require("fs");
+                  const path = process.argv[1];
+                  const lines = fs.readFileSync(path, "utf8").split(/\r?\n/);
+                  let n = 0;
+                  for (let i = 0; i < lines.length; i++) {
+                    const line = lines[i];
+                    if (line.trim() === "") continue;
+                    try { JSON.parse(line); n++; }
+                    catch (e) {
+                      console.error("INVALID " + path + ":" + (i + 1) + " -- " + e.message);
+                      process.exit(1);
+                    }
+                  }
+                  console.log("ok " + path + " (" + n + " line(s))");
+                ' "$f"; then
+                  fail=1
+                fi
+                ;;
+              *.json)
+                if ! node -e '
+                  const fs = require("fs");
+                  const path = process.argv[1];
+                  try { JSON.parse(fs.readFileSync(path, "utf8")); console.log("ok " + path); }
+                  catch (e) { console.error("INVALID " + path + " -- " + e.message); process.exit(1); }
+                ' "$f"; then
+                  fail=1
+                fi
+                ;;
+            esac
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more JSON / JSONL files failed to parse"
+            exit 1
+          fi
+
+      - name: Confirm only data paths changed (security check)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Anything that is NOT under data/** or .data/** is a code change
+          # smuggled through the data-PR path filter -- reject it.
+          non_data=$(git diff --name-only origin/main...HEAD -- ':!data/**' ':!.data/**' || true)
+          if [ -n "$non_data" ]; then
+            echo "::error::Data PR contains non-data changes -- rejecting:"
+            echo "$non_data"
+            exit 1
+          fi
+          echo "ok PR touches only data/** and .data/**"


### PR DESCRIPTION
## Summary

Cron-driven data-bot PRs (auto-merge from `data/refresh-*` branches) currently trigger the full `Typecheck, guards, tests, build, e2e` job in `ci.yml` -- a ~6-minute matrix that builds Next 15, installs Playwright, and runs the production server. None of that exercises code; data PRs only touch `data/**` JSON snapshots.

This split adds `paths-ignore` for `data/**` and `.data/**` to the `pull_request` trigger in `ci.yml`, then introduces a new lightweight `data-pr-validate.yml` workflow that runs **only** on those paths and does two real validations:

- Every changed `*.json` and `*.jsonl` file parses cleanly (per-line for JSONL, blank lines tolerated, CRLF tolerated).
- The PR contains **only** changes under `data/**` or `.data/**` -- any code file smuggled through the data-PR path filter fails the run with a clear error. This is the security gate that prevents the split from becoming a branch-protection bypass.

Net effect: data PRs go from ~6 min to <1 min; code PRs are unchanged.

## ONE-TIME REPO SETTING (required BEFORE merge)

Branch protection on `main` currently requires the status check named `Typecheck, guards, tests, build, e2e`. After `paths-ignore` lands, that check will not fire on data PRs at all -- the PR would sit forever waiting for a check that never starts. Two options to fix, pick one:

**Option A (recommended) -- require BOTH checks:**

1. Open https://github.com/0motionguy/starscreener/settings/branches
2. Edit the rule on `main` -> "Require status checks to pass before merging"
3. Keep `Typecheck, guards, tests, build, e2e` (still required for code PRs)
4. ADD `Validate data PR` (the job name from the new workflow)
5. With `paths-ignore` / `paths` on each workflow, exactly one of the two will fire per PR -- and the one that fires must pass

**Option B -- single shared check name:** Drop the existing required check and require only a generic name; not recommended because the e2e job's identity is useful in the audit log.

## What changed

- `.github/workflows/ci.yml` -- added `paths-ignore: ['data/**', '.data/**']` to the `pull_request` trigger only (push + workflow_dispatch unchanged so `main` is still gated end-to-end).
- `.github/workflows/data-pr-validate.yml` -- new file, ~110 lines. Job name `Validate data PR`. Uses `actions/checkout@v4` with `fetch-depth: 0` so `git diff origin/main...HEAD` works. No npm install -- pure node JSON.parse. 5-minute timeout. `concurrency` cancel-in-progress matches the main CI workflow.

## Edge cases handled

- Empty diff -> exits 0 with "No JSON / JSONL changes" message
- JSONL files with blank lines -> skipped via `if (line.trim() === "") continue`
- CRLF line endings -> `split(/\r?\n/)`
- Renamed / deleted files in HEAD -> `[ ! -f "$f" ] && continue`
- Paths with spaces / special chars -> `git diff -z` + `mapfile -d ''`
- Binary files in `.data/` -> excluded by glob (only `*.json` and `*.jsonl` matched)
- Both validation steps fail loudly with `::error::` annotations for GitHub UI surfacing

## Test plan

- [ ] Verify both workflow files parse via `gh workflow view` after merge
- [ ] Open a follow-up data-only PR and confirm only `Validate data PR` runs (not the full gate)
- [ ] Open a follow-up code PR and confirm only the full gate runs (not data-pr-validate)
- [ ] Negative test: open a PR that touches both `data/foo.json` AND a code file -- both workflows should fire AND data-pr-validate should fail at the security check

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
