### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-07T07:22:38Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T05:46:16.181Z",
+  "generatedAt": "2026-05-07T07:22:38.454Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",
@@ -19,38 +19,6 @@
       "asOf": "2026-04-24T01:59:01.837Z",
       "matchConfidence": "exact",
       "sourceUrl": "https://trustmrr.com/startup/postiz"
-    },
-    "srizzon/git-city": {
-      "tier": "verified_trustmrr",
-      "fullName": "srizzon/git-city",
-      "trustmrrSlug": "git-city",
-      "mrrCents": 17571,
-      "last30DaysCents": 22495,
-      "totalCents": 118793,
-      "growthMrr30d": 82.13917234055837,
-      "customers": 0,
-      "activeSubscriptions": 4,
-      "paymentProvider": "stripe",
-      "category": "SaaS",
-      "asOf": "2026-04-24T01:59:01.837Z",
-      "matchConfidence": "exact",
-      "sourceUrl": "https://trustmrr.com/startup/git-city"
-    },
-    "TGWrist/TGWrist": {
-      "tier": "verified_trustmrr",
-      "fullName": "TGWrist/TGWrist",
-      "trustmrrSlug": "habits-garden",
-      "mrrCents": 5896,
-      "last30DaysCents": 16264,
-      "totalCents": 332401,
-      "growthMrr30d": 0,
-      "customers": 0,
-      "activeSubscriptions": 10,
-      "paymentProvider": "revenuecat",
-      "category": "Mobile Apps",
-      "asOf": "2026-04-24T01:59:01.837Z",
-      "matchConfidence": "exact",
-      "sourceUrl": "https://trustmrr.com/startup/habits-garden"
     }
   }
 }


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/25481950823

Auto-merge enabled — merges once required status checks pass.