### PR TITLE
feat(platform/move1-p7): wrap remaining 14 standalone scripts via shim

### DIFF
--- a/scripts/scrape-awesome-skills.mjs
+++ b/scripts/scrape-awesome-skills.mjs
@@ -31,6 +31,7 @@ import { extractGithubRepoFullNames, extractUnknownRepoCandidates } from "./_git
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = resolve(__dirname, "..", "data");
@@ -174,8 +175,13 @@ const isDirectRun = invokedPath
   : false;
 
 if (isDirectRun) {
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "awesome-skills",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-claude-rss.mjs
+++ b/scripts/scrape-claude-rss.mjs
@@ -19,6 +19,7 @@ import { fileURLToPath } from "node:url";
 
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT = resolve(__dirname, "..", "data", "claude-rss.json");
@@ -163,8 +164,13 @@ async function main() {
   await closeDataStore();
 }
 
+// Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+// instrumentation — collection logic untouched.
 const startedAt = Date.now();
-main()
+runAsRegisteredSource({
+  sourceId: "claude-rss",
+  run: main,
+})
   .then(async () => {
     try {
       await writeSourceMetaFromOutcome({

--- a/scripts/scrape-devto.mjs
+++ b/scripts/scrape-devto.mjs
@@ -25,6 +25,7 @@ import { writeFile, mkdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import {
   fetchArticleList,
   fetchDetailsBatched,
@@ -443,8 +444,13 @@ const isDirectRun =
 
 if (isDirectRun) {
   // T2.6: metadata sidecar — distinguishes outage from quiet day.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "devto",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -21,6 +21,7 @@ import { extractGithubRepoFullNames, extractUnknownRepoCandidates } from "./_git
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(__dirname, "..");
@@ -699,8 +700,13 @@ function extractCompanyNameFromArticle(text, currentName) {
 
 // Guard so tests can import without auto-running
 if (process.argv[1] && process.argv[1].includes("scrape-funding-news")) {
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "funding-news",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-hackernews.mjs
+++ b/scripts/scrape-hackernews.mjs
@@ -22,6 +22,7 @@ import { writeFile, mkdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import {
   fetchTopStoryIds,
   fetchItemsBatched,
@@ -509,8 +510,13 @@ if (isDirectRun) {
   // The wrapper times the run + classifies the outcome (ok / empty /
   // network_error / partial) and never throws — its failure must not
   // mask the underlying scrape error.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "hackernews",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-huggingface-datasets.mjs
+++ b/scripts/scrape-huggingface-datasets.mjs
@@ -31,6 +31,7 @@ import { fileURLToPath } from "node:url";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import {
   loadHuggingfaceTokens,
   pickToken,
@@ -144,8 +145,13 @@ const isDirectRun = invokedPath
 if (isDirectRun) {
   // Always close the Redis client — ioredis otherwise keeps the event loop
   // alive and the workflow hangs until cancellation. B6 root cause.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "huggingface-datasets",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-huggingface-spaces.mjs
+++ b/scripts/scrape-huggingface-spaces.mjs
@@ -33,6 +33,7 @@ import { extractGithubRepoFullNames } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = resolve(__dirname, "..", "data");
@@ -255,8 +256,13 @@ const isDirectRun = invokedPath
 if (isDirectRun) {
   // Always close the Redis client — ioredis otherwise keeps the event loop
   // alive and the workflow hangs until cancellation. B6 root cause.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "huggingface-spaces",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-huggingface.mjs
+++ b/scripts/scrape-huggingface.mjs
@@ -32,6 +32,7 @@ import { extractGithubRepoFullNames } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import {
   loadHuggingfaceTokens,
   pickToken,
@@ -271,8 +272,15 @@ if (isDirectRun) {
   // the event loop alive and the workflow hangs for hours, getting cancelled
   // by the next cron tick — the bug that emptied huggingface-{datasets,
   // spaces}.json (B6 root cause).
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation. The script's slug in sources.json is
+  // "huggingface-models-script" (the worker fetcher slug "huggingface" is a
+  // separate intent-only stub) — see decision_pending in sources.json.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "huggingface-models-script",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-lobsters.mjs
+++ b/scripts/scrape-lobsters.mjs
@@ -34,6 +34,7 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { extractAllRepoMentions, extractUnknownRepoCandidates } from "./_github-repo-links.mjs";
 import { loadTrackedReposFromFiles } from "./_tracked-repos.mjs";
@@ -295,8 +296,13 @@ const isDirectRun = invokedPath
 
 if (isDirectRun) {
   // T2.6: metadata sidecar — distinguishes outage from quiet day.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "lobsters",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-npm-daily.mjs
+++ b/scripts/scrape-npm-daily.mjs
@@ -30,6 +30,7 @@ import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import { fetchJsonWithRetry, HttpStatusError, sleep } from "./_fetch-json.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 
@@ -302,8 +303,13 @@ const isDirectRun =
 
 if (isDirectRun) {
   // T2.6: metadata sidecar — distinguishes outage from quiet day.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "npm-daily",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-npm.mjs
+++ b/scripts/scrape-npm.mjs
@@ -21,6 +21,7 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import { fetchJsonWithRetry, HttpStatusError, sleep } from "./_fetch-json.mjs";
 import { extractUnknownRepoCandidates } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
@@ -600,8 +601,14 @@ const isDirectRun =
 
 if (isDirectRun) {
   // T2.6: metadata sidecar — distinguishes outage from quiet day.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation. sources.json id is "npm-packages" (the package's
+  // primary_output_keys) — distinct from the snapshot-style "npm-daily" row.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "npm-packages",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-producthunt.mjs
+++ b/scripts/scrape-producthunt.mjs
@@ -20,6 +20,7 @@ import { writeFile, mkdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import "./_load-env.mjs";
 import {
   phGraphQL,
@@ -502,8 +503,13 @@ const isDirectRun = invokedPath
 
 if (isDirectRun) {
   // T2.6: metadata sidecar — distinguishes outage from quiet day.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "producthunt",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-reddit.mjs
+++ b/scripts/scrape-reddit.mjs
@@ -25,6 +25,7 @@ import { writeFile, mkdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import "./_load-env.mjs";
 import {
   SUBREDDITS,
@@ -1030,8 +1031,13 @@ const modulePath = fileURLToPath(import.meta.url);
 
 if (invokedPath && resolve(invokedPath) === resolve(modulePath)) {
   // T2.6: metadata sidecar — distinguishes outage from quiet day.
+  // Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+  // instrumentation — collection logic untouched.
   const startedAt = Date.now();
-  main()
+  runAsRegisteredSource({
+    sourceId: "reddit",
+    run: main,
+  })
     .then(async () => {
       try {
         await writeSourceMetaFromOutcome({

--- a/scripts/scrape-trending.mjs
+++ b/scripts/scrape-trending.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
+import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
 const PERIODS = ["past_24_hours", "past_week", "past_month"];
 const LANGUAGES = ["All", "Python", "TypeScript", "Rust", "Go"];
@@ -330,8 +331,13 @@ async function main() {
   await appendDualWriteTrace(traceEvent);
 }
 
+// Move 1 / Phase 7: runAsRegisteredSource wraps main() purely for
+// instrumentation — collection logic untouched.
 const startedAt = Date.now();
-main()
+runAsRegisteredSource({
+  sourceId: "trending",
+  run: main,
+})
   .then(async () => {
     try {
       await writeSourceMetaFromOutcome({


### PR DESCRIPTION
Move 1 / Phase 7. Rebuilt against fresh main after #326+#329 landed (resolves merge conflicts that blocked PR #336).

Wraps 14 remaining standalone scripts via runAsRegisteredSource() shim:
- scrape-awesome-skills · scrape-claude-rss · scrape-devto · scrape-funding-news
- scrape-hackernews · scrape-huggingface-datasets · scrape-huggingface-spaces
- scrape-huggingface · scrape-lobsters · scrape-npm-daily · scrape-npm
- scrape-producthunt · scrape-reddit · scrape-trending

Combined with P4 (3 wrapped) = 17/17 standalone scripts on shim.
Collection logic untouched. Each run emits [run-summary] + registers against sources.json.

Replaces stale #336 (merge conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)