### PR TITLE
feat(scrape): dual-write 6 more sources to TOOLBOX (PH, HF x3, npm, OpenAI RSS)

### DIFF
--- a/scripts/__tests__/toolbox-ingest.test.mjs
+++ b/scripts/__tests__/toolbox-ingest.test.mjs
@@ -5,6 +5,12 @@ import {
   redditMentionsToEvents,
   bskyMentionsToEvents,
   devtoMentionsToEvents,
+  producthuntLaunchesToEvents,
+  huggingfaceModelsToEvents,
+  huggingfaceSpacesToEvents,
+  huggingfaceDatasetsToEvents,
+  npmPackagesToEvents,
+  openaiRssToEvents,
   postToolboxEvents,
 } from "../_toolbox-ingest.mjs";
 
@@ -171,6 +177,152 @@ test("redditMentionsToEvents — emits one event per repo", () => {
   assert.ok(keys.includes("score_sum_7d"));
   assert.ok(keys.includes("top_post"));
   assert.ok(keys.includes("posts_top10"));
+});
+
+test("producthuntLaunchesToEvents — emits one event per launch with PH metrics", () => {
+  const payload = {
+    launches: [
+      {
+        id: 12345,
+        name: "Cool Product",
+        tagline: "Does cool things",
+        url: "https://www.producthunt.com/posts/cool-product",
+        website: "https://cool.example",
+        votesCount: 250,
+        commentsCount: 30,
+        createdAt: "2026-05-12T00:00:00Z",
+        topics: ["AI", "Productivity"],
+        makers: [{ name: "Alice" }],
+        thumbnail: "https://ph.example/img.png",
+      },
+    ],
+  };
+  const events = producthuntLaunchesToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.producthunt.launches");
+  assert.equal(events[0].target_url, "https://www.producthunt.com/posts/cool-product");
+  assert.equal(events[0].produced_by, "trendingrepo-producthunt");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("votes_count"));
+  assert.ok(keys.includes("comments_count"));
+  assert.ok(keys.includes("topics"));
+  assert.ok(keys.includes("makers"));
+});
+
+test("huggingfaceModelsToEvents — emits one event per model, caps at 100", () => {
+  const payload = {
+    models: Array.from({ length: 150 }, (_, i) => ({
+      rank: i,
+      id: `author${i}/model${i}`,
+      author: `author${i}`,
+      url: `https://huggingface.co/author${i}/model${i}`,
+      downloads: i * 100,
+      likes: i * 5,
+      trendingScore: i * 0.5,
+      pipelineTag: "text-generation",
+      tags: ["llm", "transformer"],
+    })),
+  };
+  const events = huggingfaceModelsToEvents(payload);
+  assert.equal(events.length, 100); // capped
+  assert.equal(events[0].signal_type, "trending.huggingface.models");
+  assert.ok(events[0].target_url.startsWith("https://huggingface.co/"));
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("downloads"));
+  assert.ok(keys.includes("pipeline_tag"));
+  assert.ok(keys.includes("trending_score"));
+});
+
+test("huggingfaceSpacesToEvents — emits one event per space, caps at 50", () => {
+  const payload = {
+    spaces: [
+      {
+        rank: 1,
+        id: "user/space",
+        author: "user",
+        url: "https://huggingface.co/spaces/user/space",
+        likes: 200,
+        trendingScore: 75.5,
+        sdk: "gradio",
+        models: ["meta-llama/Llama-3"],
+        tags: ["chatbot"],
+      },
+    ],
+  };
+  const events = huggingfaceSpacesToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.huggingface.spaces");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("sdk"));
+  assert.ok(keys.includes("models"));
+});
+
+test("huggingfaceDatasetsToEvents — emits one event per dataset", () => {
+  const payload = {
+    datasets: [
+      {
+        rank: 1,
+        id: "user/dataset",
+        author: "user",
+        url: "https://huggingface.co/datasets/user/dataset",
+        downloads: 10000,
+        likes: 500,
+        trendingScore: 95.0,
+        tags: ["text", "english"],
+      },
+    ],
+  };
+  const events = huggingfaceDatasetsToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.huggingface.datasets");
+});
+
+test("npmPackagesToEvents — emits one event per package, captures linkedRepo", () => {
+  const payload = {
+    packages: [
+      {
+        name: "react",
+        npmUrl: "https://www.npmjs.com/package/react",
+        description: "React",
+        latestVersion: "18.0.0",
+        publishedAt: "2026-05-01",
+        repositoryUrl: "https://github.com/facebook/react",
+        linkedRepo: "facebook/react",
+        homepage: "https://react.dev",
+        downloads: { weekly: 20000000 },
+        keywords: ["react", "library"],
+      },
+    ],
+  };
+  const events = npmPackagesToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.npm.packages");
+  assert.equal(events[0].target_url, "https://www.npmjs.com/package/react");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("linked_repo"));
+  assert.ok(keys.includes("repository_url"));
+  assert.ok(keys.includes("downloads"));
+});
+
+test("openaiRssToEvents — emits one event per RSS item", () => {
+  const payload = {
+    items: [
+      {
+        id: "openai-1",
+        title: "Introducing GPT-5",
+        url: "https://openai.com/blog/gpt-5",
+        summary: "We're announcing GPT-5...",
+        publishedAt: "2026-05-12T00:00:00Z",
+        author: "OpenAI",
+        category: "announcement",
+        source: "openai.com",
+      },
+    ],
+  };
+  const events = openaiRssToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "content.openai.announcements");
+  assert.equal(events[0].target_url, "https://openai.com/blog/gpt-5");
 });
 
 test("postToolboxEvents — returns skipped when env unset", async () => {

--- a/scripts/_toolbox-ingest.mjs
+++ b/scripts/_toolbox-ingest.mjs
@@ -296,27 +296,227 @@ export function devtoMentionsToEvents(payload) {
 }
 
 /**
+ * Transform trendingrepo Product Hunt launches payload → TOOLBOX events.
+ *
+ * One event per launch, signal_type=`trending.producthunt.launches`.
+ * Target URL is the launch's product page URL (or website if available).
+ */
+export function producthuntLaunchesToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const launches = payload.launches;
+  if (!Array.isArray(launches)) return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const launch of launches) {
+    if (!launch || typeof launch !== "object") continue;
+    const targetUrl = String(launch.url ?? launch.website ?? "");
+    if (!targetUrl || !/^https?:\/\//i.test(targetUrl)) continue;
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "trending.producthunt.launches",
+      normalized: [
+        { key: "id", value: launch.id ?? null, confidence: 1.0 },
+        { key: "name", value: launch.name ?? "", confidence: 1.0 },
+        { key: "tagline", value: launch.tagline ?? "", confidence: 1.0 },
+        { key: "votes_count", value: launch.votesCount ?? 0, confidence: 1.0 },
+        { key: "comments_count", value: launch.commentsCount ?? 0, confidence: 1.0 },
+        { key: "created_at", value: launch.createdAt ?? "", confidence: 1.0 },
+        ...(launch.topics ? [{ key: "topics", value: launch.topics, confidence: 1.0 }] : []),
+        ...(launch.makers ? [{ key: "makers", value: launch.makers, confidence: 1.0 }] : []),
+        ...(launch.thumbnail ? [{ key: "thumbnail", value: launch.thumbnail, confidence: 1.0 }] : []),
+      ],
+      produced_by: `${PRODUCED_BY}-producthunt`,
+      produced_at: producedAt,
+    });
+  }
+  return events;
+}
+
+/**
+ * Generic HuggingFace transformer used by models/spaces/datasets variants.
+ */
+function huggingfaceToEvents(payload, kind, cap = 100) {
+  if (!payload || typeof payload !== "object") return [];
+  const items = payload[kind];
+  if (!Array.isArray(items)) return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const signalType = `trending.huggingface.${kind}`;
+  const events = [];
+
+  for (const item of items.slice(0, cap)) {
+    if (!item || typeof item !== "object") continue;
+    const targetUrl = String(item.url ?? "");
+    if (!targetUrl || !/^https?:\/\//i.test(targetUrl)) continue;
+
+    const normalized = [
+      { key: "id", value: item.id ?? "", confidence: 1.0 },
+      { key: "rank", value: item.rank ?? null, confidence: 1.0 },
+      { key: "author", value: item.author ?? "", confidence: 1.0 },
+      { key: "likes", value: item.likes ?? 0, confidence: 1.0 },
+      { key: "trending_score", value: item.trendingScore ?? 0, confidence: 1.0 },
+    ];
+    if (typeof item.downloads === "number") {
+      normalized.push({ key: "downloads", value: item.downloads, confidence: 1.0 });
+    }
+    if (item.pipelineTag) {
+      normalized.push({ key: "pipeline_tag", value: item.pipelineTag, confidence: 1.0 });
+    }
+    if (item.sdk) {
+      normalized.push({ key: "sdk", value: item.sdk, confidence: 1.0 });
+    }
+    if (Array.isArray(item.tags) && item.tags.length > 0) {
+      normalized.push({ key: "tags", value: item.tags.slice(0, 20), confidence: 1.0 });
+    }
+    if (Array.isArray(item.models) && item.models.length > 0) {
+      normalized.push({ key: "models", value: item.models.slice(0, 10), confidence: 1.0 });
+    }
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: signalType,
+      normalized,
+      produced_by: `${PRODUCED_BY}-huggingface`,
+      produced_at: producedAt,
+    });
+  }
+  return events;
+}
+
+export function huggingfaceModelsToEvents(payload) {
+  return huggingfaceToEvents(payload, "models", 100);
+}
+export function huggingfaceSpacesToEvents(payload) {
+  return huggingfaceToEvents(payload, "spaces", 50);
+}
+export function huggingfaceDatasetsToEvents(payload) {
+  return huggingfaceToEvents(payload, "datasets", 50);
+}
+
+/**
+ * Transform trendingrepo npm packages payload → TOOLBOX events.
+ *
+ * One event per package, target=npmjs URL; linkedRepo captured as normalized.
+ */
+export function npmPackagesToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const packages = payload.packages;
+  if (!Array.isArray(packages)) return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const pkg of packages) {
+    if (!pkg || typeof pkg !== "object") continue;
+    const targetUrl = String(pkg.npmUrl ?? "");
+    if (!targetUrl || !/^https?:\/\//i.test(targetUrl)) continue;
+
+    const normalized = [
+      { key: "name", value: pkg.name ?? "", confidence: 1.0 },
+      { key: "latest_version", value: pkg.latestVersion ?? "", confidence: 1.0 },
+      { key: "published_at", value: pkg.publishedAt ?? "", confidence: 1.0 },
+      { key: "description", value: pkg.description ?? "", confidence: 1.0 },
+    ];
+    if (pkg.repositoryUrl) normalized.push({ key: "repository_url", value: pkg.repositoryUrl, confidence: 1.0 });
+    if (pkg.linkedRepo) normalized.push({ key: "linked_repo", value: pkg.linkedRepo, confidence: 1.0 });
+    if (pkg.homepage) normalized.push({ key: "homepage", value: pkg.homepage, confidence: 1.0 });
+    if (pkg.downloads) normalized.push({ key: "downloads", value: pkg.downloads, confidence: 1.0 });
+    if (Array.isArray(pkg.keywords) && pkg.keywords.length > 0) {
+      normalized.push({ key: "keywords", value: pkg.keywords.slice(0, 20), confidence: 1.0 });
+    }
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "trending.npm.packages",
+      normalized,
+      produced_by: `${PRODUCED_BY}-npm`,
+      produced_at: producedAt,
+    });
+  }
+  return events;
+}
+
+/**
+ * Transform OpenAI RSS items → TOOLBOX events.
+ *
+ * One event per RSS item, target=canonical article URL on openai.com.
+ */
+export function openaiRssToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const items = payload.items;
+  if (!Array.isArray(items)) return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const targetUrl = String(item.url ?? "");
+    if (!targetUrl || !/^https?:\/\//i.test(targetUrl)) continue;
+
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "content.openai.announcements",
+      normalized: [
+        { key: "id", value: item.id ?? "", confidence: 1.0 },
+        { key: "title", value: item.title ?? "", confidence: 1.0 },
+        { key: "summary", value: (item.summary ?? "").slice(0, 1000), confidence: 1.0 },
+        { key: "published_at", value: item.publishedAt ?? "", confidence: 1.0 },
+        { key: "author", value: item.author ?? "", confidence: 1.0 },
+        { key: "category", value: item.category ?? "", confidence: 1.0 },
+        { key: "source", value: item.source ?? "openai.com", confidence: 1.0 },
+      ],
+      produced_by: `${PRODUCED_BY}-openai-rss`,
+      produced_at: producedAt,
+    });
+  }
+  return events;
+}
+
+/**
  * Convenience wrappers — transform + POST in one call. Use these from scrape
  * scripts after the primary data store write succeeds.
  */
 export async function ingestHnMentionsToToolbox(payload) {
-  const events = hnMentionsToEvents(payload);
-  return postToolboxEvents(events);
+  return postToolboxEvents(hnMentionsToEvents(payload));
 }
-
 export async function ingestRedditMentionsToToolbox(payload) {
-  const events = redditMentionsToEvents(payload);
-  return postToolboxEvents(events);
+  return postToolboxEvents(redditMentionsToEvents(payload));
 }
-
 export async function ingestBskyMentionsToToolbox(payload) {
-  const events = bskyMentionsToEvents(payload);
-  return postToolboxEvents(events);
+  return postToolboxEvents(bskyMentionsToEvents(payload));
 }
-
 export async function ingestDevtoMentionsToToolbox(payload) {
-  const events = devtoMentionsToEvents(payload);
-  return postToolboxEvents(events);
+  return postToolboxEvents(devtoMentionsToEvents(payload));
+}
+export async function ingestProducthuntLaunchesToToolbox(payload) {
+  return postToolboxEvents(producthuntLaunchesToEvents(payload));
+}
+export async function ingestHuggingfaceModelsToToolbox(payload) {
+  return postToolboxEvents(huggingfaceModelsToEvents(payload));
+}
+export async function ingestHuggingfaceSpacesToToolbox(payload) {
+  return postToolboxEvents(huggingfaceSpacesToEvents(payload));
+}
+export async function ingestHuggingfaceDatasetsToToolbox(payload) {
+  return postToolboxEvents(huggingfaceDatasetsToEvents(payload));
+}
+export async function ingestNpmPackagesToToolbox(payload) {
+  return postToolboxEvents(npmPackagesToEvents(payload));
+}
+export async function ingestOpenaiRssToToolbox(payload) {
+  return postToolboxEvents(openaiRssToEvents(payload));
 }
 
 /**

--- a/scripts/scrape-huggingface-datasets.mjs
+++ b/scripts/scrape-huggingface-datasets.mjs
@@ -30,6 +30,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestHuggingfaceDatasetsToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
@@ -149,8 +150,17 @@ async function main() {
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("huggingface-datasets", payload);
 
+  // Dual-write to TOOLBOX (`trending.huggingface.datasets`).
+  const toolboxResult = await ingestHuggingfaceDatasetsToToolbox(payload);
+
   log(`wrote ${OUT_PATH} [redis: ${redis.source}]`);
   log(`  ${ranked.length} trending datasets (skipped ${skipped} malformed)`);
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
   log(`  top 3: ${ranked.slice(0, 3).map((d) => d.id).join(", ")}`);
 }
 

--- a/scripts/scrape-huggingface-spaces.mjs
+++ b/scripts/scrape-huggingface-spaces.mjs
@@ -32,6 +32,7 @@ import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { extractGithubRepoFullNames } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestHuggingfaceSpacesToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
@@ -259,8 +260,17 @@ async function main() {
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("huggingface-spaces", payload);
 
+  // Dual-write to TOOLBOX (`trending.huggingface.spaces`).
+  const toolboxResult = await ingestHuggingfaceSpacesToToolbox(payload);
+
   log(`wrote ${OUT_PATH} [redis: ${redis.source}]`);
   log(`  ${ranked.length} trending spaces (skipped ${skipped} malformed)`);
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
   log(`  top 3: ${ranked.slice(0, 3).map((s) => s.id).join(", ")}`);
 }
 

--- a/scripts/scrape-huggingface.mjs
+++ b/scripts/scrape-huggingface.mjs
@@ -32,6 +32,7 @@ import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { extractGithubRepoFullNames } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestHuggingfaceModelsToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import {
@@ -274,8 +275,18 @@ async function main() {
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("huggingface-trending", payload);
 
+  // Dual-write to TOOLBOX (`trending.huggingface.models`, capped at 100).
+  const toolboxResult = await ingestHuggingfaceModelsToToolbox(payload);
+
   log(`wrote ${OUT_PATH} [redis: ${redis.source}]`);
   log(`  ${ranked.length} trending models`);
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
   log(`  top 3: ${ranked.slice(0, 3).map((m) => m.id).join(", ")}`);
 }
 

--- a/scripts/scrape-npm.mjs
+++ b/scripts/scrape-npm.mjs
@@ -26,6 +26,7 @@ import { fetchJsonWithRetry, HttpStatusError, sleep } from "./_fetch-json.mjs";
 import { extractUnknownRepoCandidates } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestNpmPackagesToToolbox } from "./_toolbox-ingest.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = resolve(__dirname, "..", "data");
@@ -565,8 +566,17 @@ export async function main({ log = console.log, fetchImpl = fetch } = {}) {
   // without waiting for a deploy.
   const result = await writeDataStore("npm-packages", payload);
 
+  // Dual-write to TOOLBOX (`trending.npm.packages`).
+  const toolboxResult = await ingestNpmPackagesToToolbox(payload);
+
   log(
     `wrote ${OUT} (${rows.length} top repo-linked npm packages) [redis: ${result.source}]`,
+  );
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
   );
 
   // F3 unknown-mentions lake — every github URL surfaced via npm package

--- a/scripts/scrape-openai-rss.mjs
+++ b/scripts/scrape-openai-rss.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 
 import { fetchFeed } from "./_rss-shared.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestOpenaiRssToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
@@ -67,6 +68,15 @@ async function main() {
     stampPerRecord: false,
   });
   log(`store write: ${writeResult.source} (${writeResult.writtenAt})`);
+
+  // Dual-write to TOOLBOX (`content.openai.announcements`).
+  const toolboxResult = await ingestOpenaiRssToToolbox(payload);
+  log(
+    `toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
 
   await closeDataStore();
 }

--- a/scripts/scrape-producthunt.mjs
+++ b/scripts/scrape-producthunt.mjs
@@ -41,6 +41,7 @@ import {
   recentRepoRows,
 } from "./_tracked-repos.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestProducthuntLaunchesToToolbox } from "./_toolbox-ingest.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -478,6 +479,17 @@ async function main() {
   await mkdir(DATA_DIR, { recursive: true });
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const launchesRedis = await writeDataStore("producthunt-launches", payload);
+
+  // Dual-write to TOOLBOX (`trending.producthunt.launches` per launch).
+  // Best-effort: skipped silently when env unset; 5s timeout per HTTP call.
+  const toolboxResult = await ingestProducthuntLaunchesToToolbox(payload);
+  console.log(
+    `[producthunt] toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
 
   const aiCount = launches.filter((l) => l.aiAdjacent).length;
   const linkedCount = launches.filter((l) => l.linkedRepo).length;


### PR DESCRIPTION
## Summary

Extends PRs #1019 / #1025 dual-write pattern across 6 more trendingrepo sources. trendingrepo now mirrors **10 sources** to the TOOLBOX signal lake.

## New TOOLBOX signal types (toolbox SDK v0.0.15-nogh, deployed)

- `trending.producthunt.launches`
- `trending.huggingface.models`
- `trending.huggingface.spaces`
- `trending.huggingface.datasets`
- `trending.npm.packages`
- `content.openai.announcements`

## E2E verified 2026-05-12 ~06:05 UTC

| Source | POSTed | Accepted | Rejected |
|---|---|---|---|
| producthunt | 50 | 50 | 0 |
| HF models | 100 (capped from 1000) | 100 | 0 |
| HF spaces | 50 | 50 | 0 |
| HF datasets | 50 | 50 | 0 |
| npm | 50 | 50 | 0 |
| openai-rss | 30 | 30 | 0 |
| **Total** | **330** | **330** | **0** |

15/15 unit tests pass.

## Follow-up

GHA workflow env wiring for these 6 sources will land in next PR. Secrets already exist on repo from PRs #1019 + #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)