### PR TITLE
feat(scripts): scaffold dual-write to TOOLBOX signal lake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,17 @@ WEBHOOK_SECRET_KEK=
 # Founder milestone (25 qualified referrals).
 FOUNDER_DISCORD_INVITE=
 
+# -- TOOLBOX dual-write (Phase A.3) ------------------------------------------
+# Optional fire-and-forget POST to the TOOLBOX signal lake after each
+# scripts/_data-store-write.mjs Redis write. Empty values disable the
+# helper completely; the existing Redis path is unchanged.
+# Production target: https://api.aiso.tools/v1/signals/ingest (Vultr
+# gabagool-ams, Cloudflare Tunnel ingress).
+# Secret matches /opt/toolbox/.env's TOOLBOX_INGEST_HMAC_SECRET — store
+# in 1Password under "TOOLBOX → INGEST_HMAC_SECRET".
+TOOLBOX_INGEST_URL=
+TOOLBOX_INGEST_HMAC_SECRET=
+
 # Run once after setting DATABASE_URL + DIRECT_URL:
 #   npm run db:generate     # generate SQL from src/lib/db/schema/*.ts
 #   npm run db:migrate      # apply via DIRECT_URL

--- a/scripts/_data-store-write.mjs
+++ b/scripts/_data-store-write.mjs
@@ -252,6 +252,24 @@ export async function writeDataStore(key, value, opts = {}) {
     client.set(`${META_NAMESPACE}:${normalizedKey}`, metaValue, setOpts),
   ]);
 
+  // TOOLBOX dual-write (Phase A.3). Fire-and-forget; no-op when env unset.
+  // Mapping table lives in scripts/_toolbox-ingest.mjs; datasets without
+  // an entry return zero events and skip the POST entirely.
+  try {
+    const { mapDatasetToEvents, ingestToToolbox } = await import("./_toolbox-ingest.mjs");
+    const events = mapDatasetToEvents(normalizedKey, value, writtenAt);
+    if (events.length > 0) {
+      // Don't await — let the Redis write return immediately. The HMAC POST
+      // has its own 5s timeout inside ingestToToolbox.
+      void ingestToToolbox(events).catch(() => {});
+    }
+  } catch (err) {
+    // The dual-write helper must never break the primary Redis write path.
+    console.warn(
+      `[data-store-write] toolbox dual-write helper failed: ${err && err.message ? err.message : err}`,
+    );
+  }
+
   return { source: "redis", writtenAt };
 }
 

--- a/scripts/_toolbox-ingest.mjs
+++ b/scripts/_toolbox-ingest.mjs
@@ -1,0 +1,87 @@
+// trendingrepo → TOOLBOX dual-write helper (Phase A.3).
+//
+// Fire-and-forget HMAC-signed POST to TOOLBOX `/v1/signals/ingest`. Called
+// from `scripts/_data-store-write.mjs` after each successful Redis write so
+// that real production scrape traffic populates the TOOLBOX signal lake in
+// parallel with the existing storage.
+//
+// CONFIG (env)
+//   TOOLBOX_INGEST_URL          e.g. https://api.aiso.tools/v1/signals/ingest
+//   TOOLBOX_INGEST_HMAC_SECRET  matches /opt/toolbox/.env on the VPS
+//
+// When either is unset → ingestToToolbox() returns {status:"skipped"}, no POST.
+// 5 s timeout. Errors are caught + returned in the result object; never thrown.
+//
+// MAPPING
+//   The dataset → signal_type mapping currently lives in mapDatasetToEvents().
+//   Each enabled mapping emits one or more TOOLBOX events per Redis write.
+//   Datasets without a mapping return [] and produce no POST.
+
+import { createHmac } from "node:crypto";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+const SOURCE = "trendingrepo";
+
+/**
+ * Map a (dataset key, payload) pair from `writeDataStore()` to TOOLBOX
+ * events. Return [] for datasets we haven't mapped yet — they'll skip
+ * the POST entirely. Add cases here as we migrate sources to TOOLBOX.
+ *
+ * @param {string} key       The dataset slug, e.g. "hackernews-repo-mentions"
+ * @param {unknown} payload  The value passed to writeDataStore()
+ * @param {string} writtenAt ISO timestamp when the Redis write completed
+ * @returns {Array<object>}  TOOLBOX events conforming to ingest schema
+ */
+export function mapDatasetToEvents(key, payload, writtenAt) {
+  // TODO(toolbox-mapping): fill in concrete dataset → signal_type mappings.
+  // Examples to wire next:
+  //   hackernews-repo-mentions → trending.hn.mentions (target=repo URL)
+  //   reddit-mentions          → trending.reddit.mentions
+  //   twitter-trending         → social.x.mentions
+  // Each event needs: scan_id, target_url, signal_type, normalized[], produced_by, produced_at.
+  void key;
+  void payload;
+  void writtenAt;
+  return [];
+}
+
+/**
+ * POST events to TOOLBOX. Returns a status object — never throws.
+ * Disabled when env vars unset OR events array is empty.
+ *
+ * @param {Array<object>} events
+ * @returns {Promise<{status: "ok"|"skipped"|"failed", http_status?: number, duration_ms?: number, error?: string}>}
+ */
+export async function ingestToToolbox(events) {
+  const url = process.env.TOOLBOX_INGEST_URL;
+  const secret = process.env.TOOLBOX_INGEST_HMAC_SECRET;
+  if (!url || !secret) return { status: "skipped" };
+  if (!Array.isArray(events) || events.length === 0) return { status: "skipped" };
+
+  const body = JSON.stringify({ source: SOURCE, events });
+  const sig = "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+  const startedAt = Date.now();
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-toolbox-signature": sig,
+      },
+      body,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    return {
+      status: res.ok ? "ok" : "failed",
+      http_status: res.status,
+      duration_ms: Date.now() - startedAt,
+    };
+  } catch (err) {
+    return {
+      status: "failed",
+      duration_ms: Date.now() - startedAt,
+      error: err && err.message ? err.message : String(err),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Phase A.3 of the [TOOLBOX UNIFICATION PLAN](https://github.com/0motionguy/toolbox/blob/main/docs/UNIFICATION-PLAN.md). Scaffolds the integration point so that every successful Redis write in `scripts/_data-store-write.mjs` can trigger a fire-and-forget HMAC-signed POST to TOOLBOX `/v1/signals/ingest`.

This PR ships the **plumbing only**. The mapping table inside `scripts/_toolbox-ingest.mjs` is empty so no events are emitted yet — a follow-up PR per dataset wires concrete mappings as TOOLBOX's signal_type catalog grows.

## Files

- `scripts/_toolbox-ingest.mjs` — NEW. HMAC POST helper + `mapDatasetToEvents()` skeleton. 5s `AbortSignal.timeout`.
- `scripts/_data-store-write.mjs` — calls `mapDatasetToEvents()` after the parallel Redis SETs; if it returns events, fire-and-forget POST. Wrapped in try/catch so the dual-write never breaks the primary Redis write path.
- `.env.example` — documents `TOOLBOX_INGEST_URL` + `TOOLBOX_INGEST_HMAC_SECRET`.

## Test plan

- [x] `node -c` syntax check on both .mjs files
- [ ] Add a concrete mapping for `hackernews-repo-mentions` → `trending.hn.mentions` (next PR)
- [ ] Set GH secrets, wait for next 20-min `scrape-trending` cron, watch TOOLBOX api logs for `ingest persisted`, confirm `tb_signals` rows from `worker_id LIKE 'trendingrepo-%'`
- [ ] Rollback drill: `gh secret delete TOOLBOX_INGEST_URL` and confirm the next cron still completes cleanly

## Notes

- TOOLBOX `/v1/signals/ingest` is wired and verified end-to-end (see [TOOLBOX docs/UNIFICATION-PLAN.md §6.A.5](https://github.com/0motionguy/toolbox/blob/main/docs/UNIFICATION-PLAN.md)).
- No GitHub Actions workflow files are touched in this PR — the env block injection lands together with the first concrete dataset mapping so the diff stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)