### PR TITLE
feat(x402): proxy TOOLBOX manifest from /x402

### DIFF
--- a/src/app/x402/__tests__/route.test.ts
+++ b/src/app/x402/__tests__/route.test.ts
@@ -1,12 +1,12 @@
-// E6 — coverage for the x402 HTTP 402 manifest stub.
+// Coverage for the x402 manifest proxy route.
 //
-// The route only re-exports method handlers (GET/HEAD/POST/OPTIONS) — no
-// data-store, no auth, no env. Tests construct a plain Request, invoke the
-// handler directly, and assert on status + headers + body shape.
+// The previous stub returned a static 402 manifest on GET. The route now
+// server-side-fetches the TOOLBOX manifest at api.aiso.tools/v1/x402/manifest
+// and re-emits it (200 + 60s cache). HEAD mirrors the 200. POST/OPTIONS keep
+// the legacy 402-stub / 204-Allow semantics so anything that probes them
+// still sees a usable response.
 
-import { describe, it, expect } from "vitest";
-
-import { GET, HEAD, POST, OPTIONS } from "../route";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import type { NextRequest } from "next/server";
 
@@ -14,43 +14,91 @@ function makeReq(method: string): NextRequest {
   return new Request("http://localhost/x402", { method }) as unknown as NextRequest;
 }
 
-describe("x402 route — HTTP 402 manifest stub", () => {
-  it("GET returns 402 with x402 JSON body", async () => {
-    const res = GET(makeReq("GET"));
-    expect(res.status).toBe(402);
+const MANIFEST_SAMPLE = {
+  version: "1.0",
+  currency: "USDC_BASE",
+  demo_mode: true,
+  sponge_facilitator: "https://api.paysponge.com/x402/...",
+  endpoints: [
+    {
+      path: "/v1/x402/trending/github/velocity/:owner/:name",
+      price_usdc: 0.01,
+      price_minor_units: 10000,
+      tier: 3,
+      signal_type: "trending.github.stars.velocity",
+      description: "stub",
+    },
+  ],
+};
+
+describe("x402 manifest proxy route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify(MANIFEST_SAMPLE), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("GET proxies the TOOLBOX manifest with 200 + cache header", async () => {
+    const { GET } = await import("../route");
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toMatch(/application\/json/);
-    expect(res.headers.get("X-Payment-Required")).toBe("x402");
+    expect(res.headers.get("cache-control")).toMatch(/max-age=60/);
+    expect(res.headers.get("x-source")).toBe("toolbox-manifest-proxy");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
 
     const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty("endpoints");
+    expect(Array.isArray(body.endpoints)).toBe(true);
+  });
+
+  it("GET falls back to 503 when TOOLBOX is unreachable and no cache exists", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    const { GET } = await import("../route");
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
     expect(body).toHaveProperty("type", "x402-payment-required");
-    expect(body).toHaveProperty("version");
-    expect(body).toHaveProperty("accepts");
-    expect(body).toHaveProperty("networks");
-    expect(body).toHaveProperty("description");
-    expect(body).toHaveProperty("docs");
-    expect(Array.isArray(body.accepts)).toBe(true);
-    expect(Array.isArray(body.networks)).toBe(true);
+    expect(body).toHaveProperty("manifest");
   });
 
-  it("HEAD returns 402 with X-Payment-Required header and no body", async () => {
+  it("HEAD returns 200 with manifest pointers and no body", async () => {
+    const { HEAD } = await import("../route");
     const res = HEAD(makeReq("HEAD"));
-    expect(res.status).toBe(402);
+    expect(res.status).toBe(200);
     expect(res.headers.get("X-Payment-Required")).toBe("x402");
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
-    const text = await res.text();
-    expect(text).toBe("");
+    expect(res.headers.get("X-Source")).toBe("toolbox-manifest-proxy");
+    expect(await res.text()).toBe("");
   });
 
-  it("POST returns 402 with x402 JSON body", async () => {
+  it("POST keeps the legacy 402 stub body for old probes", async () => {
+    const { POST } = await import("../route");
     const res = POST(makeReq("POST"));
     expect(res.status).toBe(402);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toHaveProperty("type", "x402-payment-required");
-    expect(body).toHaveProperty("accepts");
-    expect(body).toHaveProperty("networks");
+    expect(body).toHaveProperty("manifest");
   });
 
-  it("OPTIONS returns 204 with Allow header listing supported methods", async () => {
+  it("OPTIONS returns 204 with Allow listing supported methods", async () => {
+    const { OPTIONS } = await import("../route");
     const res = OPTIONS();
     expect(res.status).toBe(204);
     const allow = res.headers.get("Allow") ?? "";
@@ -61,7 +109,7 @@ describe("x402 route — HTTP 402 manifest stub", () => {
     expect(res.headers.get("Access-Control-Allow-Methods")).toMatch(/GET/);
   });
 
-  it("does not export handlers for unsupported methods (Next.js will 405)", async () => {
+  it("does not export handlers for unsupported methods", async () => {
     const mod = await import("../route");
     const exported = Object.keys(mod);
     expect(exported).not.toContain("DELETE");

--- a/src/app/x402/route.ts
+++ b/src/app/x402/route.ts
@@ -1,29 +1,81 @@
 import type { NextRequest } from "next/server";
 
 // x402 — HTTP 402 Payment Required entrypoint for agent-side micropayments.
-// The AISO Agent-Readiness scanner treats a 402 status (with an x402 manifest
-// payload) on this path as a positive x402 signal. This stub publishes the
-// minimum viable manifest; payment routing is intentionally not implemented
-// yet — when the protocol stabilises and a real wallet is wired in, the
-// 402 response will carry signed payment-request fields the agent can act on.
 //
-// Spec reference: https://x402.org (HTTP 402 + payment-request envelope).
-export const runtime = "edge";
+// The actual priced endpoints live on TOOLBOX (`api.aiso.tools/v1/x402/*`).
+// This route now does two things:
+//
+//   GET  — server-side fetch the TOOLBOX manifest and re-emit the JSON
+//          (with a `status: 200` and cached 60s) so AISO's
+//          `aiso.x402-discovery` scanner sees the actual menu of priced
+//          endpoints when it probes trendingrepo.com/x402.
+//   HEAD / POST / OPTIONS — preserve the previous 402-stub behaviour so
+//          legacy probes still see x402 capability (and to keep the
+//          aiso.x402-stub scanner happy if it ever lands).
+//
+// Spec reference: https://x402.org
+
+export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export function GET(_req: NextRequest): Response {
-  return jsonResponse(402);
+const TOOLBOX_MANIFEST_URL = "https://api.aiso.tools/v1/x402/manifest";
+const MANIFEST_CACHE_MS = 60_000;
+
+let manifestCache: { fetchedAt: number; body: unknown } | null = null;
+
+async function getToolboxManifest(): Promise<unknown> {
+  const now = Date.now();
+  if (manifestCache && now - manifestCache.fetchedAt < MANIFEST_CACHE_MS) {
+    return manifestCache.body;
+  }
+  try {
+    const res = await fetch(TOOLBOX_MANIFEST_URL, {
+      headers: { Accept: "application/json" },
+      // Soft timeout: AbortSignal.timeout is supported in Node 20+ (we're on 22).
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) {
+      throw new Error(`upstream ${res.status}`);
+    }
+    const body = await res.json();
+    manifestCache = { fetchedAt: now, body };
+    return body;
+  } catch {
+    // Stale-while-revalidate: return whatever we last had, even if expired.
+    if (manifestCache) return manifestCache.body;
+    return null;
+  }
+}
+
+export async function GET(_req: NextRequest): Promise<Response> {
+  const manifest = await getToolboxManifest();
+  if (manifest === null) return stubResponse(503);
+  return new Response(JSON.stringify(manifest), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=60",
+      "X-Source": "toolbox-manifest-proxy",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
 }
 
 export function HEAD(_req: NextRequest): Response {
   return new Response(null, {
-    status: 402,
-    headers: { "X-Payment-Required": "x402", "Cache-Control": "no-store" },
+    status: 200,
+    headers: {
+      "X-Payment-Required": "x402",
+      "X-Source": "toolbox-manifest-proxy",
+      "Cache-Control": "public, max-age=60",
+    },
   });
 }
 
+// Legacy POST/OPTIONS — agents that probed the old stub still get a
+// well-formed 402; bots discover the manifest via GET above.
 export function POST(_req: NextRequest): Response {
-  return jsonResponse(402);
+  return stubResponse(402);
 }
 
 export function OPTIONS(): Response {
@@ -32,11 +84,12 @@ export function OPTIONS(): Response {
     headers: {
       Allow: "GET, HEAD, POST, OPTIONS",
       "Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
+      "Access-Control-Allow-Origin": "*",
     },
   });
 }
 
-function jsonResponse(status: number): Response {
+function stubResponse(status: number): Response {
   const body = {
     type: "x402-payment-required",
     version: "0.1",
@@ -44,7 +97,8 @@ function jsonResponse(status: number): Response {
     accepts: ["x402"],
     networks: [],
     description:
-      "x402 payment manifest stub. No active payment scheme is wired yet — this endpoint exists so AI agents can detect x402 capability.",
+      "trendingrepo.com/x402 is a discovery surface — priced endpoints live on api.aiso.tools/v1/x402/*. GET this path for the manifest.",
+    manifest: TOOLBOX_MANIFEST_URL,
     docs: "https://x402.org",
     contact: "https://github.com/0motionguy/starscreener",
   };


### PR DESCRIPTION
## Summary

Replaces the static 402-stub at trendingrepo.com/x402 with a server-side proxy of api.aiso.tools/v1/x402/manifest. The actual priced endpoints live on TOOLBOX — this route just gives discovery scanners + agents a one-call view of the menu (price, signal_type, demo_mode, Sponge facilitator).

- GET → 200 + manifest JSON (60s in-process cache + Cache-Control: public,max-age=60)
- HEAD → 200 (was 402)
- POST → 402 stub (preserved, with the manifest URL in body for legacy probes)
- OPTIONS → 204 (preserved)
- Stale-while-revalidate on upstream failure; 503 only when no cache exists yet

Runtime flipped from \`edge\` → \`nodejs\` because \`fetch\` + AbortSignal.timeout need Node runtime.

6 vitest cases cover happy GET, upstream-down fallback, HEAD shape, POST stub preservation, OPTIONS, and exported method shape.

Companion to TOOLBOX PR #47 which ships the manifest endpoint + 10 more priced endpoints.

## Test plan
- [ ] Vercel preview deploy
- [ ] \`curl https://<preview>/x402 | jq '.endpoints | length'\` → 11
- [ ] \`curl -I https://<preview>/x402\` → 200 + X-Source: toolbox-manifest-proxy
- [ ] Hit when TOOLBOX is down → stale cache or 503 stub envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)