### PR TITLE
feat(scrape): batch4 dual-write to TOOLBOX (deltas, OSSInsight, npm-deps, funding+SEC)

### DIFF
--- a/scripts/__tests__/toolbox-ingest.test.mjs
+++ b/scripts/__tests__/toolbox-ingest.test.mjs
@@ -11,6 +11,11 @@ import {
   huggingfaceDatasetsToEvents,
   npmPackagesToEvents,
   openaiRssToEvents,
+  deltasToEvents,
+  ossInsightTrendingToEvents,
+  npmDependentsToEvents,
+  fundingNewsToEvents,
+  fundingSecFormdToEvents,
   postToolboxEvents,
 } from "../_toolbox-ingest.mjs";
 
@@ -352,4 +357,223 @@ test("postToolboxEvents — returns skipped on empty events array", async () => 
     delete process.env.TOOLBOX_INGEST_URL;
     delete process.env.TOOLBOX_INGEST_HMAC_SECRET;
   }
+});
+
+// --- batch4: deltas, ossinsight-trending, npm-dependents, funding-news, sec-form-d ---
+
+const FAKE_DELTAS_PAYLOAD = {
+  computedAt: "2026-05-12T07:00:00Z",
+  windows: ["1h", "24h", "7d", "30d"],
+  repos: {
+    "10270250": {
+      stars_now: 235000,
+      delta_1h: { value: 4, basis: "exact" },
+      delta_24h: { value: 80, basis: "exact" },
+      delta_7d: { value: 600, basis: "nearest" },
+      delta_30d: { value: 2400, basis: "nearest" },
+    },
+    "9999999": {
+      stars_now: 100,
+      delta_1h: { value: 0, basis: "nearest" },
+    },
+  },
+};
+
+// Mirrors production data/repo-metadata.json shape (items[] with githubId+fullName).
+const FAKE_REPO_METADATA = {
+  fetchedAt: "2026-05-12T07:00:00Z",
+  sourceCount: 1,
+  items: [
+    { githubId: 10270250, fullName: "facebook/react" },
+    // 9999999 deliberately not in metadata — should be skipped
+  ],
+};
+
+// Also test the legacy `{ repos: [{ id, full_name }] }` shape for backward-compat.
+const FAKE_REPO_METADATA_LEGACY = {
+  repos: [{ id: 10270250, full_name: "facebook/react" }],
+};
+
+test("deltasToEvents — emits stars-velocity event per mapped repo", () => {
+  const events = deltasToEvents(FAKE_DELTAS_PAYLOAD, FAKE_REPO_METADATA);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "trending.github.stars.velocity");
+  assert.equal(events[0].target_url, "https://github.com/facebook/react");
+  assert.equal(events[0].produced_by, "trendingrepo-deltas");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("stars_now"));
+  assert.ok(keys.includes("delta_24h"));
+  // Confidence 1.0 for exact basis, 0.7 for nearest.
+  const d24 = events[0].normalized.find((n) => n.key === "delta_24h");
+  assert.equal(d24.confidence, 1.0);
+  const d7 = events[0].normalized.find((n) => n.key === "delta_7d");
+  assert.equal(d7.confidence, 0.7);
+});
+
+test("deltasToEvents — skips repos missing from metadata", () => {
+  const events = deltasToEvents(FAKE_DELTAS_PAYLOAD, FAKE_REPO_METADATA);
+  // Only 10270250 is mapped; 9999999 is dropped.
+  assert.equal(events.filter((e) => e.signal_type === "trending.github.stars.velocity").length, 1);
+});
+
+test("deltasToEvents — emits fork-velocity event when forks_now present", () => {
+  const payload = {
+    repos: {
+      "10270250": {
+        stars_now: 100,
+        forks_now: 50,
+        fork_delta_24h: { value: 5 },
+      },
+    },
+  };
+  const events = deltasToEvents(payload, FAKE_REPO_METADATA);
+  assert.equal(events.length, 2);
+  const fork = events.find((e) => e.signal_type === "trending.github.fork.velocity");
+  assert.ok(fork);
+  const keys = fork.normalized.map((n) => n.key);
+  assert.ok(keys.includes("forks_now"));
+  assert.ok(keys.includes("fork_delta_24h"));
+});
+
+test("deltasToEvents — returns empty on missing payload or metadata", () => {
+  assert.deepEqual(deltasToEvents(null, FAKE_REPO_METADATA), []);
+  assert.deepEqual(deltasToEvents(FAKE_DELTAS_PAYLOAD, null), []);
+});
+
+test("deltasToEvents — accepts legacy { repos: [{ id, full_name }] } shape", () => {
+  const events = deltasToEvents(FAKE_DELTAS_PAYLOAD, FAKE_REPO_METADATA_LEGACY);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].target_url, "https://github.com/facebook/react");
+});
+
+test("ossInsightTrendingToEvents — flattens buckets, dedupes by repo", () => {
+  const payload = {
+    buckets: {
+      past_24_hours: {
+        All: [
+          { repo_name: "vercel/next.js", stars: 130000, total_score: 99 },
+          { repo_name: "ollama/ollama", stars: 90000, total_score: 88 },
+        ],
+        TypeScript: [
+          { repo_name: "vercel/next.js", stars: 130000, total_score: 95 },
+        ],
+      },
+      past_week: {
+        All: [
+          { repo_name: "vercel/next.js", stars: 130001, total_score: 70 },
+        ],
+      },
+    },
+  };
+  const events = ossInsightTrendingToEvents(payload);
+  // 2 unique repos.
+  assert.equal(events.length, 2);
+  assert.equal(events[0].signal_type, "trending.github.repos");
+  // next.js should appear first (3 appearances vs 1 for ollama).
+  assert.ok(events[0].target_url.endsWith("vercel/next.js"));
+  const appearances = events[0].normalized.find((n) => n.key === "appearances_count").value;
+  assert.equal(appearances, 3);
+});
+
+test("ossInsightTrendingToEvents — caps at 200 unique repos", () => {
+  const buckets = { past_24_hours: { All: [] } };
+  for (let i = 0; i < 300; i++) {
+    buckets.past_24_hours.All.push({
+      repo_name: `owner${i}/repo${i}`,
+      stars: 1000 - i,
+      total_score: 100 - i,
+    });
+  }
+  const events = ossInsightTrendingToEvents({ buckets });
+  assert.equal(events.length, 200);
+});
+
+test("npmDependentsToEvents — emits one event per package, skips null counts", () => {
+  const payload = {
+    fetchedAt: "2026-05-12T07:00:00Z",
+    dependents: {
+      "react": { count: 250000, fetchedAt: "2026-05-12T06:00:00Z" },
+      "lodash": { count: null }, // skipped
+      "express": { count: 80000 },
+    },
+  };
+  const events = npmDependentsToEvents(payload);
+  assert.equal(events.length, 2);
+  const react = events.find((e) => e.target_url.endsWith("/react"));
+  assert.ok(react);
+  assert.equal(react.signal_type, "trending.npm.dependents");
+  assert.equal(react.target_url, "https://www.npmjs.com/package/react");
+  assert.equal(react.produced_by, "trendingrepo-npm-dependents");
+  const dc = react.normalized.find((n) => n.key === "dependents_count");
+  assert.equal(dc.value, 250000);
+});
+
+test("fundingNewsToEvents — emits one event per signal + cross-link to GitHub", () => {
+  const payload = {
+    signals: [
+      {
+        id: "fn-1",
+        headline: "Acme raises $20M",
+        sourceUrl: "https://techcrunch.com/2026/05/12/acme-series-a",
+        publishedAt: "2026-05-12T00:00:00Z",
+        sourcePlatform: "techcrunch",
+        extracted: {
+          company: "Acme",
+          stage: "Series A",
+          amountUsd: 20_000_000,
+          investors: ["Sequoia", "a16z"],
+          githubUrl: "https://github.com/acme/acme",
+        },
+      },
+      {
+        id: "fn-2",
+        headline: "Beta seed round",
+        sourceUrl: "https://news.example/beta-seed",
+        publishedAt: "2026-05-11T00:00:00Z",
+        sourcePlatform: "news",
+        extracted: {
+          company: "Beta",
+          stage: "Seed",
+          amountUsd: 1_500_000,
+          investors: ["Y Combinator"],
+        },
+      },
+    ],
+  };
+  const events = fundingNewsToEvents(payload);
+  // 2 signals, 1 has cross-link → 3 events.
+  assert.equal(events.length, 3);
+  assert.equal(events[0].signal_type, "funding.startup");
+  assert.equal(events[0].target_url, "https://techcrunch.com/2026/05/12/acme-series-a");
+  // Cross-link event present.
+  const crossLink = events.find((e) => e.target_url === "https://github.com/acme/acme");
+  assert.ok(crossLink);
+  // Beta has no cross-link.
+  const beta = events.filter((e) => e.target_url.includes("beta-seed"));
+  assert.equal(beta.length, 1);
+});
+
+test("fundingSecFormdToEvents — emits one event per signal, no cross-link", () => {
+  const payload = {
+    signals: [
+      {
+        id: "sec-1",
+        headline: "Form D filed by Foo Inc",
+        sourceUrl: "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0001234567",
+        publishedAt: "2026-05-12T00:00:00Z",
+        extracted: {
+          company: "Foo Inc",
+          amountUsd: 5_000_000,
+          industryGroup: "SaaS",
+        },
+      },
+    ],
+  };
+  const events = fundingSecFormdToEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].signal_type, "funding.sec.formd");
+  assert.equal(events[0].produced_by, "trendingrepo-sec");
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("industry_group"));
+  assert.ok(keys.includes("amount_usd"));
 });

--- a/scripts/_toolbox-ingest.mjs
+++ b/scripts/_toolbox-ingest.mjs
@@ -485,6 +485,302 @@ export function openaiRssToEvents(payload) {
 }
 
 /**
+ * Transform compute-deltas data/deltas.json → TOOLBOX events.
+ *
+ * One event per repo for `trending.github.stars.velocity` (and a second one
+ * for `trending.github.fork.velocity` when fork data is present).
+ *
+ * `data/deltas.json` is keyed by GitHub repo ID (numeric); we resolve each ID
+ * to its `owner/name` via `data/repo-metadata.json` (already produced by
+ * scrape-trending). Repos missing from metadata are skipped.
+ *
+ * @param {object} payload         Output of compute-deltas.mjs (data/deltas.json)
+ * @param {object} repoMetadata    Output of scrape-trending (data/repo-metadata.json)
+ * @returns {Array<ToolboxEvent>}
+ */
+export function deltasToEvents(payload, repoMetadata) {
+  if (!payload || typeof payload !== "object") return [];
+  if (!payload.repos || typeof payload.repos !== "object") return [];
+  if (!repoMetadata || typeof repoMetadata !== "object") return [];
+
+  // Build id->fullName map. Production repo-metadata.json shape is
+  // `{ fetchedAt, sourceCount, items: [{ githubId, fullName, ... }, ...] }`.
+  // Tolerate `{ repos: [{ id, full_name }] }` + flat object shapes too.
+  const idToFullName = new Map();
+  let metaRepos;
+  if (Array.isArray(repoMetadata.items)) {
+    metaRepos = repoMetadata.items;
+  } else if (Array.isArray(repoMetadata.repos)) {
+    metaRepos = repoMetadata.repos;
+  } else {
+    metaRepos = Object.values(repoMetadata);
+  }
+  for (const r of metaRepos) {
+    if (!r || typeof r !== "object") continue;
+    const id = r.githubId ?? r.id ?? r.repoId;
+    const fullName = r.fullName ?? r.full_name;
+    if (id != null && typeof fullName === "string" && fullName.includes("/")) {
+      idToFullName.set(String(id), fullName);
+    }
+  }
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const [repoId, deltas] of Object.entries(payload.repos)) {
+    if (!deltas || typeof deltas !== "object") continue;
+    const fullName = idToFullName.get(String(repoId));
+    if (!fullName) continue;
+    const targetUrl = `https://github.com/${fullName}`;
+
+    // Stars-velocity event (always emitted).
+    const starsNormalized = [
+      { key: "stars_now", value: deltas.stars_now ?? 0, confidence: 1.0 },
+    ];
+    for (const win of ["1h", "24h", "7d", "30d"]) {
+      const d = deltas[`delta_${win}`];
+      if (d && typeof d === "object") {
+        const conf = d.basis === "exact" ? 1.0 : d.basis === "nearest" ? 0.7 : 0.5;
+        starsNormalized.push({ key: `delta_${win}`, value: d.value ?? null, confidence: conf });
+        if (d.basis) starsNormalized.push({ key: `delta_${win}_basis`, value: d.basis, confidence: 1.0 });
+      }
+    }
+    events.push({
+      scan_id: scanId,
+      target_url: targetUrl,
+      signal_type: "trending.github.stars.velocity",
+      normalized: starsNormalized,
+      produced_by: `${PRODUCED_BY}-deltas`,
+      produced_at: producedAt,
+    });
+
+    // Fork-velocity event — only when forks_now is present (future-proof).
+    if (typeof deltas.forks_now === "number") {
+      const forkNormalized = [
+        { key: "forks_now", value: deltas.forks_now, confidence: 1.0 },
+      ];
+      for (const win of ["1h", "24h", "7d", "30d"]) {
+        const d = deltas[`fork_delta_${win}`];
+        if (d && typeof d === "object") {
+          forkNormalized.push({ key: `fork_delta_${win}`, value: d.value ?? null, confidence: 0.7 });
+        }
+      }
+      events.push({
+        scan_id: scanId,
+        target_url: targetUrl,
+        signal_type: "trending.github.fork.velocity",
+        normalized: forkNormalized,
+        produced_by: `${PRODUCED_BY}-deltas`,
+        produced_at: producedAt,
+      });
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Transform OSSInsight scrape-trending data/trending.json → TOOLBOX events.
+ *
+ * `data/trending.json` is `{ buckets: { period: { language: [rows...] } } }`.
+ * We flatten to one event per unique repo, with appearance metadata (which
+ * period+language buckets it ranked in, and where) in the normalized array.
+ *
+ * Cap to top 200 unique repos by appearance count to keep batch volume sane.
+ *
+ * @param {object} payload  Output of scrape-trending.mjs
+ * @returns {Array<ToolboxEvent>}
+ */
+export function ossInsightTrendingToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const buckets = payload.buckets;
+  if (!buckets || typeof buckets !== "object") return [];
+
+  const repoMap = new Map(); // fullName -> { stars, appearances: [...] }
+  for (const [period, langBuckets] of Object.entries(buckets)) {
+    if (!langBuckets || typeof langBuckets !== "object") continue;
+    for (const [language, rows] of Object.entries(langBuckets)) {
+      if (!Array.isArray(rows)) continue;
+      rows.forEach((row, idx) => {
+        if (!row || typeof row !== "object") return;
+        const fullName = String(row.repo_name ?? "");
+        if (!fullName.includes("/")) return;
+        if (!repoMap.has(fullName)) {
+          repoMap.set(fullName, { stars: 0, appearances: [] });
+        }
+        const entry = repoMap.get(fullName);
+        const stars = typeof row.stars === "number" ? row.stars : 0;
+        if (stars > entry.stars) entry.stars = stars;
+        entry.appearances.push({
+          period,
+          language,
+          rank: idx + 1,
+          total_score: row.total_score ?? 0,
+        });
+      });
+    }
+  }
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const sorted = [...repoMap.entries()]
+    .sort((a, b) => b[1].appearances.length - a[1].appearances.length)
+    .slice(0, 200);
+
+  return sorted.map(([fullName, info]) => ({
+    scan_id: scanId,
+    target_url: `https://github.com/${fullName}`,
+    signal_type: "trending.github.repos",
+    normalized: [
+      { key: "stars", value: info.stars, confidence: 1.0 },
+      { key: "appearances_count", value: info.appearances.length, confidence: 1.0 },
+      { key: "appearances_top10", value: info.appearances.slice(0, 10), confidence: 1.0 },
+    ],
+    produced_by: `${PRODUCED_BY}-ossinsight`,
+    produced_at: producedAt,
+  }));
+}
+
+/**
+ * Transform npm-daily dependents map → TOOLBOX events.
+ *
+ * Payload shape: `{ fetchedAt, dependents: { "<package>": { count, fetchedAt } } }`.
+ * One event per package with a non-null count; target = npmjs package URL.
+ *
+ * @param {object} payload  { fetchedAt: string, dependents: object }
+ * @returns {Array<ToolboxEvent>}
+ */
+export function npmDependentsToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const dependents = payload.dependents;
+  if (!dependents || typeof dependents !== "object") return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const [pkgName, info] of Object.entries(dependents)) {
+    if (!pkgName || typeof pkgName !== "string") continue;
+    if (!info || typeof info !== "object") continue;
+    if (typeof info.count !== "number") continue; // skip null/unknown
+
+    events.push({
+      scan_id: scanId,
+      target_url: `https://www.npmjs.com/package/${pkgName}`,
+      signal_type: "trending.npm.dependents",
+      normalized: [
+        { key: "package", value: pkgName, confidence: 1.0 },
+        { key: "dependents_count", value: info.count, confidence: 1.0 },
+        { key: "fetched_at", value: info.fetchedAt ?? payload.fetchedAt ?? "", confidence: 1.0 },
+      ],
+      produced_by: `${PRODUCED_BY}-npm-dependents`,
+      produced_at: producedAt,
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Transform funding-news payload → TOOLBOX events.
+ *
+ * Payload shape: `{ fetchedAt, source, windowDays, signals: [...] }` where
+ * each signal is `{ id, headline, sourceUrl, publishedAt, sourcePlatform,
+ * extracted: { company, stage, amountUsd, investors, githubUrl, ... } }`.
+ *
+ * Target_url = canonical news article URL. If `extracted.githubUrl` is
+ * present, ALSO emit a second event keyed off the github URL for
+ * cross-link joins downstream.
+ *
+ * @param {object} payload  Output of scrape-funding-news.mjs
+ * @returns {Array<ToolboxEvent>}
+ */
+export function fundingNewsToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const signals = payload.signals;
+  if (!Array.isArray(signals)) return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+  const events = [];
+
+  for (const sig of signals) {
+    if (!sig || typeof sig !== "object") continue;
+    const sourceUrl = String(sig.sourceUrl ?? "");
+    if (!sourceUrl || !/^https?:\/\//i.test(sourceUrl)) continue;
+
+    const extracted = (sig.extracted && typeof sig.extracted === "object") ? sig.extracted : {};
+    const normalized = [
+      { key: "headline", value: sig.headline ?? "", confidence: 1.0 },
+      { key: "company", value: extracted.company ?? "", confidence: 0.9 },
+      { key: "round_stage", value: extracted.stage ?? "", confidence: 0.8 },
+      { key: "amount_usd", value: extracted.amountUsd ?? null, confidence: 0.8 },
+      { key: "investors", value: Array.isArray(extracted.investors) ? extracted.investors.slice(0, 20) : [], confidence: 0.7 },
+      { key: "published_at", value: sig.publishedAt ?? "", confidence: 1.0 },
+      { key: "source_platform", value: sig.sourcePlatform ?? "", confidence: 1.0 },
+    ];
+
+    const baseEvent = {
+      scan_id: scanId,
+      target_url: sourceUrl,
+      signal_type: "funding.startup",
+      normalized,
+      produced_by: `${PRODUCED_BY}-funding`,
+      produced_at: producedAt,
+    };
+    events.push(baseEvent);
+
+    // Cross-link to GitHub if present.
+    const githubUrl = extracted.githubUrl ?? extracted.linkedRepo;
+    if (typeof githubUrl === "string" && githubUrl.startsWith("https://github.com/")) {
+      events.push({ ...baseEvent, target_url: githubUrl });
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Transform SEC Form D filings payload → TOOLBOX events.
+ *
+ * Same shape as funding-news but signal_type=`funding.sec.formd` and the
+ * `extracted` carries `industryGroup` instead of investor lists. No GitHub
+ * cross-link (SEC filings rarely include repo URLs).
+ *
+ * @param {object} payload  Output of scrape-sec-form-d.mjs
+ * @returns {Array<ToolboxEvent>}
+ */
+export function fundingSecFormdToEvents(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  const signals = payload.signals;
+  if (!Array.isArray(signals)) return [];
+
+  const producedAt = new Date().toISOString();
+  const scanId = randomUUID();
+
+  return signals
+    .filter((sig) => sig && typeof sig === "object" && typeof sig.sourceUrl === "string" && /^https?:\/\//i.test(sig.sourceUrl))
+    .map((sig) => {
+      const extracted = (sig.extracted && typeof sig.extracted === "object") ? sig.extracted : {};
+      return {
+        scan_id: scanId,
+        target_url: sig.sourceUrl,
+        signal_type: "funding.sec.formd",
+        normalized: [
+          { key: "headline", value: sig.headline ?? "", confidence: 1.0 },
+          { key: "company", value: extracted.company ?? "", confidence: 0.9 },
+          { key: "amount_usd", value: extracted.amountUsd ?? null, confidence: 0.9 },
+          { key: "industry_group", value: extracted.industryGroup ?? "", confidence: 0.9 },
+          { key: "filing_date", value: sig.publishedAt ?? "", confidence: 1.0 },
+        ],
+        produced_by: `${PRODUCED_BY}-sec`,
+        produced_at: producedAt,
+      };
+    });
+}
+
+/**
  * Convenience wrappers — transform + POST in one call. Use these from scrape
  * scripts after the primary data store write succeeds.
  */
@@ -517,6 +813,21 @@ export async function ingestNpmPackagesToToolbox(payload) {
 }
 export async function ingestOpenaiRssToToolbox(payload) {
   return postToolboxEvents(openaiRssToEvents(payload));
+}
+export async function ingestDeltasToToolbox(payload, repoMetadata) {
+  return postToolboxEvents(deltasToEvents(payload, repoMetadata));
+}
+export async function ingestOssInsightTrendingToToolbox(payload) {
+  return postToolboxEvents(ossInsightTrendingToEvents(payload));
+}
+export async function ingestNpmDependentsToToolbox(payload) {
+  return postToolboxEvents(npmDependentsToEvents(payload));
+}
+export async function ingestFundingNewsToToolbox(payload) {
+  return postToolboxEvents(fundingNewsToEvents(payload));
+}
+export async function ingestFundingSecFormdToToolbox(payload) {
+  return postToolboxEvents(fundingSecFormdToEvents(payload));
 }
 
 /**

--- a/scripts/compute-deltas.mjs
+++ b/scripts/compute-deltas.mjs
@@ -23,12 +23,14 @@ import { execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestDeltasToToolbox } from "./_toolbox-ingest.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const TRENDING_PATH = resolve(ROOT, "data/trending.json");
 const TRENDING_REL = "data/trending.json";
 const OUT_PATH = resolve(ROOT, "data/deltas.json");
+const REPO_METADATA_PATH = resolve(ROOT, "data/repo-metadata.json");
 
 // Target windows. buffer_s bounds how far off a candidate commit may be
 // from `target = now - window` before we call it 'no-history'.
@@ -243,7 +245,30 @@ async function main() {
   // without waiting for a deploy.
   const result = await writeDataStore("deltas", payload);
 
+  // TOOLBOX dual-write: emit `trending.github.stars.velocity` (and
+  // `trending.github.fork.velocity` when fork data is present) per repo
+  // mapped via data/repo-metadata.json. Best-effort — env-unset = silent
+  // skip; failures never block the cron path.
+  let toolboxResult = { status: "skipped", reason: "no_metadata" };
+  try {
+    const repoMetaRaw = await readFile(REPO_METADATA_PATH, "utf8");
+    const repoMetadata = JSON.parse(repoMetaRaw);
+    toolboxResult = await ingestDeltasToToolbox(payload, repoMetadata);
+  } catch (err) {
+    toolboxResult = {
+      status: "skipped",
+      reason: `metadata_read_failed:${err?.code ?? err?.message ?? "unknown"}`,
+    };
+  }
+
   console.log(`wrote ${OUT_PATH} [redis: ${result.source}]`);
+  console.log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
   console.log(`repos: ${currentStars.size}`);
   for (const w of WINDOWS) {
     const c = coverage[w.key];

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -21,6 +21,7 @@ import { fetchArticleData } from "./_funding-article.mjs";
 import { extractGithubRepoFullNames, extractUnknownRepoCandidates } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestFundingNewsToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import { enrichInvestors } from "./_enrich-investors.mjs";
@@ -786,6 +787,7 @@ async function main() {
   // waiting for a deploy. Only mirror to Redis when the writer is targeting
   // the canonical OUT_PATH — preview/test outputs (--output=...) stay local.
   let redisInfo = "";
+  let toolboxInfo = "";
   if (outputPath === OUT_PATH) {
     const redisResult = await writeDataStore("funding-news", payload);
     if (redisResult.source !== "redis") {
@@ -794,6 +796,16 @@ async function main() {
       );
     }
     redisInfo = ` [redis: ${redisResult.source}]`;
+
+    // TOOLBOX dual-write: emit `funding.startup` per signal (+ GitHub
+    // cross-link when extracted.githubUrl present). Best-effort.
+    const toolboxResult = await ingestFundingNewsToToolbox(payload);
+    toolboxInfo =
+      ` [toolbox: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      `]`;
   }
 
   const extractedCount = allSignals.filter((s) => s.extracted !== null).length;
@@ -801,7 +813,7 @@ async function main() {
     (s) => s.extracted?.companyLogoUrl || s.extracted?.investorsEnriched?.length,
   ).length;
   console.log(
-    `[funding] wrote ${allSignals.length} signals (${extractedCount} with extraction, ${enrichedCount} enriched) to ${outputPath}${redisInfo}`,
+    `[funding] wrote ${allSignals.length} signals (${extractedCount} with extraction, ${enrichedCount} enriched) to ${outputPath}${redisInfo}${toolboxInfo}`,
   );
 
   // F3 unknown-mentions lake — every github URL surfaced in funding articles

--- a/scripts/scrape-npm-daily.mjs
+++ b/scripts/scrape-npm-daily.mjs
@@ -33,6 +33,7 @@ import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 import { fetchJsonWithRetry, HttpStatusError, sleep } from "./_fetch-json.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestNpmDependentsToToolbox } from "./_toolbox-ingest.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(__dirname, "..");
@@ -282,15 +283,27 @@ export async function main({ argv = process.argv.slice(2), log = console.log, fe
   // map without waiting for the next deploy. JSONL stays on disk for the
   // append-only history; only the dependents snapshot is small enough to
   // fit in Redis comfortably.
-  const dsResult = await writeDataStore("npm-dependents", {
+  const dependentsPayload = {
     fetchedAt: new Date().toISOString(),
     dependents,
-  });
+  };
+  const dsResult = await writeDataStore("npm-dependents", dependentsPayload);
+
+  // TOOLBOX dual-write: emit `trending.npm.dependents` per package.
+  // Best-effort — env-unset = silent skip; failures never block the cron path.
+  const toolboxResult = await ingestNpmDependentsToToolbox(dependentsPayload);
 
   const sizeJsonl = (await stat(OUT_JSONL)).size;
   const sizeDeps = (await stat(OUT_DEPENDENTS)).size;
   log(`wrote ${OUT_JSONL} (${sizeJsonl} bytes, ${existing.size} rows)`);
   log(`wrote ${OUT_DEPENDENTS} (${sizeDeps} bytes, ${Object.keys(dependents).length} packages) [redis: ${dsResult.source}]`);
+  log(
+    `  toolbox-ingest: ${toolboxResult.status}` +
+      (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+      (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+      (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+      (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+  );
   log(`done: ok=${ok} skipped=${skipped} failed=${failed}`);
   return { ok, skipped, failed };
 }

--- a/scripts/scrape-sec-form-d.mjs
+++ b/scripts/scrape-sec-form-d.mjs
@@ -57,6 +57,7 @@ import { writeFileSync, mkdirSync, existsSync } from "fs";
 
 import "./_load-env.mjs";
 import { writeDataStore } from "./_data-store-write.mjs";
+import { ingestFundingSecFormdToToolbox } from "./_toolbox-ingest.mjs";
 
 const PROJECT_ROOT = resolve(process.cwd());
 const DATA_DIR = resolve(PROJECT_ROOT, "data");
@@ -484,6 +485,16 @@ async function main() {
       );
     }
     console.log("[sec-form-d] redis write ok -> funding-news-sec");
+
+    // TOOLBOX dual-write: emit `funding.sec.formd` per Form D filing.
+    // Best-effort — env-unset = silent skip; failures never block.
+    const toolboxResult = await ingestFundingSecFormdToToolbox(payload);
+    console.log(
+      `[sec-form-d] toolbox-ingest: ${toolboxResult.status}` +
+        (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+        (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+        (toolboxResult.reason ? ` (${toolboxResult.reason})` : ""),
+    );
   }
 }
 

--- a/scripts/scrape-trending.mjs
+++ b/scripts/scrape-trending.mjs
@@ -8,6 +8,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { ingestOssInsightTrendingToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
 
@@ -282,6 +283,19 @@ async function main() {
       trendsLitePayload,
     );
     const hotRedis = await writeDataStore("hot-collections", hotCollectionsPayload);
+
+    // TOOLBOX dual-write: emit `trending.github.repos` for top 200 unique
+    // repos across all OSSInsight buckets. Best-effort — env-unset = silent
+    // skip; failures never block the cron path.
+    const toolboxResult = await ingestOssInsightTrendingToToolbox(trendsPayload);
+    console.log(
+      `  toolbox-ingest: ${toolboxResult.status}` +
+        (toolboxResult.accepted !== undefined ? ` accepted=${toolboxResult.accepted}` : "") +
+        (toolboxResult.rejected !== undefined && toolboxResult.rejected > 0 ? ` rejected=${toolboxResult.rejected}` : "") +
+        (toolboxResult.reason ? ` (${toolboxResult.reason})` : "") +
+        (toolboxResult.duration_ms !== undefined ? ` [${toolboxResult.duration_ms}ms]` : ""),
+    );
+
     traceEvent.writes.push(
       {
         key: "trending",


### PR DESCRIPTION
## What

Closes the trendingrepo→TOOLBOX dual-write loop for the remaining 4 sources via a single batch (mirrors the proven batch3 PR #1031 pattern).

**5 new transformers in `scripts/_toolbox-ingest.mjs`** producing 4 signal types:

| Transformer | TOOLBOX signal_type |
|---|---|
| `deltasToEvents` | `trending.github.stars.velocity` (+ `.fork.velocity` when present) |
| `ossInsightTrendingToEvents` | `trending.github.repos` |
| `npmDependentsToEvents` | `trending.npm.dependents` |
| `fundingNewsToEvents` | `funding.startup` (+ GitHub cross-link when extracted) |
| `fundingSecFormdToEvents` | `funding.sec.formd` |

**5 scripts wired** (insertion after primary `writeFile` + `writeDataStore`):

- `scripts/compute-deltas.mjs` (loads `data/repo-metadata.json` for repo_id→fullName mapping)
- `scripts/scrape-trending.mjs` (caps at top 200 unique repos across all OSSInsight buckets)
- `scripts/scrape-npm-daily.mjs` (after `npm-dependents.json` write)
- `scripts/scrape-funding-news.mjs` (only on canonical OUT_PATH; not on `--output=` test runs)
- `scripts/scrape-sec-form-d.mjs` (only on canonical OUT_PATH)

## Why

Bank the last 4 trendingrepo sources into the TOOLBOX signal lake. After this PR + the GHA env follow-up land, the **ATOMIC vision loop closes** — every meaningful trendingrepo signal lives in the canonical lake and downstream consumers (AISO, MCP, future external customers) can join freely.

Strategic value:
- **funding.startup + funding.sec.formd**: moat data; competitors don't have it
- **trending.github.repos**: base table for cross-source joins
- **stars/fork velocity**: the OG GitHub trending measure
- **npm.dependents**: npm equivalent of GitHub stars

Twitter (`social.x.mentions`) deferred — public Nitter pool is dead in 2026 and self-hosted Nitter requires Mirko-side guest token provisioning. Documented in memory `feedback_nitter_guest_accounts.md`.

## Verify

- `node --check` passes on all 6 modified files
- `node --test scripts/__tests__/toolbox-ingest.test.mjs` → **25/25 pass** (was 15; +10 new for batch4)
- Pattern matches PRs #1019/#1025/#1031: best-effort, env-unset = silent skip, 5s timeout, never throws back into the cron path
- TOOLBOX SDK already declares all 4 signal types (`crawl.pdf` + 4 batch4 types shipped via toolbox PR #33 / v0.0.16-nogh)

## Follow-ups

1. **Env PR (next)**: `ci/toolbox-env-batch4` adds `TOOLBOX_INGEST_URL` + `TOOLBOX_INGEST_HMAC_SECRET` to:
   - `.github/workflows/scrape-trending.yml` (covers compute-deltas + OSSInsight)
   - `.github/workflows/collect-funding.yml` (covers funding-news + SEC)
   - `.github/workflows/refresh-npm-downloads.yml`
2. **workflow_dispatch** to trigger and verify `toolbox-ingest: ok accepted=N` log lines
3. **TOOLBOX SQL probe** to confirm rows landing under each new signal_type