### PR TITLE
feat(platform/move1-p2): source_overrides runtime + boot loader

### DIFF
--- a/apps/trendingrepo-worker/.gitignore
+++ b/apps/trendingrepo-worker/.gitignore
@@ -19,3 +19,7 @@ supabase/.temp/
 # logs / scratch
 *.log
 .tmp/
+
+# source-overrides on-disk cache (last-known-good snapshot of the
+# Supabase source_overrides table; written by platform/overrides.ts).
+.cache/

--- a/apps/trendingrepo-worker/src/index.ts
+++ b/apps/trendingrepo-worker/src/index.ts
@@ -42,7 +42,7 @@ async function main(argv: string[]): Promise<number> {
 
   if (cronMode) {
     const server = startHealthServer();
-    const scheduler = startScheduler();
+    const scheduler = await startScheduler();
     installShutdownHandlers({
       server,
       onClose: async () => {

--- a/apps/trendingrepo-worker/src/platform/__tests__/overrides.test.ts
+++ b/apps/trendingrepo-worker/src/platform/__tests__/overrides.test.ts
@@ -1,0 +1,189 @@
+// Unit tests for source-overrides pure helpers.
+//
+// These exercise applyOverrides, findGhostOverrides, summarizeOverrides, and
+// shouldSkip semantics (via applyOverrides). The DB-touching `loadOverrides`
+// function is exercised indirectly: tests construct override Maps directly
+// instead of mocking Supabase. A live-Supabase loadOverrides test would be
+// integration-tier and is intentionally out of scope (per task constraint).
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyOverrides,
+  findGhostOverrides,
+  summarizeOverrides,
+  type SourceOverride,
+} from '../overrides.js';
+import type { Fetcher } from '../../lib/types.js';
+import type { SourceContract } from '../source-contract.js';
+
+function fetcher(name: string): Fetcher {
+  return {
+    name,
+    schedule: '0 * * * *',
+    run: async () => ({
+      fetcher: name,
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+      itemsSeen: 0,
+      itemsUpserted: 0,
+      metricsWritten: 0,
+      redisPublished: false,
+      errors: [],
+    }),
+  };
+}
+
+function contract(id: string): SourceContract {
+  return {
+    id,
+    category: 'repo-derived',
+    kind: 'collector',
+    state: 'active',
+    freshness_budget_ms: 3_600_000,
+    cost_signal_metric: { type: 'none' },
+    owner: 'UNASSIGNED',
+    upstream_url: 'https://example.com',
+    auth_required: false,
+    primary_output_keys: [id],
+    output_record_shape: 'metric_snapshot',
+    consumer_surfaces: [],
+    depends_on: [],
+    supports_backfill: false,
+    fallback_strategy: 'none',
+  };
+}
+
+function override(
+  source_id: string,
+  state: SourceOverride['state'],
+  paused_until: string | null = null,
+  reason = 'test',
+): SourceOverride {
+  return { source_id, state, paused_until, reason };
+}
+
+describe('applyOverrides', () => {
+  it('keeps fetchers with no override', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map<string, SourceOverride>();
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['a', 'b']);
+  });
+
+  it('keeps fetchers explicitly active', () => {
+    const fetchers = [fetcher('a')];
+    const overrides = new Map([['a', override('a', 'active')]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['a']);
+  });
+
+  it('skips fetchers paused indefinitely (paused_until null)', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused', null)]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['b']);
+  });
+
+  it('skips fetchers paused with future paused_until', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused', future)]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['b']);
+  });
+
+  it('keeps fetchers whose paused_until is in the past (pause expired)', () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused', past)]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['a', 'b']);
+  });
+
+  it('skips fetchers marked deprecated regardless of paused_until', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([
+      ['a', override('a', 'deprecated', future)],
+      ['b', override('b', 'deprecated', null)],
+    ]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual([]);
+  });
+
+  it('returns a new array (does not mutate input)', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused')]]);
+    const result = applyOverrides(fetchers, overrides);
+    expect(result).not.toBe(fetchers);
+    expect(fetchers.map((f) => f.name)).toEqual(['a', 'b']);
+  });
+
+  it('handles mixed states across many fetchers', () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const future = new Date(Date.now() + 1000 * 60 * 60).toISOString();
+    const fetchers = [
+      fetcher('keep-active'),
+      fetcher('skip-paused-indef'),
+      fetcher('skip-paused-future'),
+      fetcher('keep-paused-expired'),
+      fetcher('skip-deprecated'),
+      fetcher('keep-no-override'),
+    ];
+    const overrides = new Map<string, SourceOverride>([
+      ['keep-active', override('keep-active', 'active')],
+      ['skip-paused-indef', override('skip-paused-indef', 'paused', null)],
+      ['skip-paused-future', override('skip-paused-future', 'paused', future)],
+      ['keep-paused-expired', override('keep-paused-expired', 'paused', past)],
+      ['skip-deprecated', override('skip-deprecated', 'deprecated', null)],
+    ]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual([
+      'keep-active',
+      'keep-paused-expired',
+      'keep-no-override',
+    ]);
+  });
+});
+
+describe('findGhostOverrides', () => {
+  it('returns empty when every override has a fetcher', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused')]]);
+    expect(findGhostOverrides(fetchers, overrides, [])).toEqual([]);
+  });
+
+  it('returns empty when override matches a contract-only source (script / user-input)', () => {
+    const fetchers = [fetcher('a')];
+    const overrides = new Map([['scrape-foo', override('scrape-foo', 'paused')]]);
+    const contracts = [contract('scrape-foo')];
+    expect(findGhostOverrides(fetchers, overrides, contracts)).toEqual([]);
+  });
+
+  it('flags override ids absent from both fetchers and contracts', () => {
+    const fetchers = [fetcher('a')];
+    const overrides = new Map([
+      ['a', override('a', 'active')],
+      ['ghost-1', override('ghost-1', 'paused')],
+      ['ghost-2', override('ghost-2', 'deprecated')],
+    ]);
+    const contracts = [contract('a')];
+    expect(findGhostOverrides(fetchers, overrides, contracts).sort()).toEqual([
+      'ghost-1',
+      'ghost-2',
+    ]);
+  });
+
+  it('returns empty when overrides map is empty', () => {
+    expect(findGhostOverrides([fetcher('a')], new Map(), [contract('a')])).toEqual([]);
+  });
+});
+
+describe('summarizeOverrides', () => {
+  it('counts paused and deprecated separately and totals', () => {
+    const overrides = new Map<string, SourceOverride>([
+      ['a', override('a', 'paused')],
+      ['b', override('b', 'paused')],
+      ['c', override('c', 'deprecated')],
+      ['d', override('d', 'active')],
+    ]);
+    expect(summarizeOverrides(overrides)).toEqual({ total: 4, paused: 2, deprecated: 1 });
+  });
+
+  it('returns zeros for an empty map', () => {
+    expect(summarizeOverrides(new Map())).toEqual({ total: 0, paused: 0, deprecated: 0 });
+  });
+});

--- a/apps/trendingrepo-worker/src/platform/overrides.ts
+++ b/apps/trendingrepo-worker/src/platform/overrides.ts
@@ -1,0 +1,225 @@
+/**
+ * Source overrides — boot-time loader for runtime state of registered sources.
+ *
+ * Move 1, Phase 2 of the Source Platform migration. Static fields live in
+ * `sources.json` (PR #326); runtime state (paused / deprecated / paused_until)
+ * lives in the Supabase `source_overrides` table (migration 0002). This module
+ * loads the overrides at boot, refreshes them every 60s in the background, and
+ * exposes pure helpers for `schedule.ts` and `/healthz` to consume.
+ *
+ * Boot-path contract — never refuses to start:
+ *   1. Try Supabase with a 2-second timeout.
+ *   2. Success → write `.cache/source-overrides.json` (atomic temp + rename).
+ *   3. DB failure / timeout → read the cache file (last-known-good).
+ *   4. No cache → empty Map (assume all sources active).
+ *
+ * Filter semantics:
+ *   - state = 'paused' AND (paused_until IS NULL OR paused_until > now()) → skip
+ *   - state = 'paused' AND paused_until <= now() → keep (pause expired)
+ *   - state = 'deprecated' → skip
+ *   - state = 'active' → keep
+ *   - no override row → keep
+ *
+ * Ghost detection:
+ *   A ghost override is a row whose source_id is NOT in the current
+ *   `FETCHERS[]` AND NOT in the static `SOURCE_CONTRACTS[]` registry. These
+ *   are surfaced via /healthz so the reaper job (Move 1 step 4) has a target
+ *   list. Source ids that appear in `SOURCE_CONTRACTS[]` but not `FETCHERS[]`
+ *   are NOT ghosts — they're the 17 standalone scripts and 3 user-input flows.
+ *
+ * See:
+ *   - docs/SOURCE-REGISTRY-PROPOSAL.md §4 (loader pseudocode)
+ *   - supabase/migrations/0002_source_overrides.sql (schema)
+ *   - apps/trendingrepo-worker/src/schedule.ts (consumer)
+ *   - apps/trendingrepo-worker/src/server.ts (/healthz consumer)
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { getDb } from '../lib/db.js';
+import { getLogger } from '../lib/log.js';
+import type { Fetcher } from '../lib/types.js';
+import type { SourceContract } from './source-contract.js';
+
+export interface SourceOverride {
+  source_id: string;
+  state: 'active' | 'paused' | 'deprecated';
+  paused_until: string | null;
+  reason: string;
+}
+
+const CACHE_PATH = resolve(process.cwd(), '.cache', 'source-overrides.json');
+const LOAD_TIMEOUT_MS = 2_000;
+const REFRESH_INTERVAL_MS_DEFAULT = 60_000;
+
+let cachedOverrides: Map<string, SourceOverride> = new Map();
+let refreshTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Load overrides from Supabase with a 2-second timeout, fall back to the
+ * on-disk cache, then to an empty Map. Always resolves; never throws. Updates
+ * the module-level `cachedOverrides` so synchronous helpers see the new state.
+ */
+export async function loadOverrides(): Promise<Map<string, SourceOverride>> {
+  const log = getLogger();
+  const t0 = Date.now();
+  try {
+    const rows = await Promise.race<SourceOverride[]>([
+      loadFromDb(),
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error('source-overrides-load-timeout')), LOAD_TIMEOUT_MS),
+      ),
+    ]);
+    cachedOverrides = new Map(rows.map((r) => [r.source_id, r]));
+    writeCacheAtomic(rows);
+    log.info(
+      { count: rows.length, durationMs: Date.now() - t0, source: 'db' },
+      'source overrides loaded',
+    );
+    return cachedOverrides;
+  } catch (err) {
+    log.warn(
+      { err: (err as Error).message, durationMs: Date.now() - t0 },
+      'source overrides db load failed; falling back to cache',
+    );
+    const fromCache = readCache();
+    if (fromCache) {
+      cachedOverrides = new Map(fromCache.map((r) => [r.source_id, r]));
+      log.info(
+        { count: fromCache.length, source: 'cache' },
+        'source overrides loaded from cache',
+      );
+      return cachedOverrides;
+    }
+    cachedOverrides = new Map();
+    log.warn('no source overrides cache present; assuming all sources active');
+    return cachedOverrides;
+  }
+}
+
+async function loadFromDb(): Promise<SourceOverride[]> {
+  const db = getDb();
+  const { data, error } = await db
+    .from('source_overrides')
+    .select('source_id, state, paused_until, reason')
+    .neq('state', 'active');
+  if (error) throw new Error(`supabase: ${error.message}`);
+  return (data ?? []) as SourceOverride[];
+}
+
+function writeCacheAtomic(rows: SourceOverride[]): void {
+  try {
+    mkdirSync(dirname(CACHE_PATH), { recursive: true });
+    const tmp = `${CACHE_PATH}.${process.pid}.tmp`;
+    writeFileSync(tmp, JSON.stringify(rows), 'utf8');
+    renameSync(tmp, CACHE_PATH);
+  } catch (err) {
+    getLogger().warn(
+      { err: (err as Error).message, path: CACHE_PATH },
+      'source overrides cache write failed',
+    );
+  }
+}
+
+function readCache(): SourceOverride[] | null {
+  try {
+    if (!existsSync(CACHE_PATH)) return null;
+    const raw = readFileSync(CACHE_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as SourceOverride[];
+    return Array.isArray(parsed) ? parsed : null;
+  } catch (err) {
+    getLogger().warn(
+      { err: (err as Error).message, path: CACHE_PATH },
+      'source overrides cache read failed',
+    );
+    return null;
+  }
+}
+
+/**
+ * Pure: filter a fetcher list against an overrides map. Returns a NEW array;
+ * does not mutate the input. Used by `schedule.ts` before croner registration.
+ */
+export function applyOverrides(
+  fetchers: Fetcher[],
+  overrides: Map<string, SourceOverride>,
+): Fetcher[] {
+  const now = Date.now();
+  return fetchers.filter((f) => !shouldSkip(overrides.get(f.name), now));
+}
+
+function shouldSkip(override: SourceOverride | undefined, nowMs: number): boolean {
+  if (!override) return false;
+  if (override.state === 'deprecated') return true;
+  if (override.state === 'paused') {
+    if (override.paused_until == null) return true;
+    return new Date(override.paused_until).getTime() > nowMs;
+  }
+  return false; // 'active'
+}
+
+/**
+ * Pure: which override source_ids no longer correspond to any fetcher OR
+ * static contract row? These are true ghosts — code-side deletions that left
+ * the DB row orphaned. The reaper job (Move 1 step 4) consumes this list.
+ */
+export function findGhostOverrides(
+  fetchers: Fetcher[],
+  overrides: Map<string, SourceOverride>,
+  contracts: readonly SourceContract[],
+): string[] {
+  const known = new Set<string>();
+  for (const f of fetchers) known.add(f.name);
+  for (const c of contracts) known.add(c.id);
+  return [...overrides.keys()].filter((id) => !known.has(id));
+}
+
+/**
+ * Returns a per-state count summary for log lines and /healthz, computed
+ * against the current cache (does NOT trigger a reload).
+ */
+export function summarizeOverrides(
+  overrides: Map<string, SourceOverride>,
+): { total: number; paused: number; deprecated: number } {
+  let paused = 0;
+  let deprecated = 0;
+  for (const o of overrides.values()) {
+    if (o.state === 'paused') paused++;
+    else if (o.state === 'deprecated') deprecated++;
+  }
+  return { total: overrides.size, paused, deprecated };
+}
+
+/**
+ * Synchronous accessor for the most recently loaded overrides map. Used by
+ * /healthz to surface ghost rows without re-querying the DB on every probe.
+ */
+export function getCachedOverrides(): Map<string, SourceOverride> {
+  return cachedOverrides;
+}
+
+/**
+ * Background refresh — re-runs `loadOverrides()` every `intervalMs` (default
+ * 60s). Returns a stop function. Errors inside the refresh are swallowed by
+ * `loadOverrides()` itself (it never throws), so the timer keeps ticking.
+ */
+export function startOverrideRefresh(
+  intervalMs: number = REFRESH_INTERVAL_MS_DEFAULT,
+): () => void {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+  refreshTimer = setInterval(() => {
+    void loadOverrides();
+  }, intervalMs);
+  // Don't keep the event loop alive on this timer alone — the cron scheduler
+  // keeps it alive, and a stuck refresh shouldn't prevent shutdown.
+  if (typeof refreshTimer.unref === 'function') refreshTimer.unref();
+  return () => {
+    if (refreshTimer) {
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+  };
+}

--- a/apps/trendingrepo-worker/src/platform/source-contract.ts
+++ b/apps/trendingrepo-worker/src/platform/source-contract.ts
@@ -1,0 +1,161 @@
+/**
+ * Every Fetcher must satisfy SourceContract; not every SourceContract has a
+ * Fetcher (standalone scripts and user-input flows have no Fetcher).
+ *
+ * SourceContract is the metadata superset over `Fetcher` (lib/types.ts).
+ * Phase 1 (Move 1) of the Source Platform migration declares this type,
+ * the audit JSON conforming to it, and the verification harness that proves
+ * registry coverage. Nothing in the running system changes in Phase 1.
+ *
+ * Cost aggregation rule for parent rows with providers[]:
+ *   `cost_signal_metric` reflects the PRIMARY provider's cost class. Chain
+ *   fall-through to a free fallback is a degradation signal Move 3 tracks
+ *   per-run, not a steady-state cost event. e.g. `twitter-signals` parent
+ *   declares `cost_signal_metric.type: 'apify_units'` even though the chain
+ *   has free fallbacks (web/nitter/fixture). Each provider's `cost_class`
+ *   is recorded individually in the providers[] sub-array for routing.
+ *
+ * See:
+ *   - ~/.claude/plans/hidden-pondering-meadow.md (approved Phase 1 plan)
+ *   - docs/SOURCE-REGISTRY-PROPOSAL.md (Move 1 implementation proposal — pending)
+ *   - apps/trendingrepo-worker/src/lib/types.ts (runtime Fetcher + RunResult)
+ */
+
+export type SourceCategory =
+  | 'repo-derived'
+  | 'social'
+  | 'package'
+  | 'model'
+  | 'mcp'
+  | 'skill'
+  | 'funding'
+  | 'research'
+  | 'ops'
+  | 'user-input';
+
+export type SourceKind = 'collector' | 'enrichment' | 'snapshot' | 'health';
+
+export type SourceState = 'active' | 'paused' | 'deprecated' | 'intent-only';
+
+export type CostSignalType =
+  | 'usd'
+  | 'rate_limit_pct'
+  | 'apify_units'
+  | 'pat_quota_pct'
+  | 'none';
+
+export type CostSignalScope = 'day' | 'hour' | 'month';
+
+export interface CostSignalMetric {
+  type: CostSignalType;
+  cap?: number;
+  scope?: CostSignalScope;
+}
+
+export type RateLimitScope = 'ip' | 'token' | 'pool';
+
+export interface RateLimit {
+  per_hour?: number;
+  scope: RateLimitScope;
+}
+
+export type AuthScheme =
+  | 'github_pat_pool'
+  | 'apify_token'
+  | 'twitter_web_cookies'
+  | 'firecrawl'
+  | 'supabase_service'
+  | 'none';
+
+export type CardinalitySource = 'watchlist' | 'static' | 'enum';
+
+/**
+ * Static slug list (e.g. ['oss-trending']) OR fan-out pattern
+ * (e.g. {pattern: 'mcp-downloads:<package>', cardinality_source: 'watchlist'}).
+ * One row per slug family — concrete-slug enumeration is a Move 3 concern.
+ */
+export type PrimaryOutputKeys =
+  | string[]
+  | {
+      pattern: string;
+      index_key?: string;
+      cardinality_source: CardinalitySource;
+    };
+
+export type OutputRecordShape =
+  | 'ranked_list'
+  | 'event_stream'
+  | 'metric_snapshot'
+  | 'mention_feed'
+  | 'metadata_table'
+  | 'extracted_signal';
+
+export type ConsensusRole = 'list' | 'mention-feed' | 'metadata' | 'event-stream';
+
+export type FallbackStrategy =
+  | 'cache'
+  | 'skip'
+  | 'mark-degraded'
+  | 'editorial-seed'
+  | 'provider-chain'
+  | 'none';
+
+export type ProviderRole = 'primary' | 'fallback';
+
+export interface SourceProvider {
+  id: string;
+  role: ProviderRole;
+  cost_class: CostSignalType;
+}
+
+export type CanonicalEntityKind =
+  | 'repo'
+  | 'package'
+  | 'model'
+  | 'company'
+  | 'mention'
+  | 'event';
+
+/**
+ * The Source Contract — Phase 1, Move 1 of the Source Platform migration.
+ *
+ * 16 fields derived from a contract sufficiency stress-test against 5
+ * representative fetchers (oss-trending, funding-news, github-events,
+ * twitter-repo-signals, mcp-liveness). Every Fetcher must satisfy this
+ * contract; standalone scripts and user-input flows declare a contract
+ * without a Fetcher.
+ */
+export type SourceContract = {
+  /** Stable slug; matches Fetcher.name when one exists. */
+  id: string;
+  category: SourceCategory;
+  kind: SourceKind;
+  state: SourceState;
+  freshness_budget_ms: number;
+  cost_signal_metric: CostSignalMetric;
+  rate_limit?: RateLimit;
+  /** GitHub handle / team slug; the literal 'UNASSIGNED' is allowed in Phase 1. */
+  owner: string;
+  upstream_url: string | string[] | 'multiple';
+  auth_required: boolean;
+  auth_scheme?: AuthScheme;
+  /** Static slug list OR fan-out pattern. See PrimaryOutputKeys. */
+  primary_output_keys: PrimaryOutputKeys;
+  output_record_shape: OutputRecordShape;
+  consensus_role?: ConsensusRole;
+  /** Route paths or src/lib readers that consume this source's output. */
+  consumer_surfaces: string[];
+  /** Source ids that must run first. */
+  depends_on: string[];
+  supports_backfill: boolean;
+  fallback_strategy: FallbackStrategy;
+  /**
+   * For multi-provider sources (e.g. twitter-signals: apify→web→nitter→fixture).
+   * One contract row owns the chain; providers[] documents the ordered fallback.
+   */
+  providers?: SourceProvider[];
+  /** Forward-compat for Move 2 (canonical entities + provenance). */
+  writes_canonical_entity_kind?: CanonicalEntityKind[];
+  /** For state='intent-only': what's the ship/delete question? */
+  decision_pending?: string;
+};

--- a/apps/trendingrepo-worker/src/schedule.ts
+++ b/apps/trendingrepo-worker/src/schedule.ts
@@ -16,6 +16,12 @@ import { FETCHERS } from './registry.js';
 import { runFetcher } from './run.js';
 import { getLogger } from './lib/log.js';
 import { captureException } from './lib/sentry.js';
+import {
+  applyOverrides,
+  loadOverrides,
+  startOverrideRefresh,
+  summarizeOverrides,
+} from './platform/overrides.js';
 
 export interface ScheduledJobStatus {
   name: string;
@@ -31,11 +37,32 @@ export interface Scheduler {
   status(): ScheduledJobStatus[];
 }
 
-export function startScheduler(): Scheduler {
+export async function startScheduler(): Promise<Scheduler> {
   const log = getLogger();
   const jobs: Array<{ name: string; schedule: string; cron: Cron }> = [];
 
-  for (const fetcher of FETCHERS) {
+  // Move 1, Phase 2 — apply runtime source overrides at boot. Loader is
+  // tolerant: DB outage falls back to .cache/source-overrides.json, missing
+  // cache falls back to "all sources active". Never refuses to start. After
+  // boot, refresh every 60s in the background so a paused fetcher stops
+  // ticking within ~1 minute of the DB row landing.
+  const overrides = await loadOverrides();
+  const filtered = applyOverrides(FETCHERS, overrides);
+  const skipped = FETCHERS.filter((f) => !filtered.includes(f));
+  const summary = summarizeOverrides(overrides);
+  log.info(
+    {
+      registered: FETCHERS.length,
+      activated: filtered.length,
+      skipped: skipped.length,
+      skippedNames: skipped.map((f) => f.name),
+      overrides: summary,
+    },
+    'source overrides applied to fetcher registry',
+  );
+  startOverrideRefresh();
+
+  for (const fetcher of filtered) {
     const cron = new Cron(
       fetcher.schedule,
       {

--- a/apps/trendingrepo-worker/src/server.ts
+++ b/apps/trendingrepo-worker/src/server.ts
@@ -3,6 +3,8 @@ import { loadEnv } from './lib/env.js';
 import { getDb, pingDb } from './lib/db.js';
 import { getRedis } from './lib/redis.js';
 import { getLogger } from './lib/log.js';
+import { FETCHERS, SOURCE_CONTRACTS } from './registry.js';
+import { findGhostOverrides, getCachedOverrides } from './platform/overrides.js';
 
 interface HealthState {
   ok: boolean;
@@ -10,6 +12,12 @@ interface HealthState {
   redis: boolean;
   lastCheckAt: string;
   lastRunAt: string | null;
+  /**
+   * Override source_ids that no longer correspond to any registered fetcher
+   * AND no longer correspond to a static contract row. Empty in the green
+   * state. Reaper job (Move 1 step 4) consumes this to archive stale rows.
+   */
+  ghost_overrides: string[];
 }
 
 let cached: HealthState | null = null;
@@ -45,12 +53,14 @@ async function refreshHealth(): Promise<HealthState> {
   } catch (err) {
     log.warn(`healthcheck redis: ${(err as Error).message}`);
   }
+  const ghostOverrides = findGhostOverrides(FETCHERS, getCachedOverrides(), SOURCE_CONTRACTS);
   const state: HealthState = {
     ok: dbOk && redisOk,
     db: dbOk,
     redis: redisOk,
     lastCheckAt: new Date().toISOString(),
     lastRunAt: cached?.lastRunAt ?? null,
+    ghost_overrides: ghostOverrides,
   };
   cached = state;
   return state;

--- a/supabase/migrations/0002_source_overrides.sql
+++ b/supabase/migrations/0002_source_overrides.sql
@@ -1,0 +1,74 @@
+-- StarScreener — runtime overrides for the Source Registry (Move 1, Phase 2).
+--
+-- Purpose
+--   Pair the static `SourceContract[]` (apps/trendingrepo-worker/src/platform/
+--   sources.json) with a Supabase-backed runtime state table so ops can pause
+--   / deprecate / reactivate a source without a code deploy. Apify spend can
+--   blow $20/hr if a fetcher loops; a 4-minute Vercel/Railway deploy to pause
+--   it is unacceptable.
+--
+-- Boot-path contract
+--   The worker reads this table at boot with a 2-second timeout. Read miss
+--   (timeout, error, table absent) falls back to .cache/source-overrides.json
+--   (last-known-good); cache miss falls back to "all sources active" — the
+--   worker NEVER refuses to start. See apps/trendingrepo-worker/src/platform/
+--   overrides.ts for the loader.
+--
+-- Audit history
+--   Every insert/update/delete on `source_overrides` mirrors a row into
+--   `source_override_history` via the `source_overrides_audit` trigger so
+--   we have forensic visibility into pause/unpause cycles and
+--   ghost-row reaper deletions (Move 1 step 4 lint enforces deprecate-
+--   then-delete; the history table is the paper trail).
+--
+-- Idempotency
+--   Every CREATE uses IF NOT EXISTS; the trigger function uses
+--   CREATE OR REPLACE; the trigger itself is dropped + recreated. Re-running
+--   this migration is safe.
+
+create table if not exists source_overrides (
+  source_id        text primary key,
+  state            text not null check (state in ('active','paused','deprecated')),
+  paused_until     timestamptz,
+  reason           text not null,
+  set_by           text not null,
+  set_at           timestamptz not null default now(),
+  expected_resume  timestamptz,
+  notes            jsonb not null default '{}'
+);
+
+create index if not exists source_overrides_state_idx
+  on source_overrides(state)
+  where state <> 'active';
+
+create table if not exists source_override_history (
+  id           bigserial primary key,
+  op           text not null check (op in ('insert','update','delete')),
+  source_id    text not null,
+  state        text,
+  paused_until timestamptz,
+  reason       text,
+  set_by       text,
+  set_at       timestamptz,
+  changed_at   timestamptz not null default now(),
+  notes        jsonb
+);
+
+create or replace function source_overrides_audit() returns trigger as $$
+begin
+  if tg_op = 'DELETE' then
+    insert into source_override_history(op, source_id, state, paused_until, reason, set_by, set_at, notes)
+    values ('delete', old.source_id, old.state, old.paused_until, old.reason, old.set_by, old.set_at, old.notes);
+    return old;
+  else
+    insert into source_override_history(op, source_id, state, paused_until, reason, set_by, set_at, notes)
+    values (lower(tg_op), new.source_id, new.state, new.paused_until, new.reason, new.set_by, new.set_at, new.notes);
+    return new;
+  end if;
+end;
+$$ language plpgsql;
+
+drop trigger if exists source_overrides_audit_trg on source_overrides;
+create trigger source_overrides_audit_trg
+  after insert or update or delete on source_overrides
+  for each row execute function source_overrides_audit();


### PR DESCRIPTION
## Move 1, Phase 2 - Source Platform migration

Stacked PR on top of #326. Pairs the static `SourceContract[]` (P1) with a Supabase-backed runtime state table so ops can pause / deprecate / reactivate any source without a code deploy. Apify spend can blow $20/hr if a fetcher loops; a 4-minute Vercel/Railway deploy to pause it is unacceptable.

> **Depends on #326** landing first (or merging this on top of that branch). The `source-contract.ts` file is included here because P1-B commit `aff5579b` shipped `sources.json` and the `registry.ts` `SOURCE_CONTRACTS` export but did NOT include the type file it imports - this branch could not compile without it. Once #326 lands, the file will be a no-op include.

## What ships

### 1. Migration (idempotent)
`supabase/migrations/0002_source_overrides.sql` - 74 lines
- `source_overrides` table (state, paused_until, reason, set_by, set_at, expected_resume, notes)
- `source_override_history` table (audit trail)
- `source_overrides_audit` trigger (insert/update/delete -> history row)
- All `CREATE IF NOT EXISTS` + `CREATE OR REPLACE` + `DROP TRIGGER IF EXISTS` so re-running is safe

### 2. Boot loader
`apps/trendingrepo-worker/src/platform/overrides.ts` - 225 lines

Exports:
- `loadOverrides()` - 2-second timeout, atomic cache write, fail-safe-open
- `applyOverrides(fetchers, overrides)` - pure filter, returns new array
- `findGhostOverrides(fetchers, overrides, contracts)` - override ids missing from BOTH FETCHERS[] and SOURCE_CONTRACTS[]
- `summarizeOverrides(overrides)` - per-state count summary
- `getCachedOverrides()` - sync accessor for /healthz
- `startOverrideRefresh(intervalMs)` - 60s background refresh, returns stop fn

Boot path - **never refuses to start**:
1. Try Supabase (2s timeout) -> success: write `.cache/source-overrides.json` (atomic temp + rename)
2. DB failure / timeout -> read cache (last-known-good)
3. No cache -> empty Map (assume all sources active)

Filter semantics:
- `state=paused` AND (`paused_until IS NULL` OR `paused_until > now()`) -> skip
- `state=paused` AND `paused_until <= now()` -> keep (pause expired)
- `state=deprecated` -> skip
- `state=active` OR no override -> keep

### 3. Schedule integration
`apps/trendingrepo-worker/src/schedule.ts` - +29 / -2 lines

`startScheduler()` is now async. Before croner registration:
- `await loadOverrides()`
- `applyOverrides(FETCHERS, overrides)`
- Single info log line: `{registered, activated, skipped, skippedNames, overrides: {total, paused, deprecated}}`
- `startOverrideRefresh()` (60s background tick, `unref()`'d so it doesn't block shutdown)

`apps/trendingrepo-worker/src/index.ts` - +1 / -1 line: caller awaits `startScheduler()`

### 4. /healthz update
`apps/trendingrepo-worker/src/server.ts` - +10 lines

`HealthState` gains `ghost_overrides: string[]`. Reads the cached overrides Map (no DB hit on healthz). Empty in green state.

### 5. Tests
`apps/trendingrepo-worker/src/platform/__tests__/overrides.test.ts` - 189 lines, 14 tests

Covers `applyOverrides` (paused indef / paused future / paused expired / deprecated / active / no-override / mutation safety / mixed states), `findGhostOverrides` (no overrides / contract-only sources / true ghosts / empty inputs), `summarizeOverrides`. Mocks DB by constructing override Maps directly - no live Supabase, per task constraint.

### 6. Worker .gitignore
`.cache/` - the on-disk override snapshot.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` (worker) | PASS modulo 10 pre-existing `src/lib/llm/*` baseline errors |
| `npm run lint:guards` (root) | PASS (8 sub-checks all OK) |
| `npx vitest run src/platform/__tests__/overrides.test.ts` | 14/14 pass |
| Full worker `npx vitest run` | 371 pass, 1 skipped, 2 pre-existing failures in `consensus-trending/scoring.test.ts` (zero diff vs base on this branch; not caused by this PR) |

## Constraints respected

- No edit to P1 deliverables (sources.json, registry.ts) - frozen.
- `source-contract.ts` included only because the type file was missing from the P1-B merge state on this branch.
- No admin route to mutate `source_overrides` - Phase 3 work.
- No use of `git add -A` or `--no-verify`.
- DB-touching `loadOverrides` is unit-tested by Map construction (no live Supabase needed).

## Plan + spec

- Plan: `~/.claude/plans/hidden-pondering-meadow.md`
- Spec: `docs/SOURCE-REGISTRY-PROPOSAL.md` sections 4 (loader pseudocode) + 5 (migration sequence)

## Test plan

- [ ] Apply migration `0002_source_overrides.sql` to a Supabase project (idempotent - re-run is a no-op).
- [ ] Insert a row: `insert into source_overrides values ('hn-pulse', 'paused', null, 'test pause', 'ops');`
- [ ] Restart the worker - confirm log line `source overrides applied to fetcher registry` shows `skipped: 1, skippedNames: ['hn-pulse']`.
- [ ] Hit `/healthz` - confirm `ghost_overrides: []`.
- [ ] Insert a ghost: `insert into source_overrides values ('does-not-exist', 'paused', null, 'ghost test', 'ops');` then wait 60s for the background refresh.
- [ ] Hit `/healthz` again - confirm `ghost_overrides: ['does-not-exist']`.
- [ ] Update the original row: `update source_overrides set state='active' where source_id='hn-pulse';` - within 60s the next `loadOverrides()` tick should re-add `hn-pulse` to the schedule (confirmed on next worker restart for now; live re-arming is Phase 3).
- [ ] Drop network to Supabase - restart worker - confirm log line `source overrides db load failed; falling back to cache` and the worker stays up.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>