### PR TITLE
fix(repo-detail): defensive guards stop /repo/* 500 (pre-existing P0 since d81856ad)

### DIFF
--- a/src/app/repo/[owner]/[name]/page.tsx
+++ b/src/app/repo/[owner]/[name]/page.tsx
@@ -237,7 +237,11 @@ export default async function RepoDetailPage({ params }: PageProps) {
     // Skipped for live-fetched repos: those caches are empty by definition
     // (no collector has scanned the repo yet), so the fan-out wastes ~700ms
     // of Lambda time per cold miss for nothing.
-    await Promise.all([
+    // Defensive: Promise.allSettled so a single source rejection doesn't 500
+    // the whole page. Each refresh hook is independent — a flake in bluesky
+    // (or any cold source) must not hide the rest. Pre-existing P0 since
+    // d81856ad lived in this Promise.all.
+    const refreshOutcomes = await Promise.allSettled([
       refreshRepoMetadataFromStore(),
       refreshNpmFromStore(),
       refreshRedditMentionsFromStore(),
@@ -254,6 +258,11 @@ export default async function RepoDetailPage({ params }: PageProps) {
       refreshProducthuntLaunchesFromStore(),
       refreshStarActivityFromStore(`${owner}/${name}`),
     ]);
+    for (const outcome of refreshOutcomes) {
+      if (outcome.status === "rejected") {
+        console.warn("[repo-detail] refresh hook failed", outcome.reason);
+      }
+    }
   } else {
     isLiveFetched = true;
     // Resolve through the same bounded helper as the internal API route.
@@ -278,10 +287,19 @@ export default async function RepoDetailPage({ params }: PageProps) {
   // signal migration only has to touch `buildCanonicalRepoProfile`. For
   // live-fetched repos we pass the synthesized base repo as an override so
   // the profile builder bypasses its derived-store lookup.
-  const profile = await buildCanonicalRepoProfile(
-    baseRepo.fullName,
-    isLiveFetched ? baseRepo : undefined,
-  );
+  // Defensive: any uncaught throw in the canonical assembler must degrade to
+  // 404, not 500. The assembler stitches ~15 sync loaders + 3 async refreshes
+  // — a regression in any of them used to bleed straight through to a runtime
+  // error boundary on prod (pre-existing P0 since d81856ad).
+  let profile: Awaited<ReturnType<typeof buildCanonicalRepoProfile>> | null = null;
+  try {
+    profile = await buildCanonicalRepoProfile(
+      baseRepo.fullName,
+      isLiveFetched ? baseRepo : undefined,
+    );
+  } catch (err) {
+    console.error("[repo-detail] profile assembly failed", err);
+  }
   if (!profile) {
     notFound();
   }

--- a/src/lib/api/repo-profile.ts
+++ b/src/lib/api/repo-profile.ts
@@ -460,11 +460,18 @@ export async function buildCanonicalRepoProfile(
   // Pull fresh repo-profiles + revenue-overlays payloads from the data-store
   // before stitching. Both refreshes are internally rate-limited (30s) so a
   // burst of detail-page requests doesn't fan out to N Redis calls.
-  await Promise.all([
+  // Defensive: any one rejection must not bring down the whole assembly —
+  // each downstream getter degrades gracefully when its cache is stale.
+  const refreshOutcomes = await Promise.allSettled([
     refreshRepoProfilesFromStore(),
     refreshRevenueOverlaysFromStore(),
     refreshNpmDependentsFromStore(),
   ]);
+  for (const outcome of refreshOutcomes) {
+    if (outcome.status === "rejected") {
+      console.warn("[repo-profile] refresh hook failed", outcome.reason);
+    }
+  }
 
   // Hydrate mentions from disk. Idempotent on warm Lambdas; the store is
   // the source of truth for the recent-mentions slice + countsBySource.


### PR DESCRIPTION
## Summary

**Pre-existing P0 since 2026-05-08 (`d81856ad`).** Every `/repo/[owner]/[name]` on production returns HTTP 500 because two unprotected `Promise.all` blocks bring the whole page down on a single refresh hook rejection.

Verified prod 500s today (curl, 2026-05-10 22:30 GMT+8):
- `https://trendingrepo.com/repo/openai/whisper` → 500 (3.6s)
- `https://trendingrepo.com/repo/vercel/next.js` → 500 (2.2s)
- `https://trendingrepo.com/repo/sindresorhus/ky` → 500 (2.3s)

The page slipped past CI because [the post-deploy smoke test only probes 12 routes](https://github.com/0motionguy/starscreener/blob/main/.github/workflows/post-deploy-smoke.yml), none under `/repo/*`. Adding `/repo/*` coverage is a P3 follow-up.

## Root cause

[src/app/repo/[owner]/[name]/page.tsx:240](src/app/repo/[owner]/[name]/page.tsx#L240) — `Promise.all` over **15** refresh hooks. Any one rejection (likely culprit: a cold source like `bluesky` or a per-repo Redis miss in `refreshStarActivityFromStore`) crashes the whole page.

[src/lib/api/repo-profile.ts:463](src/lib/api/repo-profile.ts#L463) — same shape, 3 refreshes.

[`buildCanonicalRepoProfile`](src/lib/api/repo-profile.ts#L445) call site at [page.tsx:281](src/app/repo/[owner]/[name]/page.tsx#L281) had no try/catch — a runtime throw anywhere inside the canonical assembler bled straight through.

## Fix (surgical, mirrors PR #770 defensive pattern)

1. **page.tsx `Promise.all` → `Promise.allSettled`** with per-rejection `console.warn` logging. A flake in any cold source can no longer 500 the page.
2. **repo-profile.ts `Promise.all` → `Promise.allSettled`** with per-rejection logging.
3. **`buildCanonicalRepoProfile` call wrapped in try/catch** — any uncaught throw in the canonical assembler now degrades to **404** (`notFound()`) instead of 500. Better SEO, lets Next render `not-found.tsx`, and stops the runtime error boundary from showing on prod.

Total diff: **2 files, +31 / -6 lines**. No public API changes.

## Test plan

- [ ] CI: typecheck + lint:guards + build all green
- [ ] After merge: `curl -sI https://trendingrepo.com/repo/openai/whisper` returns 200 (or 404 if a regression in the assembler still slipped, but never 500)
- [ ] Vercel logs: `[repo-detail] refresh hook failed` warnings surface the underlying source rejections without taking the page down
- [ ] Sample three repos previously verified 500: `openai/whisper`, `vercel/next.js`, `sindresorhus/ky` — all return 200

## Related

- Memory: `project_repo_detail_500.md` lists 3 ranked suspects — this fix addresses #2 (`buildCanonicalRepoProfile` runtime error) and #3 (`refresh*FromStore` calls).
- PR #770 — same defensive Promise.allSettled pattern landed for /agent-commerce/facilitator + /mcp + /skills last session.
- Follow-up: extend post-deploy smoke test to cover `/repo/*` (P3 in the master plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)