### PR TITLE
fix(db): land drizzle-dependent routes

### DIFF
--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,0 +1,98 @@
+// Drizzle + postgres-js client.
+//
+// Singleton-cached so Vercel serverless lambdas and the Railway worker
+// don't re-open connections per request. Two access points:
+//
+//   - `getDb()`        — pooled (Supavisor :6543, transaction mode). Use
+//                         this everywhere at runtime: server components,
+//                         API routes, the worker. Returns a Drizzle
+//                         instance bound to the full schema barrel.
+//   - `getDirectDb()`  — unpooled (:5432). Reserved for `drizzle-kit
+//                         migrate/generate` paths. NEVER call from runtime
+//                         code; it'll exhaust your max-connections budget.
+//
+// We intentionally do NOT use `@supabase/supabase-js` — Drizzle gives us
+// type-safe SQL and we never expose the DB direct to the browser, so RLS
+// + the JS client's REST overhead would be pure cost.
+
+import "server-only";
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import * as schema from "./schema";
+
+type DbInstance = ReturnType<typeof drizzle<typeof schema>>;
+
+// Globals reused across hot reloads in dev + warm Lambdas in prod. Without
+// these, Next's dev server would open a new pool on every fast-refresh.
+declare global {
+  // eslint-disable-next-line no-var
+  var __trendingrepo_db: DbInstance | undefined;
+  // eslint-disable-next-line no-var
+  var __trendingrepo_db_direct: DbInstance | undefined;
+}
+
+function buildPooled(): DbInstance {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "[db.client] DATABASE_URL is not set. See docs/AUTH-SETUP.md.",
+    );
+  }
+  const sql = postgres(url, {
+    // Supavisor transaction mode forbids prepared statements (each
+    // statement may land on a different backend). Keep the warning quiet
+    // and rely on Drizzle's parameter binding for safety.
+    prepare: false,
+    // Vercel serverless functions reuse warm Lambdas — bound the pool
+    // tightly so a burst of requests doesn't blow Postgres' connection
+    // ceiling. 1 connection per Lambda, idle-released after 20s.
+    max: 1,
+    idle_timeout: 20,
+    // postgres-js logs every parse/bind/execute by default — too noisy.
+    onnotice: () => {},
+  });
+  return drizzle(sql, { schema, logger: process.env.DB_LOG === "1" });
+}
+
+function buildDirect(): DbInstance {
+  const url = process.env.DIRECT_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "[db.client] DIRECT_URL is not set. drizzle-kit needs the unpooled :5432 URI.",
+    );
+  }
+  const sql = postgres(url, {
+    prepare: true, // unpooled = real session, prepared statements work
+    max: 1,
+    idle_timeout: 5,
+    onnotice: () => {},
+  });
+  return drizzle(sql, { schema, logger: process.env.DB_LOG === "1" });
+}
+
+export function getDb(): DbInstance {
+  if (!globalThis.__trendingrepo_db) {
+    globalThis.__trendingrepo_db = buildPooled();
+  }
+  return globalThis.__trendingrepo_db;
+}
+
+export function getDirectDb(): DbInstance {
+  if (!globalThis.__trendingrepo_db_direct) {
+    globalThis.__trendingrepo_db_direct = buildDirect();
+  }
+  return globalThis.__trendingrepo_db_direct;
+}
+
+// Re-export the schema for ergonomic call sites:
+//   import { db, schema } from "@/lib/db/client";
+//   await db.select().from(schema.profiles).where(...);
+export const db = new Proxy({} as DbInstance, {
+  get(_, prop, receiver) {
+    return Reflect.get(getDb() as object, prop, receiver);
+  },
+});
+
+export { schema };

--- a/src/lib/db/schema/alerts.ts
+++ b/src/lib/db/schema/alerts.ts
@@ -1,0 +1,185 @@
+// Drizzle schema — `alert_rules` + `alert_events` + `alert_delivery_log`.
+//
+// Per-user alert rules sit on top of the existing pipeline trigger engine
+// (src/lib/pipeline/alerts/triggers.ts). Pipeline still emits global
+// trigger evaluations synchronously per render; the new event router
+// fans those out to matching `alert_rules` rows and inserts pending
+// `alert_events`, which the dispatcher cron drains into email/webhook
+// deliveries.
+//
+// Rule types in v1 (keep small — ship 4, learn, expand later):
+//   breakout         — repo hits ≥2 cross-source channels in 24h
+//   rank_threshold   — repo crosses into/out of a top-N category
+//   release          — new GitHub release / npm version
+//   mention_spike    — mention count exceeds Z-score threshold
+//
+// Idempotency primitive: `unique(rule_id, deduped_key)`. The router
+// computes `deduped_key = sha256(rule_id + entity_id + bucket)` where
+// `bucket = floor(now / cooldown_seconds)`. ON CONFLICT DO NOTHING is
+// the dedup mechanism — we never query "did this fire?" before insert.
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import { profiles } from "./profiles";
+import { watchlists } from "./watchlists";
+
+// ---------------------------------------------------------------------------
+// alert_rules — user-defined rules. Capped at 25 per user (enforced at
+// insert time; the limit is a sanity ceiling, not a paywall).
+// ---------------------------------------------------------------------------
+
+export const alertRules = pgTable(
+  "alert_rules",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    profileId: uuid("profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    // Null = "all watched items". Set = scope to one specific watchlist.
+    watchlistId: uuid("watchlist_id").references(() => watchlists.id, {
+      onDelete: "cascade",
+    }),
+    name: text("name").notNull(),
+    ruleType: text("rule_type").notNull(), // 'breakout'|'rank_threshold'|'release'|'mention_spike'
+    ruleConfig: jsonb("rule_config").notNull(),
+    cadence: text("cadence").notNull().default("realtime"), // 'realtime'|'daily'|'weekly'
+    // Optional webhook delivery target. https-only (validated at insert).
+    webhookUrl: text("webhook_url"),
+    // bcrypt-hashed plaintext secret. Plaintext is shown ONCE on create
+    // and never persisted — caller copies it for HMAC signing on receive.
+    webhookSecretHash: text("webhook_secret_hash"),
+    // Per-rule override of profiles.quiet_hours. Null falls back to profile.
+    quietHours: jsonb("quiet_hours"),
+    active: boolean("active").notNull().default(true),
+    lastFiredAt: timestamp("last_fired_at", { withTimezone: true }),
+    fireCountToday: integer("fire_count_today").notNull().default(0),
+    fireCountTotal: integer("fire_count_total").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index("alert_rules_profile_active_idx").on(t.profileId, t.active),
+    index("alert_rules_type_active_idx").on(t.ruleType, t.active),
+    index("alert_rules_watchlist_idx").on(t.watchlistId),
+  ],
+);
+
+export const ALERT_RULE_TYPES = [
+  "breakout",
+  "rank_threshold",
+  "release",
+  "mention_spike",
+] as const;
+export type AlertRuleType = (typeof ALERT_RULE_TYPES)[number];
+
+export const ALERT_CADENCES = ["realtime", "daily", "weekly"] as const;
+export type AlertCadence = (typeof ALERT_CADENCES)[number];
+
+export type AlertRule = typeof alertRules.$inferSelect;
+export type NewAlertRule = typeof alertRules.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// alert_events — one row per fired alert. Cron dispatcher drains pending
+// rows, sends, and updates delivery_status. mcp_only rows are never sent
+// (just queryable via the MCP `list_my_alerts` tool).
+// ---------------------------------------------------------------------------
+
+export const alertEvents = pgTable(
+  "alert_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ruleId: uuid("rule_id")
+      .notNull()
+      .references(() => alertRules.id, { onDelete: "cascade" }),
+    profileId: uuid("profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    firedAt: timestamp("fired_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    entityType: text("entity_type").notNull(), // 'repo' (only kind in v1)
+    entityId: text("entity_id").notNull(), // repo fullName, e.g. 'vercel/next.js'
+    payload: jsonb("payload").notNull(), // { title, body, url, value, threshold, ruleSnapshot }
+    deliveryChannel: text("delivery_channel").notNull(), // 'email'|'webhook'|'mcp_only'
+    deliveryStatus: text("delivery_status").notNull().default("pending"),
+    // 'pending'|'sending'|'sent'|'failed'|'bounced'|'skipped_quiet_hours'|'skipped_freq_cap'|'skipped_dedup'
+    dedupedKey: text("deduped_key").notNull(),
+    sentAt: timestamp("sent_at", { withTimezone: true }),
+    attempts: integer("attempts").notNull().default(0),
+    error: text("error"),
+  },
+  (t) => [
+    // Idempotency: the (rule_id, deduped_key) unique index makes
+    // ON CONFLICT DO NOTHING the dedup primitive.
+    uniqueIndex("alert_events_rule_dedup_uniq").on(t.ruleId, t.dedupedKey),
+    index("alert_events_rule_fired_idx").on(t.ruleId, t.firedAt),
+    index("alert_events_profile_fired_idx").on(t.profileId, t.firedAt),
+    index("alert_events_pending_idx")
+      .on(t.deliveryStatus, t.firedAt)
+      .where(sql`delivery_status = 'pending'`),
+  ],
+);
+
+export const ALERT_DELIVERY_CHANNELS = ["email", "webhook", "mcp_only"] as const;
+export type AlertDeliveryChannel = (typeof ALERT_DELIVERY_CHANNELS)[number];
+
+export const ALERT_DELIVERY_STATUSES = [
+  "pending",
+  "sending",
+  "sent",
+  "failed",
+  "bounced",
+  "skipped_quiet_hours",
+  "skipped_freq_cap",
+  "skipped_dedup",
+] as const;
+export type AlertDeliveryStatus = (typeof ALERT_DELIVERY_STATUSES)[number];
+
+export type AlertEvent = typeof alertEvents.$inferSelect;
+export type NewAlertEvent = typeof alertEvents.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// alert_delivery_log — cross-rule TTL dedup. Used when an event fires
+// repeatedly within the cooldown window; the daily cleanup cron drops
+// expired rows so the table doesn't grow unbounded.
+// ---------------------------------------------------------------------------
+
+export const alertDeliveryLog = pgTable(
+  "alert_delivery_log",
+  {
+    ruleId: uuid("rule_id")
+      .notNull()
+      .references(() => alertRules.id, { onDelete: "cascade" }),
+    dedupedKey: text("deduped_key").notNull(),
+    firedAt: timestamp("fired_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    // Use a simple counter for "how many fires in this window were
+    // suppressed" — informational, useful for debugging frequency caps.
+    suppressedCount: integer("suppressed_count").notNull().default(0),
+  },
+  (t) => [
+    // Composite primary key.
+    uniqueIndex("alert_delivery_log_pk").on(t.ruleId, t.dedupedKey),
+    index("alert_delivery_log_expires_idx").on(t.expiresAt),
+  ],
+);
+
+export type AlertDeliveryLogRow = typeof alertDeliveryLog.$inferSelect;
+export type NewAlertDeliveryLogRow = typeof alertDeliveryLog.$inferInsert;

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -1,0 +1,11 @@
+// Drizzle schema barrel — single import surface for all tables.
+//
+// Add new tables here as feature chunks land. Drizzle Kit reads this
+// directory tree (per drizzle.config.ts → schema: "./src/lib/db/schema")
+// to generate migrations, so any file referenced here will get tracked.
+
+export * from "./profiles";
+export * from "./watchlists";
+export * from "./newsletter";
+export * from "./alerts";
+export * from "./referrals";

--- a/src/lib/db/schema/newsletter.ts
+++ b/src/lib/db/schema/newsletter.ts
@@ -1,0 +1,51 @@
+// Drizzle schema — `newsletter_subscribers` table.
+//
+// Anonymous email capture, completely separate from `profiles`. Powers the
+// homepage hero capture form. Pipeline:
+//
+//   1. POST /api/newsletter/subscribe { email } → row inserted with
+//      confirmed_at = NULL and confirm_token_hash set. Confirmation email
+//      sent via Resend.
+//   2. GET  /api/newsletter/confirm?t=<token> → token verified against
+//      the row's hash, confirmed_at = now(), redirect to /thanks.
+//   3. Weekly digest cron sends to confirmed-AND-not-unsubscribed rows
+//      with the public top-breakouts digest + "create account for
+//      personalised alerts" CTA.
+//   4. GET /api/newsletter/unsubscribe?t=<token> → unsubscribed_at = now().
+//
+// Double-opt-in is mandatory in v1 — keeps domain reputation clean even
+// if a malicious actor enters a friend's email at the form. Subscribers
+// receive zero email until confirmed.
+
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+export const newsletterSubscribers = pgTable(
+  "newsletter_subscribers",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    email: text("email").notNull(),
+    source: text("source").notNull(), // 'hero' | 'footer' | 'modal' | 'inline-cta'
+    subscribedAt: timestamp("subscribed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
+    unsubscribedAt: timestamp("unsubscribed_at", { withTimezone: true }),
+    confirmTokenHash: text("confirm_token_hash").notNull(),
+    unsubscribeToken: text("unsubscribe_token").notNull(),
+  },
+  (t) => [
+    uniqueIndex("newsletter_email_uniq").on(t.email),
+    index("newsletter_unsub_token_idx").on(t.unsubscribeToken),
+  ],
+);
+
+export type NewsletterSubscriber = typeof newsletterSubscribers.$inferSelect;
+export type NewNewsletterSubscriber =
+  typeof newsletterSubscribers.$inferInsert;

--- a/src/lib/db/schema/profiles.ts
+++ b/src/lib/db/schema/profiles.ts
@@ -1,0 +1,112 @@
+// Drizzle schema — `profiles` table.
+//
+// Single source of truth for user identity + email preferences. Backed by
+// Supabase Postgres; populated via the Clerk `user.created` webhook handler
+// and refreshed on `user.updated`. The `clerk_user_id` is the unique key
+// our app uses to look up a profile from a Clerk session token at runtime.
+//
+// Column groups:
+//   - identity:    id, clerk_user_id, handle, email, display_name, avatar_url
+//   - role:        'user' | 'operator' | 'admin' | 'founder'
+//   - timestamps:  created_at, last_seen_at, deleted_at (soft delete)
+//   - email prefs: email_alerts_cadence (default 'daily'), email_*, quiet_hours, timezone
+//   - referrals:   referral_credits (counter, NOT convertible to paid time),
+//                  dismissed_invite_banner_at, public_leaderboard_optin
+//   - mcp:         mcp_token_hash + mcp_token_last4 for the read-only
+//                  "list_my_alerts" MCP token a user can issue from /you/alerts
+//
+// IMPORTANT: `referral_credits` is a pure counter for milestone math.
+// Its UI surface MUST NEVER imply convertibility to dollars or paid time —
+// that promise was explicitly cut from v1 (see plan: "Don't promise
+// convertibility — badges only").
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+export const profiles = pgTable(
+  "profiles",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+
+    // Identity (sourced from Clerk + reserved at signup)
+    clerkUserId: text("clerk_user_id").notNull(),
+    handle: text("handle").notNull(),
+    email: text("email").notNull(),
+    displayName: text("display_name"),
+    avatarUrl: text("avatar_url"),
+
+    // Role flag — 'user' default, 'operator' on 5+ qualified referrals,
+    // 'admin' (manual), 'founder' (25+ qualified referrals).
+    role: text("role").notNull().default("user"),
+
+    // Lifecycle
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+
+    // Email preferences — defaults are intentionally conservative
+    // ('daily' digest, no product updates) to minimise spam complaints
+    // when alert volume picks up.
+    emailAlertsCadence: text("email_alerts_cadence")
+      .notNull()
+      .default("daily"), // 'realtime' | 'daily' | 'weekly' | 'off'
+    emailReferralUpdates: boolean("email_referral_updates").notNull().default(true),
+    emailProductUpdates: boolean("email_product_updates").notNull().default(false),
+    emailSystem: boolean("email_system").notNull().default(true),
+    quietHours: jsonb("quiet_hours"), // { startMin: 0..1439, endMin: 0..1439 } | null
+    timezone: text("timezone").notNull().default("UTC"),
+
+    // Referral state. Counter is updated atomically by the qualify cron.
+    referralCredits: integer("referral_credits").notNull().default(0),
+    dismissedInviteBannerAt: timestamp("dismissed_invite_banner_at", {
+      withTimezone: true,
+    }),
+    publicLeaderboardOptin: boolean("public_leaderboard_optin")
+      .notNull()
+      .default(false),
+
+    // MCP read-only token (issued from /you/alerts). Plaintext shown once;
+    // we store the bcrypt hash + last 4 chars for UI display.
+    mcpTokenHash: text("mcp_token_hash"),
+    mcpTokenLast4: text("mcp_token_last4"),
+  },
+  (t) => [
+    uniqueIndex("profiles_clerk_user_id_uniq").on(t.clerkUserId),
+    uniqueIndex("profiles_handle_uniq").on(t.handle),
+    // Case-insensitive handle lookup for `/u/<handle>` routes.
+    uniqueIndex("profiles_handle_lower_uniq").on(sql`lower(${t.handle})`),
+    index("profiles_email_idx").on(t.email),
+  ],
+);
+
+export type Profile = typeof profiles.$inferSelect;
+export type NewProfile = typeof profiles.$inferInsert;
+
+/**
+ * Allowed values for `profiles.email_alerts_cadence`. Mirrors the
+ * application's runtime check; keep in sync if a value is added.
+ */
+export const EMAIL_ALERTS_CADENCES = [
+  "realtime",
+  "daily",
+  "weekly",
+  "off",
+] as const;
+export type EmailAlertsCadence = (typeof EMAIL_ALERTS_CADENCES)[number];
+
+/**
+ * Allowed values for `profiles.role`. 'operator' is auto-granted at the
+ * 5-qualified-referral milestone; 'founder' at 25; 'admin' is manual.
+ */
+export const PROFILE_ROLES = ["user", "operator", "admin", "founder"] as const;
+export type ProfileRole = (typeof PROFILE_ROLES)[number];

--- a/src/lib/db/schema/referrals.ts
+++ b/src/lib/db/schema/referrals.ts
@@ -1,0 +1,187 @@
+// Drizzle schema — `referral_codes` + `referrals` + `referral_milestones`.
+//
+// Pipeline:
+//
+//   1. Clerk webhook `user.created` → `reserveCodeFromHandle()` writes a
+//      row in `referral_codes` (URL-safe handle if available, else a
+//      base32 hash prefix).
+//   2. Visitor lands on `/?ref=<code>` → middleware sets signed
+//      `tr_ref` cookie (30-day, first-touch wins).
+//   3. Visitor signs up → `user.created` webhook reads cookie OR Clerk
+//      `unsafeMetadata.trRef` → inserts `referrals` row with
+//      `signed_up_at = now()` and computed fraud_flags.
+//   4. Hourly cron `/api/cron/referrals/qualify` finds rows where the
+//      referred user has been seen ≥24h after signup, sets `qualified_at`,
+//      increments `profiles.referral_credits`, and runs the milestone
+//      evaluator (badges-only — no convertibility promise).
+//
+// The `referrals.referred_profile_id` partial-unique-where-not-null
+// index guarantees one credit per referred user even if they sign up
+// twice (different sessions, same Clerk account → same profile id).
+
+import { sql } from "drizzle-orm";
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import { profiles } from "./profiles";
+
+// ---------------------------------------------------------------------------
+// referral_codes — one row per profile, immutable after creation.
+// ---------------------------------------------------------------------------
+
+export const referralCodes = pgTable(
+  "referral_codes",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    profileId: uuid("profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    code: text("code").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("referral_codes_profile_uniq").on(t.profileId),
+    uniqueIndex("referral_codes_code_uniq").on(t.code),
+    // Case-insensitive lookup so `?ref=Mirko` and `?ref=mirko` both
+    // resolve to the same code row.
+    uniqueIndex("referral_codes_code_lower_uniq").on(sql`lower(${t.code})`),
+  ],
+);
+
+export type ReferralCode = typeof referralCodes.$inferSelect;
+export type NewReferralCode = typeof referralCodes.$inferInsert;
+
+// ---------------------------------------------------------------------------
+// referrals — one row per (referrer, referred) pair. `referred_profile_id`
+// is null at click time, populated at signup time.
+// ---------------------------------------------------------------------------
+
+export const referrals = pgTable(
+  "referrals",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    referrerProfileId: uuid("referrer_profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    // Set once the referred user signs up. Null = click-only attribution.
+    referredProfileId: uuid("referred_profile_id").references(
+      () => profiles.id,
+      { onDelete: "set null" },
+    ),
+    referralCode: text("referral_code").notNull(),
+
+    // Milestones — populated as the referral progresses.
+    clickedAt: timestamp("clicked_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    signedUpAt: timestamp("signed_up_at", { withTimezone: true }),
+    qualifiedAt: timestamp("qualified_at", { withTimezone: true }),
+    rewardedAt: timestamp("rewarded_at", { withTimezone: true }),
+
+    // Attribution context, captured at click time from the cookie.
+    firstLandingUrl: text("first_landing_url"),
+    userAgent: text("user_agent"),
+    ipHash: text("ip_hash"), // sha256 of forwarded IP — fraud signal
+
+    // Fraud signals — array of strings. v1 logs only; admin sweep
+    // approves/rejects manually. Possible values:
+    //   'same_clerk_user'    — auto-blocked (no row insert)
+    //   'same_ip_24h'        — same IP within 24h window
+    //   'same_email_domain'  — same non-free email domain
+    //   'fast_signup'        — click-to-signup < 10s
+    //   'never_returned'     — referred user never came back
+    //   'admin_rejected'     — set by /admin/referrals reject action
+    fraudFlags: text("fraud_flags")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    // One reward per referred user — partial-unique so click-only rows
+    // (referred_profile_id IS NULL) can stack while signup-completed
+    // rows are unique. drizzle-orm doesn't support .where() on a
+    // unique index in v0.36 yet; use the SQL-level expression to express
+    // it explicitly.
+    uniqueIndex("referrals_referred_uniq")
+      .on(t.referredProfileId)
+      .where(sql`${t.referredProfileId} IS NOT NULL`),
+    index("referrals_referrer_qualified_idx").on(
+      t.referrerProfileId,
+      t.qualifiedAt,
+    ),
+    index("referrals_ip_recent_idx").on(t.ipHash, t.createdAt),
+    index("referrals_code_idx").on(t.referralCode),
+  ],
+);
+
+export type Referral = typeof referrals.$inferSelect;
+export type NewReferral = typeof referrals.$inferInsert;
+
+export const REFERRAL_FRAUD_BLOCKING = ["same_clerk_user", "admin_rejected"] as const;
+export type ReferralFraudBlockingFlag =
+  (typeof REFERRAL_FRAUD_BLOCKING)[number];
+
+// ---------------------------------------------------------------------------
+// referral_milestones — insert-once gate that idempotently records a
+// milestone unlock. The qualifier cron runs `evaluateMilestones(credits)`
+// after each successful credit increment and INSERTs all earned rows
+// with ON CONFLICT DO NOTHING. Newly-inserted rows trigger the
+// milestone-reached email + role/badge updates.
+// ---------------------------------------------------------------------------
+
+export const referralMilestones = pgTable(
+  "referral_milestones",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    profileId: uuid("profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    milestoneKey: text("milestone_key").notNull(), // 'connector'|'operator'|'founder'
+    unlockedAt: timestamp("unlocked_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("referral_milestones_uniq").on(t.profileId, t.milestoneKey),
+    index("referral_milestones_profile_idx").on(t.profileId),
+  ],
+);
+
+export const REFERRAL_MILESTONE_KEYS = [
+  "connector",
+  "operator",
+  "founder",
+] as const;
+export type ReferralMilestoneKey = (typeof REFERRAL_MILESTONE_KEYS)[number];
+
+/**
+ * Threshold table — checked against `profiles.referral_credits` after
+ * each qualifying-cron increment. Edit here to retune the program.
+ *
+ * NOTE: `connector` is the entry-level badge. `operator` ALSO upgrades
+ * `profiles.role` from 'user' to 'operator'. `founder` includes a
+ * Discord invite (FOUNDER_DISCORD_INVITE env var) in the unlock email.
+ */
+export const REFERRAL_MILESTONE_THRESHOLDS: ReadonlyArray<{
+  key: ReferralMilestoneKey;
+  threshold: number;
+}> = [
+  { key: "connector", threshold: 1 },
+  { key: "operator", threshold: 5 },
+  { key: "founder", threshold: 25 },
+];
+
+export type ReferralMilestoneRow = typeof referralMilestones.$inferSelect;
+export type NewReferralMilestoneRow = typeof referralMilestones.$inferInsert;

--- a/src/lib/db/schema/watchlists.ts
+++ b/src/lib/db/schema/watchlists.ts
@@ -1,0 +1,68 @@
+// Drizzle schema — `watchlists` + `watchlist_items` tables.
+//
+// Replaces the JSONL-backed pro-tier store at
+// `src/lib/watchlist/private-store.ts` with a relational model so the alert
+// engine can JOIN against watched items per-user. The legacy localStorage
+// Zustand store at `src/lib/store.ts` continues to work for anonymous
+// users; on first sign-in we lazy-migrate via `src/lib/auth/migrate-anon.ts`.
+//
+// Cap: max 1000 repos per user (matches private-store.MAX_PRIVATE_WATCHLIST_REPOS).
+// Enforced at insert time, not by schema constraint, so admins can hot-fix.
+
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import { profiles } from "./profiles";
+
+export const watchlists = pgTable(
+  "watchlists",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    profileId: uuid("profile_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    name: text("name").notNull().default("Default"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index("watchlists_profile_idx").on(t.profileId),
+  ],
+);
+
+export const watchlistItems = pgTable(
+  "watchlist_items",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    watchlistId: uuid("watchlist_id")
+      .notNull()
+      .references(() => watchlists.id, { onDelete: "cascade" }),
+    repoFullName: text("repo_full_name").notNull(), // 'vercel/next.js'
+    addedAt: timestamp("added_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    starsAtAdd: text("stars_at_add"), // string-encoded so very-large numbers are safe
+  },
+  (t) => [
+    // A repo appears at most once per watchlist.
+    uniqueIndex("watchlist_items_uniq").on(t.watchlistId, t.repoFullName),
+    // Fast lookup: "which watchlists track this repo?" — used by the alert
+    // event router to fan out a single trigger to every matching user.
+    index("watchlist_items_repo_idx").on(t.repoFullName),
+  ],
+);
+
+export type Watchlist = typeof watchlists.$inferSelect;
+export type NewWatchlist = typeof watchlists.$inferInsert;
+export type WatchlistItem = typeof watchlistItems.$inferSelect;
+export type NewWatchlistItem = typeof watchlistItems.$inferInsert;


### PR DESCRIPTION
## Summary

Restores 7 missing files under `src/lib/db/` that two route files on `main` import but which never landed there. Five TS2307 errors blocking every PR's CI are eliminated.

- `src/lib/db/client.ts` — Drizzle pooled + direct client wrappers
- `src/lib/db/schema/{index,profiles,referrals,newsletter,alerts,watchlists}.ts` — schema definitions

Sourced from commit `32803673` on `feat/charts-echarts-pilot` (a foundation-restore commit that was never merged back). All files are self-contained — only depend on `drizzle-orm` + `postgres`, both already in `package.json` on main.

## Why land vs. delete the routes

The routes (`/api/admin/referrals`, `/api/cron/digest/weekly`) are active features (admin moderation, weekly digest cron, newsletter fan-out). Deleting them would cascade: tests, sidebar links, cron config. Landing 7 self-contained files is far lower scope+risk than removing live routes.

## Test plan

- [x] `npm run typecheck` reports zero `Cannot find module '@/lib/db/*'` errors (was 5, now 0)
- [x] No errors on `src/app/api/admin/referrals/route.ts` or `src/app/api/cron/digest/weekly/route.ts`
- [x] 13 pre-existing errors elsewhere on `origin/main` (`@/lib/auth/server`, `@/lib/mcp-ranking`, etc.) are unchanged — out of scope for this PR
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)