### PR TITLE
feat(funding): SEC Form D amount extraction + retry hardening

### DIFF
--- a/scripts/scrape-sec-form-d.mjs
+++ b/scripts/scrape-sec-form-d.mjs
@@ -31,8 +31,8 @@
  *     sourceUrl       EDGAR filing detail URL
  *     sourcePlatform  "sec-form-d"
  *     publishedAt     filing date (ISO)
- *     extracted       { companyName, ... amount=null }
- *     tags            ["sec", "form-d", "ai"]
+ *     extracted       { companyName, amount, amountDisplay, ... }
+ *     tags            ["sec", "form-d", "ai", ...]
  *
  * AI FILTERING
  *   Uses the same AI_KEYWORDS regex as the worker fetcher so the gate
@@ -42,6 +42,14 @@
  *   The latter is implicit since we drive the fetch from
  *   `q=artificial+intelligence&forms=D` — every hit already mentions
  *   "artificial intelligence" somewhere in the filing.
+ *
+ * AMOUNT EXTRACTION
+ *   For each surviving search hit we fetch the filing's primary_doc.xml
+ *   and parse <offeringSalesAmounts><totalOfferingAmount>. We also pull
+ *   <industryGroupType> as a tag and use its "Pooled Investment Fund" /
+ *   <investmentFundInfo> markers as a defensive belt to BAD_NAME_PATTERN —
+ *   any filing identified as a fund by the XML is dropped even if the
+ *   issuer name slipped past the regex.
  */
 
 import { resolve } from "path";
@@ -121,10 +129,142 @@ const AI_NAME_HINT_RE =
 const BAD_NAME_PATTERN =
   /\b(series|fund|capital|partners|management|advisors|trust|holdings|acquisition|acquisitions|insider|nonpublic|pe |private equity|hedge|asset management|family office|spv)\b|^(hii|gaingels|bip|nv |ac )\s|\s+(i{1,3}v?|[0-9]{1,4}|[a-z])\s*(llc|lp|inc|corp)?\s*$/i;
 
-const SLEEP_MS_BETWEEN_REQUESTS = 120;
+// Politeness ceiling. SEC publishes a 10 req/s cap; we sit well under
+// it. Bumped 120 → 150ms after observing intermittent 5xx during
+// burst windows. Detail fetches use a separate per-request sleep.
+const SLEEP_MS_BETWEEN_REQUESTS = 150;
+const SLEEP_MS_BETWEEN_DETAIL_FETCHES = 100;
+
+// Retry tuning. EDGAR returns 5xx during indexing windows and the
+// network occasionally hiccups. 3 attempts (1 try + 2 retries) with
+// exponential backoff is enough to ride out 99% of transient failures
+// without hammering the host.
+const MAX_FETCH_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = [200, 800];
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Fetch with bounded retries. Retries on 5xx and network errors only —
+ * 4xx fails fast (404 means the doc isn't there, no point retrying).
+ * Returns the Response on success, throws on permanent failure.
+ */
+async function fetchWithRetry(url, options, label) {
+  let lastErr = null;
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, options);
+      if (res.ok) return res;
+      // 4xx is permanent — don't retry.
+      if (res.status >= 400 && res.status < 500) {
+        throw new Error(`${label} ${res.status} ${res.statusText}`);
+      }
+      lastErr = new Error(`${label} ${res.status} ${res.statusText}`);
+    } catch (err) {
+      lastErr = err;
+    }
+    if (attempt < MAX_FETCH_ATTEMPTS) {
+      const backoff = RETRY_BACKOFF_MS[attempt - 1] ?? 1000;
+      await sleep(backoff);
+    }
+  }
+  throw lastErr ?? new Error(`${label} failed after ${MAX_FETCH_ATTEMPTS} attempts`);
+}
+
+/**
+ * Format USD amount for display. 5_200_000 → "$5.2M", 850_000 → "$850K",
+ * 25_000_000_000 → "$25B". Mirrors the convention used elsewhere on the
+ * funding page.
+ */
+function formatAmountDisplay(amount) {
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    return "Undisclosed";
+  }
+  if (amount >= 1_000_000_000) {
+    const v = amount / 1_000_000_000;
+    return `$${v % 1 === 0 ? v.toFixed(0) : v.toFixed(1)}B`;
+  }
+  if (amount >= 1_000_000) {
+    const v = amount / 1_000_000;
+    return `$${v % 1 === 0 ? v.toFixed(0) : v.toFixed(1)}M`;
+  }
+  if (amount >= 1_000) {
+    const v = amount / 1_000;
+    return `$${v.toFixed(0)}K`;
+  }
+  return `$${amount}`;
+}
+
+/**
+ * Pluck the inner text of the first matching tag (case-insensitive).
+ * Form D primary_doc.xml is small (typically <50KB) and well-formed
+ * but we avoid pulling in an XML parser dep. Regex is sufficient
+ * for the leaf fields we need.
+ */
+function pluckTag(xml, tag) {
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i");
+  const match = xml.match(re);
+  if (!match) return null;
+  const inner = match[1].trim();
+  return inner.length > 0 ? inner : null;
+}
+
+/**
+ * Detect fund-type filings from the parsed primary_doc.xml. Drops:
+ *   - industryGroupType containing "Fund" (Pooled Investment Fund,
+ *     Hedge Fund, Other Investment Fund, etc.)
+ *   - filings carrying an <investmentFundInfo> block
+ *   - isPooledInvestmentFundType=true on typesOfSecuritiesOffered
+ * Defensive belt to BAD_NAME_PATTERN's suspenders.
+ */
+function isFundFiling(xml) {
+  const industry = pluckTag(xml, "industryGroupType");
+  if (industry && /\bfund\b/i.test(industry)) return true;
+  if (/<investmentFundInfo[\s>]/i.test(xml)) return true;
+  if (/<isPooledInvestmentFundType>\s*true\s*<\/isPooledInvestmentFundType>/i.test(xml)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Fetch + parse a single Form D filing's primary_doc.xml. Returns
+ * { amount, industryGroup, isFund } on success, null on permanent
+ * failure (the filing is dropped; the rest of the run continues).
+ */
+async function fetchFilingDetail(primaryDocUrl) {
+  if (!primaryDocUrl) return null;
+  let xml;
+  try {
+    const res = await fetchWithRetry(
+      primaryDocUrl,
+      {
+        headers: {
+          "User-Agent": USER_AGENT,
+          Accept: "application/xml,text/xml,*/*",
+        },
+      },
+      `[sec-form-d] detail`,
+    );
+    xml = await res.text();
+  } catch (err) {
+    console.warn(
+      `[sec-form-d] detail fetch failed for ${primaryDocUrl}: ${err.message}`,
+    );
+    return null;
+  }
+
+  const isFund = isFundFiling(xml);
+  const industryGroup = pluckTag(xml, "industryGroupType");
+  const amountRaw = pluckTag(xml, "totalOfferingAmount");
+  let amount = null;
+  if (amountRaw) {
+    const n = Number(amountRaw);
+    if (Number.isFinite(n) && n > 0) amount = n;
+  }
+  return { amount, industryGroup, isFund };
 }
 
 function isoDateNDaysAgo(n) {
@@ -146,17 +286,16 @@ async function fetchSearch(query, startdt, enddt) {
   url.searchParams.set("enddt", enddt);
   url.searchParams.set("hits", String(MAX_HITS_PER_QUERY));
 
-  const res = await fetch(url, {
-    headers: {
-      "User-Agent": USER_AGENT,
-      Accept: "application/json",
+  const res = await fetchWithRetry(
+    url,
+    {
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept: "application/json",
+      },
     },
-  });
-  if (!res.ok) {
-    throw new Error(
-      `[sec-form-d] search ${query} failed: ${res.status} ${res.statusText}`,
-    );
-  }
+    `[sec-form-d] search ${query}`,
+  );
   const json = await res.json();
   return json?.hits?.hits ?? [];
 }
@@ -206,8 +345,8 @@ async function main() {
   );
 
   const seenAdsh = new Set();
-  const signals = [];
-
+  // First pass: collect search hits across all queries, dedup by accession.
+  const candidates = [];
   for (const query of QUERIES) {
     let hits = [];
     try {
@@ -234,48 +373,87 @@ async function main() {
       if (isLikelyFund(issuerName)) continue;
 
       const fileDate = hit?._source?.file_date ?? null;
-      const publishedAt = fileDate
-        ? new Date(`${fileDate}T00:00:00Z`).toISOString()
-        : new Date().toISOString();
-
       const ciks = hit?._source?.ciks ?? [];
       const cik = Array.isArray(ciks) ? ciks[0] : null;
 
-      const sourceUrl =
-        buildFilingUrl(cik, adsh) ?? `https://www.sec.gov/cgi-bin/browse-edgar`;
-      const primaryDocUrl = buildPrimaryDocUrl(cik, adsh);
-
-      // Score the AI confidence: explicit name hint = high, query-only
-      // match = medium. We stamp this on extracted.confidence so the
-      // page can sort name-confirmed AI rounds to the top.
-      const nameHints = passesAiHint(issuerName);
-      const confidence = nameHints ? "high" : "medium";
-
-      signals.push({
-        id: `sec-form-d-${adsh}`,
-        headline: `${issuerName} filed Form D`,
-        description: `SEC Form D — private offering disclosure (full filing: ${primaryDocUrl ?? "n/a"})`,
-        sourceUrl,
-        sourcePlatform: "sec-form-d",
-        publishedAt,
-        discoveredAt: new Date().toISOString(),
-        extracted: {
-          companyName: issuerName,
-          companyWebsite: null,
-          companyLogoUrl: null,
-          amount: null,
-          amountDisplay: "Undisclosed",
-          currency: "USD",
-          roundType: "undisclosed",
-          investors: [],
-          investorsEnriched: [],
-          confidence,
-        },
-        tags: ["sec", "form-d", "ai", confidence === "high" ? "ai-confirmed" : "ai-keyword"],
-      });
+      candidates.push({ adsh, issuerName, fileDate, cik });
     }
     await sleep(SLEEP_MS_BETWEEN_REQUESTS);
   }
+  console.log(
+    `[sec-form-d] ${candidates.length} candidates after name-pattern filter; fetching detail`,
+  );
+
+  // Second pass: fetch primary_doc.xml for each candidate to extract
+  // dollar amount + reject fund-type filings the name regex missed.
+  const signals = [];
+  let droppedAsFund = 0;
+  let amountResolved = 0;
+  for (const { adsh, issuerName, fileDate, cik } of candidates) {
+    const sourceUrl =
+      buildFilingUrl(cik, adsh) ?? `https://www.sec.gov/cgi-bin/browse-edgar`;
+    const primaryDocUrl = buildPrimaryDocUrl(cik, adsh);
+
+    const detail = await fetchFilingDetail(primaryDocUrl);
+    await sleep(SLEEP_MS_BETWEEN_DETAIL_FETCHES);
+
+    // If the XML says it's a fund, drop — even if BAD_NAME_PATTERN
+    // missed it. industryGroupType is the canonical signal.
+    if (detail?.isFund) {
+      droppedAsFund += 1;
+      continue;
+    }
+
+    const amount = detail?.amount ?? null;
+    const amountDisplay = formatAmountDisplay(amount);
+    if (amount !== null) amountResolved += 1;
+
+    const publishedAt = fileDate
+      ? new Date(`${fileDate}T00:00:00Z`).toISOString()
+      : new Date().toISOString();
+
+    // Confidence: name-hint AND amount = high; just one = medium;
+    // neither = low. Form D doesn't expose round type so we leave
+    // that "undisclosed".
+    const nameHints = passesAiHint(issuerName);
+    let confidence;
+    if (nameHints && amount !== null) confidence = "high";
+    else if (nameHints || amount !== null) confidence = "medium";
+    else confidence = "low";
+
+    const tags = ["sec", "form-d", "ai"];
+    tags.push(nameHints ? "ai-confirmed" : "ai-keyword");
+    if (detail?.industryGroup) {
+      tags.push(`industry:${detail.industryGroup.toLowerCase().replace(/\s+/g, "-")}`);
+    }
+
+    signals.push({
+      id: `sec-form-d-${adsh}`,
+      headline: `${issuerName} filed Form D`,
+      description: `SEC Form D — private offering disclosure (full filing: ${primaryDocUrl ?? "n/a"})`,
+      sourceUrl,
+      sourcePlatform: "sec-form-d",
+      publishedAt,
+      discoveredAt: new Date().toISOString(),
+      extracted: {
+        companyName: issuerName,
+        companyWebsite: null,
+        companyLogoUrl: null,
+        amount,
+        amountDisplay,
+        currency: "USD",
+        roundType: "undisclosed",
+        investors: [],
+        investorsEnriched: [],
+        confidence,
+        industryGroup: detail?.industryGroup ?? null,
+      },
+      tags,
+    });
+  }
+  console.log(
+    `[sec-form-d] detail pass: ${amountResolved}/${signals.length} signals with amount, ${droppedAsFund} dropped as funds`,
+  );
 
   signals.sort((a, b) => {
     const ta = Date.parse(a.publishedAt);


### PR DESCRIPTION
## Summary
- Fetches each Form D hit's `primary_doc.xml` to populate `extracted.amount` (USD), `amountDisplay`, and `industryGroup` instead of the previous universal `null` / `Undisclosed`.
- Adds a defensive XML-level fund filter (industryGroupType contains "Fund", `<investmentFundInfo>` block, or `isPooledInvestmentFundType=true`) that drops fund vehicles which slipped past `BAD_NAME_PATTERN`.
- Adds shared `fetchWithRetry` (up to 3 attempts with 200ms / 800ms exponential backoff for 5xx + network errors; 4xx fails fast). Search throttle bumped 120 -> 150ms; per-detail-fetch sleep set to 100ms. Still well inside SEC's 10 req/s cap.

## Smoke test
30-day window: 47 candidates -> 39 signals after fund filter (8 dropped). **34/39 (87.2%) carry a non-null amount** -- well above the 30% target.

Top results from preview:
- Shield AI Inc -- $591.8M (high confidence)
- Beacon Biosignals -- $103.3M
- Kenny AI LLC -- $70M
- FINSTER AI -- $34.5M
- WORTH AI -- $30M

## Test plan
- [x] `DATA_STORE_DISABLE=1 node scripts/scrape-sec-form-d.mjs --output=.tmp/sec-preview.json` runs cleanly end-to-end
- [x] >= 30% of signals have a non-null `extracted.amount` (got 87%)
- [x] Fund-type filings (industryGroupType="Pooled Investment Fund" etc.) are dropped via XML check
- [ ] Verify funding page Top Rounds chart no longer clusters SEC signals at the bottom after Redis refresh
- [ ] Confirm cron run doesn't blow its 2h slot (47 candidates * 100ms detail sleep ~5s extra wall-clock)