### PR TITLE
ci(scrape-trending): pass TOOLBOX_INGEST_* secrets to scrape-hackernews + scrape-reddit

### DIFF
--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -58,6 +58,10 @@ jobs:
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
           REDDIT_USER_AGENTS: ${{ secrets.REDDIT_USER_AGENTS }}
+          # Dual-write to TOOLBOX signal lake (trending.reddit.mentions).
+          # Skipped silently when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-reddit.mjs
 
       - name: Refresh HackerNews trending + repo mentions
@@ -67,6 +71,10 @@ jobs:
         # on the same hourly cadence as Reddit (Sprint 1 finding #1).
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX signal lake (trending.hn.mentions).
+          # Skipped silently when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-hackernews.mjs
 
       - name: Refresh GitHub repo metadata


### PR DESCRIPTION
## Summary

Follow-up to PR #1019 — wires the TOOLBOX dual-write env vars (already set as repo secrets) into the cron workflow's HN + Reddit scrape steps.

Without this, PR #1019's dual-write code skips silently in GHA (env unset). With this, the next cron tick (cron: `7,27,47 * * * *` — within 20 min of merge) starts writing `trending.hn.mentions` + `trending.reddit.mentions` to TOOLBOX prod automatically.

## Change

`.github/workflows/scrape-trending.yml` — 8 added lines total (4 per step):

```diff
       env:
         REDIS_URL: ${{ secrets.REDIS_URL }}
+        # Dual-write to TOOLBOX signal lake (trending.hn.mentions).
+        # Skipped silently when unset; never blocks the primary write.
+        TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+        TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
       run: node scripts/scrape-hackernews.mjs
```

Same 4 lines added to the Reddit step.

## Secrets

Both secrets already exist on this repo (verified):
- `TOOLBOX_INGEST_URL` (set 2026-05-12 05:06:23 UTC via `gh secret set`)
- `TOOLBOX_INGEST_HMAC_SECRET` (set 2026-05-12 05:06:24 UTC via `gh secret set` — clean value, no trailing newline)

## Verify after merge

Within 20 min:
```bash
gh run list --workflow scrape-trending.yml --limit 1 --json conclusion,displayTitle
gh run view <id> --log | grep "toolbox-ingest"
# expect: "toolbox-ingest: ok accepted=N"
```

TOOLBOX side:
```sql
SELECT signal_type, count(*)
FROM tb_signals
WHERE signal_type LIKE 'trending.%.mentions'
  AND produced_at > now() - interval '30 minutes'
GROUP BY 1;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)