### PR TITLE
chore(vercel): disable preview builds by default

### DIFF
--- a/scripts/vercel-skip-data-only.sh
+++ b/scripts/vercel-skip-data-only.sh
@@ -10,15 +10,16 @@ set -euo pipefail
 branch="${VERCEL_GIT_COMMIT_REF:-}"
 vercel_env="${VERCEL_ENV:-}"
 
-# Emergency brake for billing spikes:
-# Set VERCEL_PREVIEW_BUILD_MODE=off in Project Settings -> Environment Variables
-# for Preview only. Production still uses the normal diff-based gate.
+# Preview cost brake:
+# Preview builds are skipped by default. Set VERCEL_PREVIEW_BUILD_MODE=runtime
+# for Preview when a project temporarily needs real Vercel preview builds.
+# Production still uses the normal diff-based gate.
 if [ "${VERCEL_FORCE_BUILD:-}" = "1" ]; then
   echo "[ignoreCommand] VERCEL_FORCE_BUILD=1 - building"
   exit 1
 fi
-if [ "$vercel_env" = "preview" ] && [ "${VERCEL_PREVIEW_BUILD_MODE:-runtime}" = "off" ]; then
-  echo "[ignoreCommand] preview builds disabled by VERCEL_PREVIEW_BUILD_MODE=off - skipping"
+if [ "$vercel_env" = "preview" ] && [ "${VERCEL_PREVIEW_BUILD_MODE:-off}" != "runtime" ]; then
+  echo "[ignoreCommand] preview build disabled by default - set VERCEL_PREVIEW_BUILD_MODE=runtime to build"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- make Vercel Preview builds opt-in instead of opt-out
- skip Preview deployments by default when `VERCEL_ENV=preview`
- allow temporary real previews with `VERCEL_PREVIEW_BUILD_MODE=runtime` or `VERCEL_FORCE_BUILD=1`
- leave Production on the existing diff-based gate

## Why
New PR branches may not have `VERCEL_GIT_PREVIOUS_SHA`, so a diff-only gate still lets first Preview deployments burn build CPU. This makes the cost brake deterministic for Preview while preserving Production deploy safety.

## Validation
- `bash -n scripts/vercel-skip-data-only.sh`
- `git diff --check HEAD^ HEAD -- scripts/vercel-skip-data-only.sh`
- Preview default simulation: exit 0
- Preview runtime opt-in simulation: exit 1
- Production script-only diff simulation vs origin/main: exit 0
- `npm run lint:guards`
- `npm run typecheck`