### PR TITLE
perf(vercel): skip prod build when PR diff is data-only

### DIFF
--- a/scripts/vercel-skip-data-only.sh
+++ b/scripts/vercel-skip-data-only.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Vercel ignoreCommand: skip build if only data/** or .data/** files changed.
+# Exit 0 = skip build. Exit 1 = build.
+#
+# Vercel sets VERCEL_GIT_COMMIT_REF (branch) + VERCEL_GIT_PREVIOUS_SHA (last deployed SHA).
+# When previous SHA missing (first deploy / forked repo / preview), default to building.
+set -euo pipefail
+
+prev="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [ -z "$prev" ]; then
+  echo "[ignoreCommand] no VERCEL_GIT_PREVIOUS_SHA — building"
+  exit 1
+fi
+
+# Compare current commit to last deployed; list changed files
+git fetch --depth=50 origin "$prev" 2>/dev/null || true
+
+if ! git rev-parse --verify "$prev" >/dev/null 2>&1; then
+  echo "[ignoreCommand] previous SHA $prev not in history (shallow clone) — building"
+  exit 1
+fi
+
+changed=$(git diff --name-only "$prev" HEAD || true)
+if [ -z "$changed" ]; then
+  echo "[ignoreCommand] no diff vs $prev — skipping"
+  exit 0
+fi
+
+non_data=$(echo "$changed" | grep -vE '^(data/|\.data/)' || true)
+
+if [ -z "$non_data" ]; then
+  echo "[ignoreCommand] data-only change detected — skipping build"
+  echo "$changed" | head -10 | sed 's/^/  - /'
+  exit 0
+fi
+
+echo "[ignoreCommand] non-data paths changed — building"
+echo "$non_data" | head -10 | sed 's/^/  - /'
+exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/vercel-skip-data-only.sh"
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with an `ignoreCommand` that runs `scripts/vercel-skip-data-only.sh`. When a deploy's diff is entirely under `data/**` or `.data/**`, the script exits 0 and Vercel skips the build. Any non-data path forces a build.
- Cron-driven data PRs (~100/day) currently each trigger a full Vercel production build (~6 min). Bundled JSON files are seed data baked into deploys; Redis is the runtime source of truth (see `CLAUDE.md`), so rebuilding for those PRs ships zero behavior change.
- ~99% reduction in Vercel build cost for data-only PRs (from ~600 build-minutes/day on data PRs to ~0).

Vercel docs: https://vercel.com/docs/projects/overview#ignored-build-step

## Edge cases handled

- `VERCEL_GIT_PREVIOUS_SHA` missing (first deploy, forked-repo preview): defaults to building.
- Previous SHA not in the shallow clone after `git fetch --depth=50`: defaults to building.
- Empty diff vs. previous SHA: skips.
- Mixed data + non-data paths in one commit: builds.

## Rollback

Delete `vercel.json`. No other moving parts.

## Test plan

- [ ] Merge to `main`. Watch the next Vercel deploy that originates from a data-only cron PR — confirm the build log shows `[ignoreCommand] data-only change detected — skipping build`.
- [ ] Confirm the next non-data PR (e.g. a code change) still builds and deploys normally; build log should show `[ignoreCommand] non-data paths changed — building`.
- [ ] Confirm a deploy with a missing `VERCEL_GIT_PREVIOUS_SHA` (e.g. first deploy on a new project / forked-repo preview) still builds.
