### PR TITLE
fix(hn): keep leaderboard buckets consistent

### DIFF
--- a/scripts/scrape-hackernews.mjs
+++ b/scripts/scrape-hackernews.mjs
@@ -503,7 +503,29 @@ async function main() {
     mentionsPayload.leaderboard,
     { idKey: "fullName", scoreKey: "scoreSum7d", recencyKey: "count7d" },
   );
-  const mentionsPayloadFinal = { ...mentionsPayload, leaderboard: mergedLeaderboard };
+  const mergedMentions = {};
+  for (const row of mergedLeaderboard) {
+    const fullName = row?.fullName;
+    if (typeof fullName !== "string") continue;
+    const existingBucket = existingMentions?.mentions?.[fullName];
+    if (existingBucket) mergedMentions[fullName] = existingBucket;
+  }
+  Object.assign(mergedMentions, mentionsPayload.mentions);
+  const leaderboardWithBuckets = mergedLeaderboard.filter((row) => {
+    const fullName = row?.fullName;
+    return typeof fullName === "string" && !!mergedMentions[fullName];
+  });
+  const mentionsPayloadFinal = {
+    ...mentionsPayload,
+    mentions: mergedMentions,
+    mentionsByRepoId: Object.fromEntries(
+      Object.entries(mergedMentions).map(([fullName, value]) => [
+        slugIdFromFullName(fullName),
+        value,
+      ]),
+    ),
+    leaderboard: leaderboardWithBuckets,
+  };
 
   await writeFile(TRENDING_OUT, JSON.stringify(trendingPayloadFinal, null, 2) + "\n", "utf8");
   await writeFile(MENTIONS_OUT, JSON.stringify(mentionsPayloadFinal, null, 2) + "\n", "utf8");

--- a/src/lib/hackernews.ts
+++ b/src/lib/hackernews.ts
@@ -210,8 +210,12 @@ export function getAllHnMentions(): Record<string, HnRepoMention> {
 }
 
 export function getHnLeaderboard(): HnLeaderboardEntry[] {
-  // The on-disk file is already sorted by the scraper. Surface as-is.
-  return mentionsFile.leaderboard;
+  // Keep stale keep-last-50 leaderboard rows from surfacing without a
+  // corresponding mention bucket. The scraper also preserves this invariant
+  // on new writes, but the loader has to tolerate already-committed snapshots.
+  return mentionsFile.leaderboard.filter((row) =>
+    mentionsByLowerName.has(row.fullName.toLowerCase()),
+  );
 }
 
 export function hnItemHref(id: number): string {

--- a/src/lib/pipeline/__tests__/hackernews-view.test.ts
+++ b/src/lib/pipeline/__tests__/hackernews-view.test.ts
@@ -46,6 +46,17 @@ test("getHnLeaderboard returns rows sorted by scoreSum7d desc", () => {
   }
 });
 
+test("getHnLeaderboard only returns rows with mention buckets", () => {
+  const rows = getHnLeaderboard();
+  assert.ok(rows.length > 0, "leaderboard should be non-empty");
+  for (const row of rows) {
+    assert.ok(
+      getHnMentions(row.fullName),
+      `expected ${row.fullName} to have a matching mention bucket`,
+    );
+  }
+});
+
 test("getHnTopStories(10) returns ≤10 stories sorted by trendingScore desc, all with id defined", () => {
   const stories = getHnTopStories(10);
   assert.ok(stories.length <= 10, "should return at most 10 stories");


### PR DESCRIPTION
## Summary
- Filter HN leaderboards at read time so stale keep-last-50 rows without mention buckets do not surface.
- Merge/preserve HN mention buckets alongside merged leaderboard rows in the scraper, then drop rows that still lack a bucket.
- Add a regression test proving every surfaced HN leaderboard row resolves via getHnMentions().

## Validation
- npm run typecheck
- npm run lint:guards
- npm test
- npm run build
- git diff --check
- node --test scripts/__tests__/scrape-hackernews.test.mjs
- node --test scripts/__tests__/toolbox-ingest.test.mjs
- npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/pipeline/__tests__/hackernews-view.test.ts

## Notes
- npm audit --audit-level=high still reports pre-existing dependency advisories in next, drizzle-orm, and Storybook transitive dependencies. Not bundled into this CI hotfix.