### PR TITLE
fix(scrape-npm-daily): real dependents count via ecosyste.ms

### DIFF
--- a/scripts/scrape-npm-daily.mjs
+++ b/scripts/scrape-npm-daily.mjs
@@ -119,23 +119,39 @@ async function fetchDailyDownloads(name, fetchImpl = fetch) {
   }
 }
 
-// Best-effort dependents count.
+// Best-effort dependents count via packages.ecosyste.ms.
 //
-// npm does not expose a stable public API for dependents counts. Options:
-//   1. registry.npmjs.org/-/v1/search?text=<name>&size=0 returns `total`
-//      but that's a full-text match count, not a true dependents count.
-//      It massively overcounts (any package mentioning the name matches).
-//   2. registry.npmjs.org/-/_view/dependedUpon?key=<name>  -> frequently 404
-//      in the public API; was removed from npm's replicate endpoint.
-//   3. api.npms.io/v2/package/<name> used to return a dependents number but
-//      the service is deprecated / unreliable.
+// npm itself has no stable public API for dependents counts. Every
+// first-party path is dead as of 2026:
+//   - registry.npmjs.org/-/_view/dependedUpon: removed from replicate
+//   - api.npms.io: deprecated and offline
+//   - api.npmjs.org/dependents/<name>: 404
+//   - www.npmjs.com/browse/depended/<name>: SPA-rendered, count lives
+//     in a client-side fetch, not in the static HTML
+//   - registry.npmjs.org/-/v1/search?text=<name>: normalized popularity
+//     score (0..1), not a count
 //
-// We attempt #2 (dependedUpon) and fall back to null on any failure.
-// Callers must treat `null` as "unknown, don't render" — NOT as zero.
+// Two third-party aggregators index npm:
+//   - libraries.io has a `dependents_count` field but rate-limits
+//     anonymous reads aggressively (~60 req/min) and 429s under
+//     normal cron volume on the free tier.
+//   - packages.ecosyste.ms exposes `dependent_packages_count` (npm
+//     packages depending on this one) without an API key and with
+//     no observed anonymous rate limit. ≤3s per call.
+//
+// We use ecosyste.ms. Encoding: the full package name goes in as a
+// single URL-encoded path segment (the path under /packages/ is
+// itself a segment, so "/" inside scoped names must be encoded).
+//
+// `0` maps to null because ecosyste.ms returns 0 for packages it hasn't
+// fully indexed yet (notably recently-published scoped names). The
+// downstream emission gate skips null rows, so we'd rather suppress a
+// few small / new packages than emit a misleading false-0 signal that
+// can't be distinguished from "truly unused".
+//
+// Callers must treat null as "unknown, don't render" — NOT as zero.
 async function fetchDependentsCount(name, fetchImpl = fetch) {
-  const url = `https://registry.npmjs.org/-/_view/dependedUpon?group_level=2&startkey=${encodeURIComponent(
-    JSON.stringify([name]),
-  )}&endkey=${encodeURIComponent(JSON.stringify([name, {}]))}`;
+  const url = `https://packages.ecosyste.ms/api/v1/registries/npmjs.org/packages/${encodeURIComponent(name)}`;
   try {
     const payload = await fetchJsonWithRetry(url, {
       fetchImpl,
@@ -144,16 +160,11 @@ async function fetchDependentsCount(name, fetchImpl = fetch) {
       timeoutMs: 15_000,
       headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
     });
-    const rows = Array.isArray(payload?.rows) ? payload.rows : [];
-    if (rows.length === 0) return null;
-    const total = rows.reduce(
-      (sum, row) => sum + Math.max(0, Number(row?.value) || 0),
-      0,
-    );
-    return total > 0 ? total : null;
-  } catch {
-    // TODO: consider scraping https://www.npmjs.com/browse/depended/<name>
-    // as a last resort, but that's fragile HTML parsing so we ship null.
+    const count = payload?.dependent_packages_count;
+    return typeof count === "number" && count > 0 ? count : null;
+  } catch (err) {
+    // 404 = ecosyste.ms hasn't indexed this package; not an error condition.
+    if (err instanceof HttpStatusError && err.status === 404) return null;
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Replace dead npm `_view/dependedUpon` lookup (404 since 2024) with `packages.ecosyste.ms` per-package query.
- Closes the upstream half of `trending.npm.dependents` — SDK declared the signal at toolbox v0.0.16-nogh; transformer was already null-filtering, so production rows were stuck at 0.
- 0 → null mapping in the fetch helper: ecosyste.ms returns 0 for un-indexed packages (notably very-new scoped names); treating 0 as null preserves the "unknown vs truly-zero" distinction at the emission gate.

## Why ecosyste.ms

| Source | Status | Notes |
|---|---|---|
| `registry.npmjs.org/-/_view/dependedUpon` | dead | 404 since 2024 — current code path |
| `api.npms.io` | dead | deprecated, offline |
| `api.npmjs.org/dependents/<name>` | dead | 404 |
| `www.npmjs.com/browse/depended/<name>` | SPA | count loaded client-side; not in HTML |
| `registry.npmjs.org/-/v1/search` | wrong shape | 0..1 popularity score, not a count |
| `libraries.io/api/npm/<name>` | rate-limited | 60 req/min anon → 429 under cron volume |
| **`packages.ecosyste.ms`** | ✅ works | no auth, no observed rate limit, ≤3s/call |

## Forward-test
Local smoke (4 packages, 750ms total):
- `lodash` → **159,122** dependents
- `next` → **8,463** (npm-side; ecosyste.ms separates package-deps from repo-deps)
- `react` → **275,174**
- `@anthropic-ai/claude-code` → **null** (ecosyste.ms hasn't yet indexed this scope — correctly suppressed instead of false-0)

`node --check scripts/scrape-npm-daily.mjs` → PASS.
No existing test covers `fetchDependentsCount` (the `scrape-npm.test.mjs` suite is for the sibling top-list scraper).

Production verify (post-merge, after next `scrape-npm-daily.yml` run):
\`\`\`sql
SELECT count(*), avg((value->>'count')::int)::int AS avg_dependents
FROM tb_signals
WHERE signal_type='trending.npm.dependents'
  AND produced_at > NOW() - INTERVAL '1 hour';
\`\`\`
Expected: **count > 0** (was 0 in production), avg in the 10-100000 range.

## Risk
**Low.**
- Network call shape is identical (single GET, JSON response). Existing retry / timeout / 404 handling intact via `fetchJsonWithRetry`.
- Failure mode is null (unchanged from before — old endpoint also returned null on failure).
- Worst case ecosyste.ms goes down: every package emits null, no `trending.npm.dependents` rows that run — same observable state as before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)