### PR TITLE
feat(skills): 5-tab taxonomy (Option A — awesome-* source lists)

### DIFF
--- a/src/app/skills/[slug]/page.tsx
+++ b/src/app/skills/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
   getSkillsSignalData,
   type EcosystemLeaderboardItem,
 } from "@/lib/ecosystem-leaderboards";
+import { LIST_LABELS, resolveSkillLists } from "@/lib/skills/taxonomy";
 import { absoluteUrl, SITE_NAME } from "@/lib/seo";
 import { formatNumber } from "@/lib/utils";
 
@@ -140,6 +141,7 @@ export default async function SkillDetailPage({ params }: PageProps) {
             tags={skill.tags}
             agents={skill.agents}
             sourceLabel={skill.sourceLabel}
+            awesomeLists={skill.awesomeLists}
           />
         }
         clock={
@@ -452,6 +454,7 @@ interface SkillIdentityProps {
   tags: string[];
   agents: string[];
   sourceLabel: string;
+  awesomeLists: string[] | undefined;
 }
 
 function SkillIdentity({
@@ -463,8 +466,10 @@ function SkillIdentity({
   tags,
   agents,
   sourceLabel,
+  awesomeLists,
 }: SkillIdentityProps) {
   const chips = [...new Set([...tags.slice(0, 4), ...agents.slice(0, 2)])];
+  const listSlugs = resolveSkillLists(awesomeLists);
   return (
     <div
       style={{
@@ -559,6 +564,39 @@ function SkillIdentity({
             </span>
           ))}
         </div>
+        {listSlugs.length > 0 ? (
+          <div
+            style={{
+              marginTop: 8,
+              display: "flex",
+              flexWrap: "wrap",
+              alignItems: "baseline",
+              gap: 8,
+              fontFamily: "var(--font-geist-mono), monospace",
+              fontSize: 11,
+              color: "var(--v4-ink-400)",
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+            }}
+          >
+            <span>appears in</span>
+            {listSlugs.map((slug) => (
+              <Link
+                key={slug}
+                href={`/skills?list=${slug}`}
+                style={{
+                  padding: "1px 6px",
+                  border: "1px solid var(--v4-acc)",
+                  borderRadius: 2,
+                  color: "var(--v4-acc)",
+                  textDecoration: "none",
+                }}
+              >
+                {LIST_LABELS[slug]}
+              </Link>
+            ))}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -20,6 +20,13 @@ import {
   compareBySourceNativeRank,
   getSkillsSignalData,
 } from "@/lib/ecosystem-leaderboards";
+import {
+  LIST_LABELS,
+  LIST_SLUGS,
+  isListSlug,
+  resolveSkillLists,
+  type ListSlug,
+} from "@/lib/skills/taxonomy";
 import { getDerivedRepos } from "@/lib/derived-repos";
 import { refreshTrendingFromStore } from "@/lib/trending";
 import { refreshRedditMentionsFromStore } from "@/lib/reddit-data";
@@ -124,7 +131,11 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function SkillsPage() {
+interface SkillsPageProps {
+  searchParams: Promise<{ list?: string }>;
+}
+
+export default async function SkillsPage({ searchParams }: SkillsPageProps) {
   // BUG-FIX 2026-05-03: rehydrate the in-memory caches `getDerivedRepos()`
   // depends on. Without these refreshes, `linked` repo lookups returned
   // stale (often empty) Repo objects and every star delta column rendered
@@ -144,7 +155,36 @@ export default async function SkillsPage() {
   ]);
 
   const data = await getSkillsSignalData();
-  const items = data.combined.items;
+  const allItems = data.combined.items;
+
+  // Awesome-list taxonomy filter — `?list=<slug>` filters all sections to
+  // skills that appear in the selected curator list. Unrecognised values
+  // collapse to the All view (defensive against direct-link drift).
+  const { list: rawListParam } = await searchParams;
+  const activeListSlug: ListSlug | null = isListSlug(rawListParam)
+    ? rawListParam
+    : null;
+
+  // Per-tab counts use the unfiltered set so labels stay stable as the user
+  // tabs through. Computed once, used twice (tab strip + KpiBand sub).
+  const listCounts: Record<ListSlug, number> = {
+    antigravity: 0,
+    "awesome-claude-code": 0,
+    "punkpeye-mcp": 0,
+    "wong2-mcp": 0,
+  };
+  for (const it of allItems) {
+    for (const slug of resolveSkillLists(it.awesomeLists)) {
+      listCounts[slug] += 1;
+    }
+  }
+
+  const items = activeListSlug
+    ? allItems.filter((it) =>
+        resolveSkillLists(it.awesomeLists).includes(activeListSlug),
+      )
+    : allItems;
+
   const now = Date.now();
 
   // Build a lookup of tracked GitHub repos so we can plumb real
@@ -322,6 +362,12 @@ export default async function SkillsPage() {
             pip: "var(--v4-amber)",
           },
         ]}
+      />
+
+      <ListTaxonomyTabs
+        activeSlug={activeListSlug}
+        allCount={allItems.length}
+        listCounts={listCounts}
       />
 
       <SectionHead
@@ -527,6 +573,103 @@ export default async function SkillsPage() {
         }
       />
     </main>
+  );
+}
+
+interface ListTaxonomyTabsProps {
+  activeSlug: ListSlug | null;
+  allCount: number;
+  listCounts: Record<ListSlug, number>;
+}
+
+/**
+ * 5-tab filter strip surfacing the awesome-* curator lists. Each tab is a
+ * server-side `<Link>` that updates `?list=<slug>`; the page re-renders
+ * with the filter applied. Active state via `aria-current="page"` + a
+ * solid background instead of the outlined idle style. Counts come from
+ * the unfiltered set so they remain stable while the user tabs.
+ *
+ * AGN-536 history note: a previous tab strip (24h/7d/30d windows) was CUT
+ * because the ranked columns it drove were always "—". This strip is safe
+ * because the data backing it (`awesomeLists` membership) is populated
+ * for thousands of skills today.
+ */
+function ListTaxonomyTabs({
+  activeSlug,
+  allCount,
+  listCounts,
+}: ListTaxonomyTabsProps) {
+  const tabs: Array<{
+    slug: ListSlug | null;
+    label: string;
+    count: number;
+    href: string;
+  }> = [
+    {
+      slug: null,
+      label: "All",
+      count: allCount,
+      href: "/skills",
+    },
+    ...LIST_SLUGS.map((slug) => ({
+      slug,
+      label: LIST_LABELS[slug],
+      count: listCounts[slug],
+      href: `/skills?list=${slug}`,
+    })),
+  ];
+  return (
+    <nav
+      aria-label="Filter skills by curator list"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 6,
+        padding: "12px 0 4px",
+        fontFamily: "var(--font-geist-mono), monospace",
+        fontSize: 11,
+      }}
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.slug === activeSlug;
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={isActive ? "page" : undefined}
+            style={{
+              display: "inline-flex",
+              alignItems: "baseline",
+              gap: 6,
+              padding: "5px 10px",
+              borderRadius: 3,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              textDecoration: "none",
+              border: "1px solid var(--v4-line-200)",
+              background: isActive
+                ? "var(--v4-bg-200)"
+                : "var(--v4-bg-050)",
+              color: isActive
+                ? "var(--v4-ink-000)"
+                : "var(--v4-ink-300)",
+            }}
+          >
+            <span>{tab.label}</span>
+            <span
+              style={{
+                fontSize: 10,
+                color: isActive
+                  ? "var(--v4-acc)"
+                  : "var(--v4-ink-400)",
+              }}
+            >
+              {formatNumber(tab.count)}
+            </span>
+          </Link>
+        );
+      })}
+    </nav>
   );
 }
 

--- a/src/lib/ecosystem-leaderboards.ts
+++ b/src/lib/ecosystem-leaderboards.ts
@@ -164,6 +164,14 @@ export interface EcosystemLeaderboardItem {
    * All optional — undefined when the upstream signal isn't populated.
    * The scorer drops missing terms via weight renormalization.
    */
+  /**
+   * Awesome-list curator memberships — full owner/repo IDs sourced from
+   * `awesome-skills.json` `indexBySkill[linkedRepoLower]`. Drives the
+   * /skills 5-tab filter and the /skills/[slug] "appears in" badge strip.
+   * Undefined for items not in any tracked awesome-* list. Convert to
+   * URL slugs via `resolveSkillLists()` from src/lib/skills/taxonomy.ts.
+   */
+  awesomeLists?: string[];
   forks?: number;
   forks7dAgo?: number;
   forkVelocity7d?: number;
@@ -1595,6 +1603,14 @@ function applySkillMomentum(
       .map((s) => s.toLowerCase());
     const derivativeMeta = pickByKeys(sideChannels.derivativesMeta, slugCandidates);
     const hotnessPrev7d = pickByKeys(sideChannels.hotnessPrev7d, slugCandidates);
+    // Awesome-list curator membership — full IDs (e.g. "sickn33/antigravity-…").
+    // Same lookup buildSkillItem already does for scoring; this surfaces the
+    // raw membership onto the public item so the /skills page taxonomy filter
+    // and /skills/[slug] badge strip can render without re-loading the index.
+    const awesomeLists =
+      linkedRepoLower && sideChannels.awesomeIndex[linkedRepoLower]
+        ? sideChannels.awesomeIndex[linkedRepoLower]
+        : undefined;
     const createdAt =
       asString(p.raw.created_at) ?? asString(p.raw.createdAt) ?? null;
     const lastRefreshedAt = asString(p.raw.lastRefreshedAt) ?? null;
@@ -1622,6 +1638,7 @@ function applySkillMomentum(
       lastRefreshedAt,
       hotness: scoredItem ? Math.round(scoredItem.rawScore) : undefined,
       hotnessPrev7d,
+      awesomeLists,
     };
   });
 }

--- a/src/lib/skills/taxonomy.ts
+++ b/src/lib/skills/taxonomy.ts
@@ -1,0 +1,66 @@
+// /skills taxonomy — the 4 awesome-* curator lists that ship the underlying
+// skills surface. Source: data/awesome-skills.json `lists` array (populated
+// daily by scripts/scrape-awesome-skills.mjs). Curator membership lives on
+// each EcosystemLeaderboardItem under `awesomeLists` (full owner/repo IDs);
+// this module converts those to URL-safe slugs and human labels.
+//
+// Used by:
+//   - /skills/page.tsx — 5-tab filter strip (All + 4 lists)
+//   - /skills/[slug]/page.tsx — "appears in: X, Y" badge strip
+//
+// Add a new list by appending to LIST_SLUGS + LIST_FULL_IDS + LIST_LABELS.
+// The reverse-lookup map auto-derives.
+
+export const LIST_SLUGS = [
+  "antigravity",
+  "awesome-claude-code",
+  "punkpeye-mcp",
+  "wong2-mcp",
+] as const;
+
+export type ListSlug = (typeof LIST_SLUGS)[number];
+
+export const LIST_FULL_IDS: Record<ListSlug, string> = {
+  antigravity: "sickn33/antigravity-awesome-skills",
+  "awesome-claude-code": "hesreallyhim/awesome-claude-code",
+  "punkpeye-mcp": "punkpeye/awesome-mcp-servers",
+  "wong2-mcp": "wong2/awesome-mcp-servers",
+};
+
+export const LIST_LABELS: Record<ListSlug, string> = {
+  antigravity: "Antigravity",
+  "awesome-claude-code": "Awesome Claude Code",
+  "punkpeye-mcp": "Punkpeye MCP",
+  "wong2-mcp": "Wong2 MCP",
+};
+
+const FULL_ID_TO_SLUG: Record<string, ListSlug> = Object.fromEntries(
+  Object.entries(LIST_FULL_IDS).map(([slug, fullId]) => [
+    fullId.toLowerCase(),
+    slug as ListSlug,
+  ]),
+);
+
+export function isListSlug(value: string | null | undefined): value is ListSlug {
+  if (!value) return false;
+  return (LIST_SLUGS as readonly string[]).includes(value);
+}
+
+/**
+ * Convert raw awesome-list full IDs (e.g. "sickn33/antigravity-awesome-skills")
+ * onto the small set of stable URL slugs. Unknown / unrecognised list IDs are
+ * dropped silently — when a new awesome-* list ships, taxonomy.ts has to
+ * declare it explicitly to surface in the UI.
+ */
+export function resolveSkillLists(
+  awesomeLists: ReadonlyArray<string> | null | undefined,
+): ListSlug[] {
+  if (!awesomeLists || awesomeLists.length === 0) return [];
+  const slugs = new Set<ListSlug>();
+  for (const fullId of awesomeLists) {
+    if (typeof fullId !== "string") continue;
+    const slug = FULL_ID_TO_SLUG[fullId.toLowerCase()];
+    if (slug) slugs.add(slug);
+  }
+  return [...slugs];
+}


### PR DESCRIPTION
## Summary

- Adds 5-tab taxonomy to `/skills`: **All + 4 awesome-* curator lists** sourced from existing `data/awesome-skills.json` — zero new ingest required.
- New [src/lib/skills/taxonomy.ts](src/lib/skills/taxonomy.ts) resolver maps each skill to its source list(s).
- `/skills/[slug]` detail shows "appears in: …" badges.
- **Decision recorded:** picked Option A (source-list taxonomy) over Option B (functional categories: code-review/docs/testing/refactor/security/data-analysis). Option B filed as P2 follow-up if operator likes Option A in prod.

Mission detail: [docs/handoffs/TERMINATOR-2026-05-10-MASTER-PLAN.md §M3](docs/handoffs/TERMINATOR-2026-05-10-MASTER-PLAN.md).

## Test plan

- [ ] 4 tab labels render (one per awesome-* list) plus the All default
- [ ] Filter narrows the visible list per tab
- [ ] Active tab carries `aria-current="page"`
- [ ] `/skills/[slug]` shows "appears in: …" badges
- [ ] CI: typecheck + lint:guards + build all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)