### PR TITLE
fix(crons): unblock 4 tsx scripts via server-only shim (twitter, top10, sparklines, profile-completion)

### DIFF
--- a/scripts/_server-only-shim.ts
+++ b/scripts/_server-only-shim.ts
@@ -1,0 +1,42 @@
+// Allow tsx scripts to transitively import @/lib modules that statically
+// `import "server-only"` (a Next.js build-time / runtime guard that throws
+// when loaded outside a Server Component bundle).
+//
+// Mechanism: patch `require.cache[server-only]` to an empty CJS module so
+// any subsequent ESM/CJS resolution of "server-only" returns {} instead of
+// hitting the package's top-level `throw new Error(...)`.
+//
+// Why a shim instead of removing the guard: hackernews.ts and friends use
+// `server-only` to keep client bundles from accidentally pulling 70KB of
+// bundled JSON. Removing the guard would lose that bundler-level protection
+// at production build time. This shim only intercepts at script-runtime,
+// not at Next.js bundle-time.
+//
+// MUST be the first import in any tsx script that touches @/lib/* modules
+// in the server-only chain. Confirmed broken collectors include:
+//   - scripts/collect-twitter-signals.ts (failure since the chain landed)
+
+import { createRequire } from "node:module";
+
+const __req = createRequire(import.meta.url);
+try {
+  const resolved = __req.resolve("server-only");
+  // Cast to any: Node's Module type has many required fields, but only
+  // `exports` is read by downstream code paths.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  __req.cache[resolved] = {
+    id: resolved,
+    filename: resolved,
+    loaded: true,
+    children: [],
+    exports: {},
+    paths: [],
+    parent: null,
+    isPreloading: false,
+    path: resolved,
+  } as any;
+} catch {
+  // server-only not installed (unlikely in CI/dev) — nothing to patch.
+}
+
+export {};

--- a/scripts/check-profile-completion.ts
+++ b/scripts/check-profile-completion.ts
@@ -32,6 +32,10 @@
 //
 // Env: tsx --env-file-if-exists=.env.local handles .env.local loading.
 
+// Patches require.cache for `server-only` BEFORE any @/lib transitive
+// imports trigger it. Must stay the first import.
+import "./_server-only-shim";
+
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/collect-twitter-signals.ts
+++ b/scripts/collect-twitter-signals.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// Patches require.cache for `server-only` BEFORE any @/lib transitive
+// imports trigger it. Must stay the first import.
+import "./_server-only-shim";
+
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/snapshot-top10-sparklines.ts
+++ b/scripts/snapshot-top10-sparklines.ts
@@ -8,6 +8,10 @@
 // Run as: npx tsx scripts/snapshot-top10-sparklines.ts
 // Cadence: 23:50 UTC daily, just before the bundle snapshot at 23:55.
 
+// Patches require.cache for `server-only` BEFORE any @/lib transitive
+// imports trigger it. Must stay the first import.
+import "./_server-only-shim";
+
 import { getHfModelsTrending, refreshHfModelsFromStore } from "@/lib/huggingface";
 import {
   getMcpSignalData,

--- a/scripts/snapshot-top10.ts
+++ b/scripts/snapshot-top10.ts
@@ -6,6 +6,10 @@
 //
 // Cadence: 23:55 UTC daily via .github/workflows/snapshot-top10.yml.
 
+// Patches require.cache for `server-only` BEFORE any @/lib transitive
+// imports trigger it. Must stay the first import.
+import "./_server-only-shim";
+
 import { getDerivedRepos } from "@/lib/derived-repos";
 import {
   getHfModelsTrending,


### PR DESCRIPTION
## Summary

**Four tsx-run scripts have been silently failing for days** because they pull in `@/lib` chains that transitively import `src/lib/hackernews.ts` which static-imports `server-only`. The package's top-level `throw new Error(...)` always fires in plain-Node tsx contexts, so the script dies at module-load before any actual work begins.

Verified failing on production from `gh run view <id> --log-failed`:

| Workflow | Recent runs | Cadence |
|---|---|---|
| `collect-twitter.yml` | 3/3 fail | every 3h |
| `snapshot-top10.yml` | 2/3 fail (worked 05-08) | daily 23:55 |
| `snapshot-top10-sparklines.yml` | 2/2 fail | daily 23:50 |
| `check-profile-completion.yml` | 2/2 fail | hourly |

All four hit the **identical** stack:
```
Error: This module cannot be imported from a Client Component module.
  at .../node_modules/server-only/index.js:1:7
  at .../src/lib/hackernews.ts:19:8
```

## Import chain

```
{tsx script}.ts
  → @/lib/twitter/service OR @/lib/derived-repos OR @/lib/ecosystem-leaderboards
  → src/lib/derived-repos.ts:35 imports decorateWithMentionsRollup
  → src/lib/derived-repos/decorators/mentions-rollup.ts:27 imports getHnMentions
  → src/lib/hackernews.ts:19 → import "server-only" → throws
```

`server-only` is a Next.js bundler-level guard. It works correctly for production builds (webpack/turbopack alias it to a noop in server-component bundles), but in plain-Node tsx scripts the package always throws.

## Fix

[scripts/_server-only-shim.ts](scripts/_server-only-shim.ts) patches `require.cache` so any subsequent ESM/CJS resolution of `"server-only"` returns an empty exports object. Each affected script gets `import "./_server-only-shim";` as its **first import** so the cache patch lands before any transitive `@/lib` resolution.

The bundler-level guard remains intact for production Next.js builds — this only intercepts script runtime.

## Files

- `scripts/_server-only-shim.ts` (new)
- `scripts/collect-twitter-signals.ts` — first import
- `scripts/snapshot-top10.ts` — first import
- `scripts/snapshot-top10-sparklines.ts` — first import
- `scripts/check-profile-completion.ts` — first import

## Test plan

- [x] Typecheck green (`npm run typecheck`)
- [x] Local dry-run `npm run collect:twitter:dry` survives past the import phase (before shim, dies in <1s; after shim, runs full pipeline)
- [ ] After merge, `gh workflow run collect-twitter.yml` succeeds and `data/twitter/*` updates
- [ ] After merge, `gh workflow run snapshot-top10.yml` succeeds and `top10:YYYY-MM-DD` Redis key written
- [ ] After merge, hourly `check-profile-completion.yml` runs succeed and write `data/profile-completion-queue.json`

## Follow-up

- `scripts/sweep-cross-source-mentions.ts` is a `.mts` file currently running successfully — left alone (not fixing what isn't broken)
- `scripts/build-why-narratives.ts` isn't wired into any workflow today; preemptive shim deferred until it's used
- The deeper architectural fix would be to make `mentions-rollup` lazy-import its source modules so the static chain doesn't drag `server-only` in. Held as a P3 refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)