### PR TITLE
feat(signals): honest chrome — stop broadcasting "X/8 LIVE"

### DIFF
--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -99,6 +99,10 @@ import {
   windowLabel,
 } from "@/components/signals-terminal/SourceFilterBar";
 import { matchesTopic } from "@/lib/signals/topics";
+import {
+  classifyFreshness,
+  type NewsSource,
+} from "@/lib/news/freshness";
 
 // V4 (CORPUS) primitives — page chrome.
 // /signals is the proof-of-concept consumer; this is the canonical
@@ -270,8 +274,71 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
   }
 
   // ── KPI calculations -------------------------------------------------------
-  const activeSources = (Object.entries(volume.perSource) as [SourceKey, number][])
-    .filter(([, n]) => n > 0).length;
+  // M5 (2026-05-10): "active" used to mean "has at least one item in the
+  // current window" (`volume.perSource[key] > 0`). That double-counted
+  // sources that had stale items inside the window — a cold collector with
+  // 4h-old rows still passed the >0 check. Switch to classifyFreshness()
+  // so a source counts as "live" only when its freshness verdict is "live".
+  // Mapping SourceKey → NewsSource:
+  //   hn       → hackernews (4h fast budget)
+  //   github   → hackernews (3h GHA cadence, fits the 4h fast budget)
+  //   x        → twitter    (12h scan budget)
+  //   reddit   → reddit     (4h fast budget)
+  //   bluesky  → bluesky    (4h fast budget)
+  //   devto    → devto      (26h budget)
+  //   claude   → skills     (50h slow-cron RSS — closest existing match)
+  //   openai   → skills     (50h slow-cron RSS — closest existing match)
+  const SIGNAL_FRESHNESS_SOURCE: Record<SourceKey, NewsSource> = {
+    hn: "hackernews",
+    github: "hackernews",
+    x: "twitter",
+    reddit: "reddit",
+    bluesky: "bluesky",
+    devto: "devto",
+    claude: "skills",
+    openai: "skills",
+  };
+
+  const SOURCE_FETCHED_AT: Record<SourceKey, string | null | undefined> = {
+    hn: hnFetchedAt,
+    github: ghFetchedAt,
+    x: twLatestAt,
+    reddit: getRedditFetchedAt(),
+    bluesky: blueskyFetchedAt,
+    devto: devtoFetchedAt,
+    claude: claudeFetchedAt(),
+    openai: openaiFetchedAt(),
+  };
+
+  const SOURCE_LABEL: Record<SourceKey, string> = {
+    hn: "HN",
+    github: "GH",
+    x: "X",
+    reddit: "RDT",
+    bluesky: "BSKY",
+    devto: "DEV",
+    claude: "CLA",
+    openai: "OAI",
+  };
+
+  const sourceVerdicts = (Object.keys(SIGNAL_FRESHNESS_SOURCE) as SourceKey[]).map(
+    (key) => ({
+      key,
+      label: SOURCE_LABEL[key],
+      verdict: classifyFreshness(
+        SIGNAL_FRESHNESS_SOURCE[key],
+        SOURCE_FETCHED_AT[key] ?? null,
+        nowMs,
+      ),
+    }),
+  );
+
+  const activeSources = sourceVerdicts.filter(
+    (s) => s.verdict.status === "live",
+  ).length;
+  const coldSources = sourceVerdicts
+    .filter((s) => s.verdict.status === "cold")
+    .map((s) => s.label);
 
   const dominantPct =
     volume.totalItems > 0
@@ -465,18 +532,40 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
       />
 
       <div style={{ marginBottom: 10 }}>
-        <KpiStrip
-          totalSignals={volume.totalItems}
-          changePct={volume.changePct}
-          activeSources={activeSources}
-          totalSources={8}
-          topTag={tagMomentum.topTag?.tag ?? null}
-          topTagDelta={tagMomentum.topTag?.delta ?? null}
-          topTagCount={tagMomentum.topTag?.count ?? null}
-          consensusCount={consensusCount}
-          freshnessLabel={freshnessLabel}
-          windowLabel={activeWindowLabel}
-        />
+        {activeSources === 0 ? (
+          // M5 (2026-05-10): if every source is cold, the KPI strip would
+          // render zeros across the board and amplify the "everything's
+          // broken" perception that motivated this rewrite. Replace with
+          // a single muted line — quiet, honest, and points the operator
+          // at the right surface (infra status) for the actual fix.
+          <div
+            role="status"
+            style={{
+              padding: "10px 14px",
+              border: "1px solid var(--color-border, rgba(255,255,255,0.08))",
+              borderRadius: 8,
+              color: "var(--color-muted, #888)",
+              fontFamily: "var(--font-geist-mono), monospace",
+              fontSize: 12,
+              letterSpacing: "0.06em",
+            }}
+          >
+            All sources currently degraded — see infra status.
+          </div>
+        ) : (
+          <KpiStrip
+            totalSignals={volume.totalItems}
+            changePct={volume.changePct}
+            activeSources={activeSources}
+            coldSources={coldSources}
+            topTag={tagMomentum.topTag?.tag ?? null}
+            topTagDelta={tagMomentum.topTag?.delta ?? null}
+            topTagCount={tagMomentum.topTag?.count ?? null}
+            consensusCount={consensusCount}
+            freshnessLabel={freshnessLabel}
+            windowLabel={activeWindowLabel}
+          />
+        )}
       </div>
 
       <SectionHead

--- a/src/components/signals-terminal/KpiStrip.tsx
+++ b/src/components/signals-terminal/KpiStrip.tsx
@@ -3,8 +3,16 @@ import { Metric, MetricGrid } from "@/components/ui/Metric";
 export interface KpiStripProps {
   totalSignals: number;
   changePct: number | null;
+  /** Count of sources currently classified as "live" by classifyFreshness().
+   *  We do NOT render this as `N / 8` — broadcasting "3/8" trains users to
+   *  read the surface as broken. Render the live count as a positive number
+   *  and tuck the cold roster into a collapsed disclosure. (M5, 2026-05-10) */
   activeSources: number;
-  totalSources: number;
+  /** Source keys that are currently cold. Hidden by default behind a
+   *  `<details>` so a user who wants the transparency can open it, but the
+   *  first-paint chrome doesn't advertise the breakage. Pass `[]` when no
+   *  sources are cold and the disclosure won't render. */
+  coldSources?: readonly string[];
   topTag: string | null;
   topTagDelta: number | null;
   topTagCount: number | null;
@@ -30,7 +38,7 @@ export function KpiStrip({
   totalSignals,
   changePct,
   activeSources,
-  totalSources,
+  coldSources = [],
   topTag,
   topTagDelta,
   topTagCount,
@@ -46,6 +54,13 @@ export function KpiStrip({
   // "heat index" framing read as market-data on a code-trends newsroom.
   // Code-trend KPIs (volume, sources live, top tag, consensus, freshness)
   // stay; the consensus radar already surfaces story-level intensity.
+
+  // M5 (2026-05-10): "Sources · live" used to render `activeSources / 8` and a
+  // bright "{cold} cold" sub-line. Operator feedback: that broadcasts the
+  // surface's own brokenness on first paint. New shape — a bare count + a
+  // collapsed disclosure that lists cold sources only when expanded. Cold
+  // information stays accessible (transparency rule) without being chrome.
+  const coldCount = coldSources.length;
 
   return (
     <MetricGrid columns={5}>
@@ -67,22 +82,42 @@ export function KpiStrip({
         sub={`vs prev ${windowLabel}`}
       />
       <Metric
-        label="Sources · live"
-        value={`${activeSources} / ${totalSources}`}
+        label="Live today"
+        value={activeSources.toLocaleString("en-US")}
         sub={
-          activeSources === totalSources ? (
-            <span style={{ color: "var(--color-positive)" }}>all healthy</span>
-          ) : activeSources >= Math.max(1, totalSources - 2) ? (
-            <span style={{ color: "var(--color-warning)" }}>
-              {totalSources - activeSources} stale
-            </span>
+          coldCount > 0 ? (
+            <details
+              style={{
+                display: "inline",
+                fontFamily: "var(--font-geist-mono), monospace",
+                fontSize: "11px",
+              }}
+            >
+              <summary
+                style={{
+                  cursor: "pointer",
+                  listStyle: "none",
+                  color: "var(--color-muted, #888)",
+                  outline: "none",
+                }}
+              >
+                status
+              </summary>
+              <span
+                style={{
+                  display: "inline-block",
+                  marginLeft: 6,
+                  color: "var(--color-muted, #888)",
+                }}
+              >
+                {coldSources.join(" · ")}
+              </span>
+            </details>
           ) : (
-            <span style={{ color: "var(--color-negative)" }}>
-              {totalSources - activeSources} cold
-            </span>
+            <span style={{ color: "var(--color-positive)" }}>all healthy</span>
           )
         }
-        live={activeSources === totalSources}
+        live={coldCount === 0 && activeSources > 0}
       />
       <Metric
         label="Top tag · momentum"


### PR DESCRIPTION
## Summary

- Stops `/signals` hero from broadcasting **"3 / 8 SOURCES LIVE, 5 COLD"** — operator's hard rule that surfaces shouldn't advertise their own brokenness.
- Wires existing `classifyFreshness()` ([src/lib/news/freshness.ts:111](src/lib/news/freshness.ts#L111)) into the live/cold determination instead of the count-based `perSource[key] > 0` heuristic.
- Cold sources still accessible via disclosure (transparency) but not first-paint chrome.

Mission detail: [docs/handoffs/TERMINATOR-2026-05-10-MASTER-PLAN.md §M5](docs/handoffs/TERMINATOR-2026-05-10-MASTER-PLAN.md).

## Test plan

- [ ] `/signals` hero never renders `X / Y` denominator if `X < Y`
- [ ] `npm run build && npm start` → `curl -s http://localhost:3023/signals | grep -E '/ 8'` returns nothing
- [ ] Cold sources still visible via disclosure
- [ ] CI: typecheck + lint:guards + build all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)