### PR TITLE
chore(data): refresh lobsters signals 2026-05-11T01:25:31Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-10T23:31:00.227Z",
+  "ts": "2026-05-11T01:25:31.644Z",
   "count": 1,
-  "durationMs": 2856,
+  "durationMs": 4525,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-10T23:30:57.388Z",
+  "fetchedAt": "2026-05-11T01:25:27.134Z",
   "windowDays": 7,
   "scannedStories": 76,
   "mentions": {
@@ -124,7 +124,7 @@
         "score": 1,
         "url": "https://github.com/tidwall/btype",
         "commentsUrl": "https://lobste.rs/s/0xe7hz/btype_b_tree_based_collection_types_for_go",
-        "hoursSincePosted": 8.179166666666667
+        "hoursSincePosted": 10.0875
       },
       "stories": [
         {
@@ -136,8 +136,8 @@
           "score": 1,
           "commentCount": 1,
           "createdUtc": 1778426412,
-          "ageHours": 8.179166666666667,
-          "trendingScore": 0.03079155786475897,
+          "ageHours": 10.0875,
+          "trendingScore": 0.023795523810809835,
           "tags": [
             "go",
             "performance"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-10T23:30:57.388Z",
+  "fetchedAt": "2026-05-11T01:25:27.134Z",
   "windowHours": 72,
   "scannedTotal": 76,
   "stories": [

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -128044,3 +128044,7 @@
 {"source":"hackernews","fullName":"matheussimonaci/clone-talking","observedAt":"2026-05-11T00:07:14.314Z"}
 {"source":"hackernews","fullName":"roshandubey-cloud/utilities","observedAt":"2026-05-11T00:07:14.314Z"}
 {"source":"hackernews","fullName":"altilunium/ctify_","observedAt":"2026-05-11T00:07:14.314Z"}
+{"source":"lobsters","fullName":"nooga/let-go","observedAt":"2026-05-11T01:25:31.639Z"}
+{"source":"lobsters","fullName":"bytexenon/tiny-lua-compiler","observedAt":"2026-05-11T01:25:31.639Z"}
+{"source":"lobsters","fullName":"advisories/ghsa-wpqr-6v78-jr5g","observedAt":"2026-05-11T01:25:31.639Z"}
+{"source":"lobsters","fullName":"pstron/poop","observedAt":"2026-05-11T01:25:31.639Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/25645474497

Auto-merge enabled — merges once required status checks pass.