### PR TITLE
fix(vercel): skip preview build for all data/* branches unconditionally

### DIFF
--- a/scripts/vercel-skip-data-only.sh
+++ b/scripts/vercel-skip-data-only.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Vercel ignoreCommand: skip build if only data/** or .data/** files changed.
+# Exit 0 = skip build. Exit 1 = build.
+#
+# Vercel sets VERCEL_GIT_COMMIT_REF (branch) + VERCEL_GIT_PREVIOUS_SHA (last deployed SHA).
+# When previous SHA missing (first deploy / forked repo / preview), default to building.
+set -euo pipefail
+
+prev="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [ -z "$prev" ]; then
+  echo "[ignoreCommand] no VERCEL_GIT_PREVIOUS_SHA — building"
+  exit 1
+fi
+
+# Compare current commit to last deployed; list changed files
+git fetch --depth=50 origin "$prev" 2>/dev/null || true
+
+if ! git rev-parse --verify "$prev" >/dev/null 2>&1; then
+  echo "[ignoreCommand] previous SHA $prev not in history (shallow clone) — building"
+  exit 1
+fi
+
+changed=$(git diff --name-only "$prev" HEAD || true)
+if [ -z "$changed" ]; then
+  echo "[ignoreCommand] no diff vs $prev — skipping"
+  exit 0
+fi
+
+non_data=$(echo "$changed" | grep -vE '^(data/|\.data/)' || true)
+
+if [ -z "$non_data" ]; then
+  echo "[ignoreCommand] data-only change detected — skipping build"
+  echo "$changed" | head -10 | sed 's/^/  - /'
+  exit 0
+fi
+
+echo "[ignoreCommand] non-data paths changed — building"
+echo "$non_data" | head -10 | sed 's/^/  - /'
+exit 1

--- a/scripts/vercel-skip-data-only.sh
+++ b/scripts/vercel-skip-data-only.sh
@@ -6,6 +6,18 @@
 # When previous SHA missing (first deploy / forked repo / preview), default to building.
 set -euo pipefail
 
+branch="${VERCEL_GIT_COMMIT_REF:-}"
+
+# Hard skip for data-bot branches — they only ever touch data/** by construction.
+# Skipping unconditionally beats the SHA fallback because shallow clones
+# routinely hide the previous SHA and would otherwise default to building.
+case "$branch" in
+  data/*)
+    echo "[ignoreCommand] data-bot branch ($branch) — skipping build unconditionally"
+    exit 0
+    ;;
+esac
+
 prev="${VERCEL_GIT_PREVIOUS_SHA:-}"
 if [ -z "$prev" ]; then
   echo "[ignoreCommand] no VERCEL_GIT_PREVIOUS_SHA — building"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/vercel-skip-data-only.sh"
+}


### PR DESCRIPTION
## Summary

The Vercel `ignoreCommand` defaulted to build when `VERCEL_GIT_PREVIOUS_SHA` was unavailable in shallow clones — common case for first preview on a fresh data-bot branch. Every `data/cron-freshness-*`, `data/collect-*`, `data/refresh-*` PR was triggering a 4-5 min preview build that produced nothing.

## Fix

Detect `data/*` branches via `VERCEL_GIT_COMMIT_REF` and exit 0 immediately, before the SHA-diff check.

## Why this is safe

- Data-bot branches only ever write to `data/**` by GitHub Actions workflow contract — the prefix is a sufficient signal.
- Path-diff fallback remains the safety net for non-data branches.
- No change to deployment behavior on `main`, `feat/*`, `fix/*`, etc.

## Test plan

- [ ] Merge → next data-bot PR opens → preview is **Skipped**, not **Building**
- [ ] Next non-data PR opens → preview builds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)