### PR TITLE
audit(impeccable): wave 3c — fix 4 P0 honest-chrome lies on /funding

### DIFF
--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -23,6 +23,8 @@ import { WindowedFundingBoard } from "@/components/funding/WindowedFundingBoard"
 import { companyLogoUrl } from "@/lib/logos";
 import { resolveLogoUrl } from "@/lib/logo-url";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+import { classifyFreshness } from "@/lib/news/freshness";
+import type { VerdictTone } from "@/components/ui/VerdictRibbon";
 
 export const revalidate = 60;
 
@@ -106,9 +108,11 @@ function money(value: number | null | undefined): string {
 
 function formatClock(value: string): string {
   const date = new Date(value);
-  return Number.isFinite(date.getTime())
-    ? date.toISOString().slice(11, 19)
-    : "warming";
+  if (!Number.isFinite(date.getTime())) return "—";
+  // EPOCH_ZERO sentinel — source is offline / never fetched. Don't render
+  // it as a clock-ish "warming" — let FreshnessBadge own the COLD verdict.
+  if (value.startsWith("1970-")) return "—";
+  return date.toISOString().slice(11, 19);
 }
 
 function formatAge(value: string): string {
@@ -279,6 +283,15 @@ export default async function FundingPage() {
   const megaRounds = rounds.filter((signal) => amountValue(signal) >= 100_000_000).length;
   const totalAmount = stats.totalAmountUsd ?? 0;
 
+  // Mirror the FreshnessBadge's verdict on the VerdictRibbon so a COLD or
+  // STALE feed doesn't ship a celebratory green ribbon. Same "skills"
+  // source threshold as the badge (P2 #6 — intentional reuse) keeps the
+  // two chrome signals aligned. Ribbon tones: money (green) when live,
+  // amber when warn/cold (no `red` variant on VerdictRibbon).
+  const fundingVerdict = classifyFreshness("skills", file.fetchedAt);
+  const ribbonTone: VerdictTone =
+    fundingVerdict.status === "live" ? "money" : "amber";
+
   return (
     <main className="home-surface funding-page">
       <PageHead
@@ -346,7 +359,7 @@ export default async function FundingPage() {
       />
 
       <VerdictRibbon
-        tone="money"
+        tone={ribbonTone}
         stamp={{
           eyebrow: "// CAPITAL RADAR",
           headline: `${megaRounds} mega · ${extracted} extracted`,
@@ -474,10 +487,24 @@ export default async function FundingPage() {
                     <span className="h">{signal.headline}</span>
                     <span className="meta">{sourceName(signal.sourcePlatform)} / {formatAge(signal.publishedAt)}</span>
                   </span>
-                  <span className="delta up">
-                    {signal.extracted?.confidence ?? "none"}
-                    <span className="lbl">confidence</span>
-                  </span>
+                  {(() => {
+                    const c = signal.extracted?.confidence ?? "none";
+                    // Match the freshness-honesty contract: a chip class
+                    // should reflect the value it labels, not always green.
+                    // high → up (green), medium → neutral, low/none → dn.
+                    const cls =
+                      c === "high"
+                        ? "delta up"
+                        : c === "medium"
+                          ? "delta"
+                          : "delta dn";
+                    return (
+                      <span className={cls}>
+                        {c}
+                        <span className="lbl">confidence</span>
+                      </span>
+                    );
+                  })()}
                 </Link>
               ))}
             </Card>

--- a/src/components/funding/MoverRow.tsx
+++ b/src/components/funding/MoverRow.tsx
@@ -101,7 +101,10 @@ export function MoverRow({
   const amountClean = isCleanAmount(amount);
   return (
     <Tag
-      {...(href ? { href } : {})}
+      // External destinations (the funding signal's source article) should
+      // open in a new tab so clicking a row doesn't kick the user off
+      // /funding — matches sister sp-row / funding-bar rows on this page.
+      {...(href ? { href, target: "_blank", rel: "noreferrer" } : {})}
       className={cn(
         "v4-mover-row",
         first && "v4-mover-row--first",


### PR DESCRIPTION
## Summary

Stacked on wave-2 (PR #1148). Closes the 4 P0 honest-chrome / UX-blocker findings on /funding per [funding-audit.md](docs/audits/impeccable/funding-audit.md). 6 P1s + 6 P2s flagged in the audit are deferred to follow-up.

## What changed

| # | Severity | File | Fix |
|---|---|---|---|
| 1 | P0 | (funding/page.tsx) | confidence chip color derives from `confidence` field |
| 2 | P0 | (funding/page.tsx) | drop "warming" sentinel when fetchedAt is epoch-zero |
| 3 | P0 | (funding/page.tsx) | VerdictRibbon tone reads from FreshnessBadge verdict |
| 4 | P0 | (MoverRow.tsx) | add target="_blank" + rel for nav consistency |

## Out of scope (deferred)
- 6 P1s (sub-44px tabs, missing tabpanel association, semantic gradient, decorative pip palette, operator-voice copy, RSS-in-place)
- 6 P2s (KPI pip/tone mismatch, row primitive consolidation, title casing, etc.)

## Test plan
- [x] impeccable detect clean
- [x] lint:guards green
- [x] typecheck green
- [ ] (recommended) visual smoke /funding at 375px and 1280px

🤖 Generated with [Claude Code](https://claude.com/claude-code)