### PR TITLE
ci(scrape): pass TOOLBOX_INGEST_* secrets to scrape-bluesky + scrape-devto

### DIFF
--- a/.github/workflows/scrape-bluesky.yml
+++ b/.github/workflows/scrape-bluesky.yml
@@ -35,6 +35,10 @@ jobs:
         env:
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          # Dual-write to TOOLBOX signal lake (trending.bluesky.mentions).
+          # Skipped silently when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-bluesky.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-devto.yml
+++ b/.github/workflows/scrape-devto.yml
@@ -39,6 +39,10 @@ jobs:
           REDIS_URL: ${{ secrets.REDIS_URL }}
           DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
           DEVTO_API_KEYS: ${{ secrets.DEVTO_API_KEYS }}
+          # Dual-write to TOOLBOX signal lake (trending.devto.mentions).
+          # Skipped silently when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-devto.mjs
 
       - name: Compute commit timestamp


### PR DESCRIPTION
Follow-up to PR #1025. Wires TOOLBOX env vars into scrape-bluesky + scrape-devto cron workflows. Both secrets already exist on repo from PRs #1019 + #1020. After merge, next workflow tick logs `toolbox-ingest: ok accepted=N` and writes to TOOLBOX automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)