### PR TITLE
audit(impeccable): wave 3a — thread sourceVerdicts into /signals (4 P0 closed)

### DIFF
--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -586,6 +586,11 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             quietTotal={volume.quietTotal}
             dominantSource={volume.dominantSource}
             dominantPct={dominantPct}
+            // // 01 reference panel — chart aggregates across all 8 sources.
+            // Use the cross-source freshness floor so the badge reads honestly
+            // even when individual collectors drift apart.
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE[volume.dominantSource]}
+            lastUpdatedAt={freshnessIso}
           />
         </div>
         <div className="col-5">
@@ -611,6 +616,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="/hackernews/trending"
             footerLabel={`view all ${hnTop.length}`}
             feed={{ variant: "list", items: hnList }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.hn}
+            lastUpdatedAt={SOURCE_FETCHED_AT.hn}
           />
         </div>
         <div className="col-3">
@@ -622,6 +629,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="/"
             footerLabel="view trending"
             feed={{ variant: "list", items: ghList }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.github}
+            lastUpdatedAt={SOURCE_FETCHED_AT.github}
           />
         </div>
         <div className="col-3">
@@ -633,6 +642,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="/"
             footerLabel="view all"
             feed={{ variant: "tweet", items: xTweetsOrBuzz }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.x}
+            lastUpdatedAt={SOURCE_FETCHED_AT.x}
           />
         </div>
         <div className="col-3">
@@ -644,6 +655,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="/reddit/trending"
             footerLabel={`view all ${redditAll.length}`}
             feed={{ variant: "list", items: redditList }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.reddit}
+            lastUpdatedAt={SOURCE_FETCHED_AT.reddit}
           />
         </div>
       </div>
@@ -663,6 +676,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="/bluesky/trending"
             footerLabel="view all"
             feed={{ variant: "tweet", items: bskyTweets }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.bluesky}
+            lastUpdatedAt={SOURCE_FETCHED_AT.bluesky}
           />
         </div>
         <div className="col-3">
@@ -674,6 +689,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="/devto"
             footerLabel={`view all ${devtoTop.length}`}
             feed={{ variant: "rss", items: devtoArticles }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.devto}
+            lastUpdatedAt={SOURCE_FETCHED_AT.devto}
           />
         </div>
         <div className="col-3">
@@ -685,6 +702,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="https://www.anthropic.com/news"
             footerLabel="anthropic.com/news"
             feed={{ variant: "rss", items: claudeArticles }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.claude}
+            lastUpdatedAt={SOURCE_FETCHED_AT.claude}
           />
         </div>
         <div className="col-3">
@@ -696,6 +715,8 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             footerHref="https://openai.com/news"
             footerLabel="openai.com/news"
             feed={{ variant: "rss", items: openaiArticles }}
+            freshnessSource={SIGNAL_FRESHNESS_SOURCE.openai}
+            lastUpdatedAt={SOURCE_FETCHED_AT.openai}
           />
         </div>
       </div>

--- a/src/components/signals-terminal/LiveClock.tsx
+++ b/src/components/signals-terminal/LiveClock.tsx
@@ -55,29 +55,10 @@ export function LiveClock({ initialIso }: LiveClockProps) {
         {formatUtc(now)}
       </span>
       UTC · {formatDate(now)}
-      <div style={{ marginTop: "4px" }}>
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "6px",
-            color: "var(--color-positive)",
-          }}
-        >
-          <i
-            aria-hidden
-            style={{
-              width: "6px",
-              height: "6px",
-              borderRadius: "99px",
-              background: "var(--color-positive)",
-              boxShadow: "0 0 0 3px rgba(34,197,94,0.18)",
-              animation: "pulse 1.6s ease-in-out infinite",
-            }}
-          />
-          FEED LIVE
-        </span>
-      </div>
+      {/* Removed the "FEED LIVE" block (2026-05-13) — the clock is a clock.
+          Freshness lives in the <FreshnessBadge> placed next to it; double-
+          broadcasting a hardcoded green LIVE indicator from the clock
+          violates the honest-chrome rule (CLAUDE.md). */}
     </div>
   );
 }

--- a/src/components/signals-terminal/LiveTicker.tsx
+++ b/src/components/signals-terminal/LiveTicker.tsx
@@ -59,17 +59,11 @@ export function LiveTicker({ items }: LiveTickerProps) {
           textTransform: "uppercase",
         }}
       >
-        <i
-          aria-hidden
-          style={{
-            width: "6px",
-            height: "6px",
-            borderRadius: "99px",
-            background: "var(--color-bg-canvas)",
-            animation: "pulse-dark 1.4s ease-in-out infinite",
-          }}
-        />
-        LIVE · 24H WIRE
+        {/* Dropped the pulse-dark pip + "LIVE" word (2026-05-13). The wire
+            is a 24h rollup; items can be 23h old. Pulsing "LIVE" green-on-
+            accent regardless of freshness violates the honest-chrome rule
+            (CLAUDE.md). Wire label stands alone honestly. */}
+        24H WIRE
       </div>
       <div
         style={{
@@ -155,10 +149,6 @@ export function LiveTicker({ items }: LiveTickerProps) {
         @keyframes signals-ticker-scroll {
           0% { transform: translateX(0); }
           100% { transform: translateX(-50%); }
-        }
-        @keyframes pulse-dark {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0.3; }
         }
       `}</style>
     </div>

--- a/src/components/signals-terminal/SourceFeedPanel.tsx
+++ b/src/components/signals-terminal/SourceFeedPanel.tsx
@@ -11,7 +11,9 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import type { SourceKey } from "@/lib/signals/types";
+import type { NewsSource } from "@/lib/news/freshness";
 import { Card, CardHeader } from "@/components/ui/Card";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { SourceMark, SOURCE_BRAND_COLOR } from "./SourceMark";
 
 type Variant = "list" | "tweet" | "rss";
@@ -64,6 +66,12 @@ export interface SourceFeedPanelProps {
   footerHref: string;
   footerLabel: string;
   feed: FeedItems;
+  /** Maps the panel's source onto the news-source freshness ladder so
+   * `<FreshnessBadge>` can read the verdict honestly (FRESH/STALE/COLD)
+   * instead of pinning the header to a green "LIVE" lie. */
+  freshnessSource: NewsSource;
+  /** ISO of the last successful collector write for this source. null → cold. */
+  lastUpdatedAt: string | null | undefined;
 }
 
 export function SourceFeedPanel({
@@ -74,6 +82,8 @@ export function SourceFeedPanel({
   footerHref,
   footerLabel,
   feed,
+  freshnessSource,
+  lastUpdatedAt,
 }: SourceFeedPanelProps) {
   return (
     <Card variant="panel" className="signals-panel">
@@ -81,7 +91,7 @@ export function SourceFeedPanel({
         right={
           <>
             <span style={{ fontVariantNumeric: "tabular-nums" }}>{countLabel}</span>
-            <span className="live">LIVE</span>
+            <FreshnessBadge source={freshnessSource} lastUpdatedAt={lastUpdatedAt} />
           </>
         }
       >

--- a/src/components/signals-terminal/VolumeAreaChart.tsx
+++ b/src/components/signals-terminal/VolumeAreaChart.tsx
@@ -25,7 +25,9 @@ import { Card, CardHeader } from "@/components/ui/Card";
 import { ChartStat, ChartStats, ChartWrap } from "@/components/ui/ChartShell";
 import "@/lib/charts/theme/sparkline";
 import { EChart } from "@/components/charts/EChart";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { CHART_TOKENS } from "@/lib/charts/theme/tokens";
+import type { NewsSource } from "@/lib/news/freshness";
 import type { HourBucket } from "@/lib/signals/volume";
 import type { SourceKey } from "@/lib/signals/types";
 import { SourceMark, SOURCE_BRAND_COLOR } from "./SourceMark";
@@ -138,6 +140,12 @@ export interface VolumeAreaChartProps {
   quietTotal: number;
   dominantSource: SourceKey;
   dominantPct: number;
+  /** Maps the chart's lead source onto the freshness ladder so the // 01
+   * reference panel reads honestly (FRESH/STALE/COLD) instead of pinning
+   * to a permanent green "LIVE". */
+  freshnessSource: NewsSource;
+  /** ISO of the latest data point across the stacked sources. null → cold. */
+  lastUpdatedAt: string | null | undefined;
 }
 
 export function VolumeAreaChart({
@@ -150,6 +158,8 @@ export function VolumeAreaChart({
   quietTotal,
   dominantSource,
   dominantPct,
+  freshnessSource,
+  lastUpdatedAt,
 }: VolumeAreaChartProps) {
   const deltaText =
     changePct === null ? "Δ N/A" : `Δ ${changePct >= 0 ? "+" : ""}${changePct.toFixed(1)}%`;
@@ -356,7 +366,7 @@ export function VolumeAreaChart({
         right={
           <>
             <span>{deltaText}</span>
-            <span className="live">LIVE</span>
+            <FreshnessBadge source={freshnessSource} lastUpdatedAt={lastUpdatedAt} />
           </>
         }
       >


### PR DESCRIPTION
## Summary

Stacked on wave-2 (PR #1148). Closes the 4-P0 honest-chrome cluster on /signals identified by the wave-2 audit. **Highest-leverage fix in the whole audit**: 4 P0s close from one pattern (thread existing sourceVerdicts into 4 panel components).

## What changed

Before: every `/signals` panel rendered `<span className="live">LIVE</span>` regardless of real data freshness. Cold collectors lit up green "LIVE" anyway.

After: each panel receives a `freshnessSource` + `lastUpdatedAt` prop. `<FreshnessBadge>` reads the verdict honestly (FRESH / STALE / COLD).

| File | Change |
|---|---|
| SourceFeedPanel.tsx:85 | LIVE span → FreshnessBadge |
| VolumeAreaChart.tsx:359 | same fix on // 01 reference panel |
| LiveClock.tsx:78 | drop "FEED LIVE" block + green pulse box-shadow |
| LiveTicker.tsx:72 | rename "LIVE · 24H WIRE" → "24H WIRE", drop pulse-dark |
| signals/page.tsx | build verdictBySource lookup, thread to panels |

## Test plan

- [x] impeccable detect clean
- [x] lint:guards green
- [x] typecheck green
- [ ] (recommended) visual smoke /signals at 375px and 1280px

🤖 Generated with [Claude Code](https://claude.com/claude-code)