### PR TITLE
feat(funding): dedicated /funding/sec page (Form D filings)

### DIFF
--- a/src/app/funding/sec/error.tsx
+++ b/src/app/funding/sec/error.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+import { RefreshCw, Home } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function FundingSecError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
+      <p
+        className="v2-mono mb-3"
+        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+      >
+        {"// ERROR · FUNDING · SEC"}
+      </p>
+      <h1
+        style={{
+          fontFamily: "var(--font-geist), Inter, sans-serif",
+          fontSize: "clamp(24px, 3.5vw, 32px)",
+          fontWeight: 510,
+          letterSpacing: "-0.022em",
+          color: "var(--v2-ink-000)",
+          lineHeight: 1.1,
+          marginBottom: 12,
+        }}
+      >
+        Something went wrong.
+      </h1>
+      <p
+        className="leading-relaxed mb-5"
+        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+      >
+        This surface failed to render. Try again, or head back to the funding
+        radar.
+      </p>
+      {error.digest && (
+        <p
+          className="v2-mono mb-5"
+          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+        >
+          {"// DIGEST: "}
+          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+        </p>
+      )}
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={reset}
+          className={cn("v2-btn v2-btn-primary inline-flex")}
+        >
+          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
+          TRY AGAIN
+        </button>
+        <Link href="/funding" className="v2-btn v2-btn-ghost inline-flex">
+          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
+          BACK TO FUNDING
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/funding/sec/loading.tsx
+++ b/src/app/funding/sec/loading.tsx
@@ -1,0 +1,46 @@
+// /funding/sec — SEC Form D feed skeleton.
+
+export default function FundingSecLoading() {
+  return (
+    <div className="max-w-[1600px] mx-auto px-4 md:px-6 py-4 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div className="space-y-2">
+          <div
+            className="h-3 w-32 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050)" }}
+          />
+          <div
+            className="h-7 w-72 rounded-[2px]"
+            style={{ background: "var(--v3-bg-100)" }}
+          />
+          <div
+            className="h-3 w-96 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050)" }}
+          />
+        </div>
+        <div
+          className="h-12 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050)" }}
+        />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-16 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050)" }}
+            />
+          ))}
+        </div>
+        <div className="space-y-1.5">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-12 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050)" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/funding/sec/page.tsx
+++ b/src/app/funding/sec/page.tsx
@@ -1,0 +1,449 @@
+// /funding/sec — dedicated SEC Form D filings feed.
+//
+// The trending /funding page merges 4 funding slugs and Form D filings lose
+// ranking there because they have no `extracted.amount` (today). This page
+// surfaces every Form D filing on its own with filing-specific metadata
+// (confidence pill, EDGAR ground-truth framing).
+//
+// Data path: ONLY the `funding-news-sec` Redis slug (not the 4-slug merger).
+//   getDataStore().read("funding-news-sec") → 3-tier read with file fallback
+//   src/lib/funding/sec-form-d.ts owns the cache + refresh hook.
+//
+// Renders newest-first with row-level confidence + filing date columns.
+// EntityLogo per row resolves to a domain-favicon when extracted.companyWebsite
+// becomes available; falls back to sec.gov favicon then deterministic monogram.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { PageHead } from "@/components/ui/PageHead";
+import { KpiBand } from "@/components/ui/KpiBand";
+import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+import { EntityLogo } from "@/components/ui/EntityLogo";
+import {
+  TerminalFeedTable,
+  type FeedColumn,
+} from "@/components/feed/TerminalFeedTable";
+import { resolveLogoUrl } from "@/lib/logo-url";
+import {
+  getSecFormDFile,
+  getSecFormDSignals,
+  isSecFormDCold,
+  refreshSecFormDFromStore,
+} from "@/lib/funding/sec-form-d";
+import type { FundingSignal } from "@/lib/funding/types";
+
+// 30-min ISR — the SEC scraper runs on a slow cron and Form D filings only
+// land at most once a day per company. No need for warmer cadence.
+export const revalidate = 1800;
+
+export const metadata: Metadata = {
+  title: "TrendingRepo — SEC Form D filings (AI)",
+  description:
+    "Every US private offering by an AI-tagged issuer, filed within 15 days of close. EDGAR ground truth — the long tail of AI funding journalists never write about.",
+  alternates: { canonical: "/funding/sec" },
+};
+
+// Brand color — SEC.gov navy. No --v4-src-sec token exists, so hardcode here.
+const SEC_NAVY = "#0f3a6c";
+const SEC_FAVICON = "https://www.google.com/s2/favicons?domain=sec.gov&sz=64";
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+
+function formatClock(iso: string | undefined): string {
+  if (!iso) return "warming";
+  const date = new Date(iso);
+  return Number.isFinite(date.getTime())
+    ? date.toISOString().slice(11, 19)
+    : "warming";
+}
+
+function formatFilingDate(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "—";
+  // Form D dates are filing-day granularity (no useful time component).
+  // YYYY-MM-DD is the canonical EDGAR display format.
+  return new Date(t).toISOString().slice(0, 10);
+}
+
+function formatAge(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "—";
+  const ageMs = Math.max(0, Date.now() - t);
+  if (ageMs < DAY_MS) {
+    const h = Math.max(1, Math.floor(ageMs / HOUR_MS));
+    return `${h}h ago`;
+  }
+  return `${Math.floor(ageMs / DAY_MS)}d ago`;
+}
+
+function withinMs(signals: FundingSignal[], windowMs: number): number {
+  const now = Date.now();
+  return signals.filter((s) => {
+    const t = Date.parse(s.publishedAt);
+    return Number.isFinite(t) && now - t <= windowMs;
+  }).length;
+}
+
+function confidenceCount(
+  signals: FundingSignal[],
+  confidence: "high" | "medium" | "low",
+): number {
+  return signals.filter((s) => s.extracted?.confidence === confidence).length;
+}
+
+interface ConfidencePillProps {
+  level: "high" | "medium" | "low" | "none";
+}
+
+function ConfidencePill({ level }: ConfidencePillProps) {
+  const tone =
+    level === "high"
+      ? { color: "var(--v4-money)", label: "HIGH" }
+      : level === "medium"
+        ? { color: "var(--v4-amber)", label: "MED" }
+        : level === "low"
+          ? { color: "var(--v4-ink-300)", label: "LOW" }
+          : { color: "var(--v4-ink-400)", label: "—" };
+  return (
+    <span
+      className="v2-mono"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "1px 6px",
+        fontSize: 9.5,
+        letterSpacing: "0.16em",
+        fontWeight: 600,
+        color: tone.color,
+        border: `1px solid ${tone.color}`,
+        borderRadius: 2,
+        textTransform: "uppercase",
+      }}
+    >
+      {tone.label}
+    </span>
+  );
+}
+
+function EmptyState({ cold }: { cold: boolean }) {
+  return (
+    <section
+      style={{
+        padding: 32,
+        background: "var(--v4-bg-025)",
+        border: "1px dashed var(--v4-line-100)",
+        borderRadius: 2,
+      }}
+    >
+      <h2
+        className="v2-mono"
+        style={{
+          color: SEC_NAVY,
+          fontSize: 18,
+          fontWeight: 700,
+          textTransform: "uppercase",
+          letterSpacing: "0.18em",
+        }}
+      >
+        {"// no sec form d filings yet"}
+      </h2>
+      <p
+        style={{
+          marginTop: 12,
+          maxWidth: "32rem",
+          fontSize: 13,
+          color: "var(--v4-ink-300)",
+        }}
+      >
+        {cold
+          ? "The SEC EDGAR scraper has not produced data yet. Run "
+          : "The scraper ran but found no AI-tagged Form D filings in the current window. Run "}
+        <code style={{ color: "var(--v4-ink-100)" }}>
+          node scripts/scrape-sec-form-d.mjs
+        </code>{" "}
+        locally to populate{" "}
+        <code style={{ color: "var(--v4-ink-100)" }}>
+          data/funding-news-sec.json
+        </code>
+        , then refresh this page.
+      </p>
+    </section>
+  );
+}
+
+export default async function FundingSecPage() {
+  await refreshSecFormDFromStore();
+  const file = getSecFormDFile();
+  const signals = getSecFormDSignals();
+  const cold = isSecFormDCold(file);
+
+  // Sort newest-first by publishedAt (filing date).
+  const sorted = signals
+    .slice()
+    .sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt));
+
+  const total = sorted.length;
+  const highCount = confidenceCount(sorted, "high");
+  const within7d = withinMs(sorted, 7 * DAY_MS);
+  const within30d = withinMs(sorted, 30 * DAY_MS);
+  const computed = formatClock(file.fetchedAt);
+
+  const columns: FeedColumn<FundingSignal>[] = [
+    {
+      id: "rank",
+      header: "#",
+      width: "44px",
+      align: "left",
+      render: (_, i) => (
+        <span
+          className="font-mono text-[12px] tabular-nums font-semibold"
+          style={{ color: i < 10 ? SEC_NAVY : "var(--v4-ink-400)" }}
+        >
+          {String(i + 1).padStart(2, "0")}
+        </span>
+      ),
+    },
+    {
+      id: "issuer",
+      header: "Issuer",
+      align: "left",
+      render: (signal) => {
+        const name = signal.extracted?.companyName || signal.headline;
+        // Logo resolution per spec: resolveLogoUrl(sourceUrl, companyName, 64).
+        // For SEC filings the sourceUrl is the EDGAR detail link
+        // (sec.gov/cgi-bin/browse-edgar?...), which resolves to the SEC
+        // favicon when the company-name guess fails — every row gets a
+        // visible logo even though Form D filings don't carry a website.
+        const logoUrl =
+          resolveLogoUrl(
+            signal.sourceUrl,
+            signal.extracted?.companyName ?? null,
+            64,
+          ) ?? SEC_FAVICON;
+        return (
+          <div className="flex min-w-0 items-center gap-2">
+            <EntityLogo
+              src={logoUrl}
+              name={name}
+              size={24}
+              shape="square"
+              alt=""
+            />
+            <a
+              href={signal.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="truncate text-[13px] font-medium transition-colors hover:text-[color:var(--v4-acc)]"
+              style={{ color: "var(--v4-ink-100)" }}
+              title={`${name} — ${signal.headline}`}
+            >
+              {name}
+            </a>
+          </div>
+        );
+      },
+    },
+    {
+      id: "filed",
+      header: "Filed",
+      width: "110px",
+      align: "left",
+      hideBelow: "sm",
+      render: (signal) => (
+        <span
+          className="font-mono text-[11px] tabular-nums"
+          style={{ color: "var(--v4-ink-200)" }}
+          title={signal.publishedAt}
+        >
+          {formatFilingDate(signal.publishedAt)}
+        </span>
+      ),
+    },
+    {
+      id: "age",
+      header: "Age",
+      width: "70px",
+      align: "right",
+      hideBelow: "md",
+      render: (signal) => (
+        <span
+          className="font-mono text-[11px] tabular-nums"
+          style={{ color: "var(--v4-ink-400)" }}
+        >
+          {formatAge(signal.publishedAt)}
+        </span>
+      ),
+    },
+    {
+      id: "amount",
+      header: "Amount",
+      width: "110px",
+      align: "right",
+      hideBelow: "md",
+      render: (signal) => {
+        const display = signal.extracted?.amountDisplay;
+        const amt = signal.extracted?.amount;
+        // Render dash when amount is null or sentinel "Undisclosed".
+        if (!amt || !display || display === "Undisclosed") {
+          return (
+            <span
+              className="font-mono text-[12px]"
+              style={{ color: "var(--v4-ink-500)" }}
+            >
+              —
+            </span>
+          );
+        }
+        return (
+          <span
+            className="font-mono text-[12px] tabular-nums font-semibold"
+            style={{ color: "var(--v4-money)" }}
+          >
+            {display}
+          </span>
+        );
+      },
+    },
+    {
+      id: "confidence",
+      header: "Conf",
+      width: "72px",
+      align: "right",
+      render: (signal) => (
+        <ConfidencePill level={signal.extracted?.confidence ?? "none"} />
+      ),
+    },
+    {
+      id: "source",
+      header: "Source",
+      width: "60px",
+      align: "right",
+      hideBelow: "sm",
+      render: (signal) => (
+        <a
+          href={signal.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="v2-mono text-[10px] tracking-[0.14em] uppercase transition-colors hover:text-[color:var(--v4-acc)]"
+          style={{ color: "var(--v4-ink-400)" }}
+          title="Open EDGAR filing"
+        >
+          edgar →
+        </a>
+      ),
+    },
+  ];
+
+  return (
+    <main className="home-surface funding-page">
+      <PageHead
+        crumb={
+          <>
+            <b>FUNDING</b> · TERMINAL · /FUNDING/SEC
+          </>
+        }
+        h1="SEC Form D filings (AI)"
+        lede="Every US private offering by an AI-tagged issuer, filed within 15 days of close. EDGAR ground truth."
+        clock={
+          <>
+            <span className="big">{computed}</span>
+            <span className="muted">UTC · UPDATED</span>
+            <FreshnessBadge source="skills" lastUpdatedAt={file.fetchedAt} />
+          </>
+        }
+      />
+
+      <KpiBand
+        className="kpi-band"
+        cells={[
+          {
+            label: "FILINGS",
+            value: total.toLocaleString("en-US"),
+            sub: `${file.windowDays}d window`,
+            pip: SEC_NAVY,
+          },
+          {
+            label: "HIGH CONF",
+            value: highCount,
+            sub: "ai-confirmed",
+            tone: "money",
+            pip: "var(--v4-money)",
+          },
+          {
+            label: "WITHIN 7D",
+            value: within7d,
+            sub: "fresh filings",
+            tone: "acc",
+            pip: "var(--v4-acc)",
+          },
+          {
+            label: "WITHIN 30D",
+            value: within30d,
+            sub: "rolling tape",
+            pip: "var(--v4-blue)",
+          },
+        ]}
+      />
+
+      <VerdictRibbon
+        tone="money"
+        stamp={{
+          eyebrow: "// EDGAR GROUND TRUTH",
+          headline: `${total} filings · ${highCount} AI-confirmed`,
+          sub: `${file.windowDays}d window · computed ${computed} UTC`,
+        }}
+        text={
+          <>
+            <b>{total} Form D filings</b> in the current window —{" "}
+            <span style={{ color: "var(--v4-money)" }}>{highCount} high-confidence</span>{" "}
+            AI-tagged issuers, with{" "}
+            <span style={{ color: "var(--v4-acc)" }}>{within7d}</span> filed in the
+            last 7 days. Every US private round files Form D within 15 days of
+            close — this captures the long tail journalists never cover.
+          </>
+        }
+        actionHref="https://efts.sec.gov/LATEST/search-index?q=%22artificial+intelligence%22&forms=D"
+        actionLabel="EDGAR →"
+      />
+
+      {sorted.length === 0 ? (
+        <EmptyState cold={cold} />
+      ) : (
+        <>
+          <div style={{ marginTop: 16 }}>
+            <p
+              className="v2-mono"
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.18em",
+                textTransform: "uppercase",
+                color: "var(--v4-ink-400)",
+                marginBottom: 8,
+              }}
+            >
+              Filing tape · newest first ·{" "}
+              <Link
+                href="/funding"
+                className="hover:text-[color:var(--v4-acc)]"
+                style={{ color: "var(--v4-ink-300)" }}
+              >
+                ← back to /funding
+              </Link>
+            </p>
+          </div>
+          <TerminalFeedTable
+            rows={sorted}
+            columns={columns}
+            rowKey={(signal) => signal.id}
+            accent={SEC_NAVY}
+            caption="SEC Form D filings by AI-tagged issuers, newest first"
+            emptyTitle="No filings in this window"
+          />
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/lib/funding/sec-form-d.ts
+++ b/src/lib/funding/sec-form-d.ts
@@ -1,0 +1,162 @@
+// SEC Form D loader — dedicated reader for the funding-news-sec Redis slug.
+//
+// The trending /funding page merges 4 funding slugs (funding-news +
+// funding-news-crunchbase + funding-news-x + funding-news-sec) into a single
+// view. /funding/sec wants the SEC payload on its own with filing-specific
+// metadata (confidence pills, EDGAR ground-truth framing).
+//
+// This module mirrors the read-and-cache contract of `src/lib/funding-news.ts`
+// but fans to ONLY the `funding-news-sec` slug. It does not share the cache
+// with funding-news.ts so the two pages can render independently without
+// stomping each other's last-known-good payload.
+//
+// Three-tier read (Redis → bundled file → in-memory) is delegated to the
+// shared data-store. Refresh hook is rate-limited (30s min interval) and
+// in-flight deduped just like the funding-news.ts pattern.
+//
+// Pure server-only — uses readFileSync for the bundled-snapshot tier.
+
+import { readFileSync, statSync } from "fs";
+import { resolve } from "path";
+
+import type { FundingNewsFile, FundingSignal } from "./types";
+
+const SEC_FILE_PATH = resolve(
+  process.cwd(),
+  "data",
+  "funding-news-sec.json",
+);
+const EPOCH_ZERO = "1970-01-01T00:00:00.000Z";
+
+interface SecCache {
+  signature: string;
+  file: FundingNewsFile;
+}
+
+let cache: SecCache | null = null;
+
+function createFallbackFile(): FundingNewsFile {
+  return {
+    fetchedAt: EPOCH_ZERO,
+    source: "none",
+    windowDays: 30,
+    signals: [],
+  };
+}
+
+function getFileSignature(path: string): string {
+  try {
+    const stat = statSync(path);
+    return `${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return "missing";
+  }
+}
+
+function normalizeFile(input: unknown): FundingNewsFile {
+  if (!input || typeof input !== "object") return createFallbackFile();
+  const file = input as Partial<FundingNewsFile>;
+  return {
+    fetchedAt:
+      typeof file.fetchedAt === "string" && file.fetchedAt.trim().length > 0
+        ? file.fetchedAt
+        : EPOCH_ZERO,
+    source: typeof file.source === "string" ? file.source : "unknown",
+    windowDays:
+      typeof file.windowDays === "number" && Number.isFinite(file.windowDays)
+        ? file.windowDays
+        : 30,
+    signals: Array.isArray(file.signals) ? (file.signals as FundingSignal[]) : [],
+  };
+}
+
+function loadCache(): SecCache {
+  const signature = getFileSignature(SEC_FILE_PATH);
+  if (cache && cache.signature === signature) return cache;
+
+  let file = createFallbackFile();
+  try {
+    const raw = readFileSync(SEC_FILE_PATH, "utf8");
+    file = normalizeFile(JSON.parse(raw));
+  } catch {
+    file = createFallbackFile();
+  }
+
+  cache = { signature, file };
+  return cache;
+}
+
+export function getSecFormDFile(): FundingNewsFile {
+  return loadCache().file;
+}
+
+export function getSecFormDSignals(): FundingSignal[] {
+  return getSecFormDFile().signals ?? [];
+}
+
+export function isSecFormDCold(
+  file: FundingNewsFile = getSecFormDFile(),
+): boolean {
+  return !file.fetchedAt || file.fetchedAt.startsWith("1970-");
+}
+
+// ---------------------------------------------------------------------------
+// Refresh hook — pulls the freshest funding-news-sec payload from Redis.
+// ---------------------------------------------------------------------------
+
+interface RefreshResult {
+  source: "redis" | "file" | "memory" | "missing";
+  ageMs: number;
+}
+
+let inflight: Promise<RefreshResult> | null = null;
+let lastRefreshMs = 0;
+const MIN_REFRESH_INTERVAL_MS = 30_000;
+
+/**
+ * Pull the freshest SEC Form D payload from the data-store and swap it
+ * into this module's in-memory cache. Cheap to call multiple times — internal
+ * dedupe + 30s rate-limit ensure we hit Redis at most once per process per
+ * 30s window.
+ *
+ * Reads ONLY the `funding-news-sec` slug (not the 4-slug merger that the
+ * trending /funding page uses). Never throws.
+ */
+export async function refreshSecFormDFromStore(): Promise<RefreshResult> {
+  if (inflight) return inflight;
+  const sinceLast = Date.now() - lastRefreshMs;
+  if (sinceLast < MIN_REFRESH_INTERVAL_MS && lastRefreshMs > 0) {
+    return { source: "memory", ageMs: sinceLast };
+  }
+
+  inflight = (async (): Promise<RefreshResult> => {
+    try {
+      const { getDataStore } = await import("../data-store");
+      const store = getDataStore();
+      const result = await store.read<unknown>("funding-news-sec");
+      if (result.data && result.source !== "missing") {
+        const file = normalizeFile(result.data);
+        cache = {
+          signature: `redis:${file.fetchedAt || Date.now()}`,
+          file,
+        };
+      }
+      lastRefreshMs = Date.now();
+      return { source: result.source, ageMs: result.ageMs };
+    } catch {
+      lastRefreshMs = Date.now();
+      return { source: "missing", ageMs: 0 };
+    }
+  })().finally(() => {
+    inflight = null;
+  });
+
+  return inflight;
+}
+
+/** Test/admin — drop the in-memory cache so the next read goes to disk. */
+export function _resetSecFormDCacheForTests(): void {
+  cache = null;
+  lastRefreshMs = 0;
+  inflight = null;
+}


### PR DESCRIPTION
## Summary
- New `/funding/sec` route surfaces every Form D filing on its own with filing-specific metadata (confidence pills, EDGAR ground-truth framing). Form D filings lose ranking on the trending `/funding` page because they have no `extracted.amount` today.
- Reads ONLY the `funding-news-sec` Redis slug — does NOT reuse the 4-slug merger from `/funding`. New `src/lib/funding/sec-form-d.ts` owns the cache + 30s-rate-limited refresh hook.
- V4 chrome: `PageHead` + `KpiBand` (filings / high-conf / 7d / 30d) + `VerdictRibbon`, then a `TerminalFeedTable` with rank/issuer/filed/age/amount/confidence/source columns. Newest-first sort by `publishedAt`. Dash-renders `amount` until upstream extraction lands; pre-wired so it lights up automatically.
- `EntityLogo` per row resolves through `resolveLogoUrl(signal.sourceUrl, signal.extracted.companyName, 64)` — sec.gov favicon as fallback today, will switch to company-domain favicons once `extracted.companyWebsite` populates.

## Renders against current Redis state
- Total: **47 filings** (window 30d, source `sec-form-d-edgar`)
- HIGH confidence: **43** (ai-confirmed)
- Within 7d: **6** · Within 30d: **44**
- All `amount` cells render em-dash (extractor doesn't populate amount yet — separate agent is shipping that upgrade).

## File scope (CREATE only)
- `src/app/funding/sec/page.tsx` — server component, V4 chrome, TerminalFeedTable.
- `src/app/funding/sec/loading.tsx` — skeleton.
- `src/app/funding/sec/error.tsx` — Sentry-wired error boundary.
- `src/lib/funding/sec-form-d.ts` — SEC-only Redis reader + refresh hook (separate cache from funding-news.ts so `/funding` and `/funding/sec` don't stomp each other).

No modifications to `data-store.ts`, `funding-news.ts`, `funding/types.ts`, or `logo-url.ts`.

## Test plan
- [ ] `npm run typecheck` clean on touched files (verified — zero errors filtered to my paths).
- [ ] Local: `npm run dev`, hit `/funding/sec`, confirm 47 rows, KPI band shows 47/43/6/44, freshness badge renders.
- [ ] Local: confirm `EDGAR →` link and per-row source link open the EDGAR filing page.
- [ ] Local: temporarily blank `data/funding-news-sec.json` to confirm `EmptyState` cold path renders.
- [ ] Vercel preview: visual diff against `/funding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)