### PR TITLE
audit(impeccable): wave 2 — 5 LLM audits (72 findings) + 6 mechanical fixes

### DIFF
--- a/docs/audits/impeccable/PUNCH-LIST.md
+++ b/docs/audits/impeccable/PUNCH-LIST.md
@@ -40,6 +40,64 @@ That's the entire mechanical-fix surface from the CLI alone. Further fixes requi
 
 ---
 
+## Wave 2 — LLM audits on 5 surfaces (2026-05-13, branch `audit/imp-wave-2`)
+
+PRODUCT.md + DESIGN.md unblocked impeccable's preflight gate (committed in wave-1). 5 parallel LLM audit agents ran the `/impeccable audit` methodology on the top user-facing surfaces and produced one report per surface:
+
+- [funding-audit.md](./funding-audit.md) — 4 P0 / 6 P1 / 6 P2
+- [page-audit.md](./page-audit.md) — `/` (home) — 5 P0 / 9 P1 / 8 P2
+- [signals-audit.md](./signals-audit.md) — 4 P0 / 6 P1 / 5 P2
+- [mcp-audit.md](./mcp-audit.md) — 1 P0 / 3 P1 / 5 P2
+- [skills-audit.md](./skills-audit.md) — 2 P0 / 4 P1 / 4 P2
+
+**Totals: 16 P0 / 28 P1 / 28 P2 = 72 findings across 5 surfaces.**
+
+### Dominant cross-surface patterns
+
+1. **Honest-chrome rule violations** (12+ sites): hardcoded `<span className="live">LIVE</span>` / `live-pip` / "FEED LIVE" green-pulse strings on `/signals` (×4 — and the page already computes `sourceVerdicts` via `classifyFreshness()` but doesn't thread them in!), `/` (×5), `/mcp` (.live-pip), `/skills` (.live-pip). Same defect, same fix shape.
+2. **44×44 mobile tap-target failures**: tab strips and filter chips at 22-36px tall on `/skills` tabs, `/mcp` `.fchip` filters, `/funding` tabs, `/signals` `<details>` summary.
+3. **Token drift on V4 surfaces**: undefined `--v4-up` token on `/mcp` hero (falls back to hardcoded green, breaks theme-switch); ad-hoc `borderRadius: 3` / `4` literals instead of `var(--radius-card)`.
+4. **Inline-tab reimplementation**: `/skills` reinvents the V4 `<TabBar>` primitive in ~78 LOC inline.
+
+### What wave-2 SHIPS (mechanical fixes — low risk, high certainty)
+
+1. **`/mcp` P0** — `page.tsx` `var(--v4-up, #4ade80)` → `var(--v4-money)`. Theme-switch now works on every mover row.
+2. **`/mcp` P1** — Delete `<span className="live-pip">live</span>` from `LiveMcpTable.tsx` (page already has real `<FreshnessBadge>` in PageHead; the pip was duplicate + dishonest).
+3. **`/mcp` P1** — `globals.css` `.fchip` mobile tap target: add `@media (max-width: 640px) { min-height: 44px; padding: 10px 14px; }`. Desktop unchanged.
+4. **`/mcp` P1** — `page.tsx` hero `borderRadius: 4` → `2`. Matches `--radius-card` rule.
+5. **`/mcp` P2** — `page.tsx` mover-row `borderRadius: 3` → `2` and `padding: "8px 10px"` → `"12px 10px"` (closes the 36px tap-target finding on the hero anchors).
+6. **`/skills` P0** — Delete `<span className="live-pip">live</span>` from `SkillsTopTable.tsx`. Same defect as `/mcp` #2.
+
+### What wave-2 DEFERS to wave-3 (bigger surface, needs careful threading)
+
+These fixes are clearly mechanical per the audit reports but touch more files / require careful prop threading, so they get their own PR for reviewer focus:
+
+- **`/signals` 4-P0 cluster** — thread `sourceVerdicts` into `SourceFeedPanel`, `VolumeAreaChart`, `LiveClock`, `LiveTicker` (5 files). The audit has exact patches. Highest leverage in the audit: 4 P0s close from one pattern; data is already computed.
+- **`/` (home) 5-P0 cluster** — replace 5 hardcoded "LIVE" / green-pulse strings (BubbleMap, LiveTopTable, page.tsx) with `<FreshnessBadge>`. `FreshnessBadge` is never imported by `/` today — the fix is a 5-site import + swap.
+- **`/funding` 4 P0s** — confidence chip always green, "warming" sentinel, VerdictRibbon tone locked, MoverRow same-tab link. The audit has 8 mechanical patches + 4 design-call items.
+- **`/skills` P1 cluster** — swap inline `ListTaxonomyTabs` (~78 LOC) for the canonical `<TabBar>` primitive. Closes 3 findings in one substitution but is a refactor.
+- **`/` chart-toggle "fake tabs" P0** — 3 non-interactive `<span>` styled as tabs need real interactivity or removal.
+- **`/` ConsensusRow data lie** — slice-by-array-order instead of actual firing sources.
+
+### Cross-cutting follow-ups (not surface-specific)
+
+- **Chart palette drift**: `globals.css` `--color-series-1..5` vs `tokens.ts` `SERIES_PALETTE` disagree on first series color (green vs orange). Pick one canonical order.
+- **3 coexisting type scales**: `--text-*`, `--font-size-*`, `--font-size-title-*` overlap. Pick one canonical, mark others as backwards-compat.
+- **V2/V3/V4 generation sweep**: audit which components are on which generation; plan migration.
+- **Update `.claude/skills/starscreener-*` files**: align with current radii / fonts / shadow policy, or archive as historical intent — DESIGN.md is the new source of truth.
+
+### CLI baseline progression
+
+| Snapshot | Finding count | Delta | File |
+|---|---|---|---|
+| Baseline (pre-audit) | 28 | — | `_cli-baseline.json` |
+| After wave 1 (heatmap tint) | 27 | -1 | `_cli-post-pr-a.json` |
+| After wave 2 (LLM-driven fixes) | 27 | 0 | `_cli-post-wave-2.json` |
+
+The CLI count stayed at 27 because wave-2 fixes target *LLM-flagged honest-chrome lies and tap-target failures*, not the regex anti-patterns the CLI scans for. The two are complementary: CLI catches CSS/JSX surface patterns (side-tabs, untinted blacks, layout transitions); LLM agents catch semantic / UX / a11y violations (lies in chrome, mobile reflow, data fakery, token drift). Both metrics matter; neither alone is sufficient.
+
+The 1 remaining CLI finding (`globals.css:1499` `.repo-verdict`) is a designed gradient+border pair, not slop — see Recalibration section above.
+
 ---
 
 ## Triage summary

--- a/docs/audits/impeccable/_cli-post-wave-2.json
+++ b/docs/audits/impeccable/_cli-post-wave-2.json
@@ -1,0 +1,255 @@
+[
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\app\\api\\og\\top10\\route.tsx",
+    "line": 494,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\app\\globals.css",
+    "line": 1499,
+    "snippet": "border-left: 3px solid var(--acc)",
+    "importedBy": [
+      "layout.tsx"
+    ]
+  },
+  {
+    "antipattern": "pure-black-white",
+    "name": "Pure black background",
+    "description": "Pure #000000 as a background color looks harsh and unnatural. Tint it slightly toward your brand hue (e.g., oklch(12% 0.01 250)) for a more refined feel.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\app\\sign-in\\[[...sign-in]]\\page.tsx",
+    "line": 43,
+    "snippet": "bg-black"
+  },
+  {
+    "antipattern": "pure-black-white",
+    "name": "Pure black background",
+    "description": "Pure #000000 as a background color looks harsh and unnatural. Tint it slightly toward your brand hue (e.g., oklch(12% 0.01 250)) for a more refined feel.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\app\\sign-up\\[[...sign-up]]\\page.tsx",
+    "line": 49,
+    "snippet": "bg-black"
+  },
+  {
+    "antipattern": "pure-black-white",
+    "name": "Pure black background",
+    "description": "Pure #000000 as a background color looks harsh and unnatural. Tint it slightly toward your brand hue (e.g., oklch(12% 0.01 250)) for a more refined feel.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\app\\you\\alerts\\_components\\AddAlertRuleDialog.tsx",
+    "line": 365,
+    "snippet": "bg-black",
+    "importedBy": [
+      "page.tsx"
+    ]
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\CompareClient.tsx",
+    "line": 616,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\CompareClient.tsx",
+    "line": 641,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\CompareClient.tsx",
+    "line": 704,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\CompareHeatmap.tsx",
+    "line": 223,
+    "snippet": "borderLeft: `3px solid",
+    "importedBy": [
+      "CompareHeatmapLazy.tsx"
+    ]
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\CompareHeatmap.tsx",
+    "line": 246,
+    "snippet": "borderLeft: `3px solid",
+    "importedBy": [
+      "CompareHeatmapLazy.tsx"
+    ]
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\RepoBannerCard.tsx",
+    "line": 51,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\RepoBannerCard.tsx",
+    "line": 74,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\RepoProfileColumn.tsx",
+    "line": 62,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\RepoProfileColumn.tsx",
+    "line": 82,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\compare\\RepoProfileColumn.tsx",
+    "line": 158,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "pure-black-white",
+    "name": "Pure black background",
+    "description": "Pure #000000 as a background color looks harsh and unnatural. Tint it slightly toward your brand hue (e.g., oklch(12% 0.01 250)) for a more refined feel.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\layout\\MobileDrawer.tsx",
+    "line": 85,
+    "snippet": "bg-black"
+  },
+  {
+    "antipattern": "layout-transition",
+    "name": "Layout property animation",
+    "description": "Animating width, height, padding, or margin causes layout thrash and janky performance. Use transform and opacity instead, or grid-template-rows for height animations.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\layout\\sidebar-nav.css",
+    "line": 9,
+    "snippet": "transition: padding"
+  },
+  {
+    "antipattern": "layout-transition",
+    "name": "Layout property animation",
+    "description": "Animating width, height, padding, or margin causes layout thrash and janky performance. Use transform and opacity instead, or grid-template-rows for height animations.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\layout\\sidebar-nav.css",
+    "line": 101,
+    "snippet": "transition: padding, height"
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\news\\NewsTopHeaderV3.tsx",
+    "line": 645,
+    "snippet": "borderLeft: \"4px solid",
+    "importedBy": [
+      "newsTopMetrics.ts"
+    ]
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\news\\NewsTopHeaderV3.tsx",
+    "line": 646,
+    "snippet": "borderRight: \"4px solid",
+    "importedBy": [
+      "newsTopMetrics.ts"
+    ]
+  },
+  {
+    "antipattern": "pure-black-white",
+    "name": "Pure black background",
+    "description": "Pure #000000 as a background color looks harsh and unnatural. Tint it slightly toward your brand hue (e.g., oklch(12% 0.01 250)) for a more refined feel.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\reddit\\ContentTagChips.tsx",
+    "line": 270,
+    "snippet": "bg-black",
+    "importedBy": [
+      "RedditTabsClient.tsx"
+    ]
+  },
+  {
+    "antipattern": "layout-transition",
+    "name": "Layout property animation",
+    "description": "Animating width, height, padding, or margin causes layout thrash and janky performance. Use transform and opacity instead, or grid-template-rows for height animations.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\reddit-trending\\TopicMindshareCanvas.tsx",
+    "line": 149,
+    "snippet": "transition: width",
+    "importedBy": [
+      "TopicMindshareMap.tsx"
+    ]
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\reddit-trending\\trending-helpers.ts",
+    "line": 33,
+    "snippet": "border-l-4",
+    "importedBy": [
+      "AllTrendingTabs.tsx",
+      "PostListPanel.tsx",
+      "SubredditGroupPanel.tsx"
+    ]
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\reddit-trending\\trending-helpers.ts",
+    "line": 66,
+    "snippet": "border-l-4",
+    "importedBy": [
+      "AllTrendingTabs.tsx",
+      "PostListPanel.tsx",
+      "SubredditGroupPanel.tsx"
+    ]
+  },
+  {
+    "antipattern": "side-tab",
+    "name": "Side-tab accent border",
+    "description": "Thick colored border on one side of a card — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it entirely.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\repo\\WhyBadge.tsx",
+    "line": 64,
+    "snippet": "borderLeft: `3px solid"
+  },
+  {
+    "antipattern": "pure-black-white",
+    "name": "Pure black background",
+    "description": "Pure #000000 as a background color looks harsh and unnatural. Tint it slightly toward your brand hue (e.g., oklch(12% 0.01 250)) for a more refined feel.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\tier-list\\MobileTierPicker.tsx",
+    "line": 117,
+    "snippet": "bg-black",
+    "importedBy": [
+      "TierListEditor.tsx"
+    ]
+  },
+  {
+    "antipattern": "pure-black-white",
+    "name": "Pure black background",
+    "description": "Pure #000000 as a background color looks harsh and unnatural. Tint it slightly toward your brand hue (e.g., oklch(12% 0.01 250)) for a more refined feel.",
+    "file": "C:\\dev\\trendingrepo-wt\\imp-wave-2\\src\\components\\ui\\ConfirmDialog.tsx",
+    "line": 100,
+    "snippet": "bg-black"
+  }
+]

--- a/docs/audits/impeccable/funding-audit.md
+++ b/docs/audits/impeccable/funding-audit.md
@@ -1,0 +1,160 @@
+# /funding audit — 2026-05-13
+
+## Files audited
+- [src/app/funding/page.tsx](../../../src/app/funding/page.tsx)
+- [src/app/funding/loading.tsx](../../../src/app/funding/loading.tsx)
+- [src/app/funding/error.tsx](../../../src/app/funding/error.tsx)
+- [src/components/funding/MoverRow.tsx](../../../src/components/funding/MoverRow.tsx)
+- [src/components/funding/WindowedFundingBoard.tsx](../../../src/components/funding/WindowedFundingBoard.tsx)
+- [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx)
+- [src/components/ui/PageHead.tsx](../../../src/components/ui/PageHead.tsx) (consumed)
+- [src/components/ui/KpiBand.tsx](../../../src/components/ui/KpiBand.tsx) (consumed)
+- [src/components/ui/SectionHead.tsx](../../../src/components/ui/SectionHead.tsx) (consumed)
+- [src/components/ui/VerdictRibbon.tsx](../../../src/components/ui/VerdictRibbon.tsx) (consumed)
+- [src/components/ui/Card.tsx](../../../src/components/ui/Card.tsx) (consumed)
+- [src/lib/funding-news.ts](../../../src/lib/funding-news.ts) (chrome inputs)
+- [src/lib/news/freshness.ts](../../../src/lib/news/freshness.ts) (threshold source)
+- [src/app/globals.css#L3302-3557](../../../src/app/globals.css) `.funding-page` block
+- [src/components/ui/v4.css#L1038-1157](../../../src/components/ui/v4.css) `.v4-mover-row` block
+
+## P0 findings (dishonest / broken / a11y blocker)
+
+- **Confidence chip always rendered green** — [page.tsx:474-477](../../../src/app/funding/page.tsx#L474). `<span className="delta up">{signal.extracted?.confidence ?? "none"}<span className="lbl">confidence</span></span>` — `.up` class forces `--sig-green` for *every* row regardless of value. `none` / `low` confidence reading green is a chrome lie. Fix: branch class on confidence (`high`→`up`/green, `medium`→amber, `low`/`none`→ink-400 or `.dn`). **Mechanical.**
+- **`"warming"` masquerades as a clock** — [page.tsx:107-112, 209, 295](../../../src/app/funding/page.tsx#L107). When `file.fetchedAt` is the EPOCH_ZERO sentinel (cold), `formatClock` returns `"warming"` and is rendered in the `.big` slot of the PageHead clock column. "Warming" implies *about to be live*; reality is the source is dead. Fix: render `"—"` or `"OFFLINE"` and let `FreshnessBadge` own the COLD verdict. **Mechanical.**
+- **`VerdictRibbon tone="money"` is locked** — [page.tsx:346](../../../src/app/funding/page.tsx#L346). Tone is `"money"` (green rail + green eyebrow + green stamp) regardless of freshness or signal count. When the underlying data is COLD per `FreshnessBadge`, the celebratory green verdict ribbon still ships. Mirror the FreshnessBadge tone: cold→`amber`, fresh→`money`. **Design call** (operator: confirm tone mapping table).
+- **`<MoverRow href={signal.sourceUrl}>` opens in same tab** — [page.tsx:262](../../../src/app/funding/page.tsx#L262), MoverRow itself ([MoverRow.tsx:103-104](../../../src/components/funding/MoverRow.tsx#L103)) doesn't pass `target="_blank" rel="noreferrer"`. Clicking the headline navigates away from /funding without warning. The sister `sp-row` News tape ([page.tsx:466-468](../../../src/app/funding/page.tsx#L466)) and `funding-bar` ([page.tsx:415-417](../../../src/app/funding/page.tsx#L415)) DO set `target="_blank"` — inconsistent and a user-trap. **Mechanical.**
+
+## P1 findings (visible regression)
+
+- **Tab tap targets are ~36px** — [WindowedFundingBoard.tsx:43-52](../../../src/components/funding/WindowedFundingBoard.tsx#L43) + [globals.css#L2305-2314](../../../src/app/globals.css#L2305). `.tabs .tab` `padding: 9px 14px` + `font-size: 10px` → ~34-36px height. WCAG 2.5.5 + project mobile rule require 44×44. Fix: bump padding to `12px 16px` or set `min-height: 44px`. **Mechanical.**
+- **Tab `tablist` missing tabpanel association** — [WindowedFundingBoard.tsx:38, 69](../../../src/components/funding/WindowedFundingBoard.tsx#L38). `role="tablist"` is set, tabs have `aria-selected` and `role="tab"`, but the rendered `<section className="board funding-board">` lacks `role="tabpanel"`, `id`, and `aria-labelledby`. Screen readers can't tie selection to panel content. Fix: give each tab an `id`, give the section `role="tabpanel"` + `aria-labelledby={selectedTabId}` + `id={panelId}`. **Mechanical.**
+- **`funding-bar` track gradient mixes semantic roles** — [globals.css#L3385-3389](../../../src/app/globals.css#L3385). `linear-gradient(90deg, var(--sig-green), var(--acc))` — green→orange gradient on capital bars. Green is the funding semantic (per `--v4-money`/sig-green role); brand-orange tail double-encodes "hot" on a chart that's already encoding "biggest". Fix: solid `--v4-money` or `var(--sig-green)`. **Design call.**
+- **Source-mix pip colors are decorative rotation, not source-keyed** — [page.tsx:434](../../../src/app/funding/page.tsx#L434) + [globals.css#L3323-3351](../../../src/app/globals.css#L3323). `sd-f${(index % 6) + 1}` rotates through green/orange/blue/violet/amber/cyan regardless of which source the row represents. Per project rule, source-color-keys should encode source identity (X = blue, HN = orange, etc. — `--source-x`, `--source-hackernews` tokens already exist in globals.css). Fix: map each `signal.sourcePlatform` to its `--source-*` token. **Mechanical.**
+- **`<EmptyState>` not interactive — but reads like a debug log** — [page.tsx:194-200](../../../src/app/funding/page.tsx#L194). Cold copy "Funding data has not landed yet. Run the scraper to populate the radar." talks to the operator, not the user. Public surface should read "Funding feed is cold — last scan failed. Live data will return shortly." **Design call.**
+- **VerdictRibbon `actionHref="/feeds/funding.xml"` opens RSS in-place** — [page.tsx:363-364](../../../src/app/funding/page.tsx#L363). XML files open as raw text in most browsers — same-tab navigation kicks the user out of /funding into an XML doc. Add `target="_blank" rel="noreferrer"` (or extend `VerdictRibbon` to accept that). **Mechanical.**
+
+## P2 findings (polish / drift)
+
+- **KPI pip colors don't match value tone** — [page.tsx:316-320](../../../src/app/funding/page.tsx#L316). `THIS WEEK` cell has `tone: "acc"` (orange value) with `pip: "var(--v4-blue)"` (blue pip). Visually noisy; tone and pip should agree or one should be ink-300. **Design call.**
+- **Multiple competing row primitives on one page** — `.v4-mover-row`, `.funding-bar`, `.sp-row`, `.stock-row` all coexist with slightly different padding/typography/grid templates. Long-term tech debt against the V4 corpus consolidation work. **Design call.**
+- **`sourceName` fallback returns kebab→space without title-casing** — [page.tsx:122-124](../../../src/app/funding/page.tsx#L122). Unknown source `"sec-form-d"` is in SOURCE_LABELS, but a genuinely new source ships as `"some-new-feed"` lowercase mid-row. Fix: title-case the fallback. **Mechanical.**
+- **`<span className="muted">` inside `<span className="right">`** — [WindowedFundingBoard.tsx:55-66](../../../src/components/funding/WindowedFundingBoard.tsx#L55). Inline styles re-declare font-family/letter-spacing/text-transform that the parent `.tabs .right` already sets. Redundant; drop the inline style. **Mechanical.**
+- **Loading skeleton uses `--v3-bg-050` / `--v3-bg-100`** — [loading.tsx:11, 15, 23, 30, 39](../../../src/app/funding/loading.tsx#L11). Page renders under `.funding-page` (V2 + V4 tokens). Generation mismatch between skeleton and shipped page; visually fine but drifts during theme swaps. **Design call.**
+- **`EntityLogo alt=""` is correct but commented as decorative-only** — [MoverRow.tsx:135](../../../src/components/funding/MoverRow.tsx#L135). The company name IS rendered as text adjacent, so empty alt is right per WCAG decorative-image rule. No action; flagging only because audit checklists tend to false-positive this. **Working as intended.**
+- **`FreshnessBadge source="skills"`** — [page.tsx:293](../../../src/app/funding/page.tsx#L293). `"funding"` is not a `NewsSource` variant in `freshness.ts`; the page borrows `"skills"` (→ NPM_STALE_THRESHOLD_MS = 50h). Funding-news cron cadence isn't documented here — the 50h budget is plausible but unverified. Either add `"funding"` to `NewsSource` with its own threshold, or document the intentional reuse in a comment at the call site. **Verify-in-context.**
+
+## What's working well
+
+- Real `FreshnessBadge` is wired (line 293) — no inline hardcoded "FRESH · 1H" lie. Honest chrome contract is mostly upheld.
+- `isFundingCold(file)` + `EmptyState` empty-state path exists (page.tsx:208, 367).
+- `isLikelyRoundup` filter (lines 170-177) catches "Software" / "Exclusive: ..." extraction garbage from chart inputs.
+- Stage→class regex is anchored end-of-string (MoverRow.tsx:187-195), fixing the earlier "everything is orange" bug.
+- 2px radii throughout — terminal feel preserved.
+- KPI band collapses to 2-up grid at 768px (v4.css:729-743).
+- `--v4-money` semantic green for capital, distinct from brand orange.
+- First-row left-rail uses `border-left: 2px solid var(--v4-money)` — *functional* color key (the #1 row), not decorative side-tab.
+- No card shadows; ramp-stacking via `--v4-bg-050` hover surfaces.
+- Tabs do set `role="tablist"`, `role="tab"`, `aria-selected` — half the a11y contract is honored, just incomplete.
+- Outbound News-tape rows correctly use `target="_blank" rel="noreferrer"`.
+- KPI cells use tabular-nums for stable column widths.
+
+## Verify-in-context
+- **VerdictRibbon tone mapping** when data is cold/stale (P0 #3) — operator to confirm: should the ribbon flip `money`→`amber`→`red` as `FreshnessBadge` does, or stay green and let the badge be the only freshness signal?
+- **`FreshnessBadge source="skills"` reuse** (P2 #6) — confirm intentional or add a dedicated `funding` source with its own threshold reflecting the actual funding-news cron cadence.
+- **`sd-f1..f6` decorative rotation vs source-keyed colors** (P1 #4) — palette already exists (`--source-*`); confirm we want per-source identity here.
+
+## Mechanical fixes ready to ship
+
+1. P0 #1 — branch `delta` class on confidence value (not always `up`).
+2. P0 #2 — replace `"warming"` sentinel with `"—"` or `"OFFLINE"`; let FreshnessBadge own the verdict.
+3. P0 #4 — add `target="_blank" rel="noreferrer"` to `<MoverRow href={signal.sourceUrl} ...>` (either at the call site or by defaulting inside MoverRow when the href is external).
+4. P1 #1 — tab `padding: 12px 16px` or `min-height: 44px` on `.tabs .tab`.
+5. P1 #2 — wire `id` + `role="tabpanel"` + `aria-labelledby` on the `<section className="board funding-board">`.
+6. P1 #6 — `target="_blank"` on the RSS action link in VerdictRibbon.
+7. P2 #3 — title-case the `sourceName` fallback.
+8. P2 #4 — drop the redundant inline-style override inside `.tabs .right`.
+
+## Quick-fix patches
+
+### P0 #1 — honest confidence chip
+
+Before ([page.tsx:474-477](../../../src/app/funding/page.tsx#L474)):
+```tsx
+<span className="delta up">
+  {signal.extracted?.confidence ?? "none"}
+  <span className="lbl">confidence</span>
+</span>
+```
+
+After:
+```tsx
+{(() => {
+  const c = signal.extracted?.confidence ?? "none";
+  const cls = c === "high" ? "delta up" : c === "medium" ? "delta" : "delta dn";
+  return (
+    <span className={cls}>
+      {c}
+      <span className="lbl">confidence</span>
+    </span>
+  );
+})()}
+```
+
+### P0 #2 — drop the "warming" lie
+
+Before ([page.tsx:107-112](../../../src/app/funding/page.tsx#L107)):
+```ts
+function formatClock(value: string): string {
+  const date = new Date(value);
+  return Number.isFinite(date.getTime())
+    ? date.toISOString().slice(11, 19)
+    : "warming";
+}
+```
+
+After:
+```ts
+function formatClock(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "—";
+  if (value.startsWith("1970-")) return "—"; // EPOCH_ZERO sentinel
+  return date.toISOString().slice(11, 19);
+}
+```
+
+### P0 #4 — outbound MoverRow opens in new tab
+
+Before ([page.tsx:262](../../../src/app/funding/page.tsx#L262)):
+```tsx
+href={signal.sourceUrl}
+```
+
+Apply at MoverRow.tsx:103-104 instead so every consumer is safe:
+```tsx
+<Tag
+  {...(href ? { href, target: "_blank", rel: "noreferrer" } : {})}
+  ...
+```
+
+### P1 #1 — 44px tabs
+
+Before ([globals.css#L2305-2314](../../../src/app/globals.css#L2305)):
+```css
+.tabs .tab {
+  margin-bottom: -1px;
+  padding: 9px 14px;
+  ...
+}
+```
+
+After:
+```css
+.tabs .tab {
+  margin-bottom: -1px;
+  padding: 12px 16px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  ...
+}
+```

--- a/docs/audits/impeccable/mcp-audit.md
+++ b/docs/audits/impeccable/mcp-audit.md
@@ -1,0 +1,97 @@
+# /mcp audit — 2026-05-13
+
+Focus: TRENDING THIS WEEK hero shipped in PR #829 (66cdc72e4). Audited the hero pattern, the surrounding page, and the LiveMcpTable it sits above.
+
+## Files audited
+
+- [src/app/mcp/page.tsx](../../../src/app/mcp/page.tsx) — page + `TrendingThisWeek` component (inlined)
+- [src/components/mcp/LiveMcpTable.tsx](../../../src/components/mcp/LiveMcpTable.tsx) — the leaderboard below the hero
+- [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx) — confirmed routed via `classifyFreshness()`
+- [src/lib/news/freshness.ts](../../../src/lib/news/freshness.ts) — `mcp` source uses `NPM_STALE_THRESHOLD_MS` (12h)
+- [src/app/globals.css](../../../src/app/globals.css) — `.live-pip`, `.fchip`, `.home-surface`, `.v4-kpi-band`
+- [src/components/ui/v4.css](../../../src/components/ui/v4.css) — V4 tokens used by the hero
+
+## P0 findings
+
+- **[P0] Undefined `--v4-up` token; arrow falls back to hardcoded `#4ade80`** — [page.tsx:569](../../../src/app/mcp/page.tsx#L569). The hero's delta arrow uses `color: "var(--v4-up, #4ade80)"`. `--v4-up` is not declared anywhere in `v4.css` / `globals.css` — confirmed via grep. Every mover row renders the hardcoded green, bypassing the theme system. Theme-switch + accent re-skin breaks here. Mechanical fix: replace with `var(--v4-money)` (canonical positive-delta token used elsewhere on the page).
+
+## P1 findings
+
+- **[P1] `.live-pip` violates honest-chrome rule — hardcoded "live" + green pulse glow** — [LiveMcpTable.tsx:279](../../../src/components/mcp/LiveMcpTable.tsx#L279) and [globals.css:2623-2641](../../../src/app/globals.css#L2623). The string `"live"` and a `box-shadow: 0 0 6px var(--sig-green)` pulse are literally inlined. This is the exact "hardcoded `LIVE` / green-pulse `LiveDot`" pattern the project memory `feedback_freshness_chrome_must_be_honest` flags. Page already renders a real `<FreshnessBadge>` in the PageHead — second source of truth contradicts it. Fix: delete the `.live-pip` span (or swap for a non-pulsing static count chip). Pre-existing pattern reused on `/skills` and home — note in the shared remediation.
+- **[P1] `.fchip` filter chips fail 44×44 tap target** — [globals.css:2565-2580](../../../src/app/globals.css#L2565). Padding is `4px 10px` ≈ 22-24px tall, below the 44px mobile minimum (PRODUCT.md mobile posture rule). Affects the four registry filters on /mcp and the All chip. Mechanical fix: raise to `padding: 10px 14px` or add `min-height: 44px` under `@media (max-width: 640px)`.
+- **[P1] Inline-styled hero ignores the V4 surface ramp & 2px radius rules** — [page.tsx:438-441](../../../src/app/mcp/page.tsx#L438) (`borderRadius: 4`) and [page.tsx:518](../../../src/app/mcp/page.tsx#L518) (`borderRadius: 3`). DESIGN.md says cards are 2px (`--radius-card: 0.125rem`) — these are 3/4px ad-hoc literals. Same surface (`--v4-bg-050`) repeated inside RAW PAYLOAD footer with no radius, creating inconsistent corner treatment within 30px of each other. Fix: extract to `.mcp-hero` class with `border-radius: var(--radius-card)` so it reads as one surface system.
+
+## P2 findings
+
+- **[P2] Hero `<ol>` minmax(220px, 1fr) wastes mobile vertical space** — [page.tsx:494](../../../src/app/mcp/page.tsx#L494). At 375px (16px page padding × 2 = 343px content) 220px renders exactly 1 column — correct — but stacks 5 movers vertically with logo+title+delta each on its own row. Result: the hero alone consumes ~280px before the table. Drop to `minmax(160px, 1fr)` to allow 2 columns at 343px wide, or to a single-line condensed mobile layout. Mechanical fix.
+- **[P2] Hero anchor row ~32px tall — sub-44px tap target** — [page.tsx:510-522](../../../src/app/mcp/page.tsx#L510). `padding: "8px 10px"` + 20px logo = ~36px effective tap height. Each mover link is the primary CTA into the MCP detail surface — must hit 44×44 on mobile. Mechanical fix: bump padding to `12px 10px`.
+- **[P2] Hero status string uses real-but-buried counts as a single-line wrap** — [page.tsx:469](../../../src/app/mcp/page.tsx#L469). `"5 movers · 7d window · across 1,234 servers"` lives on the right of the header with `flexWrap: "wrap"`. On 375px the status wraps to a second line that visually competes with the H3. Better: move the count next to the H3 (e.g. `// TRENDING THIS WEEK · 5/1,234`) and drop the standalone string.
+- **[P2] Empty-state copy is a developer log note in user position** — [page.tsx:481-486](../../../src/app/mcp/page.tsx#L481). The empty-state literally reads "the mcp-usage-snapshot cron writes a daily snapshot to Redis at 03:30 UTC; the 7d delta becomes computable once a snapshot from 7 days ago exists." That's internal infra detail. Per PRODUCT.md "honest-by-default" doesn't mean "leak the cron schedule" — keep the honesty but rewrite as "// no 7d movers yet. Daily snapshots are still warming up; sort the table by 24h for short-window movement."
+- **[P2] `// MCP TAPE` ribbon "source · auto · revalidate 60s" exposes implementation detail** — [page.tsx:323](../../../src/app/mcp/page.tsx#L323). The sub-stamp surfaces ISR cadence to users. Honest-chrome rule wants freshness; users don't need the revalidate window. Move to a `title` tooltip on the FreshnessBadge or drop.
+
+## What's working well (the new hero pattern — keep)
+
+- **`delta7d` is honest.** The `topMovers` filter requires `delta7d > 0 && deltaUnit !== null` ([page.tsx:295](../../../src/app/mcp/page.tsx#L295)) — no synthesized numbers, no placeholder "+12%" / "+34%" anywhere. When snapshots haven't accrued, the empty-state shows zero movers rather than fake-positive data. **This is the right pattern; the project memory explicitly warned about hardcoded delta placeholders and the hero avoids them.**
+- **`deltaUnit` distinguishes installs vs stars in the tooltip** — [page.tsx:572](../../../src/app/mcp/page.tsx#L572). Tooltip reads `+1.2k installs · 7d` or `+340 stars · 7d`. Honest about provenance, expensive to fake; replicate this pattern on /skills.
+- **FreshnessBadge wired correctly** — [page.tsx:314](../../../src/app/mcp/page.tsx#L314). `<FreshnessBadge source="mcp" lastUpdatedAt={data.fetchedAt} />` routes through `classifyFreshness()` with the right NewsSource enum. This is the one canonical freshness signal on the page.
+- **Compact-number formatting (`Intl.NumberFormat`)** — [page.tsx:500-505](../../../src/app/mcp/page.tsx#L500). Thresholds at 1000 with `notation: "compact"` keep deltas readable.
+- **Hero stays out of the table's information space.** The H3 and 5 movers consume < 220px on desktop; the table headline (sortable 24h/7d/30d columns) remains the primary scan surface. <3-second scan-time rule respected.
+
+## Verify-in-context
+
+Run before shipping fixes:
+- `npm run dev` → load `http://localhost:3023/mcp` at 375px and 1440px
+- Devtools network throttle "Slow 3G" → confirm `topMovers` populated (snapshot dependency)
+- Check `data-theme="blue"` / `data-theme="green"` swap the `↑` color (P0 verifier — undefined `--v4-up` will stay green on every theme)
+- Tab through hero anchors → focus ring uses `--v4-acc` (V4 primitive); confirm visible
+
+## Mechanical fixes ready to ship
+
+1. **P0** [page.tsx:569](../../../src/app/mcp/page.tsx#L569) — `var(--v4-up, #4ade80)` → `var(--v4-money)`
+2. **P1** [LiveMcpTable.tsx:279](../../../src/components/mcp/LiveMcpTable.tsx#L279) + [globals.css:2623](../../../src/app/globals.css#L2623) — delete `.live-pip` (3 surfaces affected; coordinate with /skills + home)
+3. **P1** [globals.css:2569](../../../src/app/globals.css#L2569) — `.fchip` padding `4px 10px` → `min-height: 44px; padding: 10px 14px;` (or behind `@media (max-width: 640px)` only)
+4. **P1** [page.tsx:441](../../../src/app/mcp/page.tsx#L441) — `borderRadius: 4` → `borderRadius: 2` (or `var(--radius-card)`)
+5. **P1** [page.tsx:518](../../../src/app/mcp/page.tsx#L518) — `borderRadius: 3` → `borderRadius: 2`
+6. **P2** [page.tsx:494](../../../src/app/mcp/page.tsx#L494) — `minmax(220px, 1fr)` → `minmax(160px, 1fr)`
+7. **P2** [page.tsx:514](../../../src/app/mcp/page.tsx#L514) — anchor padding `8px 10px` → `12px 10px`
+
+## Quick-fix patches
+
+### P0 — replace undefined token
+
+```diff
+- color: "var(--v4-up, #4ade80)",
++ color: "var(--v4-money)",
+```
+
+### P1 — kill `.live-pip` lie
+
+In [LiveMcpTable.tsx:277-280](../../../src/components/mcp/LiveMcpTable.tsx#L277):
+
+```diff
+- <span className="live-top-meta">
+-   showing <b>{rendered.length}</b> / {totalCount ?? rows.length}
+-   <span className="live-pip">live</span>
+- </span>
++ <span className="live-top-meta">
++   showing <b>{rendered.length}</b> / {totalCount ?? rows.length}
++ </span>
+```
+
+(Page already renders the real `<FreshnessBadge>` next to the H1 — the "live" pip is duplicate + dishonest chrome.)
+
+### P1 — fchip tap target
+
+In [globals.css:2565-2580](../../../src/app/globals.css#L2565):
+
+```diff
+  .live-top-filters .fchip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+-   padding: 4px 10px;
++   padding: 10px 14px;
++   min-height: 44px;
+    border: 1px solid var(--line-200);
+    border-radius: var(--radius-xs);
+```

--- a/docs/audits/impeccable/page-audit.md
+++ b/docs/audits/impeccable/page-audit.md
@@ -1,0 +1,179 @@
+## / (home) audit — 2026-05-13
+
+## Files audited
+- [src/app/page.tsx](../../../src/app/page.tsx) — entry, hero, panels, consensus / breakout / featured / TR-100 sections, FAQ, JSON-LD.
+- [src/components/home/LiveTopTable.tsx](../../../src/components/home/LiveTopTable.tsx) — sortable Live / Top 50 table.
+- [src/components/terminal/BubbleMap.tsx](../../../src/components/terminal/BubbleMap.tsx) — momentum-vs-scale radar.
+- [src/components/ui/Card.tsx](../../../src/components/ui/Card.tsx), [Metric.tsx](../../../src/components/ui/Metric.tsx), [SectionHead.tsx](../../../src/components/ui/SectionHead.tsx) — chrome primitives.
+- [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx) — sanctioned freshness pattern (NOT used on `/`).
+- [src/app/globals.css](../../../src/app/globals.css) — `.home-surface`, `.page-head`, `.hero-row/.hero-panel`, `.cons-row`, `.brk-row`, `.feat-card`, `.chart-toggle`, `.live`, `.live-pip`.
+
+## P0 findings
+
+### P0-1 — Five hardcoded "LIVE" chrome lies, no `FreshnessBadge` anywhere on `/`
+Honest freshness rule violation per `feedback_freshness_chrome_must_be_honest`. `/` never imports `FreshnessBadge` or `classifyFreshness`. Every "LIVE" / green pulse on this page is unconditionally green, even when data is hours / days stale. Sites:
+1. [src/app/page.tsx:468](../../../src/app/page.tsx#L468) — `right={<span className="live">LIVE</span>}` on every HeroPanel (Repos, Skills, MCP). Always renders green pulse via `.panel-head .right .live::before` ([globals.css:4142](../../../src/app/globals.css#L4142)).
+2. [src/app/page.tsx:944](../../../src/app/page.tsx#L944) — `<span className="live">LIVE</span>` on TR-100 Index card.
+3. [src/components/terminal/BubbleMap.tsx:200,245](../../../src/components/terminal/BubbleMap.tsx#L200) — `headerStatus = "LIVE · ${monoDate}"`, always shipped.
+4. [src/components/home/LiveTopTable.tsx:373](../../../src/components/home/LiveTopTable.tsx#L373) — `<span className="live-pip">live</span>` with glowing green dot ([globals.css:2632](../../../src/app/globals.css#L2632)).
+5. [src/app/page.tsx:865](../../../src/app/page.tsx#L865) — `<Metric ... delta="+ live" tone="positive">` literal "+ live" string.
+
+Fix: route all five through `<FreshnessBadge lastUpdatedAt={lastFetchedAt} source="repos">` (and the appropriate `source` per panel — `skills`/`mcp`). The page already imports `lastFetchedAt` ([page.tsx:14](../../../src/app/page.tsx#L14)) but only renders it in two read-only footers. **Design call** for the visual placement; **mechanical** swap for each call site.
+
+### P0-2 — Consensus row source icons are a data lie
+[src/app/page.tsx:530](../../../src/app/page.tsx#L530): `SOURCE_ICONS.slice(0, channels)` renders the first N entries of a static array `[gh, hn, r, b, d]` rather than the actual `repo.channelStatus` keys. A repo whose firing sources are `[github, twitter]` is painted as `[github, hackernews]`. Tooltip + `aria-label` repeat the same lie. **P0** because the page sells itself as "what multiple feeds agree on" — this section is the cross-source pitch.
+
+Fix: derive the source list from `repo.channelStatus` (or `repo.mentions?.perSource` like `LiveTopTable` does) and render only the ones with non-zero counts. **Design call** if you want filled vs ghost states for inactive sources.
+
+### P0-3 — Fake chart-toggle pretends to be interactive
+[src/app/page.tsx:947-951](../../../src/app/page.tsx#L947): three `<span class="tg">` styled as toggle buttons (Index / Share / Categories), no `onClick`, no `role`, no keyboard target. They look identical to the live `.fchip` filter buttons two sections above. Affordance lie; keyboard users tabbing past hit nothing. WCAG 2.4.3 + 4.1.2.
+
+Fix: either wire the three views (real toggle) or strip the toggle entirely and keep only the `30d · {total30d}` summary. **Design call**.
+
+### P0-4 — Touch targets below 44×44 on the primary mobile filter row
+[src/components/home/LiveTopTable.tsx:354-369](../../../src/components/home/LiveTopTable.tsx#L354) `.fchip` styled `padding: 4px 10px; font-size: var(--font-size-sm)` ([globals.css:2565](../../../src/app/globals.css#L2565)) → ~24-26px tall. These are the category filters on the highest-density mobile surface. PRODUCT.md mandates 44×44 minimum.
+
+Fix: bump `.live-top-filters .fchip` to `min-height: 44px; padding: 10px 12px` on `@media (max-width: 767px)`. **Mechanical**.
+
+### P0-5 — Breakout row sparkline color contradicts its own delta number
+[src/app/page.tsx:560-565](../../../src/app/page.tsx#L560): `sparkColor = velocityRatio < 1 ? red : > 1.5 ? green : cyan`. A repo with `+10/24h` (positive but below 7d-baseline) renders a **red** sparkline beside a **green** `+10` delta. The two encodings disagree on the same row.
+
+Fix: either reconcile the spark color to `delta` sign (matches LiveTopTable's pattern), or move the velocity-ratio signal into a separate text indicator and keep spark color tied to direction. **Design call**.
+
+## P1 findings
+
+### P1-1 — `cat-foot` "updated HH:MM utc" is a page-wide stamp posing as panel-level freshness
+[src/app/page.tsx:485](../../../src/app/page.tsx#L485) — every HeroPanel footer reads `updated ${lastFetchedAt UTC time}`. All three panels (Repos / Skills / MCP) display the same string because `lastFetchedAt` is the page snapshot, not per-source. Honest-by-default voice demands per-source timestamps; this string flattens three different cadences into one.
+
+Fix: thread per-board `lastFetchedAt` from the respective Redis envelopes (`skillsRes.value.fetchedAt`, `mcpRes.value.fetchedAt`) into each panel; replace the literal string with `<FreshnessBadge>`. **Design call** on which timestamp source to wire.
+
+### P1-2 — "stars today / + live" Metric tone="positive" is a fake green delta
+[src/app/page.tsx:865](../../../src/app/page.tsx#L865) — `<Metric delta="+ live" tone="positive">`. The Metric primitive renders this as a green delta pill that mimics real deltas elsewhere on the page. Reads as "+1 live unit," which is meaningless.
+
+Fix: drop `delta="+ live"`, keep the sub line. Or replace with a real "(+N in last hour)" computed delta. **Mechanical** removal.
+
+### P1-3 — Hero h1 lede contains brand fluff, not a scan answer
+[src/app/page.tsx:844-848](../../../src/app/page.tsx#L844): `<h1>One live ranking for open-source breakouts.</h1>` + lede "Repos, skills, and MCP servers ranked by cross-source agreement, star velocity, and fresh community attention." PRODUCT.md prime directive is "answer 'what's moving in GitHub' in <3 seconds." First-screen pixel real estate is spent on description, not the answer. The 6-Metric strip (the answer) sits below the fold on most laptop viewports because the hero + clock + newsletter form claim the entire above-fold band.
+
+Fix: either compress the hero (h1 → tighter scale, lede → 1 line, move newsletter below the metrics) or hoist `MetricGrid` above `.page-head`. **Design call**.
+
+### P1-4 — Newsletter form in hero competes with the scan answer
+[src/app/page.tsx:850](../../../src/app/page.tsx#L850) `<NewsletterCaptureForm source="hero" />` directly under the h1. PRODUCT.md says interface IS the tool, not the marketing — a newsletter capture in the first 200px on a screener home is a marketing pattern from the anti-feel list (BI / SaaS landing). Either drop it from the hero or move it under the FAQ.
+
+Fix: move the form to a secondary slot (between section 06 and the FAQ, or inside the footer band). **Design call**.
+
+### P1-5 — `HeroPanel` `count` overstates Skills / MCP coverage
+[src/app/page.tsx:879-880](../../../src/app/page.tsx#L879): `count={skillsItems?.length ?? skillsBoard.length}`. `skillsItems` is the **deduped** combined list; the panel headline reads "Claude skills / N tracked" using a number that wasn't deduped (and is the full leaderboard count). On a degraded `mcpRes`, the fallback `topCategoryFallback` uses derived repos with category `mcp` — count then displays the fallback's 5, masking that the MCP feed is down.
+
+Fix: derive count from the same envelope being rendered, and surface a "fallback" or "degraded" sub-label when the real feed is missing. **Design call**.
+
+### P1-6 — Bubble map header "LIVE · MM.DD" lies on every cold render
+[src/components/terminal/BubbleMap.tsx:199-200](../../../src/components/terminal/BubbleMap.tsx#L199): `headerStatus = LIVE · ${UTC month.day}`. Stamps today's date even when the underlying `repos` snapshot is hours/days old. Empty-state branch ([line 234](../../../src/components/terminal/BubbleMap.tsx#L234)) also runs a pulsing green dot via `animate-pulse` — an empty radar that pulses green = stronger lie than the populated one.
+
+Fix: wrap header + empty state in `<FreshnessBadge lastUpdatedAt={lastFetchedAt} source="repos">`. **Mechanical** at the call site, **design call** for the empty-state copy.
+
+### P1-7 — `.feat-grid` 5-column layout collapses badly at 1100-720px
+[globals.css:2156-2166](../../../src/app/globals.css#L2156): 5 cols → 3 cols at 1100px → 2 cols at 720px. The 5-card layout already over-compresses titles via `!important` overrides ([globals.css:2130-2154](../../../src/app/globals.css#L2130)). Tablet (720-1100px) crops the third card's content awkwardly because the second/third Featured cards (smaller height) sit beside a hero card that's still inline.
+
+Fix: drop to a 2-col / 1-col layout earlier (e.g. 5 → 2 at ≤1100px), or remove `!important` overrides and let the cards breathe via natural typography. **Design call**.
+
+### P1-8 — `.hero-row` 5-col grid has no mobile reflow
+[globals.css:1769-1797](../../../src/app/globals.css#L1769): `grid-template-columns: 26px 28px minmax(0, 1fr) auto 92px` — fixed sparkline 92px column. At 375px after the home-surface padding (12px×2 = 24px) and grid gutters, the `nm` column has ~80px for `nm.txt + nm.sub`. The `.txt` is `text-overflow: ellipsis` so long names truncate, but the delta-stack column is `auto` and the spark eats 92px regardless. Result on mobile: 3-4 char repo names visible.
+
+Fix: at `(max-width: 767px)`, hide the sparkline column inside `.hero-row` (mirror the `.brk-row` mobile rule at globals.css:2965), giving the name 80-120px more. **Mechanical**.
+
+### P1-9 — `feat-card .desc / .why { display: none }` is dead-code drift
+[globals.css:2135-2141](../../../src/app/globals.css#L2135): two whole classes hidden via `display: none`. Indicates the FeaturedCard component used to render `.desc` and `.why` blocks that were stripped without removing the CSS. The current `FeaturedCard` ([page.tsx:597](../../../src/app/page.tsx#L597)) never emits those classes. Drift between the V2 era and current code.
+
+Fix: delete the two rules. **Mechanical**.
+
+## P2 findings
+
+### P2-1 — Spark stroke 1.6px is one notch off the design system's 2px line spec
+[src/app/page.tsx:387](../../../src/app/page.tsx#L387) `strokeWidth={1.6}`. DESIGN.md says chart `line` is 2px. Trivial but inconsistent across the home sparklines (1.6) and the chart-theme tokens (2). **Mechanical**.
+
+### P2-2 — "NO SERIES" empty state for sparklines is loud
+[src/app/page.tsx:444](../../../src/app/page.tsx#L444) renders a dashed-border pill with uppercase "NO SERIES" text inline with live rows. Reads as an error on the hero scan even though it's just missing data. Honest, but noisy. Consider a low-contrast `—` glyph or a flat baseline mini-spark. **Design call**.
+
+### P2-3 — TR-100 Index aggregates 5 repos' sparklines into one line with no per-leader breakout
+[src/app/page.tsx:967-991](../../../src/app/page.tsx#L967) sums each bucket across 5 leaders into a single area-filled line, then renders a legend strip of the 5 names beneath. Reader can't tell which repo contributes which slice of the line — it reads as "trust us, this is the index." For a screener, the chart should be either (a) the literal stacked area per leader, or (b) the sum line + small individual sparks on the legend. **Design call**.
+
+### P2-4 — Crumb "TREND / TERMINAL / FRONT PAGE" is decorative
+[src/app/page.tsx:842](../../../src/app/page.tsx#L842): a fake breadcrumb on the homepage (since there's no parent route). PRODUCT.md anti-feel includes "Generic startup hero." A made-up breadcrumb on the root URL reads as that anti-pattern. **Design call** — kill it or replace with a real status line ("// HOME · {N} repos tracked · {lastUpdatedAt}").
+
+### P2-5 — `<details>`-based FAQ swallows keyboard focus from the `[+]/[-]` glyph
+[src/app/page.tsx:1076-1078](../../../src/app/page.tsx#L1076): `<span class="toggle-closed">[+]</span>` is `aria-hidden`. Visual ok, but the user gets no SR cue when toggling. `<details>`/`<summary>` is a11y-correct on its own (native expand state), so the `aria-hidden` glyph is redundant; just confirm SR users hear the expanded/collapsed state. Should be fine in modern UA — flag for verification. **Verify in browser**.
+
+### P2-6 — Six metrics on first row is the upper limit per DESIGN.md
+[src/app/page.tsx:863-870](../../../src/app/page.tsx#L863) `<MetricGrid columns={6}>`. At 1280px (xl breakpoint, common laptop), six columns means each metric is ~200px after padding — labels are ok but values + sub use `font-size-3xl` which can wrap into the sub. Consider `columns={5}` (drops "top category" into a sub-line, or move it into the FooterBar). **Design call**.
+
+### P2-7 — `.cons-row` and `.brk-row` first-row gradients use brand orange + green at high opacity
+[globals.css:1959](../../../src/app/globals.css#L1959) `linear-gradient(90deg, var(--acc-soft), transparent 60%)` and [globals.css:2091](../../../src/app/globals.css#L2091) `linear-gradient(90deg, rgba(34, 197, 94, 0.1), transparent 70%)`. The Consensus row uses brand orange tint, Breakout uses green — semantically: brand = "this is the top," green = "accelerating." Could double-encode (top-1 + accelerating) on the same repo in both panels, painting the same row two different tints in adjacent cards. Visually noisy but defensible. **Design call**.
+
+### P2-8 — Footer string "DATA / HH:MM:SS UTC" lies about granularity
+[src/app/page.tsx:1309](../../../src/app/page.tsx#L1309) `actions={`DATA / ${refreshedTime} UTC`}`. The home is ISR-cached 60s ([page.tsx:63](../../../src/app/page.tsx#L63)) so the timestamp is the snapshot time, but it reads as a real-time clock. Same as the page-head clock above. **Design call** — either run `<FreshnessBadge>` here too, or label it "snapshot at HH:MM."
+
+## What's working well
+
+- **Honest "NO SERIES" pattern** ([page.tsx:443-447](../../../src/app/page.tsx#L443)): missing sparkline data renders an explicit empty marker instead of a fake flat line. P0 honesty applied at the right level.
+- **Mention-count chip "skip zero-source" rule** ([LiveTopTable.tsx:483-484](../../../src/components/home/LiveTopTable.tsx#L483)): comment explains why ghost-grey chips were removed — high-quality drift correction.
+- **Sub-1% pct formatter** ([LiveTopTable.tsx:155-173](../../../src/components/home/LiveTopTable.tsx#L155)): `+<0.1%` instead of `+0%` for tiny deltas — exactly the right honesty fix.
+- **`SvgSparkline` swap from `EChartSparkline`** ([LiveTopTable.tsx:175-178](../../../src/components/home/LiveTopTable.tsx#L175)) — saves the 150KB ECharts chunk on the most data-dense surface. Performance call.
+- **Viewport-triggered prefetch** ([LiveTopTable.tsx:329](../../../src/components/home/LiveTopTable.tsx#L329)) with Save-Data + concurrency cap — perfect K2.
+- **Functional border-left rails** ([globals.css:1789-1796](../../../src/app/globals.css#L1789), [1956-1960](../../../src/app/globals.css#L1956), [2088-2092](../../../src/app/globals.css#L2088)) — every first-row left-rail is color-keyed to its tier (panel acc / consensus acc / breakout green). This is the "not decorative slop" pattern DESIGN.md defends.
+- **Sticky 2px card radii** preserved across `.feat-card`, `.cons-row`, `.brk-row`, `.hero-panel` — terminal feel intact.
+- **No card shadows** anywhere on the home surface — design system enforced.
+- **FAQ + JSON-LD pulled from one array** ([page.tsx:68-93, 1167-1180](../../../src/app/page.tsx#L1167)) — `HOMEPAGE_FAQ` is single source of truth, K2-correct.
+
+## Verify-in-context
+
+- [ ] Load `/` at 375px on a real iOS Safari — confirm `.hero-row` truncation, `.fchip` tap targets, MetricGrid 2-col reflow.
+- [ ] Stop the Redis collector + ISR-revalidate the page; verify every "LIVE" pip still renders green (this is the bug that blocks the fix being merged blind).
+- [ ] Tab through the page; confirm whether the chart-toggle `<span>`s ever land in tab order (they shouldn't) and whether the chart pretends to respond.
+- [ ] Run Lighthouse mobile — current score baseline for re-test after fixes.
+
+## Mechanical fixes ready to ship
+
+1. Delete dead `feat-card .desc / .why { display: none }` rules ([globals.css:2135-2141](../../../src/app/globals.css#L2135)).
+2. Drop `delta="+ live"` from "stars today" Metric ([page.tsx:865](../../../src/app/page.tsx#L865)).
+3. Hide `.hero-row .spark` at `(max-width: 767px)` (one CSS rule, mirrors `.brk-row` mobile pattern).
+4. Bump `.fchip` to `min-height: 44px` at `(max-width: 767px)`.
+5. Bump sparkline `strokeWidth` to 2.
+
+## Quick-fix patches (optional)
+
+```diff
+// src/app/page.tsx
+-          <Metric label="stars today" value={formatCompact(total24h)} delta="+ live" tone="positive" />
++          <Metric label="stars today" value={formatCompact(total24h)} sub="24h aggregate" tone="positive" />
+```
+
+```diff
+// src/app/page.tsx — five LIVE call sites
+- right={<span className="live">LIVE</span>}
++ right={<FreshnessBadge lastUpdatedAt={lastFetchedAt} source="repos" />}
+
+// for Skills / MCP panels use the matching `NewsSource` token
++ <FreshnessBadge lastUpdatedAt={skillsRes.value.fetchedAt} source="skills" />
++ <FreshnessBadge lastUpdatedAt={mcpRes.value.fetchedAt}   source="mcp" />
+```
+
+```css
+/* globals.css */
+@media (max-width: 767px) {
+  .hero-row { grid-template-columns: 24px 28px minmax(0, 1fr) auto; }
+  .hero-row .spark { display: none; }
+  .live-top-filters .fchip { min-height: 44px; padding: 10px 12px; }
+}
+/* delete dead rules */
+- .feat-card .desc { display: none; }
+- .feat-card .why  { display: none; }
+```
+
+```diff
+// src/app/page.tsx ConsensusRow — render only firing sources
+- {SOURCE_ICONS.slice(0, channels).map(({ key, label, Icon }) => (
++ {SOURCE_ICONS
++   .filter(({ key }) => (repo.channelStatus?.[key] ?? 0) > 0)
++   .map(({ key, label, Icon }) => (
+```

--- a/docs/audits/impeccable/signals-audit.md
+++ b/docs/audits/impeccable/signals-audit.md
@@ -1,0 +1,198 @@
+# /signals audit — 2026-05-13
+
+> Impeccable design audit on `/signals`. Reference surface for chart polish, LIVE indicators, and Tag Momentum heatmap. Project-specific rules apply: honest freshness chrome is non-negotiable; functional `borderLeft` is not "side-tab slop"; cards are 2px and shadow-free.
+
+## Files audited
+
+- [src/app/signals/page.tsx](../../../src/app/signals/page.tsx) — server route + RSC composition
+- [src/app/signals/signals.css](../../../src/app/signals/signals.css) — page-scoped grid + chip styles
+- [src/components/signals-terminal/LiveClock.tsx](../../../src/components/signals-terminal/LiveClock.tsx)
+- [src/components/signals-terminal/LiveTicker.tsx](../../../src/components/signals-terminal/LiveTicker.tsx)
+- [src/components/signals-terminal/KpiStrip.tsx](../../../src/components/signals-terminal/KpiStrip.tsx)
+- [src/components/signals-terminal/SourceFeedPanel.tsx](../../../src/components/signals-terminal/SourceFeedPanel.tsx)
+- [src/components/signals-terminal/SourceFilterBar.tsx](../../../src/components/signals-terminal/SourceFilterBar.tsx)
+- [src/components/signals-terminal/VolumeAreaChart.tsx](../../../src/components/signals-terminal/VolumeAreaChart.tsx)
+- [src/components/signals-terminal/ConsensusRadar.tsx](../../../src/components/signals-terminal/ConsensusRadar.tsx)
+- [src/components/signals-terminal/TagMomentumHeatmap.tsx](../../../src/components/signals-terminal/TagMomentumHeatmap.tsx)
+- [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx) — reference for the honest pattern
+- [src/lib/news/freshness.ts](../../../src/lib/news/freshness.ts) — `classifyFreshness()` API
+- [src/app/globals.css#L4134-L4150](../../../src/app/globals.css) — `.live` styles (green pulse)
+- [src/lib/charts/theme/tokens.ts](../../../src/lib/charts/theme/tokens.ts) — chart theme
+
+## P0 findings
+
+### 1. `<span className="live">LIVE</span>` rendered unconditionally on every source panel
+- **File**: [SourceFeedPanel.tsx:85](../../../src/components/signals-terminal/SourceFeedPanel.tsx#L85)
+- **Mechanical**: `<span className="live">LIVE</span>` is hardcoded in `CardHeader.right` and emitted by all 8 panels (HN, GH, X, Reddit, Bluesky, Dev.to, Claude RSS, OpenAI RSS). The `.live` class ([globals.css#L4142-L4150](../../../src/app/globals.css)) renders a green dot + green text with no awareness of the source's freshness verdict. Cold collectors (per PRODUCT.md: 7 of 16 sources currently degraded) light up "LIVE" green anyway.
+- **Fix**: Pass a freshness verdict into `SourceFeedPanel` and replace the static `<span className="live">LIVE</span>` with `<FreshnessBadge source={...} lastUpdatedAt={...} />`. The page already computes `sourceVerdicts` ([page.tsx:324-334](../../../src/app/signals/page.tsx#L324)) — thread that into each panel.
+- **Design call**: route via `<FreshnessBadge>` so the chrome can read FRESH/STALE/COLD honestly.
+
+### 2. `LiveClock` renders hardcoded "FEED LIVE" with green pulse, never verifying freshness
+- **File**: [LiveClock.tsx:78](../../../src/components/signals-terminal/LiveClock.tsx#L78), pulse shadow [L74](../../../src/components/signals-terminal/LiveClock.tsx#L74)
+- **Mechanical**: Inline `boxShadow: "0 0 0 3px rgba(34,197,94,0.18)"` + literal `FEED LIVE` text + green pulse animation. The shadow value duplicates `--shadow-live-small` and isn't gated on any `lastUpdatedAt`.
+- **Fix**: Either (a) accept a `freshness: FreshnessVerdict` prop and render dot color + label from the verdict, or (b) remove the "FEED LIVE" line entirely and let the `FreshnessBadge` next to the clock carry the honest signal. Pulse animation only runs when `verdict.status === "live"`.
+- **Design call**: drop or downgrade — the clock is for time, the badge is for freshness. Two channels of "LIVE" double-broadcast and undermine the honest-chrome rule.
+
+### 3. `LiveTicker` header hardcodes "LIVE · 24H WIRE" with green pulse on a 24-hour rollup
+- **File**: [LiveTicker.tsx:72](../../../src/components/signals-terminal/LiveTicker.tsx#L72), pulse [L69](../../../src/components/signals-terminal/LiveTicker.tsx#L69) (`pulse-dark 1.4s`)
+- **Mechanical**: Wire label is permanent. Ticker items can be 23h old yet the orange-on-dark "LIVE" pip pulses regardless. Animation is 1.4s — matches `--motion-duration-pulse-fast` correctly, but the *semantic* claim is wrong.
+- **Fix**: Rename label to "24H WIRE" (drop "LIVE"), or accept a `freshnessIso` prop and only show the pulse when the freshest ticker item is `< 1h` old. Page already has `freshnessIso` ([page.tsx:352-365](../../../src/app/signals/page.tsx#L352)) ready to pass down.
+- **Design call**: drop the "LIVE" word and the pulse, OR gate both on real freshness.
+
+### 4. `VolumeAreaChart` card header also pinned to `<span className="live">LIVE</span>`
+- **File**: [VolumeAreaChart.tsx:359](../../../src/components/signals-terminal/VolumeAreaChart.tsx#L359)
+- **Mechanical**: Same pattern as #1 — `CardHeader.right` emits the static `.live` pip. Volume chart can be displaying a window where every source is cold; the badge still reads "LIVE" green.
+- **Fix**: Replace with `<FreshnessBadge source="hackernews" lastUpdatedAt={freshnessIso} />` (or pass the verdict through). The chart panel is `// 01` — the reference panel — so this leaks into "what good looks like" for the rest of the codebase.
+- **Design call**: hard requirement per CLAUDE.md.
+
+## P1 findings
+
+### 5. KPI strip "≈ realtime" sub-label is hardcoded under "Data freshness"
+- **File**: [KpiStrip.tsx:144-145](../../../src/components/signals-terminal/KpiStrip.tsx#L144)
+- **Mechanical**: `sub={<span style={{ color: "var(--color-positive)" }}>≈ realtime</span>}` — green positive text under whatever `freshnessLabel` is (e.g. "3d ago"). When the underlying data is days stale the user sees "3d ago / ≈ realtime" in matching green.
+- **Fix**: Derive sub-label from a verdict — `live → "≈ realtime"`, `warn → "stale"`, `cold → "data degraded"`. Pass the verdict colour through. The page computes `coldSources` already; piggyback on the same data.
+- **Design call**: small but visible lie. P1 not P0 because the parent `freshnessLabel` does read honestly ("3d ago").
+
+### 6. Inline `<details>` summary in KpiStrip is a 44×44 mobile-tap violation + non-keyboard-discoverable
+- **File**: [KpiStrip.tsx:96-105](../../../src/components/signals-terminal/KpiStrip.tsx#L96)
+- **Mechanical**: `<summary>` rendered as plain text "status" with `listStyle: "none"`, no marker, no focus styling, no explicit width/height. Tap area is the bounding box of the word "status" (~36px wide × ~14px tall). Below the 44×44 minimum per PRODUCT.md mobile contract.
+- **Fix**: Make the summary a chip — `padding: 6px 10px; border: 1px solid var(--color-border-default); display: inline-flex; min-height: 28px;` and add `:focus-visible` outline. Show a caret/`▾` marker so users know it's expandable.
+- **Design call**: also note discoverability — a single word "status" doesn't read as actionable.
+
+### 7. KPI strip empty-state ("All sources currently degraded") uses fallback CSS vars + hardcoded radius/border
+- **File**: [page.tsx:541-554](../../../src/app/signals/page.tsx#L541)
+- **Mechanical**: `border: "1px solid var(--color-border, rgba(255,255,255,0.08))"` and `borderRadius: 8`. The card-radius standard is 2px; the correct token is `--color-border-default`. Fallback `var(--color-border, …)` will never hit the fallback in this codebase but pollutes consistency.
+- **Fix**: `border: "1px solid var(--color-border-default)"`, `borderRadius: 2`, `color: var(--color-text-subtle)`. Drop fallback args.
+- **Design call**: mechanical.
+
+### 8. Tag-momentum heatmap doesn't reflow on mobile — relies on horizontal scroll inside an already-scrollable page
+- **File**: [TagMomentumHeatmap.tsx:196](../../../src/components/signals-terminal/TagMomentumHeatmap.tsx#L196), CSS at [signals.css:54-62](../../../src/app/signals/signals.css#L54)
+- **Mechanical**: Fixed `left: 96` ECharts grid margin for tag labels, 24-column hour axis. On 375px viewport the heatmap is wider than the panel; the page-scoped `.signals-heatmap-body` then *removes* `overflow-x: auto` at `≤767px` (`overflow-x: visible`). Result on phone: the heatmap either overflows the card and gets clipped by the page horizontal-scroll lock, or the cells become un-readable squares <8px wide.
+- **Fix**: At `≤640px`, either (a) keep `overflow-x: auto` on the heatmap body and add a horizontal scroll hint, or (b) reduce the tag-list to 6 rows + compress the x-axis to 8 four-hour buckets. Density-test the readable cell size at 375px.
+- **Design call**: choose between scroll-or-compress; both are valid for the heatmap content.
+
+### 9. "ALL" filter chip is unlabelled — screen reader announces nothing
+- **File**: [SourceFilterBar.tsx:256-263](../../../src/components/signals-terminal/SourceFilterBar.tsx#L256)
+- **Mechanical**: `<Link href=…><b>ALL</b></Link>` (visible text "ALL") has `aria-pressed` but no `aria-label`. Topic ALL chip same — [L361-370](../../../src/components/signals-terminal/SourceFilterBar.tsx#L361). Source-key chips do have `aria-label={s.label}`.
+- **Fix**: Add `aria-label="All sources"` and `aria-label="All topics"` to the two ALL chips. Their visible text "ALL" is ambiguous out of context.
+- **Design call**: mechanical; trivially correct.
+
+### 10. Heatmap legend swatches are 10×10 with adjacent text — fails 44×44 tap target if made interactive later
+- **File**: [TagMomentumHeatmap.tsx:213-243](../../../src/components/signals-terminal/TagMomentumHeatmap.tsx#L213)
+- **Mechanical**: Currently informational-only (`aria-hidden`), so technically not a tap target. Flagging as P1-not-P0 because the legend would naturally become a filter toggle in a future iteration.
+- **Fix**: If/when legend becomes interactive, wrap each swatch+label in a `min-height: 28px; padding: 6px 8px` container. For now, no action needed.
+- **Design call**: design call — leave as P1 watch-list item.
+
+## P2 findings
+
+### 11. Card radius drift on KpiStrip empty-state — uses 8px, not 2px
+- Already covered as part of #7; flagging here as a P2 visual-consistency violation against the 2px card radius standard.
+
+### 12. `ageLabel()` returns "no data yet" but renders as "updated no data yet" in panel footers
+- **File**: [page.tsx:141, used at L610, L621, etc.](../../../src/app/signals/page.tsx#L141)
+- **Mechanical**: Composition produces "updated no data yet" — grammatically awkward. Cold-source footer reads less honestly than it should.
+- **Fix**: When `ageLabel === "no data yet"`, render `freshLabel={"no data yet"}` directly without the "updated " prefix.
+- **Design call**: copy nudge.
+
+### 13. Inline styles dominate — 80%+ of the visual rules live as React `style={{}}` props
+- **File**: every component in `signals-terminal/`
+- **Mechanical**: Inline styles repeat tokens like `fontFamily: "var(--font-mono)"`, `letterSpacing: "0.14em"`, `color: "var(--color-text-subtle)"` hundreds of times. Hard to audit drift, hard to swap with a theme prop later. Doesn't run through Tailwind's class detection or critical-CSS path.
+- **Fix**: Not a quick fix; flag as systemic. The page-scoped `signals.css` proves the team is willing to colocate; migrate repeated inline blobs to component-scoped CSS modules or utility classes over time.
+- **Design call**: design call — accept inline style cost during the V4 migration, then sweep.
+
+### 14. `EmptyMessage` text "no recent items — collector warming up" appears in 4+ places with subtle variants
+- **File**: [SourceFeedPanel.tsx:505-520](../../../src/components/signals-terminal/SourceFeedPanel.tsx#L505), [TagMomentumHeatmap.tsx:261-272](../../../src/components/signals-terminal/TagMomentumHeatmap.tsx#L261), [LiveTicker.tsx:142-150](../../../src/components/signals-terminal/LiveTicker.tsx#L142), [ConsensusRadar.tsx:281-292](../../../src/components/signals-terminal/ConsensusRadar.tsx#L281)
+- **Mechanical**: Four near-identical empty states (em-dash vs hyphen, different colors via different vars).
+- **Fix**: Promote to a shared `<EmptyState message />` primitive under `components/ui/`.
+- **Design call**: small consistency lift.
+
+### 15. SourceFeedPanel tweet-row avatar uses hardcoded "1.5px solid var(--color-bg-shell)" border
+- **File**: [SourceFeedPanel.tsx:335](../../../src/components/signals-terminal/SourceFeedPanel.tsx#L335)
+- **Mechanical**: Non-token 1.5px border width. The hairline ladder is 1px / 2px / 3px (`--border-width-hairline/accent/rail`). 1.5 is half-step drift.
+- **Fix**: Either 1px (`--border-width-hairline`) or 2px (`--border-width-accent`).
+- **Design call**: mechanical.
+
+## What's working well (reference patterns to propagate)
+
+1. **`SourceFeedPanel` brand-tint pattern** ([SourceFeedPanel.tsx:99-107](../../../src/components/signals-terminal/SourceFeedPanel.tsx#L99)) — `color-mix(in srgb, ${brand} 22%, transparent)` + 50% border + brand-colored mark. Reads as identity-keyed at a glance without screaming color. Use everywhere a source / repo identity needs anchoring.
+2. **`SourceMark` + brand-color CSS var pattern** — clean abstraction; chip on/off state lives in URL, color carries identity. Worth replicating on `/twitter` and `/funding`.
+3. **Cold-source disclosure pattern** ([KpiStrip.tsx:88-115](../../../src/components/signals-terminal/KpiStrip.tsx#L88)) — `<details>` collapses the "X cold" broadcast without hiding the data. Honest *and* quiet. Should propagate to `/funding` and any surface showing degraded-source counts (after tap-target fix #6).
+4. **Empty-state when all sources cold** ([page.tsx:541-554](../../../src/app/signals/page.tsx#L541)) — single muted line, no zero-bombing of every KPI. Right call; pattern should travel.
+5. **`SOURCE_FRESHNESS_SOURCE` mapping computed once at top** ([page.tsx:291-334](../../../src/app/signals/page.tsx#L291)) — clean RSC composition: 8 sources × 1 verdict each, ready to thread into panels. This is the right shape; just needs to actually reach the panels.
+6. **Topic + window filter URL-state pattern** — every filter is a `<Link>`, no client state machinery, server re-renders cheaply. Sets the bar for all filter surfaces.
+7. **Functional `borderLeft` color-keys on source panels and the vol-rail** — correctly applied per per-source identity, not decoration. Don't strip.
+8. **`ECharts` chart theme registered once and reused** via `<EChart theme="trendingrepo-dark">` — single chart language across panels.
+9. **`buildSparkline()` per-source rail under volume chart** ([VolumeAreaChart.tsx:381-449](../../../src/components/signals-terminal/VolumeAreaChart.tsx#L381)) — inline SVG (not ECharts) for 8 tiny glyphs, smart performance call. Worth documenting as a pattern in DESIGN.md.
+10. **Card radii at 2px** consistent across all panels — terminal feel preserved.
+
+## Verify-in-context
+
+- **Chart palette drift**: noted in DESIGN.md as an open follow-up — `globals.css --color-series-1` (green) vs `tokens.ts SERIES_PALETTE[0]` (orange). On `/signals`, the ConsensusRadar gives the *top* polygon `CHART_TOKENS.accent` (orange, [ConsensusRadar.tsx:104-105](../../../src/components/signals-terminal/ConsensusRadar.tsx#L104)) which forces brand-accent for the lead story. Subsequent polygons cycle the SERIES_PALETTE. Visually fine on this page, but if someone reads `--color-series-1` (green) on a sibling chart, the top-story-orange convention doesn't transfer. Not for the audit to fix.
+- **`signals.css:71` chip uses `color-mix(... var(--color-text-default))`** — relies on `--color-text-default` being a near-white. If the theme accent ever swaps to a lighter neutral the chip would invert. Low risk; flag if a new theme is added.
+- **Motion timing**: `LiveClock` pulse is `1.6s` — matches `--motion-duration-pulse`. `LiveTicker` pulse-dark is `1.4s` — matches `--motion-duration-pulse-fast`. Ticker scroll is `60s linear` — matches `--motion-duration-clock`. All correct.
+
+## Mechanical fixes ready to ship
+
+1. **SourceFeedPanel** ([L85](../../../src/components/signals-terminal/SourceFeedPanel.tsx#L85)): replace `<span className="live">LIVE</span>` with `<FreshnessBadge source={SIGNAL_FRESHNESS_SOURCE[source]} lastUpdatedAt={lastUpdatedAt} />` — accept a new `lastUpdatedAt` prop.
+2. **VolumeAreaChart** ([L359](../../../src/components/signals-terminal/VolumeAreaChart.tsx#L359)): same replacement, accept `lastUpdatedAt` prop, pass from page.
+3. **LiveTicker** ([L72](../../../src/components/signals-terminal/LiveTicker.tsx#L72)): change label "LIVE · 24H WIRE" → "24H WIRE"; remove `pulse-dark` animation OR accept `latestItemIso` prop and gate pulse on `< 1h`.
+4. **LiveClock** ([L58-L80](../../../src/components/signals-terminal/LiveClock.tsx#L58)): remove the entire "FEED LIVE" block — the clock should be a clock. Freshness lives in the `<FreshnessBadge>` placed next to it.
+5. **KpiStrip** ([L144-L145](../../../src/components/signals-terminal/KpiStrip.tsx#L144)): make "≈ realtime" conditional on a verdict prop.
+6. **SourceFilterBar** ([L256, L361](../../../src/components/signals-terminal/SourceFilterBar.tsx#L256)): add `aria-label="All sources"` / `"All topics"` to the two ALL chips.
+7. **KpiStrip empty-state in page.tsx** ([L545-L546](../../../src/app/signals/page.tsx#L545)): swap `--color-border` fallback for `--color-border-default`, `borderRadius: 8` → `borderRadius: 2`.
+8. **SourceFeedPanel tweet avatar** ([L335](../../../src/components/signals-terminal/SourceFeedPanel.tsx#L335)): `1.5px` → `1px`.
+
+## Quick-fix patches (optional)
+
+### Patch A — Page wires verdict into each SourceFeedPanel
+
+```tsx
+// page.tsx — already computes sourceVerdicts[]. Build a lookup once.
+const verdictBySource: Record<SourceKey, FreshnessVerdict> = Object.fromEntries(
+  sourceVerdicts.map((v) => [v.key, v.verdict]),
+) as Record<SourceKey, FreshnessVerdict>;
+
+// Pass into each <SourceFeedPanel ... verdict={verdictBySource[<key>]} />
+```
+
+### Patch B — SourceFeedPanel renders honest pill
+
+```tsx
+// SourceFeedPanel.tsx
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+
+interface SourceFeedPanelProps {
+  // ...
+  lastUpdatedAt: string | null | undefined;
+  freshnessSource: NewsSource; // hackernews / twitter / reddit / etc.
+}
+
+<CardHeader right={
+  <>
+    <span style={{ fontVariantNumeric: "tabular-nums" }}>{countLabel}</span>
+    <FreshnessBadge source={freshnessSource} lastUpdatedAt={lastUpdatedAt} />
+  </>
+}>
+```
+
+### Patch C — LiveClock loses the lie
+
+```tsx
+// LiveClock.tsx — delete the entire <div style={{ marginTop: "4px" }}> block.
+// Page already renders FreshnessBadge in the PageHead area; that's the honest signal.
+```
+
+---
+
+**Audit health score (estimated)**
+
+| # | Dimension | Score | Key finding |
+|---|---|---|---|
+| 1 | Accessibility | 2 | aria-label gaps on ALL chips; <details> summary too small to tap |
+| 2 | Performance | 4 | ECharts canvas, memoised options, lttb sampling, RSC composition |
+| 3 | Theming | 3 | Mostly tokenised; one 1.5px drift, one fallback-var pattern |
+| 4 | Responsive | 2 | Heatmap doesn't reflow under 640px; tap targets <44 in disclosure |
+| 5 | Anti-patterns | 1 | Four `LIVE` hardcoded indicators on the reference surface — the exact rule CLAUDE.md flags as P0 |
+| **Total** | | **12/20** | **Acceptable — once P0 honest-chrome cluster is fixed, jumps to ~18/20** |
+
+The P0 cluster is *all* the same defect: four places ([SourceFeedPanel:85](../../../src/components/signals-terminal/SourceFeedPanel.tsx#L85), [LiveClock:78](../../../src/components/signals-terminal/LiveClock.tsx#L78), [LiveTicker:72](../../../src/components/signals-terminal/LiveTicker.tsx#L72), [VolumeAreaChart:359](../../../src/components/signals-terminal/VolumeAreaChart.tsx#L359)) render permanent green "LIVE" without checking `lastUpdatedAt`. One pattern fix lands in all four. The page already computes the verdicts — it just doesn't thread them down.

--- a/docs/audits/impeccable/skills-audit.md
+++ b/docs/audits/impeccable/skills-audit.md
@@ -1,0 +1,160 @@
+# /skills audit — 2026-05-13
+
+Target: `/skills` after PR #828 (5-tab awesome-* curator taxonomy, commit `f2145d044`). Audit focuses on the inline `ListTaxonomyTabs` strip and the freshness chrome it ships with.
+
+## Files audited
+
+- [src/app/skills/page.tsx](../../../src/app/skills/page.tsx)
+- [src/components/skills/SkillsTopTable.tsx](../../../src/components/skills/SkillsTopTable.tsx)
+- [src/lib/skills/taxonomy.ts](../../../src/lib/skills/taxonomy.ts)
+- [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx)
+- [src/components/ui/TabBar.tsx](../../../src/components/ui/TabBar.tsx) (V4 primitive — unused by /skills)
+- [src/components/ui/v4.css](../../../src/components/ui/v4.css) (`.v4-tab-bar` at L516)
+- [data/awesome-skills.json](../../../data/awesome-skills.json) (4 lists, fetched 2026-05-12, ~8k rows)
+
+---
+
+## P0 findings
+
+### P0-1 — Hardcoded "live" green-pulse pip in SkillsTopTable [Mechanical]
+
+[src/components/skills/SkillsTopTable.tsx:313](../../../src/components/skills/SkillsTopTable.tsx#L313) renders `<span className="live-pip">live</span>` — a literal "live" label with a green pulse dot ([globals.css:2623-2641](../../../src/app/globals.css#L2623)). Violates the project rule: every freshness signal MUST route through `<FreshnessBadge>` + `classifyFreshness()`. Memory: `feedback_freshness_chrome_must_be_honest`.
+
+**Fix**: Replace the `live` span with `<FreshnessBadge source="skills" lastUpdatedAt={fetchedAt} />` (the page already imports the badge and renders one in `PageHead`; pass the same `data.combined.fetchedAt` down to the table or drop the in-table pip entirely — the badge in the header already covers freshness for this surface).
+
+### P0-2 — Tab tap targets fail 44×44 minimum [Mechanical]
+
+[src/app/skills/page.tsx:644](../../../src/app/skills/page.tsx#L644) — tab links render with `padding: "5px 10px"` and `fontSize: 11`, resulting in ~22px tall, ~70px wide hit boxes. PRODUCT.md mandates "44×44 minimum tap targets on every interactive element". 5 tabs on 375px are individually un-tappable for a thumb.
+
+**Fix**: Either (a) swap to the existing V4 `<TabBar>` primitive at [src/components/ui/TabBar.tsx](../../../src/components/ui/TabBar.tsx) which renders `height: 42px` + adequate horizontal padding and bumps to 44px on touch, or (b) raise inline padding to `12px 14px` minimum. See P1-1 for the consolidation play.
+
+---
+
+## P1 findings
+
+### P1-1 — Inline tab strip duplicates V4 `<TabBar>` primitive [Design]
+
+[src/app/skills/page.tsx:597-674](../../../src/app/skills/page.tsx#L597) inlines a 78-line `ListTaxonomyTabs` component with bespoke styling. The codebase already has [src/components/ui/TabBar.tsx](../../../src/components/ui/TabBar.tsx) backed by `.v4-tab-bar` in [v4.css:516](../../../src/components/ui/v4.css#L516) that ships: `height: 42px`, `overflow-x: auto` for mobile scroll, `border-bottom: 2px var(--v4-acc)` active indicator, hover transitions, the `__count` slot, and `hrefFor` link-mode for server-driven nav. Reinventing it creates drift (mobile-scroll fail per P1-2, tap-target fail per P0-2, missing focus-visible outline).
+
+**Fix**: Replace `ListTaxonomyTabs` body with `<TabBar items={…} active={activeListSlug ?? "all"} hrefFor={…}/>`. The `hrefFor` link-mode is exactly what's needed for `?list=<slug>` URL-driven tabs.
+
+### P1-2 — Tab strip wraps to 2 rows on 375px instead of horizontal scroll [Mechanical]
+
+[src/app/skills/page.tsx:626](../../../src/app/skills/page.tsx#L626) sets `flexWrap: "wrap"` with no `overflow-x: auto`. Worst-case tab label "Awesome Claude Code · 1.2k" is ~190px; 5 tabs + counts at 11px = ~700px nominal width, so 375px viewports get a 2-line stacked wrap that pushes the leaderboard down the page. The V4 `.v4-tab-bar` (L521 `overflow-x: auto; scrollbar-width: thin`) is the canonical scannable-on-mobile pattern.
+
+**Fix**: Switch to V4 `<TabBar>` (resolves with P1-1) OR add `flexWrap: "nowrap"; overflowX: "auto"; scrollbarWidth: "thin"` and remove `flexWrap: "wrap"`.
+
+### P1-3 — Top-N constants ignored on tab change; "Top skills" copy lies [Design]
+
+[src/app/skills/page.tsx:217-219](../../../src/app/skills/page.tsx#L217) renders `top {trendingItems.length} of {items.length}` — when a tab has fewer than `TRENDING_CAP` (1000) items, the section header reads "top 47 of 47" which is a misleading "top N" framing for what's actually "all 47 filtered rows". Confusing on the smaller tabs (e.g. `wong2-mcp` likely <100 items).
+
+**Fix**: When `trendingItems.length === items.length`, render `all {trendingItems.length} ranked` instead of `top N of M`. One-line guard in `SectionHead meta` prop at [skills/page.tsx:377-381](../../../src/app/skills/page.tsx#L377).
+
+### P1-4 — Inline styles bypass the design-token CSS layer [Design]
+
+`ListTaxonomyTabs`, `SkillsEmpty`, `SkillAvatar`, and the "Most-cited" grid use ~30 inline `style={{}}` blocks ([skills/page.tsx:436-562](../../../src/app/skills/page.tsx#L436)) instead of v4.css selectors. This forks the maintenance surface (theme-swap, accent recolor, density-mode `data-surface` will not affect these), and the `border-left: 3px solid` color-key pattern documented in DESIGN.md for compare/news is impossible to apply here.
+
+**Fix**: Move inline styles into a new `.v4-skills-*` block in [v4.css](../../../src/components/ui/v4.css) (or extract a `<MostCitedGrid>` component). At minimum, the empty-state inline block at [skills/page.tsx:686-700](../../../src/app/skills/page.tsx#L686) duplicates the home-page mono-caps empty state and should be the `<EmptyState>` primitive from [src/components/ui/EmptyState.tsx](../../../src/components/ui/EmptyState.tsx).
+
+---
+
+## P2 findings
+
+### P2-1 — `borderRadius: 3` on tab links exceeds `--radius-button` (2px) [Mechanical]
+
+[src/app/skills/page.tsx:645](../../../src/app/skills/page.tsx#L645) hardcodes `borderRadius: 3`. DESIGN.md spec: buttons + tabs use `--radius-button: 0.125rem` (2px) for terminal-feel. Same on pager buttons [globals.css:2663](../../../src/app/globals.css#L2663). Minor visual drift; impeccable's "sharp 2px corners" rule.
+
+**Fix**: Drop to `var(--radius-button)` (2px) — single token swap.
+
+### P2-2 — Skills table border-radius drift across sections [Mechanical]
+
+Section 02 (breakout) `<section borderRadius: 4>` at [skills/page.tsx:441](../../../src/app/skills/page.tsx#L441), Section 03 (most-cited) `<Link borderRadius: 3>` at [skills/page.tsx:526](../../../src/app/skills/page.tsx#L526), `<SkillAvatar borderRadius: 3>` at [skills/page.tsx:721](../../../src/app/skills/page.tsx#L721). Three different radii on one page — should all be `var(--radius-card)` (2px) per DESIGN.md.
+
+**Fix**: Replace literal radii with `var(--radius-card)` (or kill via P1-4 consolidation).
+
+### P2-3 — Page sets `revalidate = 60` but page reads from in-memory store [Design]
+
+[src/app/skills/page.tsx:59](../../../src/app/skills/page.tsx#L59) sets `revalidate = 60`. Each `refreshXxxFromStore()` call has its own 30s internal rate-limit, so the page can serve content as much as 90s stale while still appearing "fresh". The `<FreshnessBadge>` will surface this honestly IF the upstream `fetchedAt` is correct — but it would be cheaper / more honest to pin `revalidate = 120` and align with the source classifyFreshness threshold (NPM_STALE_THRESHOLD_MS).
+
+**Fix**: Leave as-is unless the FreshnessBadge starts reporting STALE too early; track in a follow-up.
+
+### P2-4 — `aria-current="page"` on filter chips is non-standard [Design]
+
+[src/app/skills/page.tsx:639](../../../src/app/skills/page.tsx#L639) — `aria-current="page"` typically denotes the current full-page route. These tabs only change a query-string filter; AT users may hear "current page" on every filter tab, false. ARIA APG suggests `aria-current="true"` for in-page filter state OR `aria-pressed` if treated as toggles.
+
+**Fix**: `aria-current={isActive ? "true" : undefined}` (or migrate to V4 `<TabBar>` which uses `aria-selected` correctly — P1-1).
+
+---
+
+## What's working well (5-tab pattern — what to keep)
+
+- **Server-driven URL filter via `<Link href="?list=…">`** ([skills/page.tsx:618](../../../src/app/skills/page.tsx#L618)) — bookmark-able, share-able, no client JS for the tab swap. Right pattern.
+- **`listCounts` computed from `allItems` (unfiltered)** ([skills/page.tsx:170-180](../../../src/app/skills/page.tsx#L170)) — counts stay stable as user tabs through, no flicker. Correct.
+- **Defensive `isListSlug` guard** ([skills/page.tsx:164](../../../src/app/skills/page.tsx#L164) + [taxonomy.ts:44](../../../src/lib/skills/taxonomy.ts#L44)) — unknown `?list=` collapses to All instead of empty. Right.
+- **`resolveSkillLists()` returns multi-slug membership** ([taxonomy.ts:55](../../../src/lib/skills/taxonomy.ts#L55)) — a skill in both `awesome-claude-code` AND `antigravity` is counted in both tab buckets. Right model.
+- **Top-of-page `<FreshnessBadge source="skills" lastUpdatedAt={data.combined.fetchedAt} />`** ([skills/page.tsx:292](../../../src/app/skills/page.tsx#L292)) — honest chrome already wired. The P0-1 in-table pip is the only freshness lie.
+- **Per-author cap (`PER_AUTHOR_CAP = 3`)** ([skills/page.tsx:71](../../../src/app/skills/page.tsx#L71)) — prevents one repo (e.g. `anthropics/skills` with 10+ child SKILL.md) from monopolising the leaderboard. Sharp call.
+
+---
+
+## Verify-in-context
+
+- Tab strip on `xs` (480px) and **375px**: confirm horizontal scroll vs 2-line wrap. Currently wraps — P1-2.
+- Each tab's empty path: visit `/skills?list=wong2-mcp` and verify `SkillsEmpty` renders if count is 0. Code path looks correct.
+- Keyboard tab order: `<Link>` chain in `<nav>` is natively keyboard-traversable. No tab-trap risk.
+- Color-blind verify: active tab uses `var(--v4-acc)` (brand orange) for the count color, on `var(--v4-bg-200)` background. Contrast OK but consider that **task rules suggested `--color-functional` (green) for active**. The V4 TabBar primitive itself uses `--v4-acc` (orange) — see [v4.css:556](../../../src/components/ui/v4.css#L556). This is design-system canonical; deviating from task brief, not the codebase. **Recommendation: keep brand-accent active** per system convention; do not switch to green.
+
+---
+
+## Mechanical fixes ready to ship
+
+In rough order of pickup:
+
+1. **P0-1** — delete `<span className="live-pip">live</span>` at [SkillsTopTable.tsx:313](../../../src/components/skills/SkillsTopTable.tsx#L313). One-line removal; the page header already renders the honest badge.
+2. **P0-2 + P1-1 + P1-2** — single substitution: replace inline `ListTaxonomyTabs` (~78 lines) with V4 `<TabBar items={…} active={activeListSlug ?? "all"} hrefFor={(id) => id === "all" ? "/skills" : `/skills?list=${id}`}/>`. Resolves three findings.
+3. **P1-3** — guard `SectionHead` meta to render `all N ranked` when `trendingItems.length === items.length`. Two-line change at [skills/page.tsx:377-381](../../../src/app/skills/page.tsx#L377).
+4. **P2-1 / P2-2** — token-swap radii literals to `var(--radius-button)` / `var(--radius-card)`. Mechanical replace_all in the file.
+5. **P2-4** — `aria-current="page"` → `aria-current="true"` (or drop entirely once on V4 TabBar).
+
+## Quick-fix patches (optional)
+
+**P0-1 quick patch**:
+
+```diff
+- <span className="live-top-spacer" />
+- <span className="live-top-meta">
+-   showing <b>{rangeStart}-{rangeEnd}</b> / {sorted.length}
+-   <span className="live-pip">live</span>
+- </span>
++ <span className="live-top-spacer" />
++ <span className="live-top-meta">
++   showing <b>{rangeStart}-{rangeEnd}</b> / {sorted.length}
++ </span>
+```
+
+**P1-1 quick patch** (skills/page.tsx body of `ListTaxonomyTabs`):
+
+```tsx
+import { TabBar } from "@/components/ui/TabBar";
+
+const items: TabItem[] = [
+  { id: "all", label: "ALL", count: allCount },
+  ...LIST_SLUGS.map((slug) => ({
+    id: slug,
+    label: LIST_LABELS[slug].toUpperCase(),
+    count: listCounts[slug],
+  })),
+];
+return (
+  <TabBar
+    items={items}
+    active={activeSlug ?? "all"}
+    hrefFor={(id) => (id === "all" ? "/skills" : `/skills?list=${id}`)}
+    className="v4-tab-bar--skills"
+  />
+);
+```
+
+---
+
+**Severity totals**: 2 P0 · 4 P1 · 4 P2. The 5-tab pattern itself is correct — URL-driven, defensive, stable counts. Two real defects (in-table live pip, missing mobile scroll/tap targets) and one consolidation lever (use the V4 `<TabBar>` primitive) close the polish gap.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2579,6 +2579,14 @@ body::before {
   transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
 }
 
+/* Mobile-only 44×44 tap target per PRODUCT.md mobile posture rule. */
+@media (max-width: 640px) {
+  .live-top-filters .fchip {
+    min-height: 44px;
+    padding: 10px 14px;
+  }
+}
+
 .live-top-filters .fchip:hover {
   color: var(--ink-100);
   border-color: var(--line-300);

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -437,7 +437,7 @@ function TrendingThisWeek({ movers, totalRows }: TrendingThisWeekProps) {
         marginBottom: 16,
         border: "1px solid var(--v4-line-200)",
         background: "var(--v4-bg-050)",
-        borderRadius: 4,
+        borderRadius: 2,
       }}
     >
       <header
@@ -512,9 +512,9 @@ function TrendingThisWeek({ movers, totalRows }: TrendingThisWeekProps) {
                     display: "flex",
                     alignItems: "center",
                     gap: 10,
-                    padding: "8px 10px",
+                    padding: "12px 10px",
                     border: "1px solid var(--v4-line-200)",
-                    borderRadius: 3,
+                    borderRadius: 2,
                     background: "var(--v4-bg-100)",
                     textDecoration: "none",
                     color: "var(--v4-ink-100)",
@@ -566,7 +566,7 @@ function TrendingThisWeek({ movers, totalRows }: TrendingThisWeekProps) {
                       fontFamily: "var(--font-geist-mono), monospace",
                       fontSize: 11,
                       fontWeight: 600,
-                      color: "var(--v4-up, #4ade80)",
+                      color: "var(--v4-money)",
                       flexShrink: 0,
                     }}
                     title={`+${deltaLabel} ${unitLabel} · 7d`}

--- a/src/components/mcp/LiveMcpTable.tsx
+++ b/src/components/mcp/LiveMcpTable.tsx
@@ -276,7 +276,6 @@ export function LiveMcpTable({ rows, categories, totalCount }: LiveMcpTableProps
         <span className="live-top-spacer" />
         <span className="live-top-meta">
           showing <b>{rendered.length}</b> / {totalCount ?? rows.length}
-          <span className="live-pip">live</span>
         </span>
       </div>
 

--- a/src/components/skills/SkillsTopTable.tsx
+++ b/src/components/skills/SkillsTopTable.tsx
@@ -310,7 +310,6 @@ export function SkillsTopTable({
         <span className="live-top-spacer" />
         <span className="live-top-meta">
           showing <b>{rangeStart}-{rangeEnd}</b> / {sorted.length}
-          <span className="live-pip">live</span>
         </span>
       </div>
 


### PR DESCRIPTION
## Summary

Wave-2 of the impeccable audit. Stacks on top of [wave-1 (PR #1146)](https://github.com/0motionguy/starscreener/pull/1146). PR base is `audit/imp-wave-1-clean` so the diff stays focused; once #1146 merges, GitHub auto-rebases the base to `main`.

5 parallel LLM audit agents audited the top user-facing surfaces against impeccable's methodology + project-specific honest-chrome rules. The reports are committed; **6 surgical mechanical fixes** are also included. The bigger 4-P0 clusters (honest-chrome threading on `/signals`, `/`, `/funding`) get their own PR — wave-3.

## What's in this PR

### Commit 1 — `audit(impeccable): wave-2 LLM audits on 5 surfaces (16 P0 / 28 P1 / 28 P2)`

5 audit reports + updated PUNCH-LIST.md + post-fix CLI snapshot.

| Surface | P0 | P1 | P2 | Audit report |
|---|---|---|---|---|
| `/funding` | 4 | 6 | 6 | [funding-audit.md](docs/audits/impeccable/funding-audit.md) |
| `/` (home) | 5 | 9 | 8 | [page-audit.md](docs/audits/impeccable/page-audit.md) |
| `/signals` | 4 | 6 | 5 | [signals-audit.md](docs/audits/impeccable/signals-audit.md) |
| `/mcp` | 1 | 3 | 5 | [mcp-audit.md](docs/audits/impeccable/mcp-audit.md) |
| `/skills` | 2 | 4 | 4 | [skills-audit.md](docs/audits/impeccable/skills-audit.md) |
| **Total** | **16** | **28** | **28** | |

**Dominant cross-surface patterns:**

1. **Honest-chrome violations (12+ sites)** — hardcoded `<span className="live">LIVE</span>` / `live-pip` / "FEED LIVE" green-pulse strings on every audited surface. The biggest lie: `/signals` already computes `sourceVerdicts` via `classifyFreshness()` ([page.tsx:324-334](src/app/signals/page.tsx#L324)) but doesn't thread the verdicts into the panels — every "LIVE" indicator is hardcoded regardless of real freshness.
2. **44×44 mobile tap-target failures** — tab strips and filter chips at 22-36px tall across `/skills` tabs, `/mcp` filter chips, `/funding` tabs, `/signals` disclosure.
3. **V4 token drift** — undefined `--v4-up` token on `/mcp` hero (breaks theme-switch), ad-hoc `borderRadius: 3` / `4` literals instead of `var(--radius-card)`.
4. **Inline-tab reimplementation** — `/skills` reinvents the V4 `<TabBar>` primitive in ~78 LOC.

### Commit 2 — `audit(impeccable): wave-2 mechanical fixes — /mcp + /skills (6 findings closed)`

Six surgical, mechanical fixes ready to ship in isolation:

| # | Surface | Severity | Fix | File |
|---|---|---|---|---|
| 1 | /mcp | **P0** | `var(--v4-up, #4ade80)` → `var(--v4-money)` (theme-switch now works) | [page.tsx:569](src/app/mcp/page.tsx#L569) |
| 2 | /mcp | P1 | `borderRadius: 4` → `2` (matches `--radius-card`) | [page.tsx:440](src/app/mcp/page.tsx#L440) |
| 3 | /mcp | P1+P2 | mover-row `borderRadius: 3 → 2` + `padding: "8px" → "12px"` (tap target) | [page.tsx:514-517](src/app/mcp/page.tsx#L514) |
| 4 | /mcp | P1 | Delete `.live-pip` duplicate (page has real FreshnessBadge) | [LiveMcpTable.tsx:279](src/components/mcp/LiveMcpTable.tsx#L279) |
| 5 | /mcp | P1 | `.fchip` mobile 44px tap target (`@media (max-width: 640px)`) | [globals.css:.fchip](src/app/globals.css) |
| 6 | /skills | **P0** | Delete `.live-pip` (page has real FreshnessBadge) | [SkillsTopTable.tsx:313](src/components/skills/SkillsTopTable.tsx#L313) |

## What's deferred to wave-3

The honest-chrome rule violations on `/signals`, `/`, and `/funding` are bigger than 1-line fixes — they need careful prop threading or component refactors. Each gets its own PR for reviewer focus:

- **wave-3a `/signals` honest-chrome cluster** — thread `sourceVerdicts` into `SourceFeedPanel`, `VolumeAreaChart`, `LiveClock`, `LiveTicker` (5 files). Highest-leverage fix in the entire audit: 4 P0s close from one pattern.
- **wave-3b `/` (home) honest-chrome cluster** — replace 5 hardcoded "LIVE" / green-pulse strings in BubbleMap, LiveTopTable, page.tsx with `<FreshnessBadge>`. (FreshnessBadge is never imported by `/` today — 5-site swap.)
- **wave-3c `/funding` 4 P0s** — confidence chip always green, "warming" sentinel, VerdictRibbon tone locked, MoverRow same-tab link.
- **wave-3d `/skills` inline-tab refactor** — swap `ListTaxonomyTabs` (~78 LOC inline) for the canonical V4 `<TabBar>` primitive. Closes 3 findings in one substitution.

## Test plan

- [x] `npx impeccable detect <each changed file>` → zero new findings; only the pre-existing `.repo-verdict` designed gradient pair remains
- [x] `npx impeccable detect src/` → 27 (unchanged; CLI catches regex, LLM caught semantics — they're complementary metrics)
- [x] `npm run lint:guards` → green (img-lazy ✓, keep-last-50 ✓, routes-config ✓)
- [ ] (recommended) visual smoke on `/mcp` + `/skills` at 375px and 1280px after merge to confirm fchip tap targets + missing live-pip pulse
- [ ] (next PR) wave-3 honest-chrome threading

🤖 Generated with [Claude Code](https://claude.com/claude-code)