### PR TITLE
fix(m4): solana x402 fetcher RPC_URL default — broken since launch (one-char ?? → ||)

### DIFF
--- a/scripts/fetch-solana-x402-onchain.mjs
+++ b/scripts/fetch-solana-x402-onchain.mjs
@@ -11,7 +11,12 @@ import { resolve, dirname } from "path";
 import { writeDataStore } from "./_data-store-write.mjs";
 
 const OUT_PATH = resolve(process.cwd(), ".data/solana-x402-onchain.json");
-const RPC_ENDPOINTS = (process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com")
+// Use `||` not `??`: GH Actions sets unset secret env to empty string,
+// and `??` only catches null/undefined — empty string falls through and
+// produces RPC_ENDPOINTS=[] which fails every RPC call with "Failed to
+// parse URL from undefined". Confirmed broken in the daily cron since
+// before the file ever made it into git history.
+const RPC_ENDPOINTS = (process.env.SOLANA_RPC_URL || "https://api.mainnet-beta.solana.com")
   .split(",")
   .map((s) => s.trim())
   .filter(Boolean);


### PR DESCRIPTION
## Summary

**The Solana x402 fetcher has been completely broken since it landed.** Every daily cron has been printing this — but `continue-on-error: true` masks the failure:

```
[x402-sol] rpc=undefined
[x402-sol] getSignaturesForAddress(HsozMJWWHNADoZRmhDGKzua6XW6NNfNDdQ4CkE9i5wHt) failed: Failed to parse URL from undefined
[x402-sol] getSignaturesForAddress(...) failed: Failed to parse URL from undefined  (× 16 addrs)
[x402-sol] TOTAL: 0 txs · 0 x402 settlements
```

Confirmed from `gh run view 25622615834 --log` (today's agent-commerce cron run, 2026-05-10 07:14 UTC).

## Root cause

The workflow sets `SOLANA_RPC_URL: ${{ secrets.SOLANA_RPC_URL }}` even when the secret is unset. GitHub Actions passes an **empty string** in that case. The fetcher uses:

```js
const RPC_ENDPOINTS = (process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com")
  .split(",").map(s => s.trim()).filter(Boolean);
```

`??` catches null/undefined but **not empty string**. So `""`.split(",") = [""], `.filter(Boolean)` = `[]`, and every RPC call fails parsing the empty URL.

This is why `.data/solana-x402-onchain.json` has **never been committed in repo history** despite the cron "succeeding" daily — the script writes the empty file but `git-commit-data` may be skipping it for an empty-content reason; either way, no real Solana facilitator data has ever surfaced.

## Fix

One character: `??` → `||`. Empty string is now caught by `||` and falls through to the public mainnet-beta default.

```diff
-const RPC_ENDPOINTS = (process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com")
+const RPC_ENDPOINTS = (process.env.SOLANA_RPC_URL || "https://api.mainnet-beta.solana.com")
```

Operators who provision `SOLANA_RPC_URL` (Helius/Alchemy) still override via the same secret — this only changes behavior when the secret is unset/empty.

Audited the rest of `scripts/` — no other fetchers have the same bug.

## Test plan

- [ ] CI: typecheck + lint:guards + build all green
- [ ] After merge, manually trigger `cron-agent-commerce.yml` (or wait for the 04:31 UTC daily run)
- [ ] `gh run view <id> --log | grep "x402-sol"` shows `rpc=https://api.mainnet-beta.solana.com` (or whatever's provisioned) instead of `rpc=undefined`
- [ ] After successful run, `.data/solana-x402-onchain.json` lands in main with non-zero `byFacilitator` entries
- [ ] `/agent-commerce/facilitator` page shows Solana facilitators (target: 4 → 14+ per master plan)

## Related

- Master plan M4 — facilitator data 4 → 22+ (this addresses the Solana piece; Dune wire-up is operator-blocked on `DUNE_API_KEY`; ERC-8004 fetcher is still NEW work)
- `gh run view 25622615834 --log` — verbatim error trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)