### PR TITLE
chore(data): refresh OpenAI news 2026-05-10T09:17:39Z

### DIFF
--- a/data/_meta/openai-rss.json
+++ b/data/_meta/openai-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "openai-rss",
   "reason": "ok",
-  "ts": "2026-05-09T09:04:03.918Z",
+  "ts": "2026-05-10T09:17:39.100Z",
   "count": 1,
-  "durationMs": 5280,
+  "durationMs": 1608,
   "extra": {}
 }

--- a/data/openai-rss.json
+++ b/data/openai-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-09T09:03:58.642Z",
+  "fetchedAt": "2026-05-10T09:17:37.497Z",
   "source": "openai",
   "feedUrl": "https://openai.com/news/rss.xml",
   "error": null,


### PR DESCRIPTION
Automated data refresh from `Refresh OpenAI news`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/25624985467

Auto-merge enabled — merges once required status checks pass.