### PR TITLE
ci(scrape): pass TOOLBOX_INGEST_* to scrape-trending + collect-funding + new scrape-npm-daily.yml

### DIFF
--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -35,6 +35,11 @@ jobs:
       - run: npm run scrape:funding -- --sources ${{ github.event.inputs.sources || 'techcrunch,venturebeat,sifted,arstechnica,techeu,pymnts,bbc,wired,geekwire,eu-startups,siliconcanals,techstartups,techcrunch-ai,venturebeat-ai,ai-news,ai-business,the-decoder,marktechpost,unite-ai,analytics-india,mit-tech-review-ai,synced,prnewswire-vc,newcomer,ai-snake-oil,generative-value,import-ai' }} --enrich ${{ github.event.inputs.dry_run == 'true' && '--output .tmp/funding-preview.json' || '' }}
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX signal lake (funding.startup + GitHub
+          # cross-link when extracted.githubUrl present). Skipped silently
+          # when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
       # SEC Form D filings — every US private round files within 15 days,
       # EDGAR full-text search filters to AI-mentioning filings only.
       # Continues on error so a flaky EDGAR doesn't blank the funding-news
@@ -42,6 +47,9 @@ jobs:
       - run: npm run scrape:sec-form-d ${{ github.event.inputs.dry_run == 'true' && '-- --output=.tmp/sec-form-d-preview.json' || '' }}
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX signal lake (funding.sec.formd).
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         continue-on-error: true
       - if: github.event.inputs.dry_run != 'true'
         name: Install worker fetcher deps

--- a/.github/workflows/scrape-npm-daily.yml
+++ b/.github/workflows/scrape-npm-daily.yml
@@ -1,0 +1,47 @@
+name: Scrape npm dependents (daily)
+
+# Runs scripts/scrape-npm-daily.mjs every 6h. Produces:
+#   - .data/npm-daily.jsonl       (append-only history; deduped by package+date)
+#   - .data/npm-dependents.json   (snapshot map; mirrored to Redis + TOOLBOX)
+#
+# Pre-batch4 this script existed but had no GHA cron — manual / admin-API only.
+# Batch4 added a TOOLBOX dual-write to scrape-npm-daily.mjs, so we now wire a
+# cron so trending.npm.dependents flows continuously.
+
+on:
+  schedule:
+    - cron: "13 */6 * * *"   # every 6h at :13 (off-peak; npm registry is rate-limited)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-daily-refresh
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        # _data-store-write.mjs dynamic-imports `ioredis` when REDIS_URL is set.
+        run: npm ci
+
+      - name: Snapshot npm dependents + daily downloads
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX signal lake (trending.npm.dependents).
+          # Skipped silently when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
+        run: node scripts/scrape-npm-daily.mjs

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Refresh OSSInsight trending + hot collections
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX signal lake (trending.github.repos).
+          # Skipped silently when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/scrape-trending.mjs --skip-collection-rankings
 
       - name: Discover recent GitHub repos
@@ -86,6 +90,11 @@ jobs:
       - name: Compute deltas from git history
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          # Dual-write to TOOLBOX signal lake (trending.github.stars.velocity
+          # + trending.github.fork.velocity when present).
+          # Skipped silently when unset; never blocks the primary write.
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
         run: node scripts/compute-deltas.mjs
 
       - name: Snapshot star totals into rolling history (immediate-mode deltas)


### PR DESCRIPTION
## What

Wires `TOOLBOX_INGEST_URL` + `TOOLBOX_INGEST_HMAC_SECRET` env on the workflow steps whose scripts started dual-writing to TOOLBOX in #1038 (batch4):

| Workflow | Step | Producer |
|---|---|---|
| `scrape-trending.yml` | "Refresh OSSInsight trending + hot collections" | `trending.github.repos` |
| `scrape-trending.yml` | "Compute deltas from git history" | `trending.github.stars.velocity` (+ `.fork.velocity`) |
| `collect-funding.yml` | `scrape:funding` step | `funding.startup` |
| `collect-funding.yml` | `scrape:sec-form-d` step | `funding.sec.formd` |
| **NEW** `scrape-npm-daily.yml` (every 6h at :13 UTC) | runs `scripts/scrape-npm-daily.mjs` | `trending.npm.dependents` |

## Why

Without these env vars, the dual-write code added in #1038 will silent-skip with `reason=env_unset` — exactly the same fail-safe pattern as the prior batches.

The new `scrape-npm-daily.yml` workflow file is required because `scripts/scrape-npm-daily.mjs` had no GHA cron pre-batch4 (per `docs/AUDIT-2026-05-04.md` line 154 "callers: none found"). It was previously triggered only manually or via the admin scan API.

## Verify

- Pattern matches PRs #1020/#1027/#1032 — secrets passed as step-level env, no workflow-level env so other steps stay isolated
- Existing TOOLBOX secrets (`TOOLBOX_INGEST_URL`, `TOOLBOX_INGEST_HMAC_SECRET`) are already configured on `0motionguy/starscreener` per #1019/#1027/#1032
- After merge, will trigger workflow_dispatch on each of the 3 workflows + verify `toolbox-ingest: ok accepted=N` log lines + TOOLBOX SQL probe per signal_type

## Sequencing

- This PR ships the env wiring
- Next: trigger workflow_dispatch on each workflow
- Final DoD: TOOLBOX SQL `SELECT signal_type, count(*), max(produced_at) FROM tb_signals WHERE signal_type IN (...new types...) GROUP BY 1` returns rows for all 4 new signal types