### PR TITLE
feat(scrape): dual-write Bluesky + DevTo repo-mentions to TOOLBOX

### DIFF
--- a/scripts/__tests__/toolbox-ingest.test.mjs
+++ b/scripts/__tests__/toolbox-ingest.test.mjs
@@ -3,6 +3,8 @@ import { test } from "node:test";
 import {
   hnMentionsToEvents,
   redditMentionsToEvents,
+  bskyMentionsToEvents,
+  devtoMentionsToEvents,
   postToolboxEvents,
 } from "../_toolbox-ingest.mjs";
 
@@ -101,6 +103,58 @@ test("hnMentionsToEvents — returns empty array on missing payload", () => {
   assert.deepEqual(hnMentionsToEvents(null), []);
   assert.deepEqual(hnMentionsToEvents({}), []);
   assert.deepEqual(hnMentionsToEvents({ mentions: null }), []);
+});
+
+test("bskyMentionsToEvents — emits one event per repo with bluesky-specific metrics", () => {
+  const payload = {
+    mentions: {
+      "vercel/next.js": {
+        count7d: 3,
+        likesSum7d: 50,
+        repostsSum7d: 12,
+        repliesSum7d: 8,
+        topPost: { bskyUrl: "https://bsky.app/profile/x/post/y", text: "Wow Next.js" },
+        posts: [{ bskyUrl: "https://bsky.app/profile/x/post/y" }],
+      },
+    },
+  };
+  const events = bskyMentionsToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.bluesky.mentions");
+  assert.equal(events[0].target_url, "https://github.com/vercel/next.js");
+  assert.equal(events[0].produced_by, "trendingrepo-bluesky");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("count_7d"));
+  assert.ok(keys.includes("likes_sum_7d"));
+  assert.ok(keys.includes("reposts_sum_7d"));
+  assert.ok(keys.includes("replies_sum_7d"));
+  assert.ok(keys.includes("top_post"));
+  assert.ok(keys.includes("posts_top10"));
+});
+
+test("devtoMentionsToEvents — emits one event per repo with devto-specific metrics", () => {
+  const payload = {
+    mentions: {
+      "ollama/ollama": {
+        count7d: 4,
+        reactionsSum7d: 120,
+        commentsSum7d: 15,
+        topArticle: { id: 1, title: "Running Ollama locally", reactions: 80 },
+        articles: [{ id: 1, title: "Running Ollama locally" }],
+      },
+    },
+  };
+  const events = devtoMentionsToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.devto.mentions");
+  assert.equal(events[0].target_url, "https://github.com/ollama/ollama");
+  assert.equal(events[0].produced_by, "trendingrepo-devto");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("count_7d"));
+  assert.ok(keys.includes("reactions_sum_7d"));
+  assert.ok(keys.includes("comments_sum_7d"));
+  assert.ok(keys.includes("top_article"));
+  assert.ok(keys.includes("articles_top10"));
 });
 
 test("redditMentionsToEvents — emits one event per repo", () => {

--- a/scripts/_toolbox-ingest.mjs
+++ b/scripts/_toolbox-ingest.mjs
@@ -201,6 +201,101 @@ export function redditMentionsToEvents(payload) {
 }
 
 /**
+ * Transform trendingrepo Bluesky repo-mentions payload → TOOLBOX events.
+ *
+ * One event per repo, signal_type=`trending.bluesky.mentions`. Bluesky-
+ * specific metrics: likes, reposts, replies aggregated over 7d window.
+ *
+ * @param {object} payload  Output shape of scrape-bluesky.mjs (mentions map keyed by fullName)
+ * @returns {Array<ToolboxEvent>}
+ */
+export function bskyMentionsToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const mentions = payload.mentions;
+  if (!mentions || typeof mentions !== "object") return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const [fullName, m] of Object.entries(mentions)) {
+    if (typeof fullName !== "string" || !fullName.includes("/")) continue;
+    if (!m || typeof m !== "object") continue;
+
+    const targetUrl = `https://github.com/${fullName}`;
+    const posts = Array.isArray(m.posts) ? m.posts.slice(0, 10) : [];
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "trending.bluesky.mentions",
+      normalized: [
+        { key: "count_7d", value: m.count7d ?? 0, confidence: 1.0 },
+        { key: "likes_sum_7d", value: m.likesSum7d ?? 0, confidence: 1.0 },
+        { key: "reposts_sum_7d", value: m.repostsSum7d ?? 0, confidence: 1.0 },
+        { key: "replies_sum_7d", value: m.repliesSum7d ?? 0, confidence: 1.0 },
+        ...(m.topPost
+          ? [{ key: "top_post", value: m.topPost, confidence: 1.0 }]
+          : []),
+        { key: "posts_top10", value: posts, confidence: 1.0 },
+      ],
+      produced_by: `${PRODUCED_BY}-bluesky`,
+      produced_at: producedAt,
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Transform trendingrepo dev.to repo-mentions payload → TOOLBOX events.
+ *
+ * One event per repo, signal_type=`trending.devto.mentions`. dev.to-specific
+ * metrics: reactions, comments aggregated over 7d window.
+ *
+ * @param {object} payload  Output shape of scrape-devto.mjs
+ * @returns {Array<ToolboxEvent>}
+ */
+export function devtoMentionsToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const mentions = payload.mentions;
+  if (!mentions || typeof mentions !== "object") return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const [fullName, m] of Object.entries(mentions)) {
+    if (typeof fullName !== "string" || !fullName.includes("/")) continue;
+    if (!m || typeof m !== "object") continue;
+
+    const targetUrl = `https://github.com/${fullName}`;
+    const articles = Array.isArray(m.articles)
+      ? m.articles.slice(0, 10)
+      : [];
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "trending.devto.mentions",
+      normalized: [
+        { key: "count_7d", value: m.count7d ?? 0, confidence: 1.0 },
+        { key: "reactions_sum_7d", value: m.reactionsSum7d ?? 0, confidence: 1.0 },
+        { key: "comments_sum_7d", value: m.commentsSum7d ?? 0, confidence: 1.0 },
+        ...(m.topArticle
+          ? [{ key: "top_article", value: m.topArticle, confidence: 1.0 }]
+          : []),
+        { key: "articles_top10", value: articles, confidence: 1.0 },
+      ],
+      produced_by: `${PRODUCED_BY}-devto`,
+      produced_at: producedAt,
+    });
+  }
+
+  return events;
+}
+
+/**
  * Convenience wrappers — transform + POST in one call. Use these from scrape
  * scripts after the primary data store write succeeds.
  */
@@ -211,6 +306,16 @@ export async function ingestHnMentionsToToolbox(payload) {
 
 export async function ingestRedditMentionsToToolbox(payload) {
   const events = redditMentionsToEvents(payload);
+  return postToolboxEvents(events);
+}
+
+export async function ingestBskyMentionsToToolbox(payload) {
+  const events = bskyMentionsToEvents(payload);
+  return postToolboxEvents(events);
+}
+
+export async function ingestDevtoMentionsToToolbox(payload) {
+  const events = devtoMentionsToEvents(payload);
   return postToolboxEvents(events);
 }
 

--- a/scripts/scrape-bluesky.mjs
+++ b/scripts/scrape-bluesky.mjs
@@ -54,6 +54,7 @@ import {
 } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestBskyMentionsToToolbox } from "./_toolbox-ingest.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
 
 // F3 unknown-mentions accumulator — per-run Set populated inside the
@@ -552,10 +553,21 @@ async function main() {
     );
   }
 
+  // Dual-write to TOOLBOX (`trending.bluesky.mentions` per repo). Best-effort:
+  // skipped silently when env unset; 5s timeout per HTTP call.
+  const toolboxResult = await ingestBskyMentionsToToolbox(mergedMentionsPayload);
+
   log("");
   log(`wrote ${MENTIONS_OUT} [redis: ${mentionsRedis.source}]`);
   log(`  repos with mentions: ${Object.keys(mentions).length} (${leaderboard.length} leaderboard rows)`);
   log(`wrote ${TRENDING_OUT} [redis: ${trendingRedis.source}]`);
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
   log(
     `  trending posts: ${trendingMerged.length} across ` +
       `${BLUESKY_TRENDING_QUERIES.length} queries / ${BLUESKY_QUERY_FAMILIES.length} topic families`,

--- a/scripts/scrape-devto.mjs
+++ b/scripts/scrape-devto.mjs
@@ -48,6 +48,7 @@ import {
 } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestDevtoMentionsToToolbox } from "./_toolbox-ingest.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
 
 // F3 unknown-mentions accumulator — per-run Set populated inside the
@@ -428,10 +429,21 @@ async function main() {
   const mentionsRedis = await writeDataStore("devto-mentions", mentionsPayload);
   const trendingRedis = await writeDataStore("devto-trending", trendingPayload);
 
+  // Dual-write to TOOLBOX (`trending.devto.mentions` per repo). Best-effort:
+  // skipped silently when env unset; 5s timeout per HTTP call.
+  const toolboxResult = await ingestDevtoMentionsToToolbox(mentionsPayload);
+
   log("");
   log(`wrote ${MENTIONS_OUT} [redis: ${mentionsRedis.source}]`);
   log(`  repos with mentions: ${Object.keys(mentions).length} (${leaderboard.length} leaderboard rows)`);
   log(`wrote ${TRENDING_OUT} [redis: ${trendingRedis.source}]`);
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
   log(
     `  trending articles: ${trendingArticles.length} ` +
       `(mode: ${bodyFetchMode}, slices: ${DEVTO_DISCOVERY_SLICES.length}, tags: ${DEVTO_PRIORITY_TAGS.length})`,


### PR DESCRIPTION
## Summary

Extends PR #1019's dual-write pattern to two more sources: **Bluesky** + **DevTo** repo mentions. Same fire-and-forget HMAC POST design with a 5s timeout, fail-safe when env unset.

Compounds the ATOMIC product / one-source-of-truth vision — TOOLBOX signal lake now collects HN + Reddit + Bluesky + DevTo mentions in parallel.

## Companion change

`packages/sdk/src/signal-types.ts` on TOOLBOX side gained two new entries:
- `trending.bluesky.mentions` (worker-node, TTL 1800s)
- `trending.devto.mentions` (worker-node, TTL 3600s)

Deployed as `toolbox-api:v0.0.14-nogh` simultaneously with this PR's prep. Verified live at `https://api.aiso.tools/v1/signal-types` (23 entries total).

## Verified E2E (2026-05-12 05:48 UTC)

Smoke-tested against `api.aiso.tools` production:
- **Bluesky: 73 repo events POSTed → 73 accepted → 0 rejected → 1869 ms**
- **DevTo: 34 repo events POSTed → 34 accepted → 0 rejected → 553 ms**

TOOLBOX `tb_signals` now has:
- 156 `trending.bluesky.mentions` rows
- 87 `trending.devto.mentions` rows
- 125 `trending.hn.mentions` rows (from PR #1019 cron)

## After merge — wire GHA env (separate PR)

Follow-up will add `TOOLBOX_INGEST_*` to env blocks of cron workflows that run scrape-bluesky.mjs + scrape-devto.mjs. Secrets already exist on this repo from PR #1019 + #1020.

## Tests

`scripts/__tests__/toolbox-ingest.test.mjs` — 9/9 passing (added 2 new for Bluesky + DevTo transformers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)