### PR TITLE
feat(platform/move1-p3): bind SOURCE_CONTRACTS into fetcher runtime

### DIFF
--- a/apps/trendingrepo-worker/.gitignore
+++ b/apps/trendingrepo-worker/.gitignore
@@ -19,3 +19,7 @@ supabase/.temp/
 # logs / scratch
 *.log
 .tmp/
+
+# source-overrides on-disk cache (last-known-good snapshot of the
+# Supabase source_overrides table; written by platform/overrides.ts).
+.cache/

--- a/apps/trendingrepo-worker/src/__tests__/run-contract.test.ts
+++ b/apps/trendingrepo-worker/src/__tests__/run-contract.test.ts
@@ -1,0 +1,122 @@
+// Verifies Move 1, Phase 3 contract-binding wiring in run.ts:
+//   1. A fetcher whose name matches a SOURCE_CONTRACTS row receives that
+//      contract on FetcherContext.contract.
+//   2. A fetcher whose name has no SOURCE_CONTRACTS row receives
+//      `undefined` and runFetcher does NOT throw — the missing-contract
+//      path logs a Sentry warning + log.warn and continues.
+//   3. The run-summary line is emitted on the success path (asserted via
+//      a console.log spy).
+//
+// Runs against mock Fetchers in dry-run with DATA_STORE_DISABLE so no
+// infra is required. Mirrors run-since.test.ts setup.
+
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+
+// Disable data-store and silence pino before importing the worker code.
+process.env.DATA_STORE_DISABLE = '1';
+process.env.LOG_LEVEL = 'fatal';
+process.env.NODE_ENV = 'test';
+
+const { runFetcher } = await import('../run.js');
+const { SOURCE_CONTRACTS } = await import('../registry.js');
+
+import type { Fetcher, FetcherContext, RunResult } from '../lib/types.js';
+
+function emptyResult(name: string): RunResult {
+  const now = new Date().toISOString();
+  return {
+    fetcher: name,
+    startedAt: now,
+    finishedAt: now,
+    itemsSeen: 0,
+    itemsUpserted: 0,
+    metricsWritten: 0,
+    redisPublished: false,
+    errors: [],
+  };
+}
+
+function makeMock(name: string): {
+  fetcher: Fetcher;
+  captured: { contract: FetcherContext['contract'] | undefined };
+} {
+  const captured: { contract: FetcherContext['contract'] | undefined } = {
+    contract: undefined,
+  };
+  const fetcher: Fetcher = {
+    name,
+    schedule: '0 * * * *',
+    async run(ctx: FetcherContext) {
+      captured.contract = ctx.contract;
+      return emptyResult(name);
+    },
+  };
+  return { fetcher, captured };
+}
+
+describe('runFetcher → SourceContract binding (Move 1, Phase 3)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('passes the matching SourceContract through ctx.contract', async () => {
+    // Pick the first registered contract id; that guarantees a real row
+    // exists without hard-coding a slug that could be renamed.
+    const known = SOURCE_CONTRACTS[0];
+    expect(known, 'sources.json must have at least one row').toBeDefined();
+    const { fetcher, captured } = makeMock(known!.id);
+
+    await runFetcher(fetcher, { dryRun: true });
+
+    expect(captured.contract).toBeDefined();
+    expect(captured.contract?.id).toBe(known!.id);
+    expect(typeof captured.contract?.freshness_budget_ms).toBe('number');
+  });
+
+  it('does not crash when no SOURCE_CONTRACTS row matches the fetcher name', async () => {
+    const { fetcher, captured } = makeMock(
+      '__phase3-test-unknown-source-id__',
+    );
+
+    // Must not throw. Must hand `undefined` to the fetcher.
+    await expect(runFetcher(fetcher, { dryRun: true })).resolves.toBeDefined();
+    expect(captured.contract).toBeUndefined();
+  });
+
+  it('emits a [run-summary] line on the success path', async () => {
+    const known = SOURCE_CONTRACTS[0];
+    expect(known).toBeDefined();
+    const { fetcher } = makeMock(known!.id);
+
+    await runFetcher(fetcher, { dryRun: true });
+
+    const lines = logSpy.mock.calls.map((c) => String(c[0] ?? ''));
+    const summary = lines.find((l) => l.startsWith('[run-summary]'));
+    expect(summary, 'run-summary line was not emitted').toBeDefined();
+    expect(summary).toContain(`source=${known!.id}`);
+    expect(summary).toContain('status=ok');
+    expect(summary).toMatch(/duration_ms=\d+/);
+    expect(summary).toMatch(/records_in=\d+/);
+    expect(summary).toMatch(/records_out=\d+/);
+    expect(summary).toContain(
+      `contract_freshness_budget_ms=${known!.freshness_budget_ms}`,
+    );
+  });
+
+  it('emits contract_freshness_budget_ms=missing when no contract is found', async () => {
+    const { fetcher } = makeMock('__phase3-test-unknown-source-id__');
+
+    await runFetcher(fetcher, { dryRun: true });
+
+    const lines = logSpy.mock.calls.map((c) => String(c[0] ?? ''));
+    const summary = lines.find((l) => l.startsWith('[run-summary]'));
+    expect(summary).toBeDefined();
+    expect(summary).toContain('contract_freshness_budget_ms=missing');
+  });
+});

--- a/apps/trendingrepo-worker/src/index.ts
+++ b/apps/trendingrepo-worker/src/index.ts
@@ -42,7 +42,7 @@ async function main(argv: string[]): Promise<number> {
 
   if (cronMode) {
     const server = startHealthServer();
-    const scheduler = startScheduler();
+    const scheduler = await startScheduler();
     installShutdownHandlers({
       server,
       onClose: async () => {

--- a/apps/trendingrepo-worker/src/lib/types.ts
+++ b/apps/trendingrepo-worker/src/lib/types.ts
@@ -1,5 +1,6 @@
 import type { Logger } from 'pino';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SourceContract } from '../platform/source-contract.js';
 
 export type TrendingItemType =
   | 'skill'
@@ -131,6 +132,19 @@ export interface FetcherContext {
   dryRun: boolean;
   since: Date;
   signalRunComplete: (counts: RunResult) => Promise<void>;
+  /**
+   * Static `SourceContract` row for this fetcher, looked up at run time from
+   * `SOURCE_CONTRACTS[]`. Optional because:
+   *   1. `runFetcher()` may be invoked from contexts that don't pre-populate
+   *      it (one-shot CLI debug, ad-hoc test mocks).
+   *   2. A registered fetcher may be missing a contract row during the
+   *      migration window — runFetcher logs a Sentry warning and continues
+   *      rather than crashing the whole cron tick.
+   * Move 3 will read `contract.freshness_budget_ms` and
+   * `contract.cost_signal_metric` for enforcement; Phase 3 only surfaces it
+   * for diagnostics + run-summary logging.
+   */
+  contract?: SourceContract;
 }
 
 export interface Fetcher {

--- a/apps/trendingrepo-worker/src/platform/__tests__/overrides.test.ts
+++ b/apps/trendingrepo-worker/src/platform/__tests__/overrides.test.ts
@@ -1,0 +1,189 @@
+// Unit tests for source-overrides pure helpers.
+//
+// These exercise applyOverrides, findGhostOverrides, summarizeOverrides, and
+// shouldSkip semantics (via applyOverrides). The DB-touching `loadOverrides`
+// function is exercised indirectly: tests construct override Maps directly
+// instead of mocking Supabase. A live-Supabase loadOverrides test would be
+// integration-tier and is intentionally out of scope (per task constraint).
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyOverrides,
+  findGhostOverrides,
+  summarizeOverrides,
+  type SourceOverride,
+} from '../overrides.js';
+import type { Fetcher } from '../../lib/types.js';
+import type { SourceContract } from '../source-contract.js';
+
+function fetcher(name: string): Fetcher {
+  return {
+    name,
+    schedule: '0 * * * *',
+    run: async () => ({
+      fetcher: name,
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+      itemsSeen: 0,
+      itemsUpserted: 0,
+      metricsWritten: 0,
+      redisPublished: false,
+      errors: [],
+    }),
+  };
+}
+
+function contract(id: string): SourceContract {
+  return {
+    id,
+    category: 'repo-derived',
+    kind: 'collector',
+    state: 'active',
+    freshness_budget_ms: 3_600_000,
+    cost_signal_metric: { type: 'none' },
+    owner: 'UNASSIGNED',
+    upstream_url: 'https://example.com',
+    auth_required: false,
+    primary_output_keys: [id],
+    output_record_shape: 'metric_snapshot',
+    consumer_surfaces: [],
+    depends_on: [],
+    supports_backfill: false,
+    fallback_strategy: 'none',
+  };
+}
+
+function override(
+  source_id: string,
+  state: SourceOverride['state'],
+  paused_until: string | null = null,
+  reason = 'test',
+): SourceOverride {
+  return { source_id, state, paused_until, reason };
+}
+
+describe('applyOverrides', () => {
+  it('keeps fetchers with no override', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map<string, SourceOverride>();
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['a', 'b']);
+  });
+
+  it('keeps fetchers explicitly active', () => {
+    const fetchers = [fetcher('a')];
+    const overrides = new Map([['a', override('a', 'active')]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['a']);
+  });
+
+  it('skips fetchers paused indefinitely (paused_until null)', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused', null)]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['b']);
+  });
+
+  it('skips fetchers paused with future paused_until', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused', future)]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['b']);
+  });
+
+  it('keeps fetchers whose paused_until is in the past (pause expired)', () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused', past)]]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual(['a', 'b']);
+  });
+
+  it('skips fetchers marked deprecated regardless of paused_until', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([
+      ['a', override('a', 'deprecated', future)],
+      ['b', override('b', 'deprecated', null)],
+    ]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual([]);
+  });
+
+  it('returns a new array (does not mutate input)', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused')]]);
+    const result = applyOverrides(fetchers, overrides);
+    expect(result).not.toBe(fetchers);
+    expect(fetchers.map((f) => f.name)).toEqual(['a', 'b']);
+  });
+
+  it('handles mixed states across many fetchers', () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const future = new Date(Date.now() + 1000 * 60 * 60).toISOString();
+    const fetchers = [
+      fetcher('keep-active'),
+      fetcher('skip-paused-indef'),
+      fetcher('skip-paused-future'),
+      fetcher('keep-paused-expired'),
+      fetcher('skip-deprecated'),
+      fetcher('keep-no-override'),
+    ];
+    const overrides = new Map<string, SourceOverride>([
+      ['keep-active', override('keep-active', 'active')],
+      ['skip-paused-indef', override('skip-paused-indef', 'paused', null)],
+      ['skip-paused-future', override('skip-paused-future', 'paused', future)],
+      ['keep-paused-expired', override('keep-paused-expired', 'paused', past)],
+      ['skip-deprecated', override('skip-deprecated', 'deprecated', null)],
+    ]);
+    expect(applyOverrides(fetchers, overrides).map((f) => f.name)).toEqual([
+      'keep-active',
+      'keep-paused-expired',
+      'keep-no-override',
+    ]);
+  });
+});
+
+describe('findGhostOverrides', () => {
+  it('returns empty when every override has a fetcher', () => {
+    const fetchers = [fetcher('a'), fetcher('b')];
+    const overrides = new Map([['a', override('a', 'paused')]]);
+    expect(findGhostOverrides(fetchers, overrides, [])).toEqual([]);
+  });
+
+  it('returns empty when override matches a contract-only source (script / user-input)', () => {
+    const fetchers = [fetcher('a')];
+    const overrides = new Map([['scrape-foo', override('scrape-foo', 'paused')]]);
+    const contracts = [contract('scrape-foo')];
+    expect(findGhostOverrides(fetchers, overrides, contracts)).toEqual([]);
+  });
+
+  it('flags override ids absent from both fetchers and contracts', () => {
+    const fetchers = [fetcher('a')];
+    const overrides = new Map([
+      ['a', override('a', 'active')],
+      ['ghost-1', override('ghost-1', 'paused')],
+      ['ghost-2', override('ghost-2', 'deprecated')],
+    ]);
+    const contracts = [contract('a')];
+    expect(findGhostOverrides(fetchers, overrides, contracts).sort()).toEqual([
+      'ghost-1',
+      'ghost-2',
+    ]);
+  });
+
+  it('returns empty when overrides map is empty', () => {
+    expect(findGhostOverrides([fetcher('a')], new Map(), [contract('a')])).toEqual([]);
+  });
+});
+
+describe('summarizeOverrides', () => {
+  it('counts paused and deprecated separately and totals', () => {
+    const overrides = new Map<string, SourceOverride>([
+      ['a', override('a', 'paused')],
+      ['b', override('b', 'paused')],
+      ['c', override('c', 'deprecated')],
+      ['d', override('d', 'active')],
+    ]);
+    expect(summarizeOverrides(overrides)).toEqual({ total: 4, paused: 2, deprecated: 1 });
+  });
+
+  it('returns zeros for an empty map', () => {
+    expect(summarizeOverrides(new Map())).toEqual({ total: 0, paused: 0, deprecated: 0 });
+  });
+});

--- a/apps/trendingrepo-worker/src/platform/contracts.ts
+++ b/apps/trendingrepo-worker/src/platform/contracts.ts
@@ -1,0 +1,48 @@
+/**
+ * Source contract lookup helpers.
+ *
+ * Move 1, Phase 3 of the Source Platform migration. Phase 1 landed the
+ * `SourceContract` type (source-contract.ts) and the `SOURCE_CONTRACTS[]`
+ * registry (sources.json + registry.ts). Phase 3 binds those contracts into
+ * the fetcher RUNTIME so each fetcher knows its own contract at run time
+ * (for diagnostics now, freshness/cost enforcement in Move 3).
+ *
+ * This module is the thin lookup layer between the static registry and the
+ * `runFetcher()` call site. Build-time constant cost (Map indexed by id) so
+ * cron-tick lookups never become a hotspot.
+ *
+ * See:
+ *   - apps/trendingrepo-worker/src/platform/source-contract.ts (the type)
+ *   - apps/trendingrepo-worker/src/platform/sources.json (the data)
+ *   - apps/trendingrepo-worker/src/registry.ts (SOURCE_CONTRACTS export)
+ *   - apps/trendingrepo-worker/src/run.ts (consumer)
+ *   - ~/.claude/plans/hidden-pondering-meadow.md (approved plan)
+ */
+
+import { SOURCE_CONTRACTS } from '../registry.js';
+import type { SourceContract } from './source-contract.js';
+
+// Built once at import time. SOURCE_CONTRACTS is readonly — the Map is not
+// rebuilt on subsequent calls. If a future hot-reload story for
+// `sources.json` lands, this Map will need to be rebuilt at refresh time.
+let contractsById: Map<string, SourceContract> | null = null;
+
+function getIndex(): Map<string, SourceContract> {
+  if (contractsById) return contractsById;
+  contractsById = new Map(SOURCE_CONTRACTS.map((c) => [c.id, c]));
+  return contractsById;
+}
+
+/**
+ * Look up the static `SourceContract` for a given source id (typically the
+ * `Fetcher.name`). Returns `undefined` for ids without a matching row — the
+ * caller decides whether absence is an error. `runFetcher()` treats it as a
+ * Sentry warning, not a crash.
+ *
+ * Phase 3 callers should NOT mutate the returned contract; future phases
+ * may switch this to return `Readonly<SourceContract>` once consumer call
+ * sites are typed accordingly.
+ */
+export function getContract(sourceId: string): SourceContract | undefined {
+  return getIndex().get(sourceId);
+}

--- a/apps/trendingrepo-worker/src/platform/overrides.ts
+++ b/apps/trendingrepo-worker/src/platform/overrides.ts
@@ -1,0 +1,225 @@
+/**
+ * Source overrides — boot-time loader for runtime state of registered sources.
+ *
+ * Move 1, Phase 2 of the Source Platform migration. Static fields live in
+ * `sources.json` (PR #326); runtime state (paused / deprecated / paused_until)
+ * lives in the Supabase `source_overrides` table (migration 0002). This module
+ * loads the overrides at boot, refreshes them every 60s in the background, and
+ * exposes pure helpers for `schedule.ts` and `/healthz` to consume.
+ *
+ * Boot-path contract — never refuses to start:
+ *   1. Try Supabase with a 2-second timeout.
+ *   2. Success → write `.cache/source-overrides.json` (atomic temp + rename).
+ *   3. DB failure / timeout → read the cache file (last-known-good).
+ *   4. No cache → empty Map (assume all sources active).
+ *
+ * Filter semantics:
+ *   - state = 'paused' AND (paused_until IS NULL OR paused_until > now()) → skip
+ *   - state = 'paused' AND paused_until <= now() → keep (pause expired)
+ *   - state = 'deprecated' → skip
+ *   - state = 'active' → keep
+ *   - no override row → keep
+ *
+ * Ghost detection:
+ *   A ghost override is a row whose source_id is NOT in the current
+ *   `FETCHERS[]` AND NOT in the static `SOURCE_CONTRACTS[]` registry. These
+ *   are surfaced via /healthz so the reaper job (Move 1 step 4) has a target
+ *   list. Source ids that appear in `SOURCE_CONTRACTS[]` but not `FETCHERS[]`
+ *   are NOT ghosts — they're the 17 standalone scripts and 3 user-input flows.
+ *
+ * See:
+ *   - docs/SOURCE-REGISTRY-PROPOSAL.md §4 (loader pseudocode)
+ *   - supabase/migrations/0002_source_overrides.sql (schema)
+ *   - apps/trendingrepo-worker/src/schedule.ts (consumer)
+ *   - apps/trendingrepo-worker/src/server.ts (/healthz consumer)
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { getDb } from '../lib/db.js';
+import { getLogger } from '../lib/log.js';
+import type { Fetcher } from '../lib/types.js';
+import type { SourceContract } from './source-contract.js';
+
+export interface SourceOverride {
+  source_id: string;
+  state: 'active' | 'paused' | 'deprecated';
+  paused_until: string | null;
+  reason: string;
+}
+
+const CACHE_PATH = resolve(process.cwd(), '.cache', 'source-overrides.json');
+const LOAD_TIMEOUT_MS = 2_000;
+const REFRESH_INTERVAL_MS_DEFAULT = 60_000;
+
+let cachedOverrides: Map<string, SourceOverride> = new Map();
+let refreshTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Load overrides from Supabase with a 2-second timeout, fall back to the
+ * on-disk cache, then to an empty Map. Always resolves; never throws. Updates
+ * the module-level `cachedOverrides` so synchronous helpers see the new state.
+ */
+export async function loadOverrides(): Promise<Map<string, SourceOverride>> {
+  const log = getLogger();
+  const t0 = Date.now();
+  try {
+    const rows = await Promise.race<SourceOverride[]>([
+      loadFromDb(),
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error('source-overrides-load-timeout')), LOAD_TIMEOUT_MS),
+      ),
+    ]);
+    cachedOverrides = new Map(rows.map((r) => [r.source_id, r]));
+    writeCacheAtomic(rows);
+    log.info(
+      { count: rows.length, durationMs: Date.now() - t0, source: 'db' },
+      'source overrides loaded',
+    );
+    return cachedOverrides;
+  } catch (err) {
+    log.warn(
+      { err: (err as Error).message, durationMs: Date.now() - t0 },
+      'source overrides db load failed; falling back to cache',
+    );
+    const fromCache = readCache();
+    if (fromCache) {
+      cachedOverrides = new Map(fromCache.map((r) => [r.source_id, r]));
+      log.info(
+        { count: fromCache.length, source: 'cache' },
+        'source overrides loaded from cache',
+      );
+      return cachedOverrides;
+    }
+    cachedOverrides = new Map();
+    log.warn('no source overrides cache present; assuming all sources active');
+    return cachedOverrides;
+  }
+}
+
+async function loadFromDb(): Promise<SourceOverride[]> {
+  const db = getDb();
+  const { data, error } = await db
+    .from('source_overrides')
+    .select('source_id, state, paused_until, reason')
+    .neq('state', 'active');
+  if (error) throw new Error(`supabase: ${error.message}`);
+  return (data ?? []) as SourceOverride[];
+}
+
+function writeCacheAtomic(rows: SourceOverride[]): void {
+  try {
+    mkdirSync(dirname(CACHE_PATH), { recursive: true });
+    const tmp = `${CACHE_PATH}.${process.pid}.tmp`;
+    writeFileSync(tmp, JSON.stringify(rows), 'utf8');
+    renameSync(tmp, CACHE_PATH);
+  } catch (err) {
+    getLogger().warn(
+      { err: (err as Error).message, path: CACHE_PATH },
+      'source overrides cache write failed',
+    );
+  }
+}
+
+function readCache(): SourceOverride[] | null {
+  try {
+    if (!existsSync(CACHE_PATH)) return null;
+    const raw = readFileSync(CACHE_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as SourceOverride[];
+    return Array.isArray(parsed) ? parsed : null;
+  } catch (err) {
+    getLogger().warn(
+      { err: (err as Error).message, path: CACHE_PATH },
+      'source overrides cache read failed',
+    );
+    return null;
+  }
+}
+
+/**
+ * Pure: filter a fetcher list against an overrides map. Returns a NEW array;
+ * does not mutate the input. Used by `schedule.ts` before croner registration.
+ */
+export function applyOverrides(
+  fetchers: Fetcher[],
+  overrides: Map<string, SourceOverride>,
+): Fetcher[] {
+  const now = Date.now();
+  return fetchers.filter((f) => !shouldSkip(overrides.get(f.name), now));
+}
+
+function shouldSkip(override: SourceOverride | undefined, nowMs: number): boolean {
+  if (!override) return false;
+  if (override.state === 'deprecated') return true;
+  if (override.state === 'paused') {
+    if (override.paused_until == null) return true;
+    return new Date(override.paused_until).getTime() > nowMs;
+  }
+  return false; // 'active'
+}
+
+/**
+ * Pure: which override source_ids no longer correspond to any fetcher OR
+ * static contract row? These are true ghosts — code-side deletions that left
+ * the DB row orphaned. The reaper job (Move 1 step 4) consumes this list.
+ */
+export function findGhostOverrides(
+  fetchers: Fetcher[],
+  overrides: Map<string, SourceOverride>,
+  contracts: readonly SourceContract[],
+): string[] {
+  const known = new Set<string>();
+  for (const f of fetchers) known.add(f.name);
+  for (const c of contracts) known.add(c.id);
+  return [...overrides.keys()].filter((id) => !known.has(id));
+}
+
+/**
+ * Returns a per-state count summary for log lines and /healthz, computed
+ * against the current cache (does NOT trigger a reload).
+ */
+export function summarizeOverrides(
+  overrides: Map<string, SourceOverride>,
+): { total: number; paused: number; deprecated: number } {
+  let paused = 0;
+  let deprecated = 0;
+  for (const o of overrides.values()) {
+    if (o.state === 'paused') paused++;
+    else if (o.state === 'deprecated') deprecated++;
+  }
+  return { total: overrides.size, paused, deprecated };
+}
+
+/**
+ * Synchronous accessor for the most recently loaded overrides map. Used by
+ * /healthz to surface ghost rows without re-querying the DB on every probe.
+ */
+export function getCachedOverrides(): Map<string, SourceOverride> {
+  return cachedOverrides;
+}
+
+/**
+ * Background refresh — re-runs `loadOverrides()` every `intervalMs` (default
+ * 60s). Returns a stop function. Errors inside the refresh are swallowed by
+ * `loadOverrides()` itself (it never throws), so the timer keeps ticking.
+ */
+export function startOverrideRefresh(
+  intervalMs: number = REFRESH_INTERVAL_MS_DEFAULT,
+): () => void {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+  refreshTimer = setInterval(() => {
+    void loadOverrides();
+  }, intervalMs);
+  // Don't keep the event loop alive on this timer alone — the cron scheduler
+  // keeps it alive, and a stuck refresh shouldn't prevent shutdown.
+  if (typeof refreshTimer.unref === 'function') refreshTimer.unref();
+  return () => {
+    if (refreshTimer) {
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+  };
+}

--- a/apps/trendingrepo-worker/src/platform/run-summary.ts
+++ b/apps/trendingrepo-worker/src/platform/run-summary.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-fetcher run-summary log emitter.
+ *
+ * Move 1, Phase 3 of the Source Platform migration. At the end of every
+ * `runFetcher()` call (success or error), we emit ONE structured line that
+ * a future log scraper / freshness dashboard can ingest without parsing
+ * pino's full JSON envelope. The line is intentionally human-greppable:
+ *
+ *   [run-summary] source=<id> status=<ok|err> duration_ms=<N>
+ *                 records_in=<N> records_out=<N>
+ *                 contract_freshness_budget_ms=<N|missing>
+ *
+ * Why a separate helper? Three reasons:
+ *   1. Phase 3 is purely additive — wrapping the existing pino calls would
+ *      be K3 surgery against the current observability story.
+ *   2. Move 3 will swap `console.log` for a Redis stream / Sentry breadcrumb
+ *      without re-touching every call site if the formatting lives here.
+ *   3. The constraint "don't add new dependencies" rules out any structured
+ *      logging library; plain `console.log` is the contract.
+ *
+ * See:
+ *   - apps/trendingrepo-worker/src/run.ts (consumer)
+ *   - apps/trendingrepo-worker/src/platform/source-contract.ts
+ *   - ~/.claude/plans/hidden-pondering-meadow.md (approved plan)
+ */
+
+import type { SourceContract } from './source-contract.js';
+
+export type RunSummaryStatus = 'ok' | 'err';
+
+export interface RunSummary {
+  sourceId: string;
+  status: RunSummaryStatus;
+  durationMs: number;
+  recordsIn: number;
+  recordsOut: number;
+  contract?: SourceContract;
+}
+
+/**
+ * Emit one `[run-summary] ...` line for the given fetcher run. Uses
+ * `console.log` so the line shows up in Railway / docker logs irrespective
+ * of pino's level filter. Never throws — a failing logger must not fail
+ * the cron tick.
+ */
+export function emitRunSummary(summary: RunSummary): void {
+  try {
+    const budget =
+      summary.contract && Number.isFinite(summary.contract.freshness_budget_ms)
+        ? String(summary.contract.freshness_budget_ms)
+        : 'missing';
+    // Single-line, key=value, space-separated. Stable order so a regex / awk
+    // pipeline can be authored against this format without surprise.
+    const line =
+      `[run-summary] source=${summary.sourceId}` +
+      ` status=${summary.status}` +
+      ` duration_ms=${summary.durationMs}` +
+      ` records_in=${summary.recordsIn}` +
+      ` records_out=${summary.recordsOut}` +
+      ` contract_freshness_budget_ms=${budget}`;
+    // eslint-disable-next-line no-console
+    console.log(line);
+  } catch {
+    // Swallow: emitting a summary line is observability, not correctness.
+  }
+}

--- a/apps/trendingrepo-worker/src/platform/source-contract.ts
+++ b/apps/trendingrepo-worker/src/platform/source-contract.ts
@@ -1,0 +1,161 @@
+/**
+ * Every Fetcher must satisfy SourceContract; not every SourceContract has a
+ * Fetcher (standalone scripts and user-input flows have no Fetcher).
+ *
+ * SourceContract is the metadata superset over `Fetcher` (lib/types.ts).
+ * Phase 1 (Move 1) of the Source Platform migration declares this type,
+ * the audit JSON conforming to it, and the verification harness that proves
+ * registry coverage. Nothing in the running system changes in Phase 1.
+ *
+ * Cost aggregation rule for parent rows with providers[]:
+ *   `cost_signal_metric` reflects the PRIMARY provider's cost class. Chain
+ *   fall-through to a free fallback is a degradation signal Move 3 tracks
+ *   per-run, not a steady-state cost event. e.g. `twitter-signals` parent
+ *   declares `cost_signal_metric.type: 'apify_units'` even though the chain
+ *   has free fallbacks (web/nitter/fixture). Each provider's `cost_class`
+ *   is recorded individually in the providers[] sub-array for routing.
+ *
+ * See:
+ *   - ~/.claude/plans/hidden-pondering-meadow.md (approved Phase 1 plan)
+ *   - docs/SOURCE-REGISTRY-PROPOSAL.md (Move 1 implementation proposal — pending)
+ *   - apps/trendingrepo-worker/src/lib/types.ts (runtime Fetcher + RunResult)
+ */
+
+export type SourceCategory =
+  | 'repo-derived'
+  | 'social'
+  | 'package'
+  | 'model'
+  | 'mcp'
+  | 'skill'
+  | 'funding'
+  | 'research'
+  | 'ops'
+  | 'user-input';
+
+export type SourceKind = 'collector' | 'enrichment' | 'snapshot' | 'health';
+
+export type SourceState = 'active' | 'paused' | 'deprecated' | 'intent-only';
+
+export type CostSignalType =
+  | 'usd'
+  | 'rate_limit_pct'
+  | 'apify_units'
+  | 'pat_quota_pct'
+  | 'none';
+
+export type CostSignalScope = 'day' | 'hour' | 'month';
+
+export interface CostSignalMetric {
+  type: CostSignalType;
+  cap?: number;
+  scope?: CostSignalScope;
+}
+
+export type RateLimitScope = 'ip' | 'token' | 'pool';
+
+export interface RateLimit {
+  per_hour?: number;
+  scope: RateLimitScope;
+}
+
+export type AuthScheme =
+  | 'github_pat_pool'
+  | 'apify_token'
+  | 'twitter_web_cookies'
+  | 'firecrawl'
+  | 'supabase_service'
+  | 'none';
+
+export type CardinalitySource = 'watchlist' | 'static' | 'enum';
+
+/**
+ * Static slug list (e.g. ['oss-trending']) OR fan-out pattern
+ * (e.g. {pattern: 'mcp-downloads:<package>', cardinality_source: 'watchlist'}).
+ * One row per slug family — concrete-slug enumeration is a Move 3 concern.
+ */
+export type PrimaryOutputKeys =
+  | string[]
+  | {
+      pattern: string;
+      index_key?: string;
+      cardinality_source: CardinalitySource;
+    };
+
+export type OutputRecordShape =
+  | 'ranked_list'
+  | 'event_stream'
+  | 'metric_snapshot'
+  | 'mention_feed'
+  | 'metadata_table'
+  | 'extracted_signal';
+
+export type ConsensusRole = 'list' | 'mention-feed' | 'metadata' | 'event-stream';
+
+export type FallbackStrategy =
+  | 'cache'
+  | 'skip'
+  | 'mark-degraded'
+  | 'editorial-seed'
+  | 'provider-chain'
+  | 'none';
+
+export type ProviderRole = 'primary' | 'fallback';
+
+export interface SourceProvider {
+  id: string;
+  role: ProviderRole;
+  cost_class: CostSignalType;
+}
+
+export type CanonicalEntityKind =
+  | 'repo'
+  | 'package'
+  | 'model'
+  | 'company'
+  | 'mention'
+  | 'event';
+
+/**
+ * The Source Contract — Phase 1, Move 1 of the Source Platform migration.
+ *
+ * 16 fields derived from a contract sufficiency stress-test against 5
+ * representative fetchers (oss-trending, funding-news, github-events,
+ * twitter-repo-signals, mcp-liveness). Every Fetcher must satisfy this
+ * contract; standalone scripts and user-input flows declare a contract
+ * without a Fetcher.
+ */
+export type SourceContract = {
+  /** Stable slug; matches Fetcher.name when one exists. */
+  id: string;
+  category: SourceCategory;
+  kind: SourceKind;
+  state: SourceState;
+  freshness_budget_ms: number;
+  cost_signal_metric: CostSignalMetric;
+  rate_limit?: RateLimit;
+  /** GitHub handle / team slug; the literal 'UNASSIGNED' is allowed in Phase 1. */
+  owner: string;
+  upstream_url: string | string[] | 'multiple';
+  auth_required: boolean;
+  auth_scheme?: AuthScheme;
+  /** Static slug list OR fan-out pattern. See PrimaryOutputKeys. */
+  primary_output_keys: PrimaryOutputKeys;
+  output_record_shape: OutputRecordShape;
+  consensus_role?: ConsensusRole;
+  /** Route paths or src/lib readers that consume this source's output. */
+  consumer_surfaces: string[];
+  /** Source ids that must run first. */
+  depends_on: string[];
+  supports_backfill: boolean;
+  fallback_strategy: FallbackStrategy;
+  /**
+   * For multi-provider sources (e.g. twitter-signals: apify→web→nitter→fixture).
+   * One contract row owns the chain; providers[] documents the ordered fallback.
+   */
+  providers?: SourceProvider[];
+  /** Forward-compat for Move 2 (canonical entities + provenance). */
+  writes_canonical_entity_kind?: CanonicalEntityKind[];
+  /** For state='intent-only': what's the ship/delete question? */
+  decision_pending?: string;
+};

--- a/apps/trendingrepo-worker/src/run.ts
+++ b/apps/trendingrepo-worker/src/run.ts
@@ -9,13 +9,15 @@
 // Errors are reported to Sentry + logged, then re-thrown so the caller
 // (CLI / scheduler) can decide how to respond.
 
-import { captureException } from './lib/sentry.js';
+import { captureException, captureMessage } from './lib/sentry.js';
 import { getLogger } from './lib/log.js';
 import { getRedis, setCurrentFetcherName } from './lib/redis.js';
 import { getDb } from './lib/db.js';
 import { createHttpClient } from './lib/http.js';
 import type { Fetcher, FetcherContext, RedisHandle, RunResult } from './lib/types.js';
 import { recordRun } from './server.js';
+import { getContract } from './platform/contracts.js';
+import { emitRunSummary } from './platform/run-summary.js';
 
 export interface RunOptions {
   dryRun?: boolean;
@@ -34,6 +36,7 @@ export async function runFetcher(
   const log = getLogger();
   const dryRun = opts.dryRun === true;
   const startedAt = new Date().toISOString();
+  const t0 = Date.now();
 
   if (fetcher.requiresFirecrawl && !process.env.FIRECRAWL_API_KEY) {
     log.warn(
@@ -41,6 +44,22 @@ export async function runFetcher(
       'fetcher requires FIRECRAWL_API_KEY but env is empty - skipping',
     );
     return emptyResult(fetcher.name, startedAt);
+  }
+
+  // Move 1, Phase 3 — bind static SourceContract at run time. Used for
+  // diagnostics today (run-summary line + ctx availability), freshness/cost
+  // enforcement in Move 3. Missing-contract for an active fetcher is a
+  // soft warning: log + Sentry, never crash the cron tick.
+  const contract = getContract(fetcher.name);
+  if (!contract) {
+    log.warn(
+      { fetcher: fetcher.name },
+      'fetcher has no SOURCE_CONTRACTS entry — diagnostics will be partial',
+    );
+    captureMessage(
+      `fetcher missing source contract: ${fetcher.name}`,
+      'warning',
+    );
   }
 
   // Set the writer-provenance slot so any writeDataStore() call inside the
@@ -89,6 +108,7 @@ export async function runFetcher(
       signalRunComplete: async () => {
         recordRun();
       },
+      contract,
     };
 
     log.info(
@@ -122,10 +142,26 @@ export async function runFetcher(
       );
     }
     recordRun();
+    emitRunSummary({
+      sourceId: fetcher.name,
+      status: 'ok',
+      durationMs: Date.now() - t0,
+      recordsIn: result.itemsSeen,
+      recordsOut: result.itemsUpserted,
+      contract,
+    });
     return result;
   } catch (err) {
     captureException(err, { fetcher: fetcher.name });
     log.error({ err: (err as Error).message, fetcher: fetcher.name }, 'fetcher failed');
+    emitRunSummary({
+      sourceId: fetcher.name,
+      status: 'err',
+      durationMs: Date.now() - t0,
+      recordsIn: 0,
+      recordsOut: 0,
+      contract,
+    });
     throw err;
   } finally {
     setCurrentFetcherName(null);

--- a/apps/trendingrepo-worker/src/schedule.ts
+++ b/apps/trendingrepo-worker/src/schedule.ts
@@ -16,6 +16,12 @@ import { FETCHERS } from './registry.js';
 import { runFetcher } from './run.js';
 import { getLogger } from './lib/log.js';
 import { captureException } from './lib/sentry.js';
+import {
+  applyOverrides,
+  loadOverrides,
+  startOverrideRefresh,
+  summarizeOverrides,
+} from './platform/overrides.js';
 
 export interface ScheduledJobStatus {
   name: string;
@@ -31,11 +37,32 @@ export interface Scheduler {
   status(): ScheduledJobStatus[];
 }
 
-export function startScheduler(): Scheduler {
+export async function startScheduler(): Promise<Scheduler> {
   const log = getLogger();
   const jobs: Array<{ name: string; schedule: string; cron: Cron }> = [];
 
-  for (const fetcher of FETCHERS) {
+  // Move 1, Phase 2 — apply runtime source overrides at boot. Loader is
+  // tolerant: DB outage falls back to .cache/source-overrides.json, missing
+  // cache falls back to "all sources active". Never refuses to start. After
+  // boot, refresh every 60s in the background so a paused fetcher stops
+  // ticking within ~1 minute of the DB row landing.
+  const overrides = await loadOverrides();
+  const filtered = applyOverrides(FETCHERS, overrides);
+  const skipped = FETCHERS.filter((f) => !filtered.includes(f));
+  const summary = summarizeOverrides(overrides);
+  log.info(
+    {
+      registered: FETCHERS.length,
+      activated: filtered.length,
+      skipped: skipped.length,
+      skippedNames: skipped.map((f) => f.name),
+      overrides: summary,
+    },
+    'source overrides applied to fetcher registry',
+  );
+  startOverrideRefresh();
+
+  for (const fetcher of filtered) {
     const cron = new Cron(
       fetcher.schedule,
       {

--- a/apps/trendingrepo-worker/src/server.ts
+++ b/apps/trendingrepo-worker/src/server.ts
@@ -3,6 +3,8 @@ import { loadEnv } from './lib/env.js';
 import { getDb, pingDb } from './lib/db.js';
 import { getRedis } from './lib/redis.js';
 import { getLogger } from './lib/log.js';
+import { FETCHERS, SOURCE_CONTRACTS } from './registry.js';
+import { findGhostOverrides, getCachedOverrides } from './platform/overrides.js';
 
 interface HealthState {
   ok: boolean;
@@ -10,6 +12,12 @@ interface HealthState {
   redis: boolean;
   lastCheckAt: string;
   lastRunAt: string | null;
+  /**
+   * Override source_ids that no longer correspond to any registered fetcher
+   * AND no longer correspond to a static contract row. Empty in the green
+   * state. Reaper job (Move 1 step 4) consumes this to archive stale rows.
+   */
+  ghost_overrides: string[];
 }
 
 let cached: HealthState | null = null;
@@ -45,12 +53,14 @@ async function refreshHealth(): Promise<HealthState> {
   } catch (err) {
     log.warn(`healthcheck redis: ${(err as Error).message}`);
   }
+  const ghostOverrides = findGhostOverrides(FETCHERS, getCachedOverrides(), SOURCE_CONTRACTS);
   const state: HealthState = {
     ok: dbOk && redisOk,
     db: dbOk,
     redis: redisOk,
     lastCheckAt: new Date().toISOString(),
     lastRunAt: cached?.lastRunAt ?? null,
+    ghost_overrides: ghostOverrides,
   };
   cached = state;
   return state;

--- a/supabase/migrations/0002_source_overrides.sql
+++ b/supabase/migrations/0002_source_overrides.sql
@@ -1,0 +1,74 @@
+-- StarScreener — runtime overrides for the Source Registry (Move 1, Phase 2).
+--
+-- Purpose
+--   Pair the static `SourceContract[]` (apps/trendingrepo-worker/src/platform/
+--   sources.json) with a Supabase-backed runtime state table so ops can pause
+--   / deprecate / reactivate a source without a code deploy. Apify spend can
+--   blow $20/hr if a fetcher loops; a 4-minute Vercel/Railway deploy to pause
+--   it is unacceptable.
+--
+-- Boot-path contract
+--   The worker reads this table at boot with a 2-second timeout. Read miss
+--   (timeout, error, table absent) falls back to .cache/source-overrides.json
+--   (last-known-good); cache miss falls back to "all sources active" — the
+--   worker NEVER refuses to start. See apps/trendingrepo-worker/src/platform/
+--   overrides.ts for the loader.
+--
+-- Audit history
+--   Every insert/update/delete on `source_overrides` mirrors a row into
+--   `source_override_history` via the `source_overrides_audit` trigger so
+--   we have forensic visibility into pause/unpause cycles and
+--   ghost-row reaper deletions (Move 1 step 4 lint enforces deprecate-
+--   then-delete; the history table is the paper trail).
+--
+-- Idempotency
+--   Every CREATE uses IF NOT EXISTS; the trigger function uses
+--   CREATE OR REPLACE; the trigger itself is dropped + recreated. Re-running
+--   this migration is safe.
+
+create table if not exists source_overrides (
+  source_id        text primary key,
+  state            text not null check (state in ('active','paused','deprecated')),
+  paused_until     timestamptz,
+  reason           text not null,
+  set_by           text not null,
+  set_at           timestamptz not null default now(),
+  expected_resume  timestamptz,
+  notes            jsonb not null default '{}'
+);
+
+create index if not exists source_overrides_state_idx
+  on source_overrides(state)
+  where state <> 'active';
+
+create table if not exists source_override_history (
+  id           bigserial primary key,
+  op           text not null check (op in ('insert','update','delete')),
+  source_id    text not null,
+  state        text,
+  paused_until timestamptz,
+  reason       text,
+  set_by       text,
+  set_at       timestamptz,
+  changed_at   timestamptz not null default now(),
+  notes        jsonb
+);
+
+create or replace function source_overrides_audit() returns trigger as $$
+begin
+  if tg_op = 'DELETE' then
+    insert into source_override_history(op, source_id, state, paused_until, reason, set_by, set_at, notes)
+    values ('delete', old.source_id, old.state, old.paused_until, old.reason, old.set_by, old.set_at, old.notes);
+    return old;
+  else
+    insert into source_override_history(op, source_id, state, paused_until, reason, set_by, set_at, notes)
+    values (lower(tg_op), new.source_id, new.state, new.paused_until, new.reason, new.set_by, new.set_at, new.notes);
+    return new;
+  end if;
+end;
+$$ language plpgsql;
+
+drop trigger if exists source_overrides_audit_trg on source_overrides;
+create trigger source_overrides_audit_trg
+  after insert or update or delete on source_overrides
+  for each row execute function source_overrides_audit();


### PR DESCRIPTION
## Summary

Move 1, Phase 3 of the Source Platform migration. P1 declared the `SourceContract` type + the `SOURCE_CONTRACTS[]` registry; P2 added runtime overrides; P3 binds the static contract into the fetcher RUNTIME so each fetcher knows its own contract at run time.

Stacked on `feat/source-overrides-runtime` (P2).

- New helper `apps/trendingrepo-worker/src/platform/contracts.ts` exposes `getContract(sourceId)` reading from `SOURCE_CONTRACTS` (Map-indexed, built once).
- `runFetcher()` looks up the contract by `fetcher.name`, attaches it to `FetcherContext.contract` (new optional field on the type), and treats a missing-contract for an active fetcher as a soft Sentry warning + log.warn — never a crash.
- New helper `apps/trendingrepo-worker/src/platform/run-summary.ts` emits one `[run-summary] source=<id> status=<ok|err> duration_ms=<N> records_in=<N> records_out=<N> contract_freshness_budget_ms=<N|missing>` line per run (success and error paths) via `console.log`. No new dependencies.
- This sets up Move 3 cost / freshness enforcement to read budgets from the same contract row — Phase 3 is purely additive and diagnostic.

## Files changed

- `apps/trendingrepo-worker/src/platform/contracts.ts` (new, 49 lines)
- `apps/trendingrepo-worker/src/platform/run-summary.ts` (new, 65 lines)
- `apps/trendingrepo-worker/src/lib/types.ts` (+14 lines — `contract?: SourceContract` on FetcherContext)
- `apps/trendingrepo-worker/src/run.ts` (+37/-1 lines — lookup + ctx + summary emit on both paths)
- `apps/trendingrepo-worker/src/__tests__/run-contract.test.ts` (new, 122 lines, 4 tests)

## Test plan

- [x] `npx tsc --noEmit` — zero new errors. 10 pre-existing errors in `src/lib/llm/*` are unrelated and present on `main`.
- [x] `npx vitest run src/__tests__/ src/platform/__tests__/` — 21/21 pass (4 new P3 + 3 P2 regression + 14 P2 overrides).
- [x] Run-summary line emits on both success and error paths (verified via `vi.spyOn(console, 'log')`).
- [x] Missing-contract path does NOT throw — verified by an explicit test against an unknown source id.
- [x] No new dependencies added (constraint).
- [x] `SOURCE_CONTRACTS` and `sources.json` untouched (frozen by P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)