### PR TITLE
fix(ci): keep required check for data PRs

### DIFF
--- a/.github/workflows/backup-redis-snapshot.yml
+++ b/.github/workflows/backup-redis-snapshot.yml
@@ -98,35 +98,35 @@ jobs:
             > objects.json
 
           python - <<'PY'
-import datetime
-import json
-import os
-import subprocess
+          import datetime
+          import json
+          import os
+          import subprocess
 
-bucket = os.environ["R2_BUCKET"]
-cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
+          bucket = os.environ["R2_BUCKET"]
+          cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
 
-with open("objects.json", "r", encoding="utf-8") as f:
-    payload = json.load(f)
+          with open("objects.json", "r", encoding="utf-8") as f:
+              payload = json.load(f)
 
-endpoint = os.environ.get("ENDPOINT_URL", "").strip()
+          endpoint = os.environ.get("ENDPOINT_URL", "").strip()
 
-for obj in payload.get("Contents", []):
-    key = obj["Key"]
-    last_modified = datetime.datetime.fromisoformat(obj["LastModified"].replace("Z", "+00:00"))
-    if last_modified >= cutoff:
-      continue
-    cmd = ["aws"]
-    if endpoint:
-      cmd.extend(["--endpoint-url", endpoint])
-    cmd.extend([
-      "s3api", "delete-object",
-      "--bucket", bucket,
-      "--key", key,
-    ])
-    subprocess.run(cmd, check=True)
-    print(f"Deleted expired backup: {key}")
-PY
+          for obj in payload.get("Contents", []):
+              key = obj["Key"]
+              last_modified = datetime.datetime.fromisoformat(obj["LastModified"].replace("Z", "+00:00"))
+              if last_modified >= cutoff:
+                  continue
+              cmd = ["aws"]
+              if endpoint:
+                  cmd.extend(["--endpoint-url", endpoint])
+              cmd.extend([
+                  "s3api", "delete-object",
+                  "--bucket", bucket,
+                  "--key", key,
+              ])
+              subprocess.run(cmd, check=True)
+              print(f"Deleted expired backup: {key}")
+          PY
 
       - name: Upload run artifact metadata
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    # Data-only PRs (cron-driven auto-bot) skip the full e2e suite and run
-    # the lightweight `data-pr-validate` workflow instead. Code PRs still
-    # run this gate. See .github/workflows/data-pr-validate.yml.
-    paths-ignore:
-      - 'data/**'
-      - '.data/**'
+    # Data-only PRs still need this workflow to create the branch-protected
+    # "Typecheck, guards, tests, build, e2e" context. The gate job below
+    # classifies the diff and fast-passes when only data paths changed; the
+    # lightweight `data-pr-validate` workflow does the JSON/security checks.
   push:
     branches: [main]
   workflow_dispatch:
@@ -26,50 +24,118 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify:
+    name: Classify PR paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      data_only: ${{ steps.paths.outputs.data_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: paths
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "data_only=false" >> "$GITHUB_OUTPUT"
+            echo "not a pull_request event; full CI required"
+            exit 0
+          fi
+
+          base="origin/${{ github.base_ref }}"
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+
+          mapfile -t changed < <(git diff --name-only "$base...HEAD" || true)
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "data_only=false" >> "$GITHUB_OUTPUT"
+            echo "no changed paths detected; full CI required"
+            exit 0
+          fi
+
+          data_count=0
+          non_data_count=0
+          for f in "${changed[@]}"; do
+            case "$f" in
+              data/*|.data/*)
+                data_count=$((data_count + 1))
+                ;;
+              *)
+                non_data_count=$((non_data_count + 1))
+                ;;
+            esac
+          done
+
+          if [ "$data_count" -gt 0 ] && [ "$non_data_count" -eq 0 ]; then
+            echo "data_only=true" >> "$GITHUB_OUTPUT"
+            echo "data-only PR: $data_count path(s)"
+          else
+            echo "data_only=false" >> "$GITHUB_OUTPUT"
+            echo "full CI required: $data_count data path(s), $non_data_count non-data path(s)"
+          fi
+
   gate:
     name: Typecheck, guards, tests, build, e2e
+    needs: classify
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Data-only fast path
+        if: needs.classify.outputs.data_only == 'true'
+        run: echo "Data-only PR; full CI is intentionally skipped after data-pr-validate handles JSON/path checks."
+
       - name: Checkout
+        if: needs.classify.outputs.data_only != 'true'
         uses: actions/checkout@v4
 
       # Node 22 matches engines.node in package.json. The project uses Next
       # 15 + React 19 + Vitest 2 — all expect Node 20+ at minimum.
       - name: Setup Node 22
+        if: needs.classify.outputs.data_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
+        if: needs.classify.outputs.data_only != 'true'
         run: npm ci
 
       # Step 1: typecheck. Strict tsc --noEmit. Fails fast on type drift
       # before we burn time on tests.
       - name: Typecheck
+        if: needs.classify.outputs.data_only != 'true'
         run: npm run typecheck
 
       # Step 2: 5 chained CI guards (tokens, err-message echoes, zod on
       # mutating routes, route runtime declared, error envelope shape).
       # See package.json scripts.lint:guards.
       - name: Lint guards
+        if: needs.classify.outputs.data_only != 'true'
         run: npm run lint:guards
 
       # Step 3: V3 token-budget guard. Snapshots V1 alias-name counts in
       # scripts/_v3-token-baseline.json and fails when any pattern grows.
       # Prevents regression of the V3 design sweep.
       - name: V3 token budget
+        if: needs.classify.outputs.data_only != 'true'
         run: node scripts/check-v3-token-budget.mjs
 
       # Step 4: 93 vitest tests (hooks, components, lib).
       - name: Vitest (hooks/components/lib)
+        if: needs.classify.outputs.data_only != 'true'
         run: npm run test:hooks
 
       # Step 5: existing node:test + tsx --test suites (scrapers, pipeline,
       # twitter collector, tools, portal). Same set developers run with
       # `npm test`.
       - name: Node test suite
+        if: needs.classify.outputs.data_only != 'true'
         run: npm test
 
       # Step 6: Playwright. Requires a built + running production server.
@@ -77,15 +143,19 @@ jobs:
       # playwright.config.ts on the first hit per route — production builds
       # serve every page sub-second, which is what the timeout assumes.
       - name: Install Playwright (chromium)
+        if: needs.classify.outputs.data_only != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Seed Playwright repo fixtures
+        if: needs.classify.outputs.data_only != 'true'
         run: node scripts/seed-e2e-repos.mjs
 
       - name: Build (production)
+        if: needs.classify.outputs.data_only != 'true'
         run: npm run build
 
       - name: Bundle size check (T3.3 — warn at >300 KB per client chunk)
+        if: needs.classify.outputs.data_only != 'true'
         # Catches accidental client-side bundling of heavy libs. Annotation-
         # only; never fails the build. Tighten threshold or fail-on-overage
         # once the bundle stabilizes.
@@ -112,6 +182,7 @@ jobs:
       # default). Wait until the port answers before we kick off the test
       # run; gives the runtime up to 60s to come up.
       - name: Start production server
+        if: needs.classify.outputs.data_only != 'true'
         env:
           # Smoke harness has no GITHUB_TOKEN / CRON_SECRET — env.ts's
           # production fail-closed would 500 every page request without
@@ -136,6 +207,7 @@ jobs:
       # the config skips its built-in webServer block and assumes the
       # server is already running (which it is, from the previous step).
       - name: Playwright smokes
+        if: needs.classify.outputs.data_only != 'true'
         env:
           STARSCREENER_BASE_URL: http://localhost:3023
         # Gate the functional smoke specs. The visual screenshot suite under
@@ -144,7 +216,7 @@ jobs:
         run: npm run test:e2e -- --reporter=line --grep-invert "V3 visual surfaces"
 
       - name: Stop production server
-        if: always()
+        if: always() && needs.classify.outputs.data_only != 'true'
         run: |
           if [ -f .next-pid ]; then
             kill "$(cat .next-pid)" 2>/dev/null || true
@@ -157,6 +229,8 @@ jobs:
   # gate job above.
   mcp-build:
     name: MCP server build
+    needs: classify
+    if: needs.classify.outputs.data_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/data-pr-validate.yml
+++ b/.github/workflows/data-pr-validate.yml
@@ -1,18 +1,17 @@
 name: data-pr-validate
 
 # Lightweight gate for data-only PRs (cron-driven auto-bot writes under
-# data/** and .data/**). The full e2e suite in ci.yml is skipped for these
-# paths via paths-ignore; this workflow takes its place as the required
-# status check on data PRs. Two real validations:
+# data/** and .data/**). Branch protection also requires this status on code
+# PRs, so the workflow runs for every PR and fast-passes when no data changed.
+# The full e2e suite in ci.yml fast-passes only for data-only PRs; this
+# workflow provides the JSON/path security checks for that data path. Two real
+# validations:
 #   1. Every changed JSON / JSONL file parses cleanly.
-#   2. PR touches ONLY data/** or .data/** — rejects any attempt to
-#      smuggle code changes through the data path filter.
+#   2. Data-only PRs touch ONLY data/** or .data/** — rejects any attempt to
+#      smuggle code changes through the data fast path.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'data/**'
-      - '.data/**'
 
 permissions:
   contents: read
@@ -101,12 +100,40 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Anything that is NOT under data/** or .data/** is a code change
-          # smuggled through the data-PR path filter -- reject it.
+          mapfile -t changed < <(git diff --name-only origin/main...HEAD || true)
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No changed paths detected -- full CI handles this PR"
+            exit 0
+          fi
+
+          data_count=0
+          non_data_count=0
+          for f in "${changed[@]}"; do
+            case "$f" in
+              data/*|.data/*)
+                data_count=$((data_count + 1))
+                ;;
+              *)
+                non_data_count=$((non_data_count + 1))
+                ;;
+            esac
+          done
+
+          if [ "$data_count" -eq 0 ]; then
+            echo "No data paths changed -- data validation not applicable"
+            exit 0
+          fi
+
+          if [ "$non_data_count" -eq 0 ]; then
+            echo "ok data-only PR touches only data/** and .data/**"
+            exit 0
+          fi
+
+          # Mixed code+data PRs take the full CI path; this workflow only
+          # validates any changed data payloads so the required status exists.
+          echo "Mixed PR: $data_count data path(s), $non_data_count non-data path(s); full CI handles code changes"
           non_data=$(git diff --name-only origin/main...HEAD -- ':!data/**' ':!.data/**' || true)
           if [ -n "$non_data" ]; then
-            echo "::error::Data PR contains non-data changes -- rejecting:"
+            echo "Non-data changed paths:"
             echo "$non_data"
-            exit 1
           fi
-          echo "ok PR touches only data/** and .data/**"


### PR DESCRIPTION
## Summary
- make the branch-protected CI context run for data-only PRs
- make data-pr-validate report on all PRs, fast-passing non-data/code PRs while still validating changed data files
- fix invalid YAML in backup-redis-snapshot.yml so branch pushes stop producing workflow-file failures

## Verification
- git diff --check
- npx --yes yaml-lint .github/workflows/ci.yml .github/workflows/data-pr-validate.yml .github/workflows/backup-redis-snapshot.yml
- PR checks on latest commit f47fc824: CI pass, data-pr-validate pass, gitleaks pass, Vercel pass

## Why
PR #312 proved DATA_BOT_TOKEN now opens PRs as 0motionguy, but automation PRs stayed blocked because branch protection requires both Typecheck/guards/build/e2e and Validate data PR while each workflow was path-filtered. This makes both required contexts exist on both code and data PRs.