### PR TITLE
chore(smoke): extend post-deploy probe to 16 routes (covers /repo/*, /agent-commerce/*, /trends)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -21,11 +21,15 @@ jobs:
       - name: Wait for deploy propagation
         run: sleep 30
 
-      - name: Synthetic curl checks (12 critical routes)
+      - name: Synthetic curl checks (16 critical routes)
         id: smoke
         shell: bash
         run: |
           set +e
+          # /repo/* + /agent-commerce/* + /trends added 2026-05-10. Why:
+          # the pre-existing /repo/* 500 P0 (since d81856ad) bled for days
+          # because no smoke probe covered detail pages. vercel/next.js is
+          # a long-stable canonical sample; rotate if it ever moves.
           routes=(
             "/"
             "/signals"
@@ -37,6 +41,10 @@ jobs:
             "/revenue"
             "/arxiv/trending"
             "/producthunt"
+            "/trends"
+            "/agent-commerce"
+            "/agent-commerce/facilitator"
+            "/repo/vercel/next.js"
             "/api/health?soft=1"
           )
 


### PR DESCRIPTION
## Summary

Closes the P3 gap that let the [/repo/* 500 P0 (PR #830)](https://github.com/0motionguy/starscreener/pull/830) bleed for days. The post-deploy smoke probe covered 11 routes + 1 cron probe (12 total) and missed every dynamic detail page plus the new agent-commerce + trends surfaces.

**Added 4 routes** (now 16 total):
- `/repo/vercel/next.js` — canonical long-stable sample so `/repo/*` regressions get caught in 30 minutes, not 2 days
- `/agent-commerce` — flagship M2M index
- `/agent-commerce/facilitator` — landed in PR #770
- `/trends` — 6-source index

Memory `reference_smoke_test_12_routes` and the master plan both flagged this gap.

## Test plan

- [ ] CI: workflow file syntactically valid (`actionlint` or just GH validation)
- [ ] After PR #830 merges: this workflow runs against prod and all 16 routes return 200 (current state: `/repo/vercel/next.js` would fail because of #830)
- [ ] Future regression in any of the 4 new surfaces fails the smoke job and pages ops via `OPS_ALERT_WEBHOOK`

## Related

- PR #830 — fix /repo/* 500 (must merge first; otherwise this smoke would alert)
- Memory: `reference_smoke_test_12_routes.md` — outdated after this lands
- Master plan P3 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)