### PR TITLE
fix(toolbox-ingest): strip null jsonb values + real funding field names (batch4 hotfix)

### DIFF
--- a/scripts/__tests__/toolbox-ingest.test.mjs
+++ b/scripts/__tests__/toolbox-ingest.test.mjs
@@ -508,7 +508,9 @@ test("npmDependentsToEvents — emits one event per package, skips null counts",
   assert.equal(dc.value, 250000);
 });
 
-test("fundingNewsToEvents — emits one event per signal + cross-link to GitHub", () => {
+test("fundingNewsToEvents — emits one event per signal + cross-link to GitHub (real shape)", () => {
+  // Mirrors production data/funding-news.json shape: extracted.companyName,
+  // extracted.amount, extracted.roundType (NOT company / amountUsd / stage).
   const payload = {
     signals: [
       {
@@ -518,10 +520,14 @@ test("fundingNewsToEvents — emits one event per signal + cross-link to GitHub"
         publishedAt: "2026-05-12T00:00:00Z",
         sourcePlatform: "techcrunch",
         extracted: {
-          company: "Acme",
-          stage: "Series A",
-          amountUsd: 20_000_000,
+          companyName: "Acme",
+          companyWebsite: "https://acme.example",
+          roundType: "Series A",
+          amount: 20,
+          amountDisplay: "$20M",
+          currency: "USD",
           investors: ["Sequoia", "a16z"],
+          confidence: "high",
           githubUrl: "https://github.com/acme/acme",
         },
       },
@@ -532,9 +538,9 @@ test("fundingNewsToEvents — emits one event per signal + cross-link to GitHub"
         publishedAt: "2026-05-11T00:00:00Z",
         sourcePlatform: "news",
         extracted: {
-          company: "Beta",
-          stage: "Seed",
-          amountUsd: 1_500_000,
+          companyName: "Beta",
+          roundType: "Seed",
+          amount: 1.5,
           investors: ["Y Combinator"],
         },
       },
@@ -551,9 +557,36 @@ test("fundingNewsToEvents — emits one event per signal + cross-link to GitHub"
   // Beta has no cross-link.
   const beta = events.filter((e) => e.target_url.includes("beta-seed"));
   assert.equal(beta.length, 1);
+  // Real keys present.
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("company"));
+  assert.ok(keys.includes("amount_usd"));
+  assert.ok(keys.includes("round_stage"));
+  assert.ok(keys.includes("currency"));
 });
 
-test("fundingSecFormdToEvents — emits one event per signal, no cross-link", () => {
+test("fundingNewsToEvents — null-valued fields are stripped (jsonb NOT NULL)", () => {
+  const payload = {
+    signals: [
+      {
+        sourceUrl: "https://news.example/x",
+        headline: "X raised some money",
+        publishedAt: "2026-05-12T00:00:00Z",
+        // extracted is missing entirely — only headline + published_at survive
+      },
+    ],
+  };
+  const events = fundingNewsToEvents(payload);
+  assert.equal(events.length, 1);
+  // headline + published_at; NO null amount_usd / company / etc.
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("headline"));
+  assert.ok(keys.includes("published_at"));
+  assert.ok(!keys.includes("amount_usd"));
+  assert.ok(!keys.includes("company"));
+});
+
+test("fundingSecFormdToEvents — emits one event per signal, no cross-link (real shape)", () => {
   const payload = {
     signals: [
       {
@@ -562,9 +595,13 @@ test("fundingSecFormdToEvents — emits one event per signal, no cross-link", ()
         sourceUrl: "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0001234567",
         publishedAt: "2026-05-12T00:00:00Z",
         extracted: {
-          company: "Foo Inc",
-          amountUsd: 5_000_000,
+          companyName: "Foo Inc",
+          amount: 5_000_000,
+          amountDisplay: "$5M",
+          currency: "USD",
+          roundType: "undisclosed",
           industryGroup: "SaaS",
+          confidence: "high",
         },
       },
     ],
@@ -576,4 +613,28 @@ test("fundingSecFormdToEvents — emits one event per signal, no cross-link", ()
   const keys = events[0].normalized.map((n) => n.key);
   assert.ok(keys.includes("industry_group"));
   assert.ok(keys.includes("amount_usd"));
+  assert.ok(keys.includes("currency"));
+  assert.ok(keys.includes("company"));
+});
+
+test("deltasToEvents — strips null delta values (jsonb NOT NULL)", () => {
+  const payload = {
+    repos: {
+      "10270250": {
+        stars_now: 100,
+        delta_1h: { value: null, basis: "repo-not-tracked" },
+        delta_24h: { value: 5, basis: "exact" },
+        // delta_7d / 30d missing entirely
+      },
+    },
+  };
+  const events = deltasToEvents(payload, FAKE_REPO_METADATA);
+  assert.equal(events.length, 1);
+  const keys = events[0].normalized.map((n) => n.key);
+  assert.ok(keys.includes("stars_now"));
+  assert.ok(keys.includes("delta_24h"));
+  // Null delta_1h.value gets stripped, but basis is still kept.
+  assert.ok(!keys.includes("delta_1h"));
+  assert.ok(keys.includes("delta_1h_basis"));
+  assert.ok(!keys.includes("delta_7d"));
 });

--- a/scripts/_toolbox-ingest.mjs
+++ b/scripts/_toolbox-ingest.mjs
@@ -34,6 +34,23 @@ const MAX_EVENTS_PER_BATCH = 500;
 const PRODUCED_BY = "trendingrepo";
 
 /**
+ * Push a normalized entry only if its value is non-null and non-undefined.
+ * Required because TOOLBOX `tb_signals.value` is `jsonb NOT NULL`. Sending a
+ * JS `null` materializes as SQL `NULL`, which fails the constraint and kills
+ * the whole event's persistence (single batch INSERT). Silent skip is correct
+ * because the missing field carries no information anyway.
+ */
+function pushNormalized(arr, key, value, confidence) {
+  if (value === null || value === undefined) return;
+  if (typeof value === "string" && value.length === 0) {
+    // Empty strings are OK — they materialize as JSON "" which is non-null.
+    arr.push({ key, value, confidence });
+    return;
+  }
+  arr.push({ key, value, confidence });
+}
+
+/**
  * Low-level: POST a batch of events to TOOLBOX. Never throws.
  *
  * @param {Array<ToolboxEvent>} events
@@ -534,46 +551,49 @@ export function deltasToEvents(payload, repoMetadata) {
     if (!fullName) continue;
     const targetUrl = `https://github.com/${fullName}`;
 
-    // Stars-velocity event (always emitted).
-    const starsNormalized = [
-      { key: "stars_now", value: deltas.stars_now ?? 0, confidence: 1.0 },
-    ];
+    // Stars-velocity event. Use pushNormalized to skip null delta values
+    // (basis="repo-not-tracked" / "no-history" entries); jsonb NOT NULL.
+    const starsNormalized = [];
+    pushNormalized(starsNormalized, "stars_now", deltas.stars_now ?? 0, 1.0);
     for (const win of ["1h", "24h", "7d", "30d"]) {
       const d = deltas[`delta_${win}`];
       if (d && typeof d === "object") {
         const conf = d.basis === "exact" ? 1.0 : d.basis === "nearest" ? 0.7 : 0.5;
-        starsNormalized.push({ key: `delta_${win}`, value: d.value ?? null, confidence: conf });
-        if (d.basis) starsNormalized.push({ key: `delta_${win}_basis`, value: d.basis, confidence: 1.0 });
+        pushNormalized(starsNormalized, `delta_${win}`, d.value, conf);
+        pushNormalized(starsNormalized, `delta_${win}_basis`, d.basis, 1.0);
       }
     }
-    events.push({
-      scan_id: scanId,
-      target_url: targetUrl,
-      signal_type: "trending.github.stars.velocity",
-      normalized: starsNormalized,
-      produced_by: `${PRODUCED_BY}-deltas`,
-      produced_at: producedAt,
-    });
-
-    // Fork-velocity event — only when forks_now is present (future-proof).
-    if (typeof deltas.forks_now === "number") {
-      const forkNormalized = [
-        { key: "forks_now", value: deltas.forks_now, confidence: 1.0 },
-      ];
-      for (const win of ["1h", "24h", "7d", "30d"]) {
-        const d = deltas[`fork_delta_${win}`];
-        if (d && typeof d === "object") {
-          forkNormalized.push({ key: `fork_delta_${win}`, value: d.value ?? null, confidence: 0.7 });
-        }
-      }
+    if (starsNormalized.length > 0) {
       events.push({
         scan_id: scanId,
         target_url: targetUrl,
-        signal_type: "trending.github.fork.velocity",
-        normalized: forkNormalized,
+        signal_type: "trending.github.stars.velocity",
+        normalized: starsNormalized,
         produced_by: `${PRODUCED_BY}-deltas`,
         produced_at: producedAt,
       });
+    }
+
+    // Fork-velocity event — only when forks_now is present (future-proof).
+    if (typeof deltas.forks_now === "number") {
+      const forkNormalized = [];
+      pushNormalized(forkNormalized, "forks_now", deltas.forks_now, 1.0);
+      for (const win of ["1h", "24h", "7d", "30d"]) {
+        const d = deltas[`fork_delta_${win}`];
+        if (d && typeof d === "object") {
+          pushNormalized(forkNormalized, `fork_delta_${win}`, d.value, 0.7);
+        }
+      }
+      if (forkNormalized.length > 0) {
+        events.push({
+          scan_id: scanId,
+          target_url: targetUrl,
+          signal_type: "trending.github.fork.velocity",
+          normalized: forkNormalized,
+          produced_by: `${PRODUCED_BY}-deltas`,
+          produced_at: producedAt,
+        });
+      }
     }
   }
 
@@ -685,15 +705,20 @@ export function npmDependentsToEvents(payload) {
 /**
  * Transform funding-news payload → TOOLBOX events.
  *
- * Payload shape: `{ fetchedAt, source, windowDays, signals: [...] }` where
- * each signal is `{ id, headline, sourceUrl, publishedAt, sourcePlatform,
- * extracted: { company, stage, amountUsd, investors, githubUrl, ... } }`.
+ * Production payload shape: `{ fetchedAt, signals: [...] }` where each signal is
+ * `{ id, headline, description, sourceUrl, sourcePlatform, publishedAt,
+ * discoveredAt, extracted: { companyName, companyWebsite, companyLogoUrl,
+ * amount, amountDisplay, currency, roundType, investors, investorsEnriched,
+ * confidence }, tags }`.
  *
- * Target_url = canonical news article URL. If `extracted.githubUrl` is
- * present, ALSO emit a second event keyed off the github URL for
- * cross-link joins downstream.
+ * Target_url = canonical news article URL. If a github URL is discoverable in
+ * the extracted block (rare in news but tolerated), ALSO emit a second event
+ * keyed off the github URL for cross-link joins downstream.
  *
- * @param {object} payload  Output of scrape-funding-news.mjs
+ * Uses pushNormalized to omit any null/undefined fields — tb_signals.value is
+ * jsonb NOT NULL.
+ *
+ * @param {object} payload  Output of scrape-funding-news.mjs (data/funding-news.json)
  * @returns {Array<ToolboxEvent>}
  */
 export function fundingNewsToEvents(payload) {
@@ -711,15 +736,27 @@ export function fundingNewsToEvents(payload) {
     if (!sourceUrl || !/^https?:\/\//i.test(sourceUrl)) continue;
 
     const extracted = (sig.extracted && typeof sig.extracted === "object") ? sig.extracted : {};
-    const normalized = [
-      { key: "headline", value: sig.headline ?? "", confidence: 1.0 },
-      { key: "company", value: extracted.company ?? "", confidence: 0.9 },
-      { key: "round_stage", value: extracted.stage ?? "", confidence: 0.8 },
-      { key: "amount_usd", value: extracted.amountUsd ?? null, confidence: 0.8 },
-      { key: "investors", value: Array.isArray(extracted.investors) ? extracted.investors.slice(0, 20) : [], confidence: 0.7 },
-      { key: "published_at", value: sig.publishedAt ?? "", confidence: 1.0 },
-      { key: "source_platform", value: sig.sourcePlatform ?? "", confidence: 1.0 },
-    ];
+    const normalized = [];
+    pushNormalized(normalized, "headline", sig.headline, 1.0);
+    pushNormalized(normalized, "company", extracted.companyName, 0.9);
+    pushNormalized(normalized, "company_website", extracted.companyWebsite, 0.8);
+    pushNormalized(normalized, "round_stage", extracted.roundType, 0.8);
+    pushNormalized(normalized, "amount_usd", extracted.amount, 0.8);
+    pushNormalized(normalized, "amount_display", extracted.amountDisplay, 0.8);
+    pushNormalized(normalized, "currency", extracted.currency, 0.9);
+    pushNormalized(
+      normalized,
+      "investors",
+      Array.isArray(extracted.investors) && extracted.investors.length > 0
+        ? extracted.investors.slice(0, 20)
+        : null,
+      0.7,
+    );
+    pushNormalized(normalized, "published_at", sig.publishedAt, 1.0);
+    pushNormalized(normalized, "source_platform", sig.sourcePlatform, 1.0);
+    pushNormalized(normalized, "extraction_confidence", extracted.confidence, 1.0);
+
+    if (normalized.length === 0) continue;
 
     const baseEvent = {
       scan_id: scanId,
@@ -731,7 +768,8 @@ export function fundingNewsToEvents(payload) {
     };
     events.push(baseEvent);
 
-    // Cross-link to GitHub if present.
+    // Cross-link to GitHub if discoverable. Tolerate two field names + a few
+    // common ways news scrapers might surface a repo URL.
     const githubUrl = extracted.githubUrl ?? extracted.linkedRepo;
     if (typeof githubUrl === "string" && githubUrl.startsWith("https://github.com/")) {
       events.push({ ...baseEvent, target_url: githubUrl });
@@ -744,11 +782,14 @@ export function fundingNewsToEvents(payload) {
 /**
  * Transform SEC Form D filings payload → TOOLBOX events.
  *
- * Same shape as funding-news but signal_type=`funding.sec.formd` and the
- * `extracted` carries `industryGroup` instead of investor lists. No GitHub
- * cross-link (SEC filings rarely include repo URLs).
+ * Production shape mirrors funding-news but `extracted` adds `industryGroup`
+ * (SEC's standardized industry classifier). No GitHub cross-link — SEC
+ * filings rarely include repo URLs.
  *
- * @param {object} payload  Output of scrape-sec-form-d.mjs
+ * Uses pushNormalized to omit any null/undefined fields — tb_signals.value is
+ * jsonb NOT NULL.
+ *
+ * @param {object} payload  Output of scrape-sec-form-d.mjs (data/funding-news-sec.json)
  * @returns {Array<ToolboxEvent>}
  */
 export function fundingSecFormdToEvents(payload) {
@@ -758,26 +799,38 @@ export function fundingSecFormdToEvents(payload) {
 
   const producedAt = new Date().toISOString();
   const scanId = randomUUID();
+  const events = [];
 
-  return signals
-    .filter((sig) => sig && typeof sig === "object" && typeof sig.sourceUrl === "string" && /^https?:\/\//i.test(sig.sourceUrl))
-    .map((sig) => {
-      const extracted = (sig.extracted && typeof sig.extracted === "object") ? sig.extracted : {};
-      return {
-        scan_id: scanId,
-        target_url: sig.sourceUrl,
-        signal_type: "funding.sec.formd",
-        normalized: [
-          { key: "headline", value: sig.headline ?? "", confidence: 1.0 },
-          { key: "company", value: extracted.company ?? "", confidence: 0.9 },
-          { key: "amount_usd", value: extracted.amountUsd ?? null, confidence: 0.9 },
-          { key: "industry_group", value: extracted.industryGroup ?? "", confidence: 0.9 },
-          { key: "filing_date", value: sig.publishedAt ?? "", confidence: 1.0 },
-        ],
-        produced_by: `${PRODUCED_BY}-sec`,
-        produced_at: producedAt,
-      };
+  for (const sig of signals) {
+    if (!sig || typeof sig !== "object") continue;
+    const sourceUrl = String(sig.sourceUrl ?? "");
+    if (!sourceUrl || !/^https?:\/\//i.test(sourceUrl)) continue;
+
+    const extracted = (sig.extracted && typeof sig.extracted === "object") ? sig.extracted : {};
+    const normalized = [];
+    pushNormalized(normalized, "headline", sig.headline, 1.0);
+    pushNormalized(normalized, "company", extracted.companyName, 0.9);
+    pushNormalized(normalized, "amount_usd", extracted.amount, 0.9);
+    pushNormalized(normalized, "amount_display", extracted.amountDisplay, 0.9);
+    pushNormalized(normalized, "currency", extracted.currency, 0.9);
+    pushNormalized(normalized, "round_stage", extracted.roundType, 0.8);
+    pushNormalized(normalized, "industry_group", extracted.industryGroup, 0.9);
+    pushNormalized(normalized, "filing_date", sig.publishedAt, 1.0);
+    pushNormalized(normalized, "extraction_confidence", extracted.confidence, 1.0);
+
+    if (normalized.length === 0) continue;
+
+    events.push({
+      scan_id: scanId,
+      target_url: sourceUrl,
+      signal_type: "funding.sec.formd",
+      normalized,
+      produced_by: `${PRODUCED_BY}-sec`,
+      produced_at: producedAt,
     });
+  }
+
+  return events;
 }
 
 /**


### PR DESCRIPTION
## Two bugs in batch4 (#1038)

### Bug 1: jsonb NOT NULL violation kills events

`tb_signals.value` is `jsonb NOT NULL`. The TOOLBOX api persists each event's normalized array as a single batched INSERT — when ANY entry has JS `null` value, drizzle materializes that as SQL NULL, the constraint fails, and the **whole event's batch INSERT aborts**.

**Symptoms in production after #1038 + #1040 merged:**
- `trending.github.stars.velocity`: only 790 rows landed (~25% of expected ~3,000) because compute-deltas had ~75% `repo-not-tracked` / `no-history` entries with null values
- `funding.startup`: **0 rows** despite 50 events POSTed (every event had `amount_usd: null` because of bug #2)

### Bug 2: funding-news + sec-form-d field-name drift

The transformer used speculative field names that don't exist in production data:

| Transformer used | Production actually has |
|---|---|
| `extracted.company` | `extracted.companyName` |
| `extracted.amountUsd` | `extracted.amount` |
| `extracted.stage` | `extracted.roundType` |

(Verified by eyeballing `data/funding-news.json` + `data/funding-news-sec.json` from origin/main.)

## Fix

- New `pushNormalized(arr, key, value, confidence)` helper at adapter top — skips when value is null/undefined; empty strings allowed (they're JSON `""`, non-null)
- `deltasToEvents`: use `pushNormalized` for every entry — skips repo-not-tracked / no-history null cases
- `fundingNewsToEvents`: real field names + `pushNormalized`. Adds bonus real fields: `company_website`, `currency`, `amount_display`, `extraction_confidence`
- `fundingSecFormdToEvents`: same shape + null-stripping

## Tests

- 25 → 27 (+2 new: `funding-null-stripped` + `deltas-null-stripped`)
- All existing tests updated to use real production field names
- `node --test` 27/27 pass

## Verify after merge

```bash
gh workflow run scrape-trending.yml -R 0motionguy/starscreener
gh workflow run collect-funding.yml -R 0motionguy/starscreener
# Wait ~10 min, then SQL probe:
ssh ...vultr... "docker exec ... psql ... -c \"SELECT signal_type, count(*), max(produced_at) FROM tb_signals \
  WHERE signal_type IN ('funding.startup','funding.sec.formd','trending.github.stars.velocity', \
                         'trending.github.fork.velocity','trending.github.repos','trending.npm.dependents') \
  GROUP BY 1 ORDER BY 1;\""
```

Expected: rows climb significantly (funding.startup from 0 → ~30+, stars.velocity from 790 → ~3,000+).