### PR TITLE
chore(data): refresh lobsters signals 2026-05-10T19:42:09Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-10T18:34:17.258Z",
+  "ts": "2026-05-10T19:42:09.798Z",
   "count": 1,
-  "durationMs": 2764,
+  "durationMs": 3635,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-10T18:34:14.510Z",
+  "fetchedAt": "2026-05-10T19:42:06.178Z",
   "windowDays": 7,
   "scannedStories": 76,
   "mentions": {
@@ -124,7 +124,7 @@
         "score": 1,
         "url": "https://github.com/tidwall/btype",
         "commentsUrl": "https://lobste.rs/s/0xe7hz/btype_b_tree_based_collection_types_for_go",
-        "hoursSincePosted": 3.233888888888889
+        "hoursSincePosted": 4.365
       },
       "stories": [
         {
@@ -136,8 +136,8 @@
           "score": 1,
           "commentCount": 0,
           "createdUtc": 1778426412,
-          "ageHours": 3.233888888888889,
-          "trendingScore": 0.08351476280050006,
+          "ageHours": 4.365,
+          "trendingScore": 0.0622733727642905,
           "tags": [
             "go",
             "performance"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-10T18:34:14.510Z",
+  "fetchedAt": "2026-05-10T19:42:06.178Z",
   "windowHours": 72,
   "scannedTotal": 76,
   "stories": [

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -124828,3 +124828,5 @@
 {"source":"bluesky","fullName":"alesimula/mu","observedAt":"2026-05-10T19:35:50.152Z"}
 {"source":"bluesky","fullName":"alesimula/murine-launcher","observedAt":"2026-05-10T19:35:50.152Z"}
 {"source":"bluesky","fullName":"beyondthecode-bc/snatch","observedAt":"2026-05-10T19:35:50.152Z"}
+{"source":"lobsters","fullName":"advisories/ghsa-wpqr-6v78-jr5g","observedAt":"2026-05-10T19:42:09.792Z"}
+{"source":"lobsters","fullName":"pstron/poop","observedAt":"2026-05-10T19:42:09.792Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/25637956821

Auto-merge enabled — merges once required status checks pass.