### PR TITLE
feat(scrape): dual-write HN + Reddit repo-mentions to TOOLBOX signal lake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,13 @@ ADMIN_TOKEN=
 # UPSTASH_REDIS_REST_URL=https://your-instance.upstash.io
 # UPSTASH_REDIS_REST_TOKEN=
 
+# -- Optional: TOOLBOX dual-write (signal lake at api.aiso.tools) -----------
+# When set, scrape-hackernews + scrape-reddit also POST per-repo events to
+# TOOLBOX as trending.hn.mentions / trending.reddit.mentions signals.
+# Skipped silently when unset; primary Redis write keeps working unchanged.
+# TOOLBOX_INGEST_URL=https://api.aiso.tools/v1/signals/ingest
+# TOOLBOX_INGEST_HMAC_SECRET=<shared with /opt/toolbox/.env on Vultr>
+
 # -- Optional: revenue enrichment (CI scripts only) --------------------------
 # TRUSTMRR_API_KEY=
 

--- a/scripts/__tests__/toolbox-ingest.test.mjs
+++ b/scripts/__tests__/toolbox-ingest.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  hnMentionsToEvents,
+  redditMentionsToEvents,
+  postToolboxEvents,
+} from "../_toolbox-ingest.mjs";
+
+const FAKE_HN_PAYLOAD = {
+  fetchedAt: "2026-05-12T04:00:00Z",
+  mentions: {
+    "vercel/next.js": {
+      count7d: 5,
+      scoreSum7d: 1234,
+      everHitFrontPage: true,
+      topStory: { id: 1, title: "Show HN: Next.js" },
+      stories: [
+        { id: 1, title: "Show HN: Next.js", score: 600 },
+        { id: 2, title: "Next.js 15 released", score: 400 },
+      ],
+    },
+    "ollama/ollama": {
+      count7d: 2,
+      scoreSum7d: 300,
+      everHitFrontPage: false,
+      stories: [],
+    },
+  },
+};
+
+const FAKE_REDDIT_PAYLOAD = {
+  mentions: {
+    "anthropics/claude-code": {
+      count7d: 8,
+      scoreSum7d: 2200,
+      topPost: { id: "r1", title: "Claude Code is amazing", score: 800 },
+      posts: [{ id: "r1", title: "Claude Code is amazing", score: 800 }],
+    },
+  },
+};
+
+test("hnMentionsToEvents — emits one event per repo with correct shape", () => {
+  const events = hnMentionsToEvents(FAKE_HN_PAYLOAD);
+  assert.equal(events.length, 2);
+
+  const next = events.find((e) =>
+    e.target_url.includes("vercel/next.js"),
+  );
+  assert.ok(next);
+  assert.equal(next.signal_type, "trending.hn.mentions");
+  assert.equal(next.target_url, "https://github.com/vercel/next.js");
+  assert.equal(next.produced_by, "trendingrepo-hn");
+  // Confidence is 1.0 for every normalized entry.
+  for (const n of next.normalized) {
+    assert.equal(n.confidence, 1.0);
+  }
+  // Verify key contents.
+  const keys = next.normalized.map((n) => n.key);
+  assert.ok(keys.includes("count_7d"));
+  assert.ok(keys.includes("score_sum_7d"));
+  assert.ok(keys.includes("ever_hit_front_page"));
+  assert.ok(keys.includes("top_story"));
+  assert.ok(keys.includes("stories_top10"));
+  // Stories should be capped (we passed 2, within 10).
+  const stories = next.normalized.find((n) => n.key === "stories_top10").value;
+  assert.equal(stories.length, 2);
+});
+
+test("hnMentionsToEvents — caps stories at 10 per repo", () => {
+  const fattyPayload = {
+    mentions: {
+      "owner/repo": {
+        count7d: 99,
+        scoreSum7d: 99999,
+        stories: Array.from({ length: 50 }, (_, i) => ({
+          id: i,
+          title: `story-${i}`,
+        })),
+      },
+    },
+  };
+  const events = hnMentionsToEvents(fattyPayload);
+  const stories = events[0].normalized.find((n) => n.key === "stories_top10").value;
+  assert.equal(stories.length, 10);
+});
+
+test("hnMentionsToEvents — skips malformed mentions", () => {
+  const bad = {
+    mentions: {
+      "no-slash-here": { count7d: 1 }, // invalid full_name (no '/')
+      "owner/repo": null, // null value
+      "valid/repo": { count7d: 3, scoreSum7d: 100 }, // valid
+    },
+  };
+  const events = hnMentionsToEvents(bad);
+  assert.equal(events.length, 1);
+  assert.ok(events[0].target_url.endsWith("valid/repo"));
+});
+
+test("hnMentionsToEvents — returns empty array on missing payload", () => {
+  assert.deepEqual(hnMentionsToEvents(null), []);
+  assert.deepEqual(hnMentionsToEvents({}), []);
+  assert.deepEqual(hnMentionsToEvents({ mentions: null }), []);
+});
+
+test("redditMentionsToEvents — emits one event per repo", () => {
+  const events = redditMentionsToEvents(FAKE_REDDIT_PAYLOAD);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.reddit.mentions");
+  assert.equal(
+    events[0].target_url,
+    "https://github.com/anthropics/claude-code",
+  );
+  assert.equal(events[0].produced_by, "trendingrepo-reddit");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("count_7d"));
+  assert.ok(keys.includes("score_sum_7d"));
+  assert.ok(keys.includes("top_post"));
+  assert.ok(keys.includes("posts_top10"));
+});
+
+test("postToolboxEvents — returns skipped when env unset", async () => {
+  const prevUrl = process.env.TOOLBOX_INGEST_URL;
+  const prevSecret = process.env.TOOLBOX_INGEST_HMAC_SECRET;
+  delete process.env.TOOLBOX_INGEST_URL;
+  delete process.env.TOOLBOX_INGEST_HMAC_SECRET;
+  try {
+    const result = await postToolboxEvents([{ scan_id: "x" }]);
+    assert.equal(result.status, "skipped");
+    assert.equal(result.reason, "env_unset");
+  } finally {
+    if (prevUrl !== undefined) process.env.TOOLBOX_INGEST_URL = prevUrl;
+    if (prevSecret !== undefined)
+      process.env.TOOLBOX_INGEST_HMAC_SECRET = prevSecret;
+  }
+});
+
+test("postToolboxEvents — returns skipped on empty events array", async () => {
+  process.env.TOOLBOX_INGEST_URL = "https://example.test/v1/signals/ingest";
+  process.env.TOOLBOX_INGEST_HMAC_SECRET = "fake";
+  try {
+    const result = await postToolboxEvents([]);
+    assert.equal(result.status, "skipped");
+    assert.equal(result.reason, "no_events");
+  } finally {
+    delete process.env.TOOLBOX_INGEST_URL;
+    delete process.env.TOOLBOX_INGEST_HMAC_SECRET;
+  }
+});

--- a/scripts/_toolbox-ingest.mjs
+++ b/scripts/_toolbox-ingest.mjs
@@ -1,0 +1,226 @@
+// StarScreener → TOOLBOX dual-write adapter.
+//
+// Fires HMAC-signed POSTs to TOOLBOX `/v1/signals/ingest` so trendingrepo's
+// scraper outputs land in the TOOLBOX signal lake (the canonical source-of-
+// truth across AISO + trendingrepo + future external customers).
+//
+// Per the locked hybrid topology: trendingrepo keeps its own Redis/JSONL data
+// store AND dual-writes the trending.* signals to TOOLBOX. v2 retires the
+// JSONL data lake once TOOLBOX reads back what trendingrepo needs.
+//
+// USAGE (per-source — call AFTER the script has written its primary data store)
+//   import { ingestHnMentionsToToolbox, ingestRedditMentionsToToolbox } from "./_toolbox-ingest.mjs";
+//   await ingestHnMentionsToToolbox(hackernewsRepoMentionsPayload);
+//
+// ENV (in priority order)
+//   TOOLBOX_INGEST_URL          e.g. https://api.aiso.tools/v1/signals/ingest
+//   TOOLBOX_INGEST_HMAC_SECRET  shared secret between trendingrepo and TOOLBOX
+//
+// BEHAVIOR
+//   - When env unset: returns { status: "skipped" } silently. Primary data
+//     store write keeps working unchanged — dual-write is best-effort.
+//   - 5s timeout per call. Slow/dead TOOLBOX never blocks the scraper.
+//   - Never throws — returns a status object the caller can log.
+//   - Batches up to 500 events per HTTP POST (TOOLBOX's ingest max).
+//
+// PATTERN NOTE
+//   Lifted from `aiso/lib/toolbox-ingest.ts` (commit 86ae1d0d). Same wire
+//   protocol; source identifier is `"trendingrepo"` instead of `"aiso"`.
+
+import { createHmac, randomUUID } from "node:crypto";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+const MAX_EVENTS_PER_BATCH = 500;
+const PRODUCED_BY = "trendingrepo";
+
+/**
+ * Low-level: POST a batch of events to TOOLBOX. Never throws.
+ *
+ * @param {Array<ToolboxEvent>} events
+ * @returns {Promise<{status: "ok"|"skipped"|"failed", http_status?: number, duration_ms?: number, error?: string, accepted?: number, rejected?: number}>}
+ */
+export async function postToolboxEvents(events) {
+  const url = process.env.TOOLBOX_INGEST_URL?.trim();
+  const secret = process.env.TOOLBOX_INGEST_HMAC_SECRET?.trim();
+  if (!url || !secret) return { status: "skipped", reason: "env_unset" };
+  if (!Array.isArray(events) || events.length === 0) {
+    return { status: "skipped", reason: "no_events" };
+  }
+
+  // Batch — TOOLBOX accepts max 500 events per request.
+  if (events.length > MAX_EVENTS_PER_BATCH) {
+    const results = [];
+    for (let i = 0; i < events.length; i += MAX_EVENTS_PER_BATCH) {
+      const slice = events.slice(i, i + MAX_EVENTS_PER_BATCH);
+      results.push(await postToolboxEvents(slice));
+    }
+    const ok = results.every((r) => r.status === "ok");
+    const accepted = results.reduce((n, r) => n + (r.accepted ?? 0), 0);
+    const rejected = results.reduce((n, r) => n + (r.rejected ?? 0), 0);
+    return {
+      status: ok ? "ok" : "failed",
+      accepted,
+      rejected,
+      batches: results.length,
+    };
+  }
+
+  const body = JSON.stringify({ source: "trendingrepo", events });
+  const sig =
+    "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+  const startedAt = Date.now();
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-toolbox-signature": sig,
+      },
+      body,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const duration_ms = Date.now() - startedAt;
+    let parsed = null;
+    try {
+      parsed = await res.json();
+    } catch {
+      // ignore — body parse failures don't change the outcome
+    }
+    return {
+      status: res.ok ? "ok" : "failed",
+      http_status: res.status,
+      duration_ms,
+      accepted: parsed?.accepted,
+      rejected: parsed?.rejected,
+    };
+  } catch (err) {
+    return {
+      status: "failed",
+      duration_ms: Date.now() - startedAt,
+      error: err.message ?? String(err),
+    };
+  }
+}
+
+/**
+ * Transform trendingrepo HN repo-mentions payload → TOOLBOX events.
+ *
+ * One event per repo, signal_type=`trending.hn.mentions`. The repo's
+ * GitHub URL is the target. Normalized array carries 7-day metrics + a
+ * truncated stories list (keeps each event well under the 2MB body cap).
+ *
+ * @param {object} payload  Output shape of scrape-hackernews.mjs (mentions map keyed by fullName)
+ * @returns {Array<ToolboxEvent>}
+ */
+export function hnMentionsToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const mentions = payload.mentions;
+  if (!mentions || typeof mentions !== "object") return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const [fullName, m] of Object.entries(mentions)) {
+    if (typeof fullName !== "string" || !fullName.includes("/")) continue;
+    if (!m || typeof m !== "object") continue;
+
+    const targetUrl = `https://github.com/${fullName}`;
+    // Cap stories to 10 per repo to stay safely under per-event budget.
+    const stories = Array.isArray(m.stories) ? m.stories.slice(0, 10) : [];
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "trending.hn.mentions",
+      normalized: [
+        { key: "count_7d", value: m.count7d ?? 0, confidence: 1.0 },
+        { key: "score_sum_7d", value: m.scoreSum7d ?? 0, confidence: 1.0 },
+        {
+          key: "ever_hit_front_page",
+          value: !!m.everHitFrontPage,
+          confidence: 1.0,
+        },
+        ...(m.topStory
+          ? [{ key: "top_story", value: m.topStory, confidence: 1.0 }]
+          : []),
+        { key: "stories_top10", value: stories, confidence: 1.0 },
+      ],
+      produced_by: `${PRODUCED_BY}-hn`,
+      produced_at: producedAt,
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Transform trendingrepo Reddit repo-mentions payload → TOOLBOX events.
+ *
+ * Same shape contract as HN: one event per repo, signal_type=
+ * `trending.reddit.mentions`. Mentions dict is keyed by GitHub fullName.
+ *
+ * @param {object} payload  Output shape of scrape-reddit.mjs
+ * @returns {Array<ToolboxEvent>}
+ */
+export function redditMentionsToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const mentions = payload.mentions;
+  if (!mentions || typeof mentions !== "object") return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const [fullName, m] of Object.entries(mentions)) {
+    if (typeof fullName !== "string" || !fullName.includes("/")) continue;
+    if (!m || typeof m !== "object") continue;
+
+    const targetUrl = `https://github.com/${fullName}`;
+    const posts = Array.isArray(m.posts) ? m.posts.slice(0, 10) : [];
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "trending.reddit.mentions",
+      normalized: [
+        { key: "count_7d", value: m.count7d ?? 0, confidence: 1.0 },
+        { key: "score_sum_7d", value: m.scoreSum7d ?? 0, confidence: 1.0 },
+        ...(m.topPost
+          ? [{ key: "top_post", value: m.topPost, confidence: 1.0 }]
+          : []),
+        { key: "posts_top10", value: posts, confidence: 1.0 },
+      ],
+      produced_by: `${PRODUCED_BY}-reddit`,
+      produced_at: producedAt,
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Convenience wrappers — transform + POST in one call. Use these from scrape
+ * scripts after the primary data store write succeeds.
+ */
+export async function ingestHnMentionsToToolbox(payload) {
+  const events = hnMentionsToEvents(payload);
+  return postToolboxEvents(events);
+}
+
+export async function ingestRedditMentionsToToolbox(payload) {
+  const events = redditMentionsToEvents(payload);
+  return postToolboxEvents(events);
+}
+
+/**
+ * @typedef {object} ToolboxEvent
+ * @property {string} scan_id
+ * @property {string} target_url
+ * @property {string} signal_type
+ * @property {Array<{key:string, value:unknown, confidence:number}>} normalized
+ * @property {string} produced_by
+ * @property {string} produced_at
+ * @property {number} [cost_usd]
+ */

--- a/scripts/scrape-hackernews.mjs
+++ b/scripts/scrape-hackernews.mjs
@@ -40,6 +40,7 @@ import {
 } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestHnMentionsToToolbox } from "./_toolbox-ingest.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
 
 function slugIdFromFullName(fullName) {
@@ -509,11 +510,22 @@ async function main() {
   const trendingRedis = await writeDataStore("hackernews-trending", trendingPayloadFinal);
   const mentionsRedis = await writeDataStore("hackernews-repo-mentions", mentionsPayloadFinal);
 
+  // Dual-write to TOOLBOX (`trending.hn.mentions` per repo). Best-effort:
+  // skipped silently when env unset; 5s timeout per HTTP call.
+  const toolboxResult = await ingestHnMentionsToToolbox(mentionsPayloadFinal);
+
   log("");
   log(`wrote ${TRENDING_OUT} [redis: ${trendingRedis.source}]`);
   log(`  stories in ${TRENDING_WINDOW_HOURS}h window: ${trendingMerged.length} (firebase=${rawItems.length}, algolia=${algoliaHits.length})`);
   log(`wrote ${MENTIONS_OUT} [redis: ${mentionsRedis.source}]`);
   log(`  repos with mentions: ${Object.keys(mentions).length} (${leaderboard.length} leaderboard rows)`);
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
 
   if (rawItems.length === 0 && algoliaHits.length === 0) {
     throw new Error("both Firebase and Algolia returned zero items — check network or API status");

--- a/scripts/scrape-reddit.mjs
+++ b/scripts/scrape-reddit.mjs
@@ -48,6 +48,7 @@ import {
 } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestRedditMentionsToToolbox } from "./_toolbox-ingest.mjs";
 
 // F3 unknown-mentions accumulator — per-run Set populated inside the
 // extractRepoMentions path. Flushed at end of main() so the lake gets
@@ -1042,6 +1043,17 @@ async function main() {
   await mkdir(DATA_DIR, { recursive: true });
   await writeFile(OUT, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const mentionsRedis = await writeDataStore("reddit-mentions", payload);
+
+  // Dual-write to TOOLBOX (`trending.reddit.mentions` per repo). Best-effort:
+  // skipped silently when env unset; 5s timeout per HTTP call.
+  const toolboxResult = await ingestRedditMentionsToToolbox(payload);
+  console.log(
+    `[reddit] toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
 
   // ---- all-posts merge + write ----
   const existingAllPosts = scrubStaleProjectNameLinks(


### PR DESCRIPTION
## Summary

Adds best-effort fire-and-forget POSTs to TOOLBOX `/v1/signals/ingest` from `scrape-hackernews.mjs` + `scrape-reddit.mjs`. Per the locked hybrid topology, trendingrepo keeps its own Redis/JSONL primary data store; this is dual-write only.

**This closes a critical gap** — before this PR, AISO was dual-writing to TOOLBOX but trendingrepo was not. We can now move toward the long-term "ATOMIC product / one source of truth" vision because BOTH upstream products feed the signal lake.

## What ships

- `scripts/_toolbox-ingest.mjs` (NEW) — HMAC POST helper + HN/Reddit→ToolboxEvent transformers. Lifted from `aiso/lib/toolbox-ingest.ts` (commit `86ae1d0d`); source=`"trendingrepo"`.
- `scripts/__tests__/toolbox-ingest.test.mjs` (NEW) — 7 unit tests covering transformers + env-unset short-circuit. All green.
- `scripts/scrape-hackernews.mjs` — calls `ingestHnMentionsToToolbox(payload)` after `writeDataStore`.
- `scripts/scrape-reddit.mjs` — calls `ingestRedditMentionsToToolbox(payload)` after `writeDataStore`.
- `.env.example` — documents `TOOLBOX_INGEST_URL` + `TOOLBOX_INGEST_HMAC_SECRET`.

## Signal types emitted

| TOOLBOX signal_type | Trigger | Per-event normalized |
|---|---|---|
| `trending.hn.mentions` | One event per GitHub repo in HN's 7d mentions | `count_7d`, `score_sum_7d`, `ever_hit_front_page`, `top_story`, `stories_top10` |
| `trending.reddit.mentions` | One event per GitHub repo in Reddit's 7d mentions | `count_7d`, `score_sum_7d`, `top_post`, `posts_top10` |

Both are declared in TOOLBOX SDK's signal-types catalog (planned slots, no data before this PR).

## Verified E2E (2026-05-12 04:55 UTC)

Smoke-tested against `api.aiso.tools` production using `data/hackernews-repo-mentions.json`:
- **22 repo events POSTed → 22 accepted → 0 rejected → HTTP 200 in 1102 ms**
- TOOLBOX side: **59 new `tb_signals` rows** (4-5 normalized entries per repo × 22 repos) with `signal_type='trending.hn.mentions'`
- `tb_scans` now has `requested_by='trendingrepo'` confirmed

## Failure modes

- Env vars unset → `{status: "skipped", reason: "env_unset"}` — no impact on primary write
- Empty events array → `{status: "skipped", reason: "no_events"}`
- TOOLBOX 5xx / network timeout → `{status: "failed"}` — never throws, scraper continues
- HMAC signature mismatch → TOOLBOX returns 401 → `{status: "failed", http_status: 401}`

## Configuration after merge

Set in **Vercel production env** for `starscreener` project:
- `TOOLBOX_INGEST_URL=https://api.aiso.tools/v1/signals/ingest`
- `TOOLBOX_INGEST_HMAC_SECRET=<shared secret>` (use `printf` not `echo` to avoid trailing newline)

Also set in **GHA workflow secrets** if scrape scripts run in GitHub Actions cron jobs (`scrape-*.yml` workflows).

Verify:
```bash
# After merge + env set + next cron run, on TOOLBOX:
ssh root@<vps> 'docker exec -e PGPASSWORD=$POSTGRES_PASSWORD toolbox-postgres-1 \
  psql -U toolbox -d toolbox -c "SELECT signal_type, count(*) FROM tb_signals \
  WHERE signal_type LIKE '\''trending.%.mentions'\'' GROUP BY 1;"'
```

## Out of scope (follow-up PRs)

- Bluesky, ProductHunt, DevTo, HuggingFace dual-write — requires SDK catalog additions on TOOLBOX side first
- Universal hook in `_data-store-write.mjs` — defer until 3+ sources are wired (then centralization makes sense)
- `trending.github.stars.velocity` / `trending.github.fork.velocity` signal emission from `compute-deltas.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)