### PR TITLE
fix(gitignore/AGN-195-followup): allowlist 3 .data/*.jsonl committed by cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ next-env.d.ts
 !/.data/twitter-repo-signals.jsonl
 !/.data/twitter-scans.jsonl
 !/.data/twitter-ingestion-audit.jsonl
+!/.data/trending-dual-write-trace.jsonl
+!/.data/aiso-rescan-queue.jsonl
+!/.data/mcp-usage.jsonl
 
 # local Claude Code workspace (agent prompts, skills, settings)
 /.claude/


### PR DESCRIPTION
Reshipping #309 (closed accidentally). 11+ cron workflows fail every tick on git add — they try to commit .data/*.jsonl trace/queue files that PR #195 broadened the gitignore to block. None ever committed (git log empty for all 3), but workflows clearly intend to commit them. Three-line allowlist fix.

Verified failure: https://github.com/0motionguy/starscreener/actions/runs/25473989390 shows: `The following paths are ignored by one of your .gitignore files: .data/trending-dual-write-trace.jsonl`.