### PR TITLE
feat(funding): enrich investors[] for RSS extractions

### DIFF
--- a/apps/trendingrepo-worker/src/lib/sources/enrich-investors.ts
+++ b/apps/trendingrepo-worker/src/lib/sources/enrich-investors.ts
@@ -1,0 +1,182 @@
+// Worker-local mirror of src/lib/funding/enrich-investors.ts. Both modules
+// must stay in sync — the frontend extractor and the worker extractor ship
+// to the same data shape (FundingExtraction.investorsEnriched). Whenever
+// you add an investor to one file, add it to the other; same for matching
+// rules. The mirror exists because the worker has rootDir=src and cannot
+// reach across the monorepo boundary at TypeScript compile time.
+
+export interface KnownInvestor {
+  name: string;
+  aliases: readonly string[];
+  domain?: string;
+  github?: string;
+}
+
+export interface InvestorEnriched {
+  name: string;
+  isKnown: boolean;
+  confidence: 'high' | 'medium' | 'low';
+  logoUrl?: string;
+}
+
+export const KNOWN_INVESTORS: ReadonlyArray<KnownInvestor> = [
+  { name: 'Andreessen Horowitz', aliases: ['andreessen horowitz', 'a16z', 'andreessen', 'ah capital', 'a16z crypto'], domain: 'a16z.com' },
+  { name: 'Sequoia Capital', aliases: ['sequoia capital', 'sequoia', 'sequoia china', 'sequoia india', 'peak xv'], domain: 'sequoiacap.com' },
+  { name: 'Lightspeed Venture Partners', aliases: ['lightspeed venture partners', 'lightspeed', 'lightspeed ventures'], domain: 'lsvp.com' },
+  { name: 'Khosla Ventures', aliases: ['khosla ventures', 'khosla', 'vinod khosla'], domain: 'khoslaventures.com' },
+  { name: 'Founders Fund', aliases: ['founders fund', 'founders found', 'peter thiel', 'thiel'], domain: 'foundersfund.com' },
+  { name: 'Google Ventures', aliases: ['google ventures', 'gv', 'gradient ventures'], domain: 'gv.com' },
+  { name: 'NEA', aliases: ['nea', 'new enterprise associates'], domain: 'nea.com' },
+  { name: 'Index Ventures', aliases: ['index ventures', 'index'], domain: 'indexventures.com' },
+  { name: 'Kleiner Perkins', aliases: ['kleiner perkins', 'kleiner', 'kpcb'], domain: 'kleinerperkins.com' },
+  { name: 'Greylock', aliases: ['greylock', 'greylock partners'], domain: 'greylock.com' },
+  { name: 'Bessemer Venture Partners', aliases: ['bessemer venture partners', 'bessemer', 'bvp'], domain: 'bvp.com' },
+  { name: 'Accel', aliases: ['accel', 'accel partners'], domain: 'accel.com' },
+  { name: 'IVP', aliases: ['ivp', 'institutional venture partners'], domain: 'ivp.com' },
+  { name: 'Benchmark', aliases: ['benchmark', 'benchmark capital'], domain: 'benchmark.com' },
+  { name: 'Y Combinator', aliases: ['y combinator', 'yc', 'ycombinator'], domain: 'ycombinator.com' },
+  { name: 'Tiger Global', aliases: ['tiger global', 'tiger global management', 'tiger'], domain: 'tigerglobal.com' },
+  { name: 'SoftBank', aliases: ['softbank', 'softbank vision fund', 'vision fund', 'softbank group'], domain: 'softbank.com' },
+  { name: 'NVentures', aliases: ['nventures', 'nvidia ventures', 'nvidia'], domain: 'nvidia.com' },
+  { name: 'Microsoft', aliases: ['microsoft', 'microsoft m12', 'm12', 'microsoft ventures'], domain: 'microsoft.com' },
+  { name: 'Salesforce Ventures', aliases: ['salesforce ventures', 'salesforce'], domain: 'salesforce.com' },
+  { name: 'Insight Partners', aliases: ['insight partners', 'insight venture partners', 'insight'], domain: 'insightpartners.com' },
+  { name: 'General Catalyst', aliases: ['general catalyst', 'gc'], domain: 'generalcatalyst.com' },
+  { name: 'Coatue', aliases: ['coatue', 'coatue management'], domain: 'coatue.com' },
+  { name: 'Thrive Capital', aliases: ['thrive capital', 'thrive', 'joshua kushner'], domain: 'thrivecap.com' },
+  { name: 'Redpoint Ventures', aliases: ['redpoint ventures', 'redpoint'], domain: 'redpoint.com' },
+  { name: 'First Round Capital', aliases: ['first round capital', 'first round'], domain: 'firstround.com' },
+  { name: 'Bain Capital Ventures', aliases: ['bain capital ventures', 'bain capital', 'bcv'], domain: 'baincapitalventures.com' },
+  { name: 'Greenoaks', aliases: ['greenoaks', 'greenoaks capital'], domain: 'greenoaks.com' },
+  { name: 'BlackRock', aliases: ['blackrock', 'blackrock private equity'], domain: 'blackrock.com' },
+  { name: 'Fidelity', aliases: ['fidelity', 'fidelity management', 'fmr'], domain: 'fidelity.com' },
+  { name: 'Bond Capital', aliases: ['bond capital', 'bond'], domain: 'bondcap.com' },
+  { name: 'D1 Capital', aliases: ['d1 capital', 'd1'], domain: 'd1capital.com' },
+  { name: 'Dragoneer', aliases: ['dragoneer', 'dragoneer investment group'], domain: 'dragoneer.com' },
+  { name: 'T. Rowe Price', aliases: ['t. rowe price', 't rowe price', 't.rowe price', 'trowe price'], domain: 'troweprice.com' },
+  { name: 'Wellington Management', aliases: ['wellington management', 'wellington'], domain: 'wellington.com' },
+  { name: 'Baillie Gifford', aliases: ['baillie gifford'], domain: 'bailliegifford.com' },
+  { name: 'Lux Capital', aliases: ['lux capital', 'lux'], domain: 'luxcapital.com' },
+  { name: 'Menlo Ventures', aliases: ['menlo ventures', 'menlo'], domain: 'menlovc.com' },
+  { name: 'Mayfield', aliases: ['mayfield', 'mayfield fund'], domain: 'mayfield.com' },
+  { name: 'Norwest Venture Partners', aliases: ['norwest venture partners', 'norwest', 'nvp'], domain: 'nvp.com' },
+  { name: 'True Ventures', aliases: ['true ventures'], domain: 'trueventures.com' },
+  { name: 'Uncork Capital', aliases: ['uncork capital', 'uncork'], domain: 'uncorkcapital.com' },
+  { name: 'Slow Ventures', aliases: ['slow ventures', 'slow'], domain: 'slow.co' },
+  { name: 'SV Angel', aliases: ['sv angel', 'ron conway'], domain: 'svangel.com' },
+  { name: 'DCM Ventures', aliases: ['dcm ventures', 'dcm'], domain: 'dcm.com' },
+  { name: '8VC', aliases: ['8vc'], domain: '8vc.com' },
+  { name: 'Valor Equity Partners', aliases: ['valor equity partners', 'valor'], domain: 'valorep.com' },
+  { name: 'Alkeon Capital', aliases: ['alkeon capital', 'alkeon'], domain: 'alkeon.com' },
+  { name: 'Iconiq Capital', aliases: ['iconiq capital', 'iconiq', 'iconiq growth'], domain: 'iconiqcapital.com' },
+  { name: 'Spark Capital', aliases: ['spark capital', 'spark'], domain: 'sparkcapital.com' },
+  { name: 'Battery Ventures', aliases: ['battery ventures', 'battery'], domain: 'battery.com' },
+  { name: 'Costanoa Ventures', aliases: ['costanoa ventures', 'costanoa'], domain: 'costanoa.vc' },
+  { name: 'Founder Collective', aliases: ['founder collective'], domain: 'foundercollective.com' },
+  { name: 'Initialized Capital', aliases: ['initialized capital', 'initialized'], domain: 'initialized.com' },
+  { name: 'Conviction', aliases: ['conviction', 'conviction partners', 'sarah guo'], domain: 'conviction.com' },
+  { name: 'Radical Ventures', aliases: ['radical ventures', 'radical'], domain: 'radical.vc' },
+  { name: 'Balderton Capital', aliases: ['balderton capital', 'balderton'], domain: 'balderton.com' },
+  { name: 'Atomico', aliases: ['atomico'], domain: 'atomico.com' },
+  { name: 'Creandum', aliases: ['creandum'], domain: 'creandum.com' },
+  { name: 'Northzone', aliases: ['northzone'], domain: 'northzone.com' },
+  { name: 'Point Nine', aliases: ['point nine', 'point nine capital', 'p9'], domain: 'pointnine.com' },
+  { name: 'Hoxton Ventures', aliases: ['hoxton ventures', 'hoxton'], domain: 'hoxtonventures.com' },
+  { name: 'Nat Friedman', aliases: ['nat friedman', 'daniel gross', 'nat & daniel', 'nat and daniel'], domain: 'nat.org' },
+];
+
+function normalize(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[.,&'’()]/g, ' ')
+    .replace(/\b(capital|ventures|venture|partners|partner|management|group|llc|inc|fund|holdings|the)\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+interface NormalizedIndexEntry {
+  key: string;
+  investor: KnownInvestor;
+}
+
+const NORMALIZED_INDEX: ReadonlyArray<NormalizedIndexEntry> = (() => {
+  const entries: NormalizedIndexEntry[] = [];
+  for (const investor of KNOWN_INVESTORS) {
+    const seen = new Set<string>();
+    for (const alias of [investor.name, ...investor.aliases]) {
+      const key = normalize(alias);
+      if (key.length === 0 || seen.has(key)) continue;
+      seen.add(key);
+      entries.push({ key, investor });
+    }
+  }
+  entries.sort((a, b) => b.key.length - a.key.length);
+  return entries;
+})();
+
+function buildLogoUrl(investor: KnownInvestor): string | null {
+  if (investor.domain) return `https://logo.clearbit.com/${investor.domain}`;
+  if (investor.github) return `https://github.com/${investor.github}.png`;
+  return null;
+}
+
+function tokensOf(s: string): string[] {
+  return s.split(/\s+/).filter((t) => t.length > 0);
+}
+
+function tokenSubsetMatch(haystackTokens: string[], needleTokens: string[]): boolean {
+  // Whole-token subset in either direction. Prevents partial substring
+  // accidents like "vision" matching "visionaries".
+  if (haystackTokens.length === 0 || needleTokens.length === 0) return false;
+  const haySet = new Set(haystackTokens);
+  const needleSet = new Set(needleTokens);
+  const needleInHay = needleTokens.every((t) => haySet.has(t));
+  const hayInNeedle = haystackTokens.every((t) => needleSet.has(t));
+  return needleInHay || hayInNeedle;
+}
+
+function findKnownInvestor(rawName: string): KnownInvestor | null {
+  const n = normalize(rawName);
+  if (n.length === 0 || n.length < 3) return null;
+  for (const entry of NORMALIZED_INDEX) {
+    if (entry.key === n) return entry.investor;
+  }
+  const nTokens = tokensOf(n);
+  for (const entry of NORMALIZED_INDEX) {
+    if (entry.key.length < 3) continue;
+    const eTokens = tokensOf(entry.key);
+    if (tokenSubsetMatch(nTokens, eTokens)) return entry.investor;
+  }
+  return null;
+}
+
+export function enrichInvestors(rawNames: readonly string[]): InvestorEnriched[] {
+  const out: InvestorEnriched[] = [];
+  const seen = new Set<string>();
+  for (const raw of rawNames) {
+    const trimmed = (raw ?? '').trim();
+    if (!trimmed) continue;
+    const known = findKnownInvestor(trimmed);
+    if (known) {
+      const dedupeKey = `known:${known.name.toLowerCase()}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      const logoUrl = buildLogoUrl(known);
+      const enriched: InvestorEnriched = {
+        name: known.name,
+        isKnown: true,
+        confidence: 'high',
+      };
+      if (logoUrl) enriched.logoUrl = logoUrl;
+      out.push(enriched);
+    } else {
+      const dedupeKey = `raw:${trimmed.toLowerCase()}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      out.push({ name: trimmed, isKnown: false, confidence: 'low' });
+    }
+  }
+  return out;
+}

--- a/apps/trendingrepo-worker/src/lib/sources/funding-extract.ts
+++ b/apps/trendingrepo-worker/src/lib/sources/funding-extract.ts
@@ -2,6 +2,8 @@
 // scripts/scrape-funding-news.mjs. Detects company name, $ amount, round
 // type, and tags from a headline + description string. No HTTP, no I/O.
 
+import { enrichInvestors } from './enrich-investors.js';
+
 const ROUND_PATTERNS: { type: string; patterns: RegExp[] }[] = [
   { type: 'pre-seed', patterns: [/\bpre[-\s]?seed\b/i, /\bpreseed\b/i] },
   { type: 'seed', patterns: [/\bseed\b/i] },
@@ -203,7 +205,12 @@ export interface FundingExtraction {
   currency: string;
   roundType: string;
   investors: string[];
-  investorsEnriched: Array<{ name: string; isKnown: boolean; confidence: 'high' | 'medium' | 'low' }>;
+  investorsEnriched: Array<{
+    name: string;
+    isKnown: boolean;
+    confidence: 'high' | 'medium' | 'low';
+    logoUrl?: string;
+  }>;
   confidence: 'none' | 'low' | 'medium' | 'high';
 }
 
@@ -271,6 +278,68 @@ export function getKnownCompanyDomain(companyName: string | null | undefined): s
   return info?.domain ?? null;
 }
 
+// Investor cue patterns — pull candidate names from headline + description.
+// Mirrors the same set used by the legacy `_funding-article.mjs` pass and
+// the frontend `extractInvestorsFromText`. Output names then go through
+// enrichInvestors() so canonical / known-VC handling is consistent.
+// First character: A-Z for proper-noun firms, a-z for lowercase
+// abbreviations like "a16z", digits cover "8VC". cleanInvestorCandidate
+// + INVESTOR_NAME_STOP_WORDS reject noise that slips through.
+const INVESTOR_CUE_PATTERNS: RegExp[] = [
+  /(?:led|co-led)\s+by\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|\bin\b|\bto\b|\bfor\b|\bat\b|$)/g,
+  /(?:backed|backing|funded|supported)\s+(?:by\s+|from\s+)([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|\bin\b|\bto\b|\bfor\b|\bat\b|$)/g,
+  /investors?\s+(?:include|included|are|were)\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /(?:participated|joined)\s+(?:by|in)\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /(?:money|funding|investment)\s+from\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /\bfrom\s+([A-Za-z0-9][A-Za-z0-9&.'’-]+(?:\s+[A-Z][A-Za-z0-9&.'’-]+){0,3})\b(?=\s+for|\s+to|\s+at|\s+as|\s*[.,;])/g,
+  /participation\s+from\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\bwith\b|\band\s+(?:no\b|other\b|undisclosed))/g,
+];
+
+const INVESTOR_TRAILING_NOISE = /\b(?:and|with|along|together|as|in|on|at|for|from|to|the)$/i;
+
+const INVESTOR_NAME_STOP_WORDS = new Set<string>([
+  'the', 'a', 'an', 'this', 'that', 'it', 'company', 'startup', 'firm',
+  'fund', 'previous', 'existing', 'new', 'several', 'multiple', 'various',
+  'other', 'investors', 'backers', 'funders', 'including', 'among', 'such',
+  'shareholders', 'current', 'former', 'undisclosed', 'yesterday', 'today',
+  'last', 'year', 'month', 'week',
+]);
+
+function cleanInvestorCandidate(raw: string): string | null {
+  let s = raw.replace(/\s+/g, ' ').trim();
+  for (let i = 0; i < 3; i += 1) {
+    const m = s.match(/\s+(\S+)$/);
+    if (m && INVESTOR_TRAILING_NOISE.test(m[1] ?? '')) {
+      s = s.slice(0, s.length - (m[1] ?? '').length).trim();
+    } else {
+      break;
+    }
+  }
+  if (s.length < 2) return null;
+  if (INVESTOR_NAME_STOP_WORDS.has(s.toLowerCase())) return null;
+  return s;
+}
+
+export function extractInvestorsFromText(text: string): string[] {
+  const found: string[] = [];
+  const seen = new Set<string>();
+  for (const pattern of INVESTOR_CUE_PATTERNS) {
+    for (const match of text.matchAll(pattern)) {
+      const raw = match[1] ?? '';
+      const parts = raw.split(/\s*(?:,|\band\b|\bwith\b)\s*/i);
+      for (const part of parts) {
+        const cleaned = cleanInvestorCandidate(part);
+        if (!cleaned) continue;
+        const key = cleaned.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        found.push(cleaned);
+      }
+    }
+  }
+  return found;
+}
+
 export function extractFunding(headline: string, description: string): FundingExtraction | null {
   const combined = `${headline} ${description}`;
   const companyName = extractCompanyName(headline);
@@ -288,6 +357,9 @@ export function extractFunding(headline: string, description: string): FundingEx
   const knownDomain = getKnownCompanyDomain(companyName);
   const companyWebsite = knownDomain ? `https://${knownDomain}` : null;
 
+  const investors = extractInvestorsFromText(combined);
+  const investorsEnriched = enrichInvestors(investors);
+
   return {
     companyName: companyName ?? 'Unknown',
     companyWebsite,
@@ -296,8 +368,8 @@ export function extractFunding(headline: string, description: string): FundingEx
     amountDisplay: amount?.display ?? 'Undisclosed',
     currency: 'USD',
     roundType: roundType ?? 'undisclosed',
-    investors: [],
-    investorsEnriched: [],
+    investors,
+    investorsEnriched,
     confidence,
   };
 }

--- a/scripts/_enrich-investors.mjs
+++ b/scripts/_enrich-investors.mjs
@@ -1,0 +1,169 @@
+// Mirror of src/lib/funding/enrich-investors.ts kept in plain ESM so the
+// legacy `scrape-funding-news.mjs` pipeline can call it without a TS build.
+// The three mirrors (frontend / worker / script) MUST stay in sync — when
+// you add an investor in one place, add it in the others. Used by:
+//   - scripts/_funding-article.mjs (article enrichment)
+//   - scripts/scrape-funding-news.mjs (post-extraction enrichment of
+//     RSS-derived investors[] arrays).
+
+export const KNOWN_INVESTORS = [
+  { name: 'Andreessen Horowitz', aliases: ['andreessen horowitz', 'a16z', 'andreessen', 'ah capital', 'a16z crypto'], domain: 'a16z.com' },
+  { name: 'Sequoia Capital', aliases: ['sequoia capital', 'sequoia', 'sequoia china', 'sequoia india', 'peak xv'], domain: 'sequoiacap.com' },
+  { name: 'Lightspeed Venture Partners', aliases: ['lightspeed venture partners', 'lightspeed', 'lightspeed ventures'], domain: 'lsvp.com' },
+  { name: 'Khosla Ventures', aliases: ['khosla ventures', 'khosla', 'vinod khosla'], domain: 'khoslaventures.com' },
+  { name: 'Founders Fund', aliases: ['founders fund', 'founders found', 'peter thiel', 'thiel'], domain: 'foundersfund.com' },
+  { name: 'Google Ventures', aliases: ['google ventures', 'gv', 'gradient ventures'], domain: 'gv.com' },
+  { name: 'NEA', aliases: ['nea', 'new enterprise associates'], domain: 'nea.com' },
+  { name: 'Index Ventures', aliases: ['index ventures', 'index'], domain: 'indexventures.com' },
+  { name: 'Kleiner Perkins', aliases: ['kleiner perkins', 'kleiner', 'kpcb'], domain: 'kleinerperkins.com' },
+  { name: 'Greylock', aliases: ['greylock', 'greylock partners'], domain: 'greylock.com' },
+  { name: 'Bessemer Venture Partners', aliases: ['bessemer venture partners', 'bessemer', 'bvp'], domain: 'bvp.com' },
+  { name: 'Accel', aliases: ['accel', 'accel partners'], domain: 'accel.com' },
+  { name: 'IVP', aliases: ['ivp', 'institutional venture partners'], domain: 'ivp.com' },
+  { name: 'Benchmark', aliases: ['benchmark', 'benchmark capital'], domain: 'benchmark.com' },
+  { name: 'Y Combinator', aliases: ['y combinator', 'yc', 'ycombinator'], domain: 'ycombinator.com' },
+  { name: 'Tiger Global', aliases: ['tiger global', 'tiger global management', 'tiger'], domain: 'tigerglobal.com' },
+  { name: 'SoftBank', aliases: ['softbank', 'softbank vision fund', 'vision fund', 'softbank group'], domain: 'softbank.com' },
+  { name: 'NVentures', aliases: ['nventures', 'nvidia ventures', 'nvidia'], domain: 'nvidia.com' },
+  { name: 'Microsoft', aliases: ['microsoft', 'microsoft m12', 'm12', 'microsoft ventures'], domain: 'microsoft.com' },
+  { name: 'Salesforce Ventures', aliases: ['salesforce ventures', 'salesforce'], domain: 'salesforce.com' },
+  { name: 'Insight Partners', aliases: ['insight partners', 'insight venture partners', 'insight'], domain: 'insightpartners.com' },
+  { name: 'General Catalyst', aliases: ['general catalyst', 'gc'], domain: 'generalcatalyst.com' },
+  { name: 'Coatue', aliases: ['coatue', 'coatue management'], domain: 'coatue.com' },
+  { name: 'Thrive Capital', aliases: ['thrive capital', 'thrive', 'joshua kushner'], domain: 'thrivecap.com' },
+  { name: 'Redpoint Ventures', aliases: ['redpoint ventures', 'redpoint'], domain: 'redpoint.com' },
+  { name: 'First Round Capital', aliases: ['first round capital', 'first round'], domain: 'firstround.com' },
+  { name: 'Bain Capital Ventures', aliases: ['bain capital ventures', 'bain capital', 'bcv'], domain: 'baincapitalventures.com' },
+  { name: 'Greenoaks', aliases: ['greenoaks', 'greenoaks capital'], domain: 'greenoaks.com' },
+  { name: 'BlackRock', aliases: ['blackrock', 'blackrock private equity'], domain: 'blackrock.com' },
+  { name: 'Fidelity', aliases: ['fidelity', 'fidelity management', 'fmr'], domain: 'fidelity.com' },
+  { name: 'Bond Capital', aliases: ['bond capital', 'bond'], domain: 'bondcap.com' },
+  { name: 'D1 Capital', aliases: ['d1 capital', 'd1'], domain: 'd1capital.com' },
+  { name: 'Dragoneer', aliases: ['dragoneer', 'dragoneer investment group'], domain: 'dragoneer.com' },
+  { name: 'T. Rowe Price', aliases: ['t. rowe price', 't rowe price', 't.rowe price', 'trowe price'], domain: 'troweprice.com' },
+  { name: 'Wellington Management', aliases: ['wellington management', 'wellington'], domain: 'wellington.com' },
+  { name: 'Baillie Gifford', aliases: ['baillie gifford'], domain: 'bailliegifford.com' },
+  { name: 'Lux Capital', aliases: ['lux capital', 'lux'], domain: 'luxcapital.com' },
+  { name: 'Menlo Ventures', aliases: ['menlo ventures', 'menlo'], domain: 'menlovc.com' },
+  { name: 'Mayfield', aliases: ['mayfield', 'mayfield fund'], domain: 'mayfield.com' },
+  { name: 'Norwest Venture Partners', aliases: ['norwest venture partners', 'norwest', 'nvp'], domain: 'nvp.com' },
+  { name: 'True Ventures', aliases: ['true ventures'], domain: 'trueventures.com' },
+  { name: 'Uncork Capital', aliases: ['uncork capital', 'uncork'], domain: 'uncorkcapital.com' },
+  { name: 'Slow Ventures', aliases: ['slow ventures', 'slow'], domain: 'slow.co' },
+  { name: 'SV Angel', aliases: ['sv angel', 'ron conway'], domain: 'svangel.com' },
+  { name: 'DCM Ventures', aliases: ['dcm ventures', 'dcm'], domain: 'dcm.com' },
+  { name: '8VC', aliases: ['8vc'], domain: '8vc.com' },
+  { name: 'Valor Equity Partners', aliases: ['valor equity partners', 'valor'], domain: 'valorep.com' },
+  { name: 'Alkeon Capital', aliases: ['alkeon capital', 'alkeon'], domain: 'alkeon.com' },
+  { name: 'Iconiq Capital', aliases: ['iconiq capital', 'iconiq', 'iconiq growth'], domain: 'iconiqcapital.com' },
+  { name: 'Spark Capital', aliases: ['spark capital', 'spark'], domain: 'sparkcapital.com' },
+  { name: 'Battery Ventures', aliases: ['battery ventures', 'battery'], domain: 'battery.com' },
+  { name: 'Costanoa Ventures', aliases: ['costanoa ventures', 'costanoa'], domain: 'costanoa.vc' },
+  { name: 'Founder Collective', aliases: ['founder collective'], domain: 'foundercollective.com' },
+  { name: 'Initialized Capital', aliases: ['initialized capital', 'initialized'], domain: 'initialized.com' },
+  { name: 'Conviction', aliases: ['conviction', 'conviction partners', 'sarah guo'], domain: 'conviction.com' },
+  { name: 'Radical Ventures', aliases: ['radical ventures', 'radical'], domain: 'radical.vc' },
+  { name: 'Balderton Capital', aliases: ['balderton capital', 'balderton'], domain: 'balderton.com' },
+  { name: 'Atomico', aliases: ['atomico'], domain: 'atomico.com' },
+  { name: 'Creandum', aliases: ['creandum'], domain: 'creandum.com' },
+  { name: 'Northzone', aliases: ['northzone'], domain: 'northzone.com' },
+  { name: 'Point Nine', aliases: ['point nine', 'point nine capital', 'p9'], domain: 'pointnine.com' },
+  { name: 'Hoxton Ventures', aliases: ['hoxton ventures', 'hoxton'], domain: 'hoxtonventures.com' },
+  { name: 'Nat Friedman', aliases: ['nat friedman', 'daniel gross', 'nat & daniel', 'nat and daniel'], domain: 'nat.org' },
+];
+
+function normalize(input) {
+  return String(input ?? '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[.,&'’()]/g, ' ')
+    .replace(/\b(capital|ventures|venture|partners|partner|management|group|llc|inc|fund|holdings|the)\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const NORMALIZED_INDEX = (() => {
+  const entries = [];
+  for (const investor of KNOWN_INVESTORS) {
+    const seen = new Set();
+    for (const alias of [investor.name, ...investor.aliases]) {
+      const key = normalize(alias);
+      if (key.length === 0 || seen.has(key)) continue;
+      seen.add(key);
+      entries.push({ key, investor });
+    }
+  }
+  entries.sort((a, b) => b.key.length - a.key.length);
+  return entries;
+})();
+
+function buildLogoUrl(investor) {
+  if (investor.domain) return `https://logo.clearbit.com/${investor.domain}`;
+  if (investor.github) return `https://github.com/${investor.github}.png`;
+  return null;
+}
+
+function tokensOf(s) {
+  return s.split(/\s+/).filter((t) => t.length > 0);
+}
+
+function tokenSubsetMatch(haystackTokens, needleTokens) {
+  // True iff every needle token appears as a whole-token in haystack OR
+  // every haystack token appears as a whole-token in needle. Both
+  // directions cover "Andreessen" vs "Andreessen Horowitz" and
+  // "Andreessen Horowitz Capital" vs "Andreessen Horowitz" symmetrically,
+  // while preventing partial substring matches like "vision" matching
+  // "visionaries".
+  if (haystackTokens.length === 0 || needleTokens.length === 0) return false;
+  const haySet = new Set(haystackTokens);
+  const needleSet = new Set(needleTokens);
+  const needleInHay = needleTokens.every((t) => haySet.has(t));
+  const hayInNeedle = haystackTokens.every((t) => needleSet.has(t));
+  return needleInHay || hayInNeedle;
+}
+
+export function findKnownInvestor(rawName) {
+  const n = normalize(rawName);
+  if (n.length === 0) return null;
+  for (const entry of NORMALIZED_INDEX) {
+    if (entry.key === n) return entry.investor;
+  }
+  const nTokens = tokensOf(n);
+  for (const entry of NORMALIZED_INDEX) {
+    if (entry.key.length < 3) continue;
+    if (n.length < 3) continue;
+    const eTokens = tokensOf(entry.key);
+    if (tokenSubsetMatch(nTokens, eTokens)) return entry.investor;
+  }
+  return null;
+}
+
+export function enrichInvestors(rawNames) {
+  const out = [];
+  const seen = new Set();
+  for (const raw of rawNames ?? []) {
+    const trimmed = String(raw ?? '').trim();
+    if (!trimmed) continue;
+    const known = findKnownInvestor(trimmed);
+    if (known) {
+      const dedupeKey = `known:${known.name.toLowerCase()}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      const logoUrl = buildLogoUrl(known);
+      const enriched = {
+        name: known.name,
+        isKnown: true,
+        confidence: 'high',
+      };
+      if (logoUrl) enriched.logoUrl = logoUrl;
+      out.push(enriched);
+    } else {
+      const dedupeKey = `raw:${trimmed.toLowerCase()}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      out.push({ name: trimmed, isKnown: false, confidence: 'low' });
+    }
+  }
+  return out;
+}

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -22,6 +22,7 @@ import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
+import { enrichInvestors } from "./_enrich-investors.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(__dirname, "..");
@@ -435,6 +436,62 @@ function extractTags(headline, description) {
   return tags;
 }
 
+// Mirror of extractInvestorsFromText() in the worker / frontend extractors.
+// Pulls candidate names from "led by X", "from Y", "backed by Z" cues.
+// First char allows A-Z, a-z, digits — covers "a16z", "8VC", proper nouns.
+const INVESTOR_CUE_PATTERNS = [
+  /(?:led|co-led)\s+by\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|\bin\b|\bto\b|\bfor\b|\bat\b|$)/g,
+  /(?:backed|backing|funded|supported)\s+(?:by\s+|from\s+)([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|\bin\b|\bto\b|\bfor\b|\bat\b|$)/g,
+  /investors?\s+(?:include|included|are|were)\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /(?:participated|joined)\s+(?:by|in)\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /(?:money|funding|investment)\s+from\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /\bfrom\s+([A-Za-z0-9][A-Za-z0-9&.'’-]+(?:\s+[A-Z][A-Za-z0-9&.'’-]+){0,3})\b(?=\s+for|\s+to|\s+at|\s+as|\s*[.,;])/g,
+  /participation\s+from\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\bwith\b|\band\s+(?:no\b|other\b|undisclosed))/g,
+];
+const INVESTOR_TRAILING_NOISE = /\b(?:and|with|along|together|as|in|on|at|for|from|to|the)$/i;
+const INVESTOR_NAME_STOP_WORDS_LOCAL = new Set([
+  "the", "a", "an", "this", "that", "it", "company", "startup", "firm",
+  "fund", "previous", "existing", "new", "several", "multiple", "various",
+  "other", "investors", "backers", "funders", "including", "among", "such",
+  "shareholders", "current", "former", "undisclosed", "yesterday", "today",
+  "last", "year", "month", "week",
+]);
+
+function cleanInvestorCandidate(raw) {
+  let s = String(raw ?? "").replace(/\s+/g, " ").trim();
+  for (let i = 0; i < 3; i += 1) {
+    const m = s.match(/\s+(\S+)$/);
+    if (m && INVESTOR_TRAILING_NOISE.test(m[1] ?? "")) {
+      s = s.slice(0, s.length - (m[1] ?? "").length).trim();
+    } else {
+      break;
+    }
+  }
+  if (s.length < 2) return null;
+  if (INVESTOR_NAME_STOP_WORDS_LOCAL.has(s.toLowerCase())) return null;
+  return s;
+}
+
+function extractInvestorsFromText(text) {
+  const found = [];
+  const seen = new Set();
+  for (const pattern of INVESTOR_CUE_PATTERNS) {
+    for (const match of text.matchAll(pattern)) {
+      const raw = match[1] ?? "";
+      const parts = raw.split(/\s*(?:,|\band\b|\bwith\b)\s*/i);
+      for (const part of parts) {
+        const cleaned = cleanInvestorCandidate(part);
+        if (!cleaned) continue;
+        const key = cleaned.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        found.push(cleaned);
+      }
+    }
+  }
+  return found;
+}
+
 function extractFunding(headline, description) {
   const combined = `${headline} ${description}`;
   const companyName = extractCompanyName(headline);
@@ -452,6 +509,9 @@ function extractFunding(headline, description) {
   const companyLogoUrl = getKnownCompanyLogoUrl(companyName);
   const companyWebsite = getKnownCompanyDomain(companyName) ? `https://${getKnownCompanyDomain(companyName)}` : null;
 
+  const investors = extractInvestorsFromText(combined);
+  const investorsEnriched = enrichInvestors(investors);
+
   return {
     companyName: companyName ?? "Unknown",
     companyWebsite,
@@ -460,8 +520,8 @@ function extractFunding(headline, description) {
     amountDisplay: amount?.display ?? "Undisclosed",
     currency: "USD",
     roundType: roundType ?? "undisclosed",
-    investors: [],
-    investorsEnriched: [],
+    investors,
+    investorsEnriched,
     confidence,
   };
 }
@@ -634,7 +694,11 @@ async function main() {
             }
           }
 
-          // Update investors if found
+          // Update investors if found. Article extraction emits a richer
+          // shape ({ name, isKnown, confidence }) — we merge by lowercased
+          // raw name into the dedupe set, then rebuild investorsEnriched
+          // wholesale via enrichInvestors() so canonical names + logo URLs
+          // come from the shared known-investors database.
           if (result.investors.length > 0) {
             const existingNames = new Set(
               signal.extracted.investors.map((n) => n.toLowerCase()),
@@ -642,14 +706,12 @@ async function main() {
             for (const inv of result.investors) {
               if (!existingNames.has(inv.name.toLowerCase())) {
                 signal.extracted.investors.push(inv.name);
-                signal.extracted.investorsEnriched.push({
-                  name: inv.name,
-                  isKnown: inv.isKnown,
-                  confidence: inv.confidence,
-                });
                 existingNames.add(inv.name.toLowerCase());
               }
             }
+            signal.extracted.investorsEnriched = enrichInvestors(
+              signal.extracted.investors,
+            );
           }
 
           // Better company name from article if current one looks weak

--- a/src/lib/funding/enrich-investors.ts
+++ b/src/lib/funding/enrich-investors.ts
@@ -1,0 +1,111 @@
+// Enriches raw investor names parsed from RSS funding signals.
+//
+// Input: raw strings like "a16z", "Andreessen Horowitz", "Greylock Partners",
+// "TypeOne Ventures" — what the regex extractor pulled out of a headline or
+// article body.
+//
+// Output: normalized records of shape
+//   { name: canonicalName, isKnown: true,  confidence: 'high', logoUrl }
+//   { name: rawName,       isKnown: false, confidence: 'low' }
+//
+// Matching is case-insensitive + suffix-stripped (Capital / Ventures /
+// Partners / LLC / Inc all collapse). Aliases are configured in
+// known-investors.ts. Both extractors (worker + legacy) call this with the
+// same input shape so the data downstream is identical.
+
+import {
+  KNOWN_INVESTORS,
+  NORMALIZED_INDEX,
+  buildInvestorLogoUrl,
+  normalizeInvestorName,
+  type KnownInvestor,
+} from './known-investors';
+
+export interface InvestorEnriched {
+  name: string;
+  isKnown: boolean;
+  confidence: 'high' | 'medium' | 'low';
+  logoUrl?: string;
+}
+
+function tokensOf(s: string): string[] {
+  return s.split(/\s+/).filter((t) => t.length > 0);
+}
+
+function tokenSubsetMatch(haystackTokens: string[], needleTokens: string[]): boolean {
+  // True iff every needle token appears as a whole-token in haystack OR
+  // every haystack token appears as a whole-token in needle. Both
+  // directions cover "Andreessen" vs "Andreessen Horowitz" and
+  // "Andreessen Horowitz Capital" vs "Andreessen Horowitz" symmetrically,
+  // while preventing partial substring matches like "vision" matching
+  // "visionaries".
+  if (haystackTokens.length === 0 || needleTokens.length === 0) return false;
+  const haySet = new Set(haystackTokens);
+  const needleSet = new Set(needleTokens);
+  const needleInHay = needleTokens.every((t) => haySet.has(t));
+  const hayInNeedle = haystackTokens.every((t) => needleSet.has(t));
+  return needleInHay || hayInNeedle;
+}
+
+export function findKnownInvestor(rawName: string): KnownInvestor | null {
+  const normalized = normalizeInvestorName(rawName);
+  if (normalized.length === 0) return null;
+
+  // Exact match first — fast-path for canonical / well-formed inputs.
+  for (const entry of NORMALIZED_INDEX) {
+    if (entry.key === normalized) return entry.investor;
+  }
+
+  // Token-subset match in either direction. Whole-token comparison
+  // prevents accidents like "vision" (alias of SoftBank's "vision fund")
+  // matching the unrelated word "visionaries". NORMALIZED_INDEX is sorted
+  // longest-first so multi-word aliases beat their single-word prefixes.
+  if (normalized.length < 3) return null;
+  const nTokens = tokensOf(normalized);
+  for (const entry of NORMALIZED_INDEX) {
+    if (entry.key.length < 3) continue;
+    const eTokens = tokensOf(entry.key);
+    if (tokenSubsetMatch(nTokens, eTokens)) return entry.investor;
+  }
+  return null;
+}
+
+export function enrichInvestors(rawNames: readonly string[]): InvestorEnriched[] {
+  const out: InvestorEnriched[] = [];
+  const seen = new Set<string>(); // dedupe by canonical-or-raw name
+
+  for (const raw of rawNames) {
+    const trimmed = (raw ?? '').trim();
+    if (!trimmed) continue;
+
+    const known = findKnownInvestor(trimmed);
+    if (known) {
+      const dedupeKey = `known:${known.name.toLowerCase()}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      const logoUrl = buildInvestorLogoUrl(known);
+      const enriched: InvestorEnriched = {
+        name: known.name,
+        isKnown: true,
+        confidence: 'high',
+      };
+      if (logoUrl) enriched.logoUrl = logoUrl;
+      out.push(enriched);
+    } else {
+      const dedupeKey = `raw:${trimmed.toLowerCase()}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      out.push({
+        name: trimmed,
+        isKnown: false,
+        confidence: 'low',
+      });
+    }
+  }
+
+  return out;
+}
+
+// Re-export the database for callers that need it (e.g. the page-side card
+// renderer that wants the logo for every known investor it shows).
+export { KNOWN_INVESTORS, type KnownInvestor };

--- a/src/lib/funding/extract.ts
+++ b/src/lib/funding/extract.ts
@@ -18,6 +18,7 @@ import type {
   FundingSignal,
   FundingStats,
 } from "./types";
+import { enrichInvestors } from "./enrich-investors";
 
 // ---------------------------------------------------------------------------
 // Round-type keywords
@@ -295,6 +296,76 @@ export function extractTags(headline: string, description: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// Investor extraction from text
+// ---------------------------------------------------------------------------
+//
+// Pulls candidate investor names from headline + description using cue
+// patterns ("led by X", "from Y", "backed by Z"). The matched names are then
+// passed to enrichInvestors() which canonicalises against KNOWN_INVESTORS
+// and tags each name with isKnown / confidence / logoUrl. Conservative on
+// purpose — false positives here pollute the page, so anything ambiguous
+// stays out of the raw list.
+
+// First character: A-Z covers proper-noun firms, a-z covers lowercase
+// abbreviations like "a16z", digits cover "8VC". We rely on the trailing
+// word-boundary set + cleanInvestorCandidate stop-words to reject noise.
+const INVESTOR_CUE_PATTERNS: RegExp[] = [
+  /(?:led|co-led)\s+by\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|\bin\b|\bto\b|\bfor\b|\bat\b|$)/g,
+  /(?:backed|backing|funded|supported)\s+(?:by\s+|from\s+)([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|\bin\b|\bto\b|\bfor\b|\bat\b|$)/g,
+  /investors?\s+(?:include|included|are|were)\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /(?:participated|joined)\s+(?:by|in)\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /(?:money|funding|investment)\s+from\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\band\b|\bwith\b|$)/g,
+  /\bfrom\s+([A-Za-z0-9][A-Za-z0-9&.'’-]+(?:\s+[A-Z][A-Za-z0-9&.'’-]+){0,3})\b(?=\s+for|\s+to|\s+at|\s+as|\s*[.,;])/g,
+  // Participation cue: "with participation from X (and|,) Y"
+  /participation\s+from\s+([A-Za-z0-9][A-Za-z0-9&.\s'’-]+?)(?:,|;|\.|\bwith\b|\band\s+(?:no\b|other\b|undisclosed))/g,
+];
+
+const INVESTOR_TRAILING_NOISE = /\b(?:and|with|along|together|as|in|on|at|for|from|to|the)$/i;
+
+const INVESTOR_NAME_STOP_WORDS = new Set([
+  "the", "a", "an", "this", "that", "it", "company", "startup", "firm",
+  "fund", "previous", "existing", "new", "several", "multiple", "various",
+  "other", "investors", "backers", "funders", "including", "among", "such",
+  "shareholders", "current", "former", "undisclosed", "yesterday", "today",
+  "last", "year", "month", "week",
+]);
+
+function cleanInvestorCandidate(raw: string): string | null {
+  let s = raw.replace(/\s+/g, " ").trim();
+  for (let i = 0; i < 3; i += 1) {
+    const m = s.match(/\s+(\S+)$/);
+    if (m && INVESTOR_TRAILING_NOISE.test(m[1])) {
+      s = s.slice(0, s.length - m[1].length).trim();
+    } else {
+      break;
+    }
+  }
+  if (s.length < 2) return null;
+  if (INVESTOR_NAME_STOP_WORDS.has(s.toLowerCase())) return null;
+  return s;
+}
+
+export function extractInvestorsFromText(text: string): string[] {
+  const found: string[] = [];
+  const seen = new Set<string>();
+  for (const pattern of INVESTOR_CUE_PATTERNS) {
+    for (const match of text.matchAll(pattern)) {
+      const raw = match[1] ?? "";
+      const parts = raw.split(/\s*(?:,|\band\b|\bwith\b)\s*/i);
+      for (const part of parts) {
+        const cleaned = cleanInvestorCandidate(part);
+        if (!cleaned) continue;
+        const key = cleaned.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        found.push(cleaned);
+      }
+    }
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
 // Main extraction entry point
 // ---------------------------------------------------------------------------
 
@@ -322,6 +393,9 @@ export function extractFundingFromHeadline(
     confidence = "low";
   }
 
+  const investors = extractInvestorsFromText(combined);
+  const investorsEnriched = enrichInvestors(investors);
+
   return {
     companyName: companyName ?? "Unknown",
     companyWebsite: null,
@@ -330,8 +404,8 @@ export function extractFundingFromHeadline(
     amountDisplay: amount?.display ?? "Undisclosed",
     currency: "USD",
     roundType: roundType ?? "undisclosed",
-    investors: [],
-    investorsEnriched: [],
+    investors,
+    investorsEnriched,
     confidence,
   };
 }

--- a/src/lib/funding/known-investors.ts
+++ b/src/lib/funding/known-investors.ts
@@ -1,0 +1,395 @@
+// Known VC firms and angel investors most-often mentioned in AI funding rounds.
+// Used by enrichInvestors() to map raw names parsed from RSS headlines/bodies
+// to a canonical name + logo URL + known/unknown classification.
+//
+// To add an investor: append to KNOWN_INVESTORS with the canonical name,
+// every plausible alias seen in the wild, the firm's primary domain (used to
+// build a Clearbit logo URL) and any github org for fallback avatar lookup.
+//
+// Matching strategy (see enrich-investors.ts):
+//   1. Lowercase + collapse whitespace + strip suffixes ("Capital", "Ventures",
+//      "Partners", "LLC", "Inc") on the raw name AND each alias key.
+//   2. Match if normalized raw equals a normalized alias OR if either
+//      normalized form contains the other. This handles "a16z" vs
+//      "Andreessen Horowitz" and "Sequoia" vs "Sequoia Capital" symmetrically.
+//
+// Logo strategy:
+//   - When `domain` is set, build `https://logo.clearbit.com/<domain>`.
+//   - When only `github` is set, build `https://github.com/<org>.png`.
+//   - The page falls back to the firm's initials when both are missing.
+
+export interface KnownInvestor {
+  /** Canonical display name. */
+  name: string;
+  /** Aliases seen in the wild (lowercase or original casing — both are
+   *  normalized at match time). Always include the canonical name in lowercase. */
+  aliases: readonly string[];
+  /** Primary domain — used to build a Clearbit logo URL when present. */
+  domain?: string;
+  /** GitHub org — used as a logo fallback when no domain is available. */
+  github?: string;
+}
+
+export const KNOWN_INVESTORS: ReadonlyArray<KnownInvestor> = [
+  {
+    name: 'Andreessen Horowitz',
+    aliases: ['andreessen horowitz', 'a16z', 'andreessen', 'ah capital', 'a16z crypto'],
+    domain: 'a16z.com',
+  },
+  {
+    name: 'Sequoia Capital',
+    aliases: ['sequoia capital', 'sequoia', 'sequoia china', 'sequoia india', 'peak xv'],
+    domain: 'sequoiacap.com',
+  },
+  {
+    name: 'Lightspeed Venture Partners',
+    aliases: ['lightspeed venture partners', 'lightspeed', 'lightspeed ventures'],
+    domain: 'lsvp.com',
+  },
+  {
+    name: 'Khosla Ventures',
+    aliases: ['khosla ventures', 'khosla', 'vinod khosla'],
+    domain: 'khoslaventures.com',
+  },
+  {
+    name: 'Founders Fund',
+    aliases: ['founders fund', 'founders found', 'peter thiel', 'thiel'],
+    domain: 'foundersfund.com',
+  },
+  {
+    name: 'Google Ventures',
+    aliases: ['google ventures', 'gv', 'gradient ventures'],
+    domain: 'gv.com',
+  },
+  {
+    name: 'NEA',
+    aliases: ['nea', 'new enterprise associates'],
+    domain: 'nea.com',
+  },
+  {
+    name: 'Index Ventures',
+    aliases: ['index ventures', 'index'],
+    domain: 'indexventures.com',
+  },
+  {
+    name: 'Kleiner Perkins',
+    aliases: ['kleiner perkins', 'kleiner', 'kpcb'],
+    domain: 'kleinerperkins.com',
+  },
+  {
+    name: 'Greylock',
+    aliases: ['greylock', 'greylock partners'],
+    domain: 'greylock.com',
+  },
+  {
+    name: 'Bessemer Venture Partners',
+    aliases: ['bessemer venture partners', 'bessemer', 'bvp'],
+    domain: 'bvp.com',
+  },
+  {
+    name: 'Accel',
+    aliases: ['accel', 'accel partners'],
+    domain: 'accel.com',
+  },
+  {
+    name: 'IVP',
+    aliases: ['ivp', 'institutional venture partners'],
+    domain: 'ivp.com',
+  },
+  {
+    name: 'Benchmark',
+    aliases: ['benchmark', 'benchmark capital'],
+    domain: 'benchmark.com',
+  },
+  {
+    name: 'Y Combinator',
+    aliases: ['y combinator', 'yc', 'ycombinator'],
+    domain: 'ycombinator.com',
+  },
+  {
+    name: 'Tiger Global',
+    aliases: ['tiger global', 'tiger global management', 'tiger'],
+    domain: 'tigerglobal.com',
+  },
+  {
+    name: 'SoftBank',
+    aliases: ['softbank', 'softbank vision fund', 'vision fund', 'softbank group'],
+    domain: 'softbank.com',
+  },
+  {
+    name: 'NVentures',
+    aliases: ['nventures', 'nvidia ventures', 'nvidia'],
+    domain: 'nvidia.com',
+  },
+  {
+    name: 'Microsoft',
+    aliases: ['microsoft', 'microsoft m12', 'm12', 'microsoft ventures'],
+    domain: 'microsoft.com',
+  },
+  {
+    name: 'Salesforce Ventures',
+    aliases: ['salesforce ventures', 'salesforce'],
+    domain: 'salesforce.com',
+  },
+  {
+    name: 'Insight Partners',
+    aliases: ['insight partners', 'insight venture partners', 'insight'],
+    domain: 'insightpartners.com',
+  },
+  {
+    name: 'General Catalyst',
+    aliases: ['general catalyst', 'gc'],
+    domain: 'generalcatalyst.com',
+  },
+  {
+    name: 'Coatue',
+    aliases: ['coatue', 'coatue management'],
+    domain: 'coatue.com',
+  },
+  {
+    name: 'Thrive Capital',
+    aliases: ['thrive capital', 'thrive', 'joshua kushner'],
+    domain: 'thrivecap.com',
+  },
+  {
+    name: 'Redpoint Ventures',
+    aliases: ['redpoint ventures', 'redpoint'],
+    domain: 'redpoint.com',
+  },
+  {
+    name: 'First Round Capital',
+    aliases: ['first round capital', 'first round'],
+    domain: 'firstround.com',
+  },
+  {
+    name: 'Bain Capital Ventures',
+    aliases: ['bain capital ventures', 'bain capital', 'bcv'],
+    domain: 'baincapitalventures.com',
+  },
+  {
+    name: 'Greenoaks',
+    aliases: ['greenoaks', 'greenoaks capital'],
+    domain: 'greenoaks.com',
+  },
+  {
+    name: 'BlackRock',
+    aliases: ['blackrock', 'blackrock private equity'],
+    domain: 'blackrock.com',
+  },
+  {
+    name: 'Fidelity',
+    aliases: ['fidelity', 'fidelity management', 'fmr'],
+    domain: 'fidelity.com',
+  },
+  {
+    name: 'Bond Capital',
+    aliases: ['bond capital', 'bond'],
+    domain: 'bondcap.com',
+  },
+  {
+    name: 'D1 Capital',
+    aliases: ['d1 capital', 'd1'],
+    domain: 'd1capital.com',
+  },
+  {
+    name: 'Dragoneer',
+    aliases: ['dragoneer', 'dragoneer investment group'],
+    domain: 'dragoneer.com',
+  },
+  {
+    name: 'T. Rowe Price',
+    aliases: ['t. rowe price', 't rowe price', 't.rowe price', 'trowe price'],
+    domain: 'troweprice.com',
+  },
+  {
+    name: 'Wellington Management',
+    aliases: ['wellington management', 'wellington'],
+    domain: 'wellington.com',
+  },
+  {
+    name: 'Baillie Gifford',
+    aliases: ['baillie gifford'],
+    domain: 'bailliegifford.com',
+  },
+  {
+    name: 'Lux Capital',
+    aliases: ['lux capital', 'lux'],
+    domain: 'luxcapital.com',
+  },
+  {
+    name: 'Menlo Ventures',
+    aliases: ['menlo ventures', 'menlo'],
+    domain: 'menlovc.com',
+  },
+  {
+    name: 'Mayfield',
+    aliases: ['mayfield', 'mayfield fund'],
+    domain: 'mayfield.com',
+  },
+  {
+    name: 'Norwest Venture Partners',
+    aliases: ['norwest venture partners', 'norwest', 'nvp'],
+    domain: 'nvp.com',
+  },
+  {
+    name: 'True Ventures',
+    aliases: ['true ventures'],
+    domain: 'trueventures.com',
+  },
+  {
+    name: 'Uncork Capital',
+    aliases: ['uncork capital', 'uncork'],
+    domain: 'uncorkcapital.com',
+  },
+  {
+    name: 'Slow Ventures',
+    aliases: ['slow ventures', 'slow'],
+    domain: 'slow.co',
+  },
+  {
+    name: 'SV Angel',
+    aliases: ['sv angel', 'ron conway'],
+    domain: 'svangel.com',
+  },
+  {
+    name: 'DCM Ventures',
+    aliases: ['dcm ventures', 'dcm'],
+    domain: 'dcm.com',
+  },
+  {
+    name: '8VC',
+    aliases: ['8vc'],
+    domain: '8vc.com',
+  },
+  {
+    name: 'Valor Equity Partners',
+    aliases: ['valor equity partners', 'valor'],
+    domain: 'valorep.com',
+  },
+  {
+    name: 'Alkeon Capital',
+    aliases: ['alkeon capital', 'alkeon'],
+    domain: 'alkeon.com',
+  },
+  {
+    name: 'Iconiq Capital',
+    aliases: ['iconiq capital', 'iconiq', 'iconiq growth'],
+    domain: 'iconiqcapital.com',
+  },
+  {
+    name: 'Spark Capital',
+    aliases: ['spark capital', 'spark'],
+    domain: 'sparkcapital.com',
+  },
+  {
+    name: 'Battery Ventures',
+    aliases: ['battery ventures', 'battery'],
+    domain: 'battery.com',
+  },
+  {
+    name: 'Costanoa Ventures',
+    aliases: ['costanoa ventures', 'costanoa'],
+    domain: 'costanoa.vc',
+  },
+  {
+    name: 'Founder Collective',
+    aliases: ['founder collective'],
+    domain: 'foundercollective.com',
+  },
+  {
+    name: 'Initialized Capital',
+    aliases: ['initialized capital', 'initialized'],
+    domain: 'initialized.com',
+  },
+  {
+    name: 'Conviction',
+    aliases: ['conviction', 'conviction partners', 'sarah guo'],
+    domain: 'conviction.com',
+  },
+  {
+    name: 'Radical Ventures',
+    aliases: ['radical ventures', 'radical'],
+    domain: 'radical.vc',
+  },
+  {
+    name: 'Balderton Capital',
+    aliases: ['balderton capital', 'balderton'],
+    domain: 'balderton.com',
+  },
+  {
+    name: 'Atomico',
+    aliases: ['atomico'],
+    domain: 'atomico.com',
+  },
+  {
+    name: 'Creandum',
+    aliases: ['creandum'],
+    domain: 'creandum.com',
+  },
+  {
+    name: 'Northzone',
+    aliases: ['northzone'],
+    domain: 'northzone.com',
+  },
+  {
+    name: 'Point Nine',
+    aliases: ['point nine', 'point nine capital', 'p9'],
+    domain: 'pointnine.com',
+  },
+  {
+    name: 'Hoxton Ventures',
+    aliases: ['hoxton ventures', 'hoxton'],
+    domain: 'hoxtonventures.com',
+  },
+  {
+    name: 'Nat Friedman',
+    aliases: ['nat friedman', 'daniel gross', 'nat & daniel', 'nat and daniel'],
+    domain: 'nat.org',
+  },
+];
+
+// Pre-computed normalized lookup index, keyed by normalized alias to the
+// canonical record. Built once at module load — adding investors costs O(n)
+// alias additions, not O(n) rebuild on every enrich call.
+export interface NormalizedIndexEntry {
+  /** Original normalized alias key (used for prefix/contains comparisons). */
+  key: string;
+  investor: KnownInvestor;
+}
+
+function normalize(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '') // strip diacritics
+    .replace(/[.,&'’()]/g, ' ')
+    .replace(/\b(capital|ventures|venture|partners|partner|management|group|llc|inc|fund|holdings|the)\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeInvestorName(input: string): string {
+  return normalize(input);
+}
+
+export const NORMALIZED_INDEX: ReadonlyArray<NormalizedIndexEntry> = (() => {
+  const entries: NormalizedIndexEntry[] = [];
+  for (const investor of KNOWN_INVESTORS) {
+    const seen = new Set<string>();
+    for (const alias of [investor.name, ...investor.aliases]) {
+      const key = normalize(alias);
+      if (key.length === 0 || seen.has(key)) continue;
+      seen.add(key);
+      entries.push({ key, investor });
+    }
+  }
+  // Longer keys first — prevents "ai" matching before "andreessen horowitz".
+  entries.sort((a, b) => b.key.length - a.key.length);
+  return entries;
+})();
+
+export function buildInvestorLogoUrl(investor: KnownInvestor): string | null {
+  if (investor.domain) return `https://logo.clearbit.com/${investor.domain}`;
+  if (investor.github) return `https://github.com/${investor.github}.png`;
+  return null;
+}

--- a/src/lib/funding/types.ts
+++ b/src/lib/funding/types.ts
@@ -63,6 +63,9 @@ export interface FundingInvestorRef {
   name: string;
   isKnown: boolean;
   confidence: "high" | "medium" | "low";
+  /** Logo URL for known investors (Clearbit or GitHub avatar). Optional —
+   *  only set when enrichInvestors() matched a canonical KNOWN_INVESTORS entry. */
+  logoUrl?: string;
 }
 
 /** Investor reference (Phase 2). */


### PR DESCRIPTION
## Summary
- Adds `src/lib/funding/known-investors.ts` (~60 well-known VC firms / angels) + `enrichInvestors()` helper that maps raw names to `{ name, isKnown, confidence, logoUrl }`.
- Wires enrichment into all three extractors (frontend, worker, legacy script) so RSS-extracted signals now get a populated `investorsEnriched[]` instead of `[]`.
- Adds a conservative regex pass for "led by X", "from Y", "backed by Z", "with participation from X" cues in headline+description so RSS-only flow gets raw `investors[]` populated where the text contains the cue.

## Known investors encoded (60 total)
Andreessen Horowitz, Sequoia Capital, Lightspeed, Khosla Ventures, Founders Fund, Google Ventures (GV), NEA, Index Ventures, Kleiner Perkins, Greylock, Bessemer, Accel, IVP, Benchmark, Y Combinator, Tiger Global, SoftBank, NVentures (NVIDIA), Microsoft (M12), Salesforce Ventures, Insight Partners, General Catalyst, Coatue, Thrive Capital, Redpoint, First Round, Bain Capital Ventures, Greenoaks, BlackRock, Fidelity, Bond, D1 Capital, Dragoneer, T. Rowe Price, Wellington, Baillie Gifford, Lux Capital, Menlo, Mayfield, Norwest, True Ventures, Uncork, Slow Ventures, SV Angel, DCM, 8VC, Valor Equity, Alkeon, Iconiq, Spark, Battery, Costanoa, Founder Collective, Initialized, Conviction, Radical Ventures, Balderton, Atomico, Creandum, Northzone, Point Nine, Hoxton, Nat Friedman.

## Sample RSS signals from current `data/funding-news.json` that now enrich
| Headline (truncated) | Raw investors | Enriched canonical |
|---|---|---|
| Sierra raises $175M Series B... led by Greenoaks | `["Greenoaks"]` | Greenoaks (known, logo) |
| Groq raises $640M Series D... led by BlackRock | `["BlackRock"]` | BlackRock (known, logo) |
| Tessera Labs raises $60M led by Andreessen Horowitz | `["Andreessen Horowitz"]` | Andreessen Horowitz (known, logo) |
| Ethos raises $22.75M from a16z | `["a16z"]` | Andreessen Horowitz (canonicalised, logo) |
| Cursor raises $2B led by Thrive Capital with participation from a16z and Sequoia | `["Thrive Capital","a16z","Sequoia"]` | All three canonicalised + logos |
| ReFiBuy raises $13.6M from NewRoad Capital Partners | `["NewRoad Capital Partners"]` | Unknown (kept as raw, low confidence) |

## Architecture note
The worker (`apps/trendingrepo-worker/`) has `rootDir: src` so cannot reach `src/lib/funding/`. The legacy `.mjs` script can't import TypeScript without a build. So the known-investors database is mirrored across three sibling files (frontend `.ts`, worker `.ts`, scripts `.mjs`). Each file documents the mirror requirement at the top.

## Test plan
- [x] Frontend `tsc --noEmit -p .` clean (verified)
- [x] Worker `tsc --noEmit` clean (verified)
- [x] `node --check scripts/scrape-funding-news.mjs` and `scripts/_enrich-investors.mjs` (verified)
- [x] End-to-end test of legacy `extractFunding()` on realistic headlines — investors extracted + enriched as expected
- [x] Token-aware matcher rejects partial substrings (e.g. "Visionaries" no longer matches SoftBank's "vision fund" alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)