### PR TITLE
feat(platform/move1-p4): script-runner shim for standalone collectors (3 of 17 wrapped)

### DIFF
--- a/docs/SOURCE-PLATFORM-SCRIPT-WRAPPING.md
+++ b/docs/SOURCE-PLATFORM-SCRIPT-WRAPPING.md
@@ -1,0 +1,99 @@
+# Wrapping a standalone collector script as a registered source
+
+Move 1 / Phase 4 of the Source Platform migration registers the 17 standalone
+`scripts/scrape-*.mjs` (and `collect-*.ts`) collectors as platform sources
+without changing what they do. Each wrapped script becomes auditable against
+[`apps/trendingrepo-worker/src/platform/sources.json`](../apps/trendingrepo-worker/src/platform/sources.json)
+and emits a structured `[run-summary]` line that the worker's run summaries
+already follow.
+
+## What the shim handles for free
+
+[`scripts/_source-script-runner.mjs`](../scripts/_source-script-runner.mjs)
+exports one function:
+
+```js
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
+
+await runAsRegisteredSource({
+  sourceId: "bluesky",
+  run: async () => { /* …existing collection logic… */ },
+});
+```
+
+Behaviour the shim adds (collection logic untouched):
+
+- **Registry verification.** Loads `apps/trendingrepo-worker/src/platform/sources.json`
+  on first call, looks up `sourceId`. If the slug is missing, logs a single
+  stderr warning — does NOT block the run (registry drift is a control-plane
+  problem, not a collection failure).
+- **Run summary.** Emits a single stdout line per run:
+  `[run-summary] source=<id> status=<ok|error> duration_ms=<ms>` (plus
+  `error="…"` on failure). GHA log-shippers can grep this identically across
+  worker fetchers and standalone scripts.
+- **Re-throws on error.** The wrapped run()'s rejection is re-raised so the
+  GitHub Actions step is marked failed — exactly as before. The shim never
+  swallows.
+
+What the shim does NOT do:
+
+- It does **not** mutate the caller's behaviour around `process.exit` /
+  `process.exitCode`, meta-sidecar writes, or `closeDataStore()` cleanup.
+  Those stay in the script's existing `.then/.catch/.finally` chain.
+- It does **not** import worker `.ts` code — scripts run as plain `node` so
+  the registry JSON is read directly.
+- It does **not** consume anything from the contract row beyond `id`. Move 3
+  will start using `freshness_budget_ms`, `cost_signal_metric`, etc. for
+  enforcement; Phase 4 only proves the registration trace.
+
+## How to wrap a remaining script
+
+1. Confirm the script's slug is already in `sources.json`. If not, add a
+   contract row first (see [`docs/SOURCE-FLEET-AUDIT-2026-05-07.md`](./SOURCE-FLEET-AUDIT-2026-05-07.md)
+   for the row format).
+2. Add the import near the other shared-helper imports:
+   ```js
+   import { runAsRegisteredSource } from "./_source-script-runner.mjs";
+   ```
+3. Find the script's bottom block where `main()` is invoked (usually inside
+   an `if (isDirectRun)` gate, or unconditionally for scripts like
+   `scrape-openai-rss.mjs`). Replace the bare `main()` call with:
+   ```js
+   runAsRegisteredSource({
+     sourceId: "<your-slug>",
+     run: main,
+   })
+   ```
+   Keep the surrounding `.then(...).catch(...).finally(closeDataStore)`
+   chain exactly as-is.
+4. Verify nothing else changed: `git diff scripts/<your-script>.mjs` should
+   show only the import + the `main` → `runAsRegisteredSource({...})` swap.
+5. Run the script's existing test if one exists
+   (`npm run test:<slug>` — see `package.json` scripts/test:* family).
+6. Trigger the GH Actions workflow once and confirm the new
+   `[run-summary] source=<slug> status=ok duration_ms=…` line appears in the
+   workflow log.
+
+## What a contract row needs
+
+Reference: [`apps/trendingrepo-worker/src/platform/source-contract.ts`](../apps/trendingrepo-worker/src/platform/source-contract.ts)
+(`SourceContract` type — 16 fields). At minimum a script-backed source
+declares: `id`, `category`, `kind`, `state`, `freshness_budget_ms`,
+`cost_signal_metric`, `owner` (`UNASSIGNED` allowed in Phase 1),
+`upstream_url`, `auth_required`, `primary_output_keys`, `output_record_shape`,
+`consumer_surfaces`, `depends_on`, `supports_backfill`, `fallback_strategy`.
+The contract row does not reference the script path — the verifier
+(`npm run verify:sources`, see Phase 1B) cross-checks that every script slug
+has a row.
+
+## Status: 3 of 17 wrapped
+
+Migrated in this PR:
+
+- `scripts/scrape-bluesky.mjs` (sourceId `bluesky`, social)
+- `scripts/scrape-arxiv.mjs` (sourceId `arxiv`, research)
+- `scripts/scrape-openai-rss.mjs` (sourceId `openai-rss`, research)
+
+The remaining 14 are tracked as a follow-up "phase 4 backfill" task — they
+are functionally identical wraps and can be done as a single batch once the
+pattern is socialised.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "audit:github-token-callsites": "node scripts/audit-github-token-callsites.mjs",
     "update:badges": "node scripts/update-readme-badges.mjs",
     "test": "npm run test:scraper-shared && npm run test:reddit && npm run test:hn && npm run test:bsky && npm run test:ph && npm run test:devto && npm run test:npm && npm run test:funding && npm run test:twitter-collector && tsx --test src/lib/__tests__/*.test.ts src/lib/pipeline/__tests__/*.test.ts src/lib/twitter/__tests__/*.test.ts src/tools/__tests__/*.test.ts src/portal/__tests__/*.test.ts",
-    "test:scraper-shared": "node --test scripts/__tests__/fetch-json.test.mjs scripts/__tests__/github-repo-links.test.mjs scripts/__tests__/reddit-shared.test.mjs scripts/__tests__/tracked-repos.test.mjs scripts/__tests__/source-watchers.test.mjs scripts/__tests__/trustmrr-sync-mode.test.mjs scripts/__tests__/promote-unknown-mentions.test.mjs",
+    "test:scraper-shared": "node --test scripts/__tests__/fetch-json.test.mjs scripts/__tests__/github-repo-links.test.mjs scripts/__tests__/reddit-shared.test.mjs scripts/__tests__/tracked-repos.test.mjs scripts/__tests__/source-watchers.test.mjs scripts/__tests__/trustmrr-sync-mode.test.mjs scripts/__tests__/promote-unknown-mentions.test.mjs scripts/__tests__/source-script-runner.test.mjs",
     "test:reddit": "node --test scripts/__tests__/classify-post.test.mjs scripts/__tests__/scrape-reddit.test.mjs",
     "test:hn": "node --test scripts/__tests__/scrape-hackernews.test.mjs",
     "test:bsky": "node --test scripts/__tests__/scrape-bluesky.test.mjs",

--- a/scripts/__tests__/source-script-runner.test.mjs
+++ b/scripts/__tests__/source-script-runner.test.mjs
@@ -1,0 +1,124 @@
+// Move 1 / Phase 4 — smoke tests for scripts/_source-script-runner.mjs.
+//
+// The shim is pure instrumentation: it loads sources.json, calls run(),
+// emits a [run-summary] line, and re-throws on failure. Three tests cover
+// the success path, the failure path, and the unknown-sourceId warning.
+//
+// We capture stdout/stderr by stubbing process.stdout.write / process.stderr.write
+// — node:test doesn't ship a `t.snapshot` helper for stream output and the
+// shim's contract is "one specific stdout line per run", which is easy to
+// assert via substring match.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  runAsRegisteredSource,
+  _resetForTests,
+} from "../_source-script-runner.mjs";
+
+function captureStreams() {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  const out = [];
+  const err = [];
+  process.stdout.write = (chunk, ...rest) => {
+    out.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return origOut(chunk, ...rest);
+  };
+  process.stderr.write = (chunk, ...rest) => {
+    err.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return origErr(chunk, ...rest);
+  };
+  return {
+    out,
+    err,
+    restore() {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    },
+  };
+}
+
+test("runAsRegisteredSource: success path emits [run-summary] status=ok", async () => {
+  _resetForTests();
+  const cap = captureStreams();
+  try {
+    const result = await runAsRegisteredSource({
+      sourceId: "bluesky",
+      run: async () => "stub-ok",
+    });
+    assert.equal(result, "stub-ok");
+    const summary = cap.out.find((line) => line.startsWith("[run-summary]"));
+    assert.ok(summary, "expected a [run-summary] line on stdout");
+    assert.match(summary, /source=bluesky/);
+    assert.match(summary, /status=ok/);
+    assert.match(summary, /duration_ms=\d+/);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("runAsRegisteredSource: failure path emits status=error and re-throws", async () => {
+  _resetForTests();
+  const cap = captureStreams();
+  try {
+    await assert.rejects(
+      async () =>
+        runAsRegisteredSource({
+          sourceId: "bluesky",
+          run: async () => {
+            throw new Error("simulated upstream failure");
+          },
+        }),
+      /simulated upstream failure/,
+    );
+    const summary = cap.out.find((line) => line.startsWith("[run-summary]"));
+    assert.ok(summary, "expected a [run-summary] line on stdout even on failure");
+    assert.match(summary, /source=bluesky/);
+    assert.match(summary, /status=error/);
+    assert.match(summary, /error="simulated upstream failure"/);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("runAsRegisteredSource: still emits run-summary for unknown / missing-registry sourceId", async () => {
+  _resetForTests();
+  const cap = captureStreams();
+  try {
+    const result = await runAsRegisteredSource({
+      sourceId: "definitely-not-a-registered-source-xyzzy",
+      run: async () => 42,
+    });
+    assert.equal(result, 42);
+    // Either branch is acceptable: registry-missing OR slug-not-in-registry.
+    // Both are graceful warnings that don't block collection. The contract
+    // is that the run still completes and emits a run-summary line.
+    const warned = cap.err.some(
+      (line) =>
+        line.includes("[source-script-runner] warn: sourceId") ||
+        line.includes("[source-script-runner] warn: could not read registry"),
+    );
+    assert.ok(
+      warned,
+      "expected a registry-related warning on stderr (slug-missing OR registry-missing)",
+    );
+    const summary = cap.out.find((line) => line.startsWith("[run-summary]"));
+    assert.ok(summary, "still expected the run-summary line for unknown source");
+    assert.match(summary, /status=ok/);
+  } finally {
+    cap.restore();
+  }
+});
+
+test("runAsRegisteredSource: rejects missing sourceId / run", async () => {
+  _resetForTests();
+  await assert.rejects(
+    () => runAsRegisteredSource({ sourceId: "", run: async () => 0 }),
+    /sourceId is required/,
+  );
+  await assert.rejects(
+    () => runAsRegisteredSource({ sourceId: "bluesky", run: undefined }),
+    /run must be an async function/,
+  );
+});

--- a/scripts/_source-script-runner.mjs
+++ b/scripts/_source-script-runner.mjs
@@ -1,0 +1,127 @@
+// Source-platform shim — Move 1, Phase 4.
+//
+// Wraps a standalone collector script (scripts/scrape-*.mjs etc.) in a
+// thin "registered source" envelope so the script:
+//   1. is verified against apps/trendingrepo-worker/src/platform/sources.json
+//      at startup (typo-proofs sourceId; surfaces drift between code + audit),
+//   2. emits a structured `[run-summary] source=<id> status=... duration_ms=...`
+//      stdout line that the GHA workflow + log shippers can parse identically
+//      to the worker's run summaries,
+//   3. re-throws on error so the workflow run is marked failed.
+//
+// Behaviour of the wrapped run() is unchanged. This file is a pure
+// instrumentation wrap; the script's own try/catch + meta-sidecar /
+// data-store writes still run. If the script doesn't already do its own
+// stderr error logging, the shim still re-throws so the GHA step shows red.
+//
+// USAGE
+//   import { runAsRegisteredSource } from "./_source-script-runner.mjs";
+//
+//   await runAsRegisteredSource({
+//     sourceId: "bluesky",
+//     run: async () => {
+//       // …existing collection logic, untouched…
+//     },
+//   });
+//
+// JSON IS READ DIRECTLY from apps/trendingrepo-worker/src/platform/sources.json
+// — we deliberately do NOT import worker .ts code from a .mjs script, since
+// the scripts run as plain `node` (no tsx). If the registry file is missing
+// (fresh checkout, foreign worktree) the shim logs a single warning and runs
+// the script anyway: the registry is a control-plane artefact, not a hard
+// dependency of collection.
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REGISTRY_PATH = resolve(
+  __dirname,
+  "..",
+  "apps",
+  "trendingrepo-worker",
+  "src",
+  "platform",
+  "sources.json",
+);
+
+let cachedRegistry = null;
+
+async function loadRegistry() {
+  if (cachedRegistry !== null) return cachedRegistry;
+  try {
+    const raw = await readFile(REGISTRY_PATH, "utf8");
+    const parsed = JSON.parse(raw);
+    cachedRegistry = Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    process.stderr.write(
+      `[source-script-runner] warn: could not read registry at ${REGISTRY_PATH} (${err.message ?? err}) — running without contract verification\n`,
+    );
+    cachedRegistry = [];
+  }
+  return cachedRegistry;
+}
+
+function findContract(registry, sourceId) {
+  return registry.find((row) => row && row.id === sourceId) ?? null;
+}
+
+function emitRunSummary({ sourceId, status, durationMs, error }) {
+  const errSuffix = error
+    ? ` error="${String(error.message ?? error).replace(/"/g, '\\"').slice(0, 200)}"`
+    : "";
+  process.stdout.write(
+    `[run-summary] source=${sourceId} status=${status} duration_ms=${durationMs}${errSuffix}\n`,
+  );
+}
+
+/**
+ * Wrap a standalone collector run() in the source-platform envelope.
+ *
+ * @param {{ sourceId: string; run: () => Promise<unknown> }} opts
+ * @returns {Promise<unknown>} the wrapped run()'s resolved value
+ * @throws  re-throws whatever run() threw, after emitting the failure summary
+ */
+export async function runAsRegisteredSource({ sourceId, run }) {
+  if (typeof sourceId !== "string" || !sourceId.trim()) {
+    throw new Error(
+      "[source-script-runner] sourceId is required and must be a non-empty string",
+    );
+  }
+  if (typeof run !== "function") {
+    throw new Error("[source-script-runner] run must be an async function");
+  }
+
+  const registry = await loadRegistry();
+  const contract = findContract(registry, sourceId);
+  if (registry.length > 0 && !contract) {
+    process.stderr.write(
+      `[source-script-runner] warn: sourceId "${sourceId}" not found in sources.json — register it before this script ships to prod\n`,
+    );
+  }
+
+  const startedAt = Date.now();
+  try {
+    const result = await run();
+    emitRunSummary({
+      sourceId,
+      status: "ok",
+      durationMs: Date.now() - startedAt,
+    });
+    return result;
+  } catch (err) {
+    emitRunSummary({
+      sourceId,
+      status: "error",
+      durationMs: Date.now() - startedAt,
+      error: err,
+    });
+    throw err;
+  }
+}
+
+/** Test-only — drop the cached registry so tests can re-stub the file. */
+export function _resetForTests() {
+  cachedRegistry = null;
+}

--- a/scripts/scrape-arxiv.mjs
+++ b/scripts/scrape-arxiv.mjs
@@ -39,6 +39,7 @@ import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { loadTrackedReposFromFiles } from "./_tracked-repos.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = resolve(__dirname, "..", "data");
@@ -288,8 +289,13 @@ const isDirectRun = invokedPath
   : false;
 
 if (isDirectRun) {
+  // Move 1 / Phase 4: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "arxiv",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-bluesky.mjs
+++ b/scripts/scrape-bluesky.mjs
@@ -29,6 +29,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import "./_load-env.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import {
   createSession,
   searchPostsAllPages,
@@ -517,8 +518,14 @@ const isDirectRun = invokedPath
 if (isDirectRun) {
   // T2.6: same metadata-sidecar pattern as scrape-hackernews — lets the
   // SRE freshness probe distinguish Bluesky outage from a quiet day.
+  // Move 1 / Phase 4: collection logic untouched; runAsRegisteredSource
+  // wraps the existing main() so the run emits a [run-summary] line and
+  // stays auditable against apps/trendingrepo-worker/src/platform/sources.json.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "bluesky",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-openai-rss.mjs
+++ b/scripts/scrape-openai-rss.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { fetchFeed } from "./_rss-shared.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT = resolve(__dirname, "..", "data", "openai-rss.json");
@@ -70,8 +71,13 @@ async function main() {
   await closeDataStore();
 }
 
+// Move 1 / Phase 4: runAsRegisteredSource wraps main() purely for
+// instrumentation — collection logic untouched.
 const startedAt = Date.now();
-main()
+runAsRegisteredSource({
+  sourceId: "openai-rss",
+  run: main,
+})
   .then(async () => {
     try {
       await writeSourceMetaFromOutcome({


### PR DESCRIPTION
## Summary

Move 1 / Phase 4 of the Source Platform migration registers the standalone `scripts/scrape-*.mjs` collectors as platform sources without changing what they do. They get audited like worker fetchers.

Adds `scripts/_source-script-runner.mjs` (~125 LOC) — a thin shim that wraps a script's `main()` so the run:

- looks up its `sourceId` in `apps/trendingrepo-worker/src/platform/sources.json` and warns on stderr if the slug is missing (does NOT block — registry drift is a control-plane issue, not a collection failure),
- emits a structured `[run-summary] source=<id> status=ok|error duration_ms=<n>` line that GHA log-shippers can parse identically to the worker's run summaries,
- re-throws on failure so the workflow run is marked failed.

Three representative scripts migrated to prove the pattern (collection logic untouched — purely instrumentation wrap):

- `scripts/scrape-bluesky.mjs` (sourceId `bluesky`, social)
- `scripts/scrape-arxiv.mjs` (sourceId `arxiv`, research)
- `scripts/scrape-openai-rss.mjs` (sourceId `openai-rss`, research)

Doc: [`docs/SOURCE-PLATFORM-SCRIPT-WRAPPING.md`](../blob/feat/source-script-runner/docs/SOURCE-PLATFORM-SCRIPT-WRAPPING.md) — explains how to wrap a remaining script, what the contract row needs, and what the wrapper handles for free.

## Backlog — 14 remaining scripts (phase 4 backfill)

These scripts are already declared in `sources.json` but not yet wrapped. Each is a functionally identical 5-line swap (`main()` → `runAsRegisteredSource({ sourceId, run: main })`), so they can ship as a single batch once the pattern is socialised:

- `scripts/scrape-trending.mjs` (sourceId `trending`)
- `scripts/scrape-reddit.mjs` (sourceId `reddit`)
- `scripts/scrape-hackernews.mjs` (sourceId `hackernews`)
- `scripts/scrape-producthunt.mjs` (sourceId `producthunt`)
- `scripts/scrape-devto.mjs` (sourceId `devto`)
- `scripts/scrape-lobsters.mjs` (sourceId `lobsters`)
- `scripts/scrape-claude-rss.mjs` (sourceId `claude-rss`)
- `scripts/scrape-huggingface.mjs` (sourceId `huggingface-models-script`)
- `scripts/scrape-funding-news.mjs` (sourceId `funding-news`)
- `scripts/scrape-npm.mjs` (sourceId `npm-packages`)
- `scripts/collect-twitter-signals.ts` (sourceId `twitter-signals` — note: TS, will need a small TS wrapper)
- `scripts/ping-mcp-liveness.mjs` (sourceId `mcp-liveness`)
- `scripts/enrich-arxiv.mjs` (sourceId `arxiv-enriched`)
- `scripts/build-agent-commerce-seed.mjs` (sourceId `agent-commerce`)

(Plus the 2 x402-onchain `fetch-*.mjs` scripts and `run-shadow-scoring.mjs` once their `decision_pending:` rename calls in `sources.json` are resolved.)

## Test plan

- [x] `node --test scripts/__tests__/source-script-runner.test.mjs` — 4/4 pass (success path, failure path, unknown-sourceId warn, input validation)
- [x] `npm run test:scraper-shared` — 50/50 pass (new test joined the bundle in `package.json`)
- [x] `npm run test:bsky` — 17/17 pass (bluesky scraper logic intact; the "importing as a module does not run the scraper" test still passes, confirming `isDirectRun` gate preserved)
- [x] `node --check` on all 4 modified `.mjs` files — clean
- [ ] One live GHA run on each of the 3 migrated workflows to confirm the new `[run-summary]` line appears (pre-merge smoke)

## Constraints honoured

- Did not migrate all 17 scripts — the remaining 14 are a follow-up phase 4 backfill task
- Did not change any script's collection logic — purely instrumentation wrap
- Did not use `--no-verify` — pre-commit hook ran clean
- Did not `git add -A` — staged exactly 7 files explicitly

Generated with [Claude Code](https://claude.com/claude-code)
