### PR TITLE
feat(lib): TOOLBOX read adapters — HN + Reddit + Bluesky + dev.to mentions (Phase A.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ ADMIN_TOKEN=
 # TOOLBOX_INGEST_URL=https://api.aiso.tools/v1/signals/ingest
 # TOOLBOX_INGEST_HMAC_SECRET=<shared with /opt/toolbox/.env on Vultr>
 
+# -- Optional: TOOLBOX READ mode (Phase A.2 reader-switch) -------------------
+# Per-source feature flags. When TOOLBOX_READ_<SOURCE>=true AND
+# TOOLBOX_API_URL + TOOLBOX_API_KEY are set, the matching refresh hook
+# fetches from TOOLBOX's /v1/signals/leaderboard endpoint instead of the
+# legacy Redis-first data-store read. Falls back silently to legacy on any
+# TOOLBOX failure (network, auth, shape).
+# TOOLBOX_API_URL=https://api.aiso.tools
+# TOOLBOX_API_KEY=tbk_live_<32-char-token-from-mint-key-CLI>
+# TOOLBOX_READ_HN_MENTIONS=true
+
 # -- Optional: revenue enrichment (CI scripts only) --------------------------
 # TRUSTMRR_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,8 @@ ADMIN_TOKEN=
 # TOOLBOX_API_URL=https://api.aiso.tools
 # TOOLBOX_API_KEY=tbk_live_<32-char-token-from-mint-key-CLI>
 # TOOLBOX_READ_HN_MENTIONS=true
+# TOOLBOX_READ_BLUESKY_MENTIONS=true
+# TOOLBOX_READ_DEVTO_MENTIONS=true
 
 # -- Optional: revenue enrichment (CI scripts only) --------------------------
 # TRUSTMRR_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,7 @@ ADMIN_TOKEN=
 # TOOLBOX_READ_HN_MENTIONS=true
 # TOOLBOX_READ_BLUESKY_MENTIONS=true
 # TOOLBOX_READ_DEVTO_MENTIONS=true
+# TOOLBOX_READ_REDDIT_MENTIONS=true
 
 # -- Optional: revenue enrichment (CI scripts only) --------------------------
 # TRUSTMRR_API_KEY=

--- a/src/lib/__tests__/toolbox-store.test.ts
+++ b/src/lib/__tests__/toolbox-store.test.ts
@@ -1,0 +1,243 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { fetchHnMentionsFromToolbox } from "../toolbox-store";
+
+function fakeFetch(responses: {
+  status?: number;
+  body?: unknown;
+  throwError?: Error;
+}): typeof fetch {
+  return (async () => {
+    if (responses.throwError) throw responses.throwError;
+    return {
+      ok: (responses.status ?? 200) >= 200 && (responses.status ?? 200) < 300,
+      status: responses.status ?? 200,
+      json: async () => responses.body,
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+test("returns shaped HnMentionsFile on happy-path response", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 2,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/vercel/next.js",
+            scan_id: "s1",
+            run_id: "r1",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: {
+              count_7d: 12,
+              score_sum_7d: 1500,
+              ever_hit_front_page: true,
+              top_story: { id: 1, title: "...", score: 300, url: "...", hoursSincePosted: 4 },
+              stories_top10: [],
+            },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/openai/whisper",
+            scan_id: "s1",
+            run_id: "r2",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T02:00:00Z",
+            fields: {
+              count_7d: 5,
+              score_sum_7d: 800,
+              ever_hit_front_page: false,
+              stories_top10: [],
+            },
+          },
+        ],
+      },
+    }),
+  });
+
+  assert.ok(result, "expected a non-null HnMentionsFile");
+  assert.equal(Object.keys(result!.mentions).length, 2);
+  assert.ok(result!.mentions["vercel/next.js"]);
+  assert.equal(result!.mentions["vercel/next.js"].count7d, 12);
+  assert.equal(result!.mentions["vercel/next.js"].scoreSum7d, 1500);
+  assert.equal(result!.mentions["vercel/next.js"].everHitFrontPage, true);
+  assert.equal(result!.mentions["openai/whisper"].topStory, null);
+  assert.equal(result!.windowDays, 7);
+  assert.equal(result!.fetchedAt, "2026-05-13T03:00:00.000Z");
+});
+
+test("leaderboard is sorted by scoreSum7d desc", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 3,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/a/low",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 1, score_sum_7d: 10, ever_hit_front_page: false, stories_top10: [] },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/b/high",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 9, score_sum_7d: 999, ever_hit_front_page: false, stories_top10: [] },
+          },
+          {
+            target_id: "t3",
+            target_kind: "url",
+            target_identity: "https://github.com/c/mid",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 5, score_sum_7d: 500, ever_hit_front_page: false, stories_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.deepEqual(
+    result!.leaderboard.map((r) => r.fullName),
+    ["b/high", "c/mid", "a/low"],
+  );
+});
+
+test("returns null on non-2xx response", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ status: 503 }),
+  });
+  assert.equal(result, null);
+});
+
+test("returns null on fetch throw (network error)", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ throwError: new Error("ECONNREFUSED") }),
+  });
+  assert.equal(result, null);
+});
+
+test("returns null when response body is malformed (no targets array)", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ body: { count: 0 } }),
+  });
+  assert.equal(result, null);
+});
+
+test("skips events with non-github target_identity", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 2,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://example.com/not-a-repo",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 99, score_sum_7d: 99, ever_hit_front_page: false, stories_top10: [] },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/real/repo",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 3, score_sum_7d: 30, ever_hit_front_page: false, stories_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.mentions).length, 1);
+  assert.ok(result!.mentions["real/repo"]);
+});
+
+test("skips events lacking count_7d field", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 1,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/x/y",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { score_sum_7d: 100, ever_hit_front_page: false, stories_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.mentions).length, 0);
+  assert.equal(result!.leaderboard.length, 0);
+});
+
+test("builds mentionsByRepoId with slugified keys", async () => {
+  const result = await fetchHnMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 1,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/Vercel/Next.JS",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.hn.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 1, score_sum_7d: 1, ever_hit_front_page: false, stories_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  // Slugifier preserves the source case for `mentions` keys; `mentionsByRepoId`
+  // lowercases + replaces `/` and `.`.
+  assert.ok(result!.mentionsByRepoId);
+  assert.ok(result!.mentionsByRepoId!["vercel--next-js"]);
+});

--- a/src/lib/__tests__/toolbox-store.test.ts
+++ b/src/lib/__tests__/toolbox-store.test.ts
@@ -1,7 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { fetchHnMentionsFromToolbox } from "../toolbox-store";
+import {
+  fetchBlueskyMentionsFromToolbox,
+  fetchDevtoMentionsFromToolbox,
+  fetchHnMentionsFromToolbox,
+} from "../toolbox-store";
 
 function fakeFetch(responses: {
   status?: number;
@@ -240,4 +244,290 @@ test("builds mentionsByRepoId with slugified keys", async () => {
   // lowercases + replaces `/` and `.`.
   assert.ok(result!.mentionsByRepoId);
   assert.ok(result!.mentionsByRepoId!["vercel--next-js"]);
+});
+
+// ---------------------------------------------------------------------------
+// Bluesky mentions adapter
+// ---------------------------------------------------------------------------
+
+test("bsky: returns shaped BskyMentionsFile on happy-path response", async () => {
+  const result = await fetchBlueskyMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 2,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/vercel/next.js",
+            scan_id: "s",
+            run_id: "r1",
+            signal_type: "trending.bluesky.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: {
+              count_7d: 7,
+              likes_sum_7d: 234,
+              reposts_sum_7d: 12,
+              replies_sum_7d: 4,
+              top_post: { uri: "at://did/post/1", cid: "c", bskyUrl: "https://bsky.app/...", text: "..." },
+              posts_top10: [],
+            },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/openai/whisper",
+            scan_id: "s",
+            run_id: "r2",
+            signal_type: "trending.bluesky.mentions",
+            produced_at: "2026-05-13T02:00:00Z",
+            fields: {
+              count_7d: 3,
+              likes_sum_7d: 100,
+              reposts_sum_7d: 5,
+              replies_sum_7d: 1,
+              posts_top10: [],
+            },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.mentions).length, 2);
+  assert.equal(result!.mentions["vercel/next.js"].count7d, 7);
+  assert.equal(result!.mentions["vercel/next.js"].likesSum7d, 234);
+  assert.equal(result!.mentions["vercel/next.js"].repostsSum7d, 12);
+  assert.equal(result!.mentions["vercel/next.js"].repliesSum7d, 4);
+  assert.equal(result!.mentions["openai/whisper"].topPost, null);
+  assert.equal(result!.windowDays, 7);
+  assert.equal(result!.fetchedAt, "2026-05-13T03:00:00.000Z");
+});
+
+test("bsky: leaderboard is sorted by likesSum7d desc", async () => {
+  const result = await fetchBlueskyMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 3,
+        targets: [
+          {
+            target_id: "1",
+            target_kind: "url",
+            target_identity: "https://github.com/a/low",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.bluesky.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 1, likes_sum_7d: 10, reposts_sum_7d: 0, replies_sum_7d: 0, posts_top10: [] },
+          },
+          {
+            target_id: "2",
+            target_kind: "url",
+            target_identity: "https://github.com/b/high",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.bluesky.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 9, likes_sum_7d: 999, reposts_sum_7d: 0, replies_sum_7d: 0, posts_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.deepEqual(
+    result!.leaderboard.map((r) => r.fullName),
+    ["b/high", "a/low"],
+  );
+});
+
+test("bsky: returns null on non-2xx", async () => {
+  const result = await fetchBlueskyMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ status: 503 }),
+  });
+  assert.equal(result, null);
+});
+
+test("bsky: returns null on fetch throw", async () => {
+  const result = await fetchBlueskyMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ throwError: new Error("ECONNRESET") }),
+  });
+  assert.equal(result, null);
+});
+
+test("bsky: skips events lacking count_7d", async () => {
+  const result = await fetchBlueskyMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 1,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/x/y",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.bluesky.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { likes_sum_7d: 100, posts_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.mentions).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// dev.to mentions adapter
+// ---------------------------------------------------------------------------
+
+test("devto: returns shaped DevtoMentionsFile on happy-path response", async () => {
+  const result = await fetchDevtoMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 2,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/vercel/next.js",
+            scan_id: "s",
+            run_id: "r1",
+            signal_type: "trending.devto.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: {
+              count_7d: 5,
+              reactions_sum_7d: 150,
+              comments_sum_7d: 22,
+              top_article: { id: 9, title: "Why X", url: "...", author: "u", reactions: 80, comments: 10, hoursSincePosted: 6, readingTime: 4 },
+              articles_top10: [],
+            },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/openai/whisper",
+            scan_id: "s",
+            run_id: "r2",
+            signal_type: "trending.devto.mentions",
+            produced_at: "2026-05-13T02:00:00Z",
+            fields: {
+              count_7d: 2,
+              reactions_sum_7d: 40,
+              comments_sum_7d: 3,
+              articles_top10: [],
+            },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.mentions).length, 2);
+  assert.equal(result!.mentions["vercel/next.js"].count7d, 5);
+  assert.equal(result!.mentions["vercel/next.js"].reactionsSum7d, 150);
+  assert.equal(result!.mentions["vercel/next.js"].commentsSum7d, 22);
+  assert.equal(result!.mentions["openai/whisper"].topArticle, null);
+  assert.equal(result!.windowDays, 7);
+  assert.equal(result!.bodyFetchMode, "description-only");
+  assert.equal(result!.fetchedAt, "2026-05-13T03:00:00.000Z");
+});
+
+test("devto: leaderboard is sorted by reactionsSum7d desc", async () => {
+  const result = await fetchDevtoMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 3,
+        targets: [
+          {
+            target_id: "1",
+            target_kind: "url",
+            target_identity: "https://github.com/a/low",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.devto.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 1, reactions_sum_7d: 5, comments_sum_7d: 0, articles_top10: [] },
+          },
+          {
+            target_id: "2",
+            target_kind: "url",
+            target_identity: "https://github.com/b/high",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.devto.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 5, reactions_sum_7d: 500, comments_sum_7d: 0, articles_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.deepEqual(
+    result!.leaderboard.map((r) => r.fullName),
+    ["b/high", "a/low"],
+  );
+});
+
+test("devto: returns null on non-2xx", async () => {
+  const result = await fetchDevtoMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ status: 502 }),
+  });
+  assert.equal(result, null);
+});
+
+test("devto: skips non-github targets", async () => {
+  const result = await fetchDevtoMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 2,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://dev.to/article",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.devto.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 9, reactions_sum_7d: 9, comments_sum_7d: 0, articles_top10: [] },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/real/repo",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.devto.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 2, reactions_sum_7d: 20, comments_sum_7d: 0, articles_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.mentions).length, 1);
+  assert.ok(result!.mentions["real/repo"]);
 });

--- a/src/lib/__tests__/toolbox-store.test.ts
+++ b/src/lib/__tests__/toolbox-store.test.ts
@@ -5,6 +5,7 @@ import {
   fetchBlueskyMentionsFromToolbox,
   fetchDevtoMentionsFromToolbox,
   fetchHnMentionsFromToolbox,
+  fetchRedditMentionsFromToolbox,
 } from "../toolbox-store";
 
 function fakeFetch(responses: {
@@ -494,6 +495,135 @@ test("devto: returns null on non-2xx", async () => {
   });
   assert.equal(result, null);
 });
+
+// ---------------------------------------------------------------------------
+// Reddit mentions adapter
+// ---------------------------------------------------------------------------
+
+test("reddit: returns shaped RedditMentionsFile + maps score_sum_7d → upvotes7d", async () => {
+  const result = await fetchRedditMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 2,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/vercel/next.js",
+            scan_id: "s",
+            run_id: "r1",
+            signal_type: "trending.reddit.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: {
+              count_7d: 4,
+              score_sum_7d: 5400,
+              top_post: { /* ignored — not in local type */ },
+              posts_top10: [],
+            },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/openai/whisper",
+            scan_id: "s",
+            run_id: "r2",
+            signal_type: "trending.reddit.mentions",
+            produced_at: "2026-05-13T02:00:00Z",
+            fields: {
+              count_7d: 2,
+              score_sum_7d: 800,
+              posts_top10: [],
+            },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.mentions).length, 2);
+  // Critical: the wire field is `score_sum_7d` but the local canonical is `upvotes7d`.
+  assert.equal(result!.mentions["vercel/next.js"].upvotes7d, 5400);
+  assert.equal(result!.mentions["vercel/next.js"].count7d, 4);
+  assert.equal(result!.mentions["openai/whisper"].upvotes7d, 800);
+  assert.equal(result!.cold, false);
+  assert.equal(result!.fetchedAt, "2026-05-13T03:00:00.000Z");
+});
+
+test("reddit: leaderboard tie-breaks count7d then alphabetic", async () => {
+  const result = await fetchRedditMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({
+      body: {
+        count: 3,
+        targets: [
+          {
+            target_id: "t1",
+            target_kind: "url",
+            target_identity: "https://github.com/z/equal",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.reddit.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 5, score_sum_7d: 100, posts_top10: [] },
+          },
+          {
+            target_id: "t2",
+            target_kind: "url",
+            target_identity: "https://github.com/a/equal",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.reddit.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 5, score_sum_7d: 100, posts_top10: [] },
+          },
+          {
+            target_id: "t3",
+            target_kind: "url",
+            target_identity: "https://github.com/b/winner",
+            scan_id: "s",
+            run_id: "r",
+            signal_type: "trending.reddit.mentions",
+            produced_at: "2026-05-13T03:00:00Z",
+            fields: { count_7d: 1, score_sum_7d: 999, posts_top10: [] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.ok(result);
+  assert.deepEqual(
+    result!.leaderboard!.map((r) => r.fullName),
+    // upvotes7d=999 wins; then upvotes7d=100 ties → count7d=5 ties → alpha: a < z
+    ["b/winner", "a/equal", "z/equal"],
+  );
+});
+
+test("reddit: returns null on non-2xx", async () => {
+  const result = await fetchRedditMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ status: 502 }),
+  });
+  assert.equal(result, null);
+});
+
+test("reddit: cold=true when zero mentions reconstructed", async () => {
+  const result = await fetchRedditMentionsFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test_key",
+    fetchImpl: fakeFetch({ body: { count: 0, targets: [] } }),
+  });
+  assert.ok(result);
+  assert.equal(result!.cold, true);
+  assert.equal(Object.keys(result!.mentions).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// (devto regression block continues below)
+// ---------------------------------------------------------------------------
 
 test("devto: skips non-github targets", async () => {
   const result = await fetchDevtoMentionsFromToolbox({

--- a/src/lib/bluesky.ts
+++ b/src/lib/bluesky.ts
@@ -243,6 +243,17 @@ export async function refreshBlueskyMentionsFromStore(): Promise<{
     return { source: "memory", ageMs: Date.now() - lastRefreshMs };
   }
   inflight = (async () => {
+    // Phase A.2: TOOLBOX_READ_BLUESKY_MENTIONS=true routes through
+    // /v1/signals/leaderboard. Null return → legacy data-store path runs.
+    const toolboxFile = await tryFetchBskyFromToolbox();
+    if (toolboxFile) {
+      mentionsFile = toolboxFile;
+      enrichBskyWindowedCounts(mentionsFile);
+      mentionsByLowerName = buildBskyMentionsByLowerName(mentionsFile);
+      lastRefreshMs = Date.now();
+      return { source: "toolbox", ageMs: 0 };
+    }
+
     const { getDataStore } = await import("./data-store");
     const result = await getDataStore().read<BskyMentionsFile>(
       "bluesky-mentions",
@@ -258,4 +269,13 @@ export async function refreshBlueskyMentionsFromStore(): Promise<{
     inflight = null;
   });
   return inflight;
+}
+
+async function tryFetchBskyFromToolbox(): Promise<BskyMentionsFile | null> {
+  if (process.env.TOOLBOX_READ_BLUESKY_MENTIONS !== "true") return null;
+  const apiUrl = process.env.TOOLBOX_API_URL;
+  const apiKey = process.env.TOOLBOX_API_KEY;
+  if (!apiUrl || !apiKey) return null;
+  const { fetchBlueskyMentionsFromToolbox } = await import("./toolbox-store");
+  return fetchBlueskyMentionsFromToolbox({ apiUrl, apiKey });
 }

--- a/src/lib/devto.ts
+++ b/src/lib/devto.ts
@@ -253,6 +253,17 @@ export async function refreshDevtoMentionsFromStore(): Promise<{
     return { source: "memory", ageMs: Date.now() - lastRefreshMs };
   }
   inflight = (async () => {
+    // Phase A.2: TOOLBOX_READ_DEVTO_MENTIONS=true routes through
+    // /v1/signals/leaderboard. Null return → legacy data-store path runs.
+    const toolboxFile = await tryFetchDevtoFromToolbox();
+    if (toolboxFile) {
+      mentionsFile = toolboxFile;
+      enrichDevtoWindowedCounts(mentionsFile);
+      mentionsByLowerName = buildDevtoMentionsByLowerName(mentionsFile);
+      lastRefreshMs = Date.now();
+      return { source: "toolbox", ageMs: 0 };
+    }
+
     const { getDataStore } = await import("./data-store");
     const result = await getDataStore().read<DevtoMentionsFile>(
       "devto-mentions",
@@ -268,4 +279,13 @@ export async function refreshDevtoMentionsFromStore(): Promise<{
     inflight = null;
   });
   return inflight;
+}
+
+async function tryFetchDevtoFromToolbox(): Promise<DevtoMentionsFile | null> {
+  if (process.env.TOOLBOX_READ_DEVTO_MENTIONS !== "true") return null;
+  const apiUrl = process.env.TOOLBOX_API_URL;
+  const apiKey = process.env.TOOLBOX_API_KEY;
+  if (!apiUrl || !apiKey) return null;
+  const { fetchDevtoMentionsFromToolbox } = await import("./toolbox-store");
+  return fetchDevtoMentionsFromToolbox({ apiUrl, apiKey });
 }

--- a/src/lib/hackernews.ts
+++ b/src/lib/hackernews.ts
@@ -249,6 +249,20 @@ export async function refreshHackernewsMentionsFromStore(): Promise<{
     return { source: "memory", ageMs: Date.now() - lastRefreshMs };
   }
   inflight = (async () => {
+    // Phase A.2.1: when TOOLBOX_READ_HN_MENTIONS=true and TOOLBOX_API_*
+    // env vars are present, try TOOLBOX's /v1/signals/leaderboard first.
+    // Returns null on any error → fall through to the legacy data-store
+    // path so a TOOLBOX outage degrades to existing behaviour.
+    const toolboxFile = await tryFetchHnMentionsFromToolbox();
+    if (toolboxFile) {
+      mentionsFile = toolboxFile;
+      enrichHnWindowedCounts(mentionsFile);
+      mentionsByLowerName = buildMentionsByLowerName(mentionsFile);
+      mentionsByRepoId = buildMentionsByRepoId(mentionsFile);
+      lastRefreshMs = Date.now();
+      return { source: "toolbox", ageMs: 0 };
+    }
+
     const { getDataStore } = await import("./data-store");
     const result = await getDataStore().read<HnMentionsFile>(
       "hackernews-repo-mentions",
@@ -265,4 +279,13 @@ export async function refreshHackernewsMentionsFromStore(): Promise<{
     inflight = null;
   });
   return inflight;
+}
+
+async function tryFetchHnMentionsFromToolbox(): Promise<HnMentionsFile | null> {
+  if (process.env.TOOLBOX_READ_HN_MENTIONS !== "true") return null;
+  const apiUrl = process.env.TOOLBOX_API_URL;
+  const apiKey = process.env.TOOLBOX_API_KEY;
+  if (!apiUrl || !apiKey) return null;
+  const { fetchHnMentionsFromToolbox } = await import("./toolbox-store");
+  return fetchHnMentionsFromToolbox({ apiUrl, apiKey });
 }

--- a/src/lib/reddit-data.ts
+++ b/src/lib/reddit-data.ts
@@ -260,6 +260,26 @@ export async function refreshRedditMentionsFromStore(): Promise<{
     return { source: "memory", ageMs: Date.now() - lastRefreshMs };
   }
   inflight = (async () => {
+    // Phase A.2: TOOLBOX_READ_REDDIT_MENTIONS=true routes through
+    // /v1/signals/leaderboard. Null return → legacy data-store path.
+    const toolboxFile = await tryFetchRedditFromToolbox();
+    if (toolboxFile) {
+      const file = normalizeFile(toolboxFile);
+      enrichWindowedCounts(file);
+      const mentionsByLowerName = new Map<string, RedditRepoMention>();
+      for (const [fullName, mention] of Object.entries(file.mentions)) {
+        mentionsByLowerName.set(fullName.toLowerCase(), mention);
+      }
+      cache = {
+        signature: `toolbox:${Date.now()}`,
+        file,
+        mentionsByLowerName,
+        fromRedis: true,
+      };
+      lastRefreshMs = Date.now();
+      return { source: "toolbox", ageMs: 0 };
+    }
+
     const { getDataStore } = await import("./data-store");
     const result = await getDataStore().read<RedditMentionsFile>(
       "reddit-mentions",
@@ -288,4 +308,13 @@ export async function refreshRedditMentionsFromStore(): Promise<{
     inflight = null;
   });
   return inflight;
+}
+
+async function tryFetchRedditFromToolbox(): Promise<RedditMentionsFile | null> {
+  if (process.env.TOOLBOX_READ_REDDIT_MENTIONS !== "true") return null;
+  const apiUrl = process.env.TOOLBOX_API_URL;
+  const apiKey = process.env.TOOLBOX_API_KEY;
+  if (!apiUrl || !apiKey) return null;
+  const { fetchRedditMentionsFromToolbox } = await import("./toolbox-store");
+  return fetchRedditMentionsFromToolbox({ apiUrl, apiKey });
 }

--- a/src/lib/toolbox-store.ts
+++ b/src/lib/toolbox-store.ts
@@ -5,18 +5,14 @@
 // us flip per-source readers to TOOLBOX without changing the UI layer.
 //
 // Each fetchXFromToolbox() returns the legacy file shape (HnMentionsFile,
-// etc.) or `null` on any failure — callers fall back to the legacy
-// data-store path on null. This keeps the per-source feature flag a
-// one-line guard at the refresh hook and preserves degraded-render
+// BskyMentionsFile, etc.) or `null` on any failure — callers fall back to
+// the legacy data-store path on null. This keeps the per-source feature
+// flag a one-line guard at the refresh hook and preserves degraded-render
 // behaviour when TOOLBOX is unreachable.
 //
 // Endpoint: GET /v1/signals/leaderboard?type=<signal_type>&limit=...
 // Reconstructs logical events server-side (TOOLBOX's tb_signals is EAV);
 // each returned row is one repo's most recent event.
-//
-// Adapter contract (per-source):
-//   fetchHnMentionsFromToolbox({ apiUrl, apiKey, limit?, timeoutMs? })
-//     → HnMentionsFile | null
 
 import "server-only";
 
@@ -27,6 +23,20 @@ import type {
   HnStory,
   HnStoryRef,
 } from "./hackernews";
+import type {
+  BskyLeaderboardEntry,
+  BskyMentionsFile,
+  BskyPost,
+  BskyPostRef,
+  BskyRepoMention,
+} from "./bluesky";
+import type {
+  DevtoArticle,
+  DevtoLeaderboardEntry,
+  DevtoMentionsFile,
+  DevtoRepoMention,
+  DevtoTopArticleRef,
+} from "./devto";
 
 const DEFAULT_LIMIT = 500;
 const DEFAULT_TIMEOUT_MS = 8_000;
@@ -76,53 +86,20 @@ function slugIdFromFullName(fullName: string): string {
     .replace(/[^a-z0-9-]/g, "");
 }
 
-function eventToMention(event: ToolboxEvent): HnRepoMention | null {
-  const f = event.fields;
-  if (typeof f !== "object" || f === null) return null;
-  const count7d = typeof f.count_7d === "number" ? f.count_7d : null;
-  if (count7d === null) return null;
-  const scoreSum7d = typeof f.score_sum_7d === "number" ? f.score_sum_7d : 0;
-  const everHitFrontPage =
-    typeof f.ever_hit_front_page === "boolean" ? f.ever_hit_front_page : false;
-  const topStory =
-    f.top_story && typeof f.top_story === "object"
-      ? (f.top_story as HnStoryRef)
-      : null;
-  const stories = Array.isArray(f.stories_top10) ? (f.stories_top10 as HnStory[]) : [];
-  return {
-    count7d,
-    scoreSum7d,
-    everHitFrontPage,
-    topStory,
-    stories,
-  };
-}
-
-/**
- * Fetch the latest HN mentions snapshot from TOOLBOX and shape it into an
- * HnMentionsFile. Returns null on any error so the caller can fall back to
- * the legacy data-store path without throwing.
- *
- * Caveat: TOOLBOX's dual-write caps stories at 10 per repo (see
- * trendingrepo's `scripts/_toolbox-ingest.mjs`), so windowed counts
- * (count24h, count30d) computed at reader load time will undercount for
- * viral repos with more than 10 stories in a 7-day window. Acceptable for
- * the tracer-bullet flip; revisit if it materially shifts ranking.
- */
-export async function fetchHnMentionsFromToolbox(
+async function fetchLeaderboardEvents(
   opts: ToolboxFetchOptions,
-): Promise<HnMentionsFile | null> {
+  signalType: string,
+): Promise<ToolboxLeaderboardResponse | null> {
   const limit = opts.limit ?? DEFAULT_LIMIT;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
   if (typeof fetchImpl !== "function") return null;
 
   const base = opts.apiUrl.replace(/\/+$/, "");
-  const url = `${base}/v1/signals/leaderboard?type=trending.hn.mentions&limit=${limit}`;
+  const url = `${base}/v1/signals/leaderboard?type=${encodeURIComponent(signalType)}&limit=${limit}`;
 
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), timeoutMs);
-  let body: ToolboxLeaderboardResponse | null = null;
   try {
     const res = await fetchImpl(url, {
       headers: {
@@ -132,30 +109,77 @@ export async function fetchHnMentionsFromToolbox(
       signal: ac.signal,
     });
     if (!res.ok) return null;
-    body = (await res.json()) as ToolboxLeaderboardResponse;
+    const body = (await res.json()) as ToolboxLeaderboardResponse;
+    if (!body || !Array.isArray(body.targets)) return null;
+    return body;
   } catch {
     return null;
   } finally {
     clearTimeout(timer);
   }
+}
 
-  if (!body || !Array.isArray(body.targets)) return null;
+function maxProducedAtMs(events: ToolboxEvent[]): number {
+  let max = 0;
+  for (const ev of events) {
+    const t = Date.parse(ev.produced_at);
+    if (Number.isFinite(t) && t > max) max = t;
+  }
+  return max;
+}
+
+function isoFromMaxOrNow(maxMs: number): string {
+  return (maxMs > 0 ? new Date(maxMs) : new Date()).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// HN mentions adapter
+// ---------------------------------------------------------------------------
+
+function eventToHnMention(event: ToolboxEvent): HnRepoMention | null {
+  const f = event.fields;
+  if (typeof f !== "object" || f === null) return null;
+  const count7d = typeof f.count_7d === "number" ? f.count_7d : null;
+  if (count7d === null) return null;
+  return {
+    count7d,
+    scoreSum7d: typeof f.score_sum_7d === "number" ? f.score_sum_7d : 0,
+    everHitFrontPage:
+      typeof f.ever_hit_front_page === "boolean" ? f.ever_hit_front_page : false,
+    topStory:
+      f.top_story && typeof f.top_story === "object"
+        ? (f.top_story as HnStoryRef)
+        : null,
+    stories: Array.isArray(f.stories_top10) ? (f.stories_top10 as HnStory[]) : [],
+  };
+}
+
+/**
+ * Fetch the latest HN mentions snapshot from TOOLBOX and shape it into an
+ * HnMentionsFile. Returns null on any error so the caller can fall back to
+ * the legacy data-store path without throwing.
+ *
+ * Caveat: TOOLBOX's dual-write caps stories at 10 per repo. Windowed counts
+ * (count24h, count30d) computed at reader load time from `stories` will
+ * undercount for viral repos with >10 stories in 7 days. Acceptable for
+ * the tracer-bullet flip; documented inline.
+ */
+export async function fetchHnMentionsFromToolbox(
+  opts: ToolboxFetchOptions,
+): Promise<HnMentionsFile | null> {
+  const body = await fetchLeaderboardEvents(opts, "trending.hn.mentions");
+  if (!body) return null;
 
   const mentions: Record<string, HnRepoMention> = {};
   const mentionsByRepoId: Record<string, HnRepoMention> = {};
-  let latestProducedAtMs = 0;
 
   for (const ev of body.targets) {
     const fullName = extractGithubFullName(ev.target_identity);
     if (!fullName) continue;
-    const mention = eventToMention(ev);
+    const mention = eventToHnMention(ev);
     if (!mention) continue;
     mentions[fullName] = mention;
     mentionsByRepoId[slugIdFromFullName(fullName)] = mention;
-    const producedAtMs = Date.parse(ev.produced_at);
-    if (Number.isFinite(producedAtMs) && producedAtMs > latestProducedAtMs) {
-      latestProducedAtMs = producedAtMs;
-    }
   }
 
   const leaderboard: HnLeaderboardEntry[] = Object.entries(mentions)
@@ -167,15 +191,126 @@ export async function fetchHnMentionsFromToolbox(
     .sort((a, b) => b.scoreSum7d - a.scoreSum7d);
 
   return {
-    fetchedAt:
-      latestProducedAtMs > 0
-        ? new Date(latestProducedAtMs).toISOString()
-        : new Date().toISOString(),
+    fetchedAt: isoFromMaxOrNow(maxProducedAtMs(body.targets)),
     windowDays: 7,
     scannedAlgoliaHits: 0,
     scannedFirebaseItems: 0,
     mentions,
     mentionsByRepoId,
+    leaderboard,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bluesky mentions adapter
+// ---------------------------------------------------------------------------
+
+function eventToBskyMention(event: ToolboxEvent): BskyRepoMention | null {
+  const f = event.fields;
+  if (typeof f !== "object" || f === null) return null;
+  const count7d = typeof f.count_7d === "number" ? f.count_7d : null;
+  if (count7d === null) return null;
+  return {
+    count7d,
+    likesSum7d: typeof f.likes_sum_7d === "number" ? f.likes_sum_7d : 0,
+    repostsSum7d: typeof f.reposts_sum_7d === "number" ? f.reposts_sum_7d : 0,
+    repliesSum7d: typeof f.replies_sum_7d === "number" ? f.replies_sum_7d : 0,
+    topPost:
+      f.top_post && typeof f.top_post === "object"
+        ? (f.top_post as BskyPostRef)
+        : null,
+    posts: Array.isArray(f.posts_top10) ? (f.posts_top10 as BskyPost[]) : [],
+  };
+}
+
+export async function fetchBlueskyMentionsFromToolbox(
+  opts: ToolboxFetchOptions,
+): Promise<BskyMentionsFile | null> {
+  const body = await fetchLeaderboardEvents(opts, "trending.bluesky.mentions");
+  if (!body) return null;
+
+  const mentions: Record<string, BskyRepoMention> = {};
+  for (const ev of body.targets) {
+    const fullName = extractGithubFullName(ev.target_identity);
+    if (!fullName) continue;
+    const mention = eventToBskyMention(ev);
+    if (!mention) continue;
+    mentions[fullName] = mention;
+  }
+
+  const leaderboard: BskyLeaderboardEntry[] = Object.entries(mentions)
+    .map(([fullName, m]) => ({
+      fullName,
+      count7d: m.count7d,
+      likesSum7d: m.likesSum7d,
+    }))
+    .sort((a, b) => b.likesSum7d - a.likesSum7d);
+
+  return {
+    fetchedAt: isoFromMaxOrNow(maxProducedAtMs(body.targets)),
+    windowDays: 7,
+    scannedPosts: 0,
+    searchQuery: "",
+    pagesFetched: 0,
+    mentions,
+    leaderboard,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// dev.to mentions adapter
+// ---------------------------------------------------------------------------
+
+function eventToDevtoMention(event: ToolboxEvent): DevtoRepoMention | null {
+  const f = event.fields;
+  if (typeof f !== "object" || f === null) return null;
+  const count7d = typeof f.count_7d === "number" ? f.count_7d : null;
+  if (count7d === null) return null;
+  return {
+    count7d,
+    reactionsSum7d:
+      typeof f.reactions_sum_7d === "number" ? f.reactions_sum_7d : 0,
+    commentsSum7d:
+      typeof f.comments_sum_7d === "number" ? f.comments_sum_7d : 0,
+    topArticle:
+      f.top_article && typeof f.top_article === "object"
+        ? (f.top_article as DevtoTopArticleRef)
+        : null,
+    articles: Array.isArray(f.articles_top10)
+      ? (f.articles_top10 as DevtoArticle[])
+      : [],
+  };
+}
+
+export async function fetchDevtoMentionsFromToolbox(
+  opts: ToolboxFetchOptions,
+): Promise<DevtoMentionsFile | null> {
+  const body = await fetchLeaderboardEvents(opts, "trending.devto.mentions");
+  if (!body) return null;
+
+  const mentions: Record<string, DevtoRepoMention> = {};
+  for (const ev of body.targets) {
+    const fullName = extractGithubFullName(ev.target_identity);
+    if (!fullName) continue;
+    const mention = eventToDevtoMention(ev);
+    if (!mention) continue;
+    mentions[fullName] = mention;
+  }
+
+  const leaderboard: DevtoLeaderboardEntry[] = Object.entries(mentions)
+    .map(([fullName, m]) => ({
+      fullName,
+      count7d: m.count7d,
+      reactionsSum7d: m.reactionsSum7d,
+    }))
+    .sort((a, b) => b.reactionsSum7d - a.reactionsSum7d);
+
+  return {
+    fetchedAt: isoFromMaxOrNow(maxProducedAtMs(body.targets)),
+    windowDays: 7,
+    scannedArticles: 0,
+    bodyFetchMode: "description-only",
+    mentions,
     leaderboard,
   };
 }

--- a/src/lib/toolbox-store.ts
+++ b/src/lib/toolbox-store.ts
@@ -1,0 +1,181 @@
+// TOOLBOX read adapter — Phase A.2 reader-switch
+//
+// Reads aggregated signal events from TOOLBOX (api.aiso.tools) and shapes
+// them into the same data structures the local data-store returns. Lets
+// us flip per-source readers to TOOLBOX without changing the UI layer.
+//
+// Each fetchXFromToolbox() returns the legacy file shape (HnMentionsFile,
+// etc.) or `null` on any failure — callers fall back to the legacy
+// data-store path on null. This keeps the per-source feature flag a
+// one-line guard at the refresh hook and preserves degraded-render
+// behaviour when TOOLBOX is unreachable.
+//
+// Endpoint: GET /v1/signals/leaderboard?type=<signal_type>&limit=...
+// Reconstructs logical events server-side (TOOLBOX's tb_signals is EAV);
+// each returned row is one repo's most recent event.
+//
+// Adapter contract (per-source):
+//   fetchHnMentionsFromToolbox({ apiUrl, apiKey, limit?, timeoutMs? })
+//     → HnMentionsFile | null
+
+import "server-only";
+
+import type {
+  HnLeaderboardEntry,
+  HnMentionsFile,
+  HnRepoMention,
+  HnStory,
+  HnStoryRef,
+} from "./hackernews";
+
+const DEFAULT_LIMIT = 500;
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+interface ToolboxEvent {
+  target_id: string;
+  target_kind: string;
+  target_identity: string;
+  scan_id: string;
+  run_id: string;
+  signal_type: string;
+  produced_at: string;
+  fields: Record<string, unknown>;
+}
+
+interface ToolboxLeaderboardResponse {
+  count: number;
+  targets: ToolboxEvent[];
+}
+
+export interface ToolboxFetchOptions {
+  apiUrl: string;
+  apiKey: string;
+  limit?: number;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+function extractGithubFullName(targetIdentity: string): string | null {
+  try {
+    const url = new URL(targetIdentity);
+    const host = url.hostname.toLowerCase();
+    if (host !== "github.com" && host !== "www.github.com") return null;
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    return `${parts[0]}/${parts[1]}`;
+  } catch {
+    return null;
+  }
+}
+
+function slugIdFromFullName(fullName: string): string {
+  return String(fullName)
+    .toLowerCase()
+    .replace(/\//g, "--")
+    .replace(/\./g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+function eventToMention(event: ToolboxEvent): HnRepoMention | null {
+  const f = event.fields;
+  if (typeof f !== "object" || f === null) return null;
+  const count7d = typeof f.count_7d === "number" ? f.count_7d : null;
+  if (count7d === null) return null;
+  const scoreSum7d = typeof f.score_sum_7d === "number" ? f.score_sum_7d : 0;
+  const everHitFrontPage =
+    typeof f.ever_hit_front_page === "boolean" ? f.ever_hit_front_page : false;
+  const topStory =
+    f.top_story && typeof f.top_story === "object"
+      ? (f.top_story as HnStoryRef)
+      : null;
+  const stories = Array.isArray(f.stories_top10) ? (f.stories_top10 as HnStory[]) : [];
+  return {
+    count7d,
+    scoreSum7d,
+    everHitFrontPage,
+    topStory,
+    stories,
+  };
+}
+
+/**
+ * Fetch the latest HN mentions snapshot from TOOLBOX and shape it into an
+ * HnMentionsFile. Returns null on any error so the caller can fall back to
+ * the legacy data-store path without throwing.
+ *
+ * Caveat: TOOLBOX's dual-write caps stories at 10 per repo (see
+ * trendingrepo's `scripts/_toolbox-ingest.mjs`), so windowed counts
+ * (count24h, count30d) computed at reader load time will undercount for
+ * viral repos with more than 10 stories in a 7-day window. Acceptable for
+ * the tracer-bullet flip; revisit if it materially shifts ranking.
+ */
+export async function fetchHnMentionsFromToolbox(
+  opts: ToolboxFetchOptions,
+): Promise<HnMentionsFile | null> {
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") return null;
+
+  const base = opts.apiUrl.replace(/\/+$/, "");
+  const url = `${base}/v1/signals/leaderboard?type=trending.hn.mentions&limit=${limit}`;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  let body: ToolboxLeaderboardResponse | null = null;
+  try {
+    const res = await fetchImpl(url, {
+      headers: {
+        authorization: `Bearer ${opts.apiKey}`,
+        accept: "application/json",
+      },
+      signal: ac.signal,
+    });
+    if (!res.ok) return null;
+    body = (await res.json()) as ToolboxLeaderboardResponse;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!body || !Array.isArray(body.targets)) return null;
+
+  const mentions: Record<string, HnRepoMention> = {};
+  const mentionsByRepoId: Record<string, HnRepoMention> = {};
+  let latestProducedAtMs = 0;
+
+  for (const ev of body.targets) {
+    const fullName = extractGithubFullName(ev.target_identity);
+    if (!fullName) continue;
+    const mention = eventToMention(ev);
+    if (!mention) continue;
+    mentions[fullName] = mention;
+    mentionsByRepoId[slugIdFromFullName(fullName)] = mention;
+    const producedAtMs = Date.parse(ev.produced_at);
+    if (Number.isFinite(producedAtMs) && producedAtMs > latestProducedAtMs) {
+      latestProducedAtMs = producedAtMs;
+    }
+  }
+
+  const leaderboard: HnLeaderboardEntry[] = Object.entries(mentions)
+    .map(([fullName, m]) => ({
+      fullName,
+      count7d: m.count7d,
+      scoreSum7d: m.scoreSum7d,
+    }))
+    .sort((a, b) => b.scoreSum7d - a.scoreSum7d);
+
+  return {
+    fetchedAt:
+      latestProducedAtMs > 0
+        ? new Date(latestProducedAtMs).toISOString()
+        : new Date().toISOString(),
+    windowDays: 7,
+    scannedAlgoliaHits: 0,
+    scannedFirebaseItems: 0,
+    mentions,
+    mentionsByRepoId,
+    leaderboard,
+  };
+}

--- a/src/lib/toolbox-store.ts
+++ b/src/lib/toolbox-store.ts
@@ -37,6 +37,12 @@ import type {
   DevtoRepoMention,
   DevtoTopArticleRef,
 } from "./devto";
+import type {
+  RedditLeaderboardEntry,
+  RedditMentionsFile,
+  RedditPost,
+  RedditRepoMention,
+} from "./reddit";
 
 const DEFAULT_LIMIT = 500;
 const DEFAULT_TIMEOUT_MS = 8_000;
@@ -311,6 +317,68 @@ export async function fetchDevtoMentionsFromToolbox(
     scannedArticles: 0,
     bodyFetchMode: "description-only",
     mentions,
+    leaderboard,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reddit mentions adapter
+//
+// Field-name remap: the dual-write (`scripts/_toolbox-ingest.mjs:189`) sends
+// `score_sum_7d` but the local canonical field is `upvotes7d` (see
+// `RedditRepoMention` in src/lib/reddit.ts). Mapping happens in
+// eventToRedditMention. The over-sent `top_post` field is ignored — local
+// type carries no per-mention topPost.
+// ---------------------------------------------------------------------------
+
+function eventToRedditMention(event: ToolboxEvent): RedditRepoMention | null {
+  const f = event.fields;
+  if (typeof f !== "object" || f === null) return null;
+  const count7d = typeof f.count_7d === "number" ? f.count_7d : null;
+  if (count7d === null) return null;
+  return {
+    count7d,
+    upvotes7d: typeof f.score_sum_7d === "number" ? f.score_sum_7d : 0,
+    posts: Array.isArray(f.posts_top10) ? (f.posts_top10 as RedditPost[]) : [],
+  };
+}
+
+export async function fetchRedditMentionsFromToolbox(
+  opts: ToolboxFetchOptions,
+): Promise<RedditMentionsFile | null> {
+  const body = await fetchLeaderboardEvents(opts, "trending.reddit.mentions");
+  if (!body) return null;
+
+  const mentions: Record<string, RedditRepoMention> = {};
+  for (const ev of body.targets) {
+    const fullName = extractGithubFullName(ev.target_identity);
+    if (!fullName) continue;
+    const mention = eventToRedditMention(ev);
+    if (!mention) continue;
+    mentions[fullName] = mention;
+  }
+
+  const leaderboard: RedditLeaderboardEntry[] = Object.entries(mentions)
+    .map(([fullName, m]) => ({
+      fullName,
+      count7d: m.count7d,
+      upvotes7d: m.upvotes7d,
+    }))
+    .sort((a, b) => {
+      if (b.upvotes7d !== a.upvotes7d) return b.upvotes7d - a.upvotes7d;
+      if (b.count7d !== a.count7d) return b.count7d - a.count7d;
+      return a.fullName.localeCompare(b.fullName);
+    });
+
+  return {
+    fetchedAt: isoFromMaxOrNow(maxProducedAtMs(body.targets)),
+    cold: Object.keys(mentions).length === 0,
+    scannedSubreddits: [],
+    scannedPostsTotal: 0,
+    mentions,
+    // `topPosts` not transmitted by dual-write. buildGlobalRedditPosts falls
+    // through to flattenMentionPosts(file) when topPosts is empty.
+    topPosts: [],
     leaderboard,
   };
 }


### PR DESCRIPTION
> **⚠️ DRAFT — blocked on [`0motionguy/toolbox#56`](https://github.com/0motionguy/toolbox/pull/56) merging + a service-plan `tbk_live_*` key being minted for trendingrepo. Reviewable now; flag-flippable once the upstream `/v1/signals/leaderboard` endpoint is live on `api.aiso.tools`.**

## Summary

Adds env-flagged read paths that pull aggregated repo-mentions from TOOLBOX's `/v1/signals/leaderboard?type=...` endpoint and shape the response back into the existing `HnMentionsFile` / `RedditMentionsFile` / `BskyMentionsFile` / `DevtoMentionsFile` contracts. Four sources in one PR — the full **mentions pack** — because they share a single adapter module. Flag flips happen at deploy time, per-source, on independent timelines.

| Source | Env flag | Refresh hook touched | Signal type | Notes |
|---|---|---|---|---|
| Hacker News mentions | `TOOLBOX_READ_HN_MENTIONS` | `refreshHackernewsMentionsFromStore()` | `trending.hn.mentions` | Highest-quality data; flip first |
| **Reddit mentions** | `TOOLBOX_READ_REDDIT_MENTIONS` | `refreshRedditMentionsFromStore()` | `trending.reddit.mentions` | **Wire field `score_sum_7d` remaps to local canonical `upvotes7d`**; over-sent `top_post` is ignored |
| Bluesky mentions | `TOOLBOX_READ_BLUESKY_MENTIONS` | `refreshBlueskyMentionsFromStore()` | `trending.bluesky.mentions` | |
| dev.to mentions | `TOOLBOX_READ_DEVTO_MENTIONS` | `refreshDevtoMentionsFromStore()` | `trending.devto.mentions` | |

When the per-source flag is `true` **and** `TOOLBOX_API_URL`/`TOOLBOX_API_KEY` are set, that source's refresh hook tries TOOLBOX first. Any failure (network, auth, shape) returns `null` and the legacy Redis-first data-store path runs as before. All flags default OFF — **zero change to current behaviour**.

## Files

| File | Type | Purpose |
|---|---|---|
| `src/lib/toolbox-store.ts` | NEW | 4× `fetchXFromToolbox()` adapters + shared `fetchLeaderboardEvents` helper |
| `src/lib/__tests__/toolbox-store.test.ts` | NEW | 21 node:test cases — 8 HN + 5 Bluesky + 4 dev.to + 4 Reddit |
| `src/lib/hackernews.ts` | MOD | `tryFetchHnMentionsFromToolbox()` branch in refresh |
| `src/lib/bluesky.ts` | MOD | `tryFetchBskyFromToolbox()` branch in refresh |
| `src/lib/devto.ts` | MOD | `tryFetchDevtoFromToolbox()` branch in refresh |
| `src/lib/reddit-data.ts` | MOD | `tryFetchRedditFromToolbox()` branch in refresh |
| `.env.example` | MOD | Documents 4 per-source flags + the shared `TOOLBOX_API_URL` / `TOOLBOX_API_KEY` block |

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `node:test src/lib/__tests__/toolbox-store.test.ts` — 21/21 pass
- [x] `node:test src/lib/pipeline/__tests__/{hackernews,bluesky,reddit}-view.test.ts` — 27/27 pass (regression)
- [ ] **Per-source rollout (after toolbox#56 merges + service-plan key minted):**
  1. HN first (highest data quality in TOOLBOX). Flip `TOOLBOX_READ_HN_MENTIONS=true` on **preview** Vercel deployment, compare `/hackernews/trending` against prod for 24 h. If clean → flip on prod.
  2. Reddit next (the field-name remap is the most worth-watching case). Same 24 h dual-read window on preview.
  3. Bluesky.
  4. dev.to.
- [ ] Roll back: unset the relevant flag (instantaneous; legacy path resumes on next ISR window).

## Known caveats

**(1) Stories/posts cap.** The TOOLBOX dual-write caps the per-event stories/posts/articles array at 10 (`scripts/_toolbox-ingest.mjs`). Windowed counts `count24h` / `count30d` computed at reader load time will **undercount** for viral repos with >10 mentions in a 7-day window. Acceptable for the tracer-bullet flip — documented inline in `toolbox-store.ts`. Upstream fix: send precomputed `count_24h` / `count_30d` in the dual-write.

**(2) Reddit `top_post` is over-sent.** Dual-write sends `top_post` per repo, but `RedditRepoMention` has no `topPost` field (only the file-level `topPosts` array). Adapter ignores `top_post`; consumers use `buildGlobalRedditPosts` which falls through `allPosts → topPosts → flattenMentionPosts(mentions)`. Since `topPosts: []` is returned, the flatten path runs — correct behavior, just slightly less efficient than serving a pre-aggregated `topPosts`.

**(3) `reddit-all-data.ts` NOT touched.** There's a second Reddit refresh hook (`refreshRedditAllPostsFromStore()` for the `reddit-all-posts` data file). No corresponding TOOLBOX signal type exists yet — only `trending.reddit.mentions` is dual-written. If/when a `trending.reddit.all_posts` signal lands, a sibling adapter can mirror this PR's pattern.

## What's deliberately NOT in this PR

- `trending.github.fork.velocity` + `trending.github.stars.velocity` — design plan complete at `~/.claude/plans/phase-a2-velocity-design-2026-05-13.md`; gated on this PR proving clean + a cold-start semantic decision.
- `trending.github.repos` — same wider-blast-radius concern as velocity.
- Any consumer-side changes — the adapter preserves the legacy file shape, so render code is unchanged.

## Related

- TOOLBOX endpoint PR: [`0motionguy/toolbox#56`](https://github.com/0motionguy/toolbox/pull/56)
- TOOLBOX hardening (separate scope): [`0motionguy/toolbox#57`](https://github.com/0motionguy/toolbox/pull/57)
- TOOLBOX MEGA handover refresh: [`0motionguy/toolbox#58`](https://github.com/0motionguy/toolbox/pull/58)
- Velocity adapter design plan: `~/.claude/plans/phase-a2-velocity-design-2026-05-13.md` (reference memory `phase_a2_velocity_plan.md`)

## Commit log

- `848da5ce9` — initial HN adapter (Phase A.2.1)
- `ac326c014` — Bluesky + dev.to adapters; extract shared `fetchLeaderboardEvents` helper
- `885e3641d` — Reddit adapter; field-name remap (`score_sum_7d` → `upvotes7d`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)