### PR TITLE
ci(scrape): pass TOOLBOX_INGEST_* secrets to 6 batch3 scrape workflows

### DIFF
--- a/.github/workflows/scrape-huggingface-datasets.yml
+++ b/.github/workflows/scrape-huggingface-datasets.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Refresh HuggingFace trending datasets
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX (trending.huggingface.datasets).
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-huggingface-datasets.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-huggingface-spaces.yml
+++ b/.github/workflows/scrape-huggingface-spaces.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Refresh HuggingFace trending spaces
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX (trending.huggingface.spaces).
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-huggingface-spaces.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-huggingface.yml
+++ b/.github/workflows/scrape-huggingface.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Refresh HuggingFace trending models
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX (trending.huggingface.models).
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-huggingface.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-npm.yml
+++ b/.github/workflows/scrape-npm.yml
@@ -35,6 +35,11 @@ jobs:
         run: npm ci
 
       - name: Scrape npm packages
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX (trending.npm.packages).
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-npm.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-openai-rss.yml
+++ b/.github/workflows/scrape-openai-rss.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Refresh OpenAI news RSS
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX (content.openai.announcements).
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-openai-rss.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-producthunt.yml
+++ b/.github/workflows/scrape-producthunt.yml
@@ -37,6 +37,9 @@ jobs:
           PRODUCTHUNT_TOKEN: ${{ secrets.PRODUCTHUNT_TOKEN }}
           PRODUCTHUNT_TOKENS: ${{ secrets.PRODUCTHUNT_TOKENS }}
           GITHUB_TOKEN: ${{ github.token }}
+          # Dual-write to TOOLBOX (trending.producthunt.launches).
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-producthunt.mjs
 
       - name: Compute commit timestamp


### PR DESCRIPTION
Follow-up to PR #1031. Wires TOOLBOX env vars (already in repo secrets) into 6 cron workflows: producthunt + huggingface(x3) + npm + openai-rss. After merge, next cron tick on each fires dual-write automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)