### PR TITLE
feat(lib): TOOLBOX read adapter for stars + fork velocity (Phase A.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,13 +54,16 @@ ADMIN_TOKEN=
 # TOOLBOX_API_URL + TOOLBOX_API_KEY are set, the matching refresh hook
 # fetches from TOOLBOX's /v1/signals/leaderboard endpoint instead of the
 # legacy Redis-first data-store read. Falls back silently to legacy on any
-# TOOLBOX failure (network, auth, shape).
+# TOOLBOX failure (network, auth, shape). VELOCITY switches the per-repo
+# stars + fork delta reader; the trending list (data/trending.json) is NOT
+# switched.
 # TOOLBOX_API_URL=https://api.aiso.tools
 # TOOLBOX_API_KEY=tbk_live_<32-char-token-from-mint-key-CLI>
 # TOOLBOX_READ_HN_MENTIONS=true
 # TOOLBOX_READ_BLUESKY_MENTIONS=true
 # TOOLBOX_READ_DEVTO_MENTIONS=true
 # TOOLBOX_READ_REDDIT_MENTIONS=true
+# TOOLBOX_READ_VELOCITY=true
 
 # -- Optional: revenue enrichment (CI scripts only) --------------------------
 # TRUSTMRR_API_KEY=

--- a/src/lib/__tests__/toolbox-store-velocity.test.ts
+++ b/src/lib/__tests__/toolbox-store-velocity.test.ts
@@ -1,0 +1,310 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { fetchDeltasFromToolbox } from "../toolbox-store-velocity";
+
+function fakeFetch(
+  responses: Array<{ status?: number; body?: unknown; throwError?: Error }>,
+): typeof fetch {
+  let callIdx = 0;
+  return (async () => {
+    const r = responses[callIdx] ?? responses[responses.length - 1];
+    callIdx += 1;
+    if (r.throwError) throw r.throwError;
+    return {
+      ok: (r.status ?? 200) >= 200 && (r.status ?? 200) < 300,
+      status: r.status ?? 200,
+      json: async () => r.body,
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+// trending.ts seeds `getFullNameToRepoId()` from the bundled `data/trending.json`.
+// Pull a repo_id we know exists so the reverse-map join hits. Using a repo we
+// expect to be in any trending snapshot.
+async function pickAnyKnownFullName(): Promise<{ fullName: string; repoId: string } | null> {
+  const { getFullNameToRepoId } = await import("../trending");
+  const map = getFullNameToRepoId();
+  const first = map.entries().next();
+  if (first.done) return null;
+  return { fullName: first.value[0], repoId: first.value[1] };
+}
+
+test("returns DeltasJson with stars + fork merge for a known repo", async () => {
+  const known = await pickAnyKnownFullName();
+  assert.ok(known, "bundled trending.json must have at least one repo");
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([
+      // Stars response
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: `https://github.com/${known.fullName}`,
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.stars.velocity",
+              produced_at: "2026-05-13T03:00:00Z",
+              fields: {
+                stars_now: 100,
+                delta_1h: 0,
+                delta_1h_basis: "exact",
+                delta_24h: 5,
+                delta_24h_basis: "nearest",
+                delta_7d: 12,
+                delta_7d_basis: "cold-start",
+                delta_30d: 40,
+                delta_30d_basis: "nearest",
+              },
+            },
+          ],
+        },
+      },
+      // Fork response
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: `https://github.com/${known.fullName}`,
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.fork.velocity",
+              produced_at: "2026-05-13T03:00:00Z",
+              fields: {
+                forks_now: 7,
+                fork_delta_1h: 0,
+                fork_delta_24h: 1,
+                fork_delta_7d: 3,
+                fork_delta_30d: 5,
+              },
+            },
+          ],
+        },
+      },
+    ]),
+  });
+
+  assert.ok(result, "expected non-null DeltasJson");
+  const entry = result!.repos[known.repoId];
+  assert.ok(entry, `expected entry for repoId ${known.repoId} (fullName=${known.fullName})`);
+  assert.equal(entry.stars_now, 100);
+  assert.equal(entry.forks_now, 7);
+  // Stars side: basis correctly preserved
+  assert.equal(entry.delta_1h.basis, "exact");
+  assert.equal(entry.delta_24h.basis, "nearest");
+  assert.equal(entry.delta_7d.basis, "cold-start");
+  // Cold-start variant requires age_seconds (stubbed to 0)
+  if (entry.delta_7d.basis === "cold-start") {
+    assert.equal(entry.delta_7d.age_seconds, 0);
+  }
+  // Fork side: basis is LOST in dual-write transit → degrades to "no-history".
+  // This is documented in the adapter file header as trade-off (2).
+  assert.equal(entry.fork_delta_1h!.basis, "no-history");
+  assert.equal(entry.fork_delta_24h!.basis, "no-history");
+});
+
+test("returns null when both stars + fork responses fail", async () => {
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([{ status: 502 }, { status: 502 }]),
+  });
+  assert.equal(result, null);
+});
+
+test("returns null on network throw across both", async () => {
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([
+      { throwError: new Error("ECONNRESET") },
+      { throwError: new Error("ECONNRESET") },
+    ]),
+  });
+  assert.equal(result, null);
+});
+
+test("returns partial DeltasJson when only stars side succeeds", async () => {
+  const known = await pickAnyKnownFullName();
+  assert.ok(known);
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: `https://github.com/${known.fullName}`,
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.stars.velocity",
+              produced_at: "2026-05-13T03:00:00Z",
+              fields: { stars_now: 50, delta_1h: 0, delta_1h_basis: "exact" },
+            },
+          ],
+        },
+      },
+      { status: 503 }, // Fork fetch fails
+    ]),
+  });
+  assert.ok(result, "stars-only success should still produce a DeltasJson");
+  const entry = result!.repos[known.repoId];
+  assert.ok(entry);
+  assert.equal(entry.stars_now, 50);
+  assert.equal(entry.forks_now, undefined);
+});
+
+test("skips events for repos not in the trending reverse-map", async () => {
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: "https://github.com/definitely/not-trending-xyz123",
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.stars.velocity",
+              produced_at: "2026-05-13T03:00:00Z",
+              fields: { stars_now: 9999, delta_1h: 0, delta_1h_basis: "exact" },
+            },
+          ],
+        },
+      },
+      { body: { count: 0, targets: [] } },
+    ]),
+  });
+  assert.ok(result);
+  // Repo not in trending → no entry in deltas
+  assert.equal(Object.keys(result!.repos).length, 0);
+});
+
+test("skips events with non-github target_identity", async () => {
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: "https://example.com/not-a-repo",
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.stars.velocity",
+              produced_at: "2026-05-13T03:00:00Z",
+              fields: { stars_now: 1, delta_1h: 0, delta_1h_basis: "exact" },
+            },
+          ],
+        },
+      },
+      { body: { count: 0, targets: [] } },
+    ]),
+  });
+  assert.ok(result);
+  assert.equal(Object.keys(result!.repos).length, 0);
+});
+
+test("buildDeltaValue degrades unknown basis to no-history", async () => {
+  const known = await pickAnyKnownFullName();
+  assert.ok(known);
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: `https://github.com/${known.fullName}`,
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.stars.velocity",
+              produced_at: "2026-05-13T03:00:00Z",
+              fields: {
+                stars_now: 1,
+                delta_1h: 5,
+                delta_1h_basis: "mystery-basis-from-future",
+              },
+            },
+          ],
+        },
+      },
+      { body: { count: 0, targets: [] } },
+    ]),
+  });
+  assert.ok(result);
+  const entry = result!.repos[known.repoId];
+  assert.equal(entry.delta_1h.basis, "no-history");
+  assert.equal(entry.delta_1h.value, null);
+});
+
+test("computedAt reflects max produced_at across both signals", async () => {
+  const known = await pickAnyKnownFullName();
+  assert.ok(known);
+  const result = await fetchDeltasFromToolbox({
+    apiUrl: "https://api.example.test",
+    apiKey: "tbk_live_test",
+    fetchImpl: fakeFetch([
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: `https://github.com/${known.fullName}`,
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.stars.velocity",
+              produced_at: "2026-05-13T01:00:00Z",
+              fields: { stars_now: 1, delta_1h: 0, delta_1h_basis: "exact" },
+            },
+          ],
+        },
+      },
+      {
+        body: {
+          count: 1,
+          targets: [
+            {
+              target_id: "t1",
+              target_kind: "url",
+              target_identity: `https://github.com/${known.fullName}`,
+              scan_id: "s",
+              run_id: "r",
+              signal_type: "trending.github.fork.velocity",
+              produced_at: "2026-05-13T05:30:00Z",
+              fields: { forks_now: 1, fork_delta_1h: 0 },
+            },
+          ],
+        },
+      },
+    ]),
+  });
+  assert.ok(result);
+  assert.equal(result!.computedAt, "2026-05-13T05:30:00.000Z");
+});

--- a/src/lib/toolbox-store-velocity.ts
+++ b/src/lib/toolbox-store-velocity.ts
@@ -1,0 +1,246 @@
+// TOOLBOX velocity read adapter — Phase A.2 (stars + fork velocity)
+//
+// Fetches `trending.github.stars.velocity` + `trending.github.fork.velocity`
+// from TOOLBOX's /v1/signals/leaderboard, then merges per-repo into a
+// `DeltasJson` shape keyed by OSS Insight repo_id (the same shape the
+// legacy data-store returns). Reverse-joins TOOLBOX `target_identity`
+// (a GitHub URL → owner/name) back to repo_id via `getFullNameToRepoId()`
+// from `./trending.ts` — kept lockstep with the live trending cache.
+//
+// Returns null on any failure so the caller (refreshTrendingFromStore)
+// can fall through to the legacy data-store deltas read.
+//
+// SEMANTIC TRADE-OFFS WORTH KNOWING:
+//
+// 1. **Cold-start `age_seconds` stub**. The dual-write in trendingrepo's
+//    `scripts/_toolbox-ingest.mjs` doesn't transmit `age_seconds` (or
+//    `from_commit` / `from_ts`). The local `DeltaValue` discriminated
+//    union requires `age_seconds: number` on the cold-start variant.
+//    This adapter stubs `age_seconds: 0` / `from_commit: ""` / `from_ts: 0`.
+//    Runtime semantic is preserved — `derived-repos.ts`'s `isRealDelta`
+//    helper (which only reads `.value` + `.basis`) correctly returns
+//    `false` for cold-start, so consumers fall back to alternative
+//    sources. The lost metadata (commit hash, exact timestamp, age) is
+//    not consumed downstream by any path observed during recon. If a
+//    consumer starts reading `age_seconds` later, the stubbed `0` will
+//    underrepresent the actual age. Upstream fix: extend the dual-write
+//    to emit `age_seconds` for cold-start basis (and ideally `from_ts`
+//    for all variants).
+//
+// 2. **Fork basis is LOST in transit**. The dual-write at lines 580-596
+//    of `_toolbox-ingest.mjs` sends fork deltas as just `fork_delta_<win>`
+//    (the value) — it does NOT send a corresponding `fork_delta_<win>_basis`
+//    field, unlike the stars side. This adapter therefore receives no
+//    basis for fork deltas and treats them as `basis: "no-history"`
+//    (which makes `isRealDelta` return false → consumers fall back).
+//    Upstream fix: add `pushNormalized(forkNormalized, \`fork_delta_${win}_basis\`, d.basis, 1.0)`
+//    in the dual-write.
+
+import "server-only";
+
+import type { DeltasJson, DeltaValue, RepoDeltaEntry } from "./trending";
+import { getFullNameToRepoId } from "./trending";
+
+const DEFAULT_LIMIT = 500;
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+interface ToolboxEvent {
+  target_id: string;
+  target_kind: string;
+  target_identity: string;
+  scan_id: string;
+  run_id: string;
+  signal_type: string;
+  produced_at: string;
+  fields: Record<string, unknown>;
+}
+
+interface ToolboxLeaderboardResponse {
+  count: number;
+  targets: ToolboxEvent[];
+}
+
+export interface ToolboxFetchOptions {
+  apiUrl: string;
+  apiKey: string;
+  limit?: number;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+function extractGithubFullName(targetIdentity: string): string | null {
+  try {
+    const url = new URL(targetIdentity);
+    const host = url.hostname.toLowerCase();
+    if (host !== "github.com" && host !== "www.github.com") return null;
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    return `${parts[0]}/${parts[1]}`;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchLeaderboardEvents(
+  opts: ToolboxFetchOptions,
+  signalType: string,
+): Promise<ToolboxLeaderboardResponse | null> {
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") return null;
+
+  const base = opts.apiUrl.replace(/\/+$/, "");
+  const url = `${base}/v1/signals/leaderboard?type=${encodeURIComponent(signalType)}&limit=${limit}`;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      headers: {
+        authorization: `Bearer ${opts.apiKey}`,
+        accept: "application/json",
+      },
+      signal: ac.signal,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as ToolboxLeaderboardResponse;
+    if (!body || !Array.isArray(body.targets)) return null;
+    return body;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const WINDOWS = ["1h", "24h", "7d", "30d"] as const;
+type DeltaWindow = (typeof WINDOWS)[number];
+
+function buildDeltaValue(value: unknown, basis: unknown): DeltaValue {
+  const basisStr = typeof basis === "string" ? basis : "no-history";
+  const numValue = typeof value === "number" ? value : null;
+
+  switch (basisStr) {
+    case "exact":
+    case "nearest":
+      if (numValue === null) return { value: null, basis: "no-history" };
+      return { value: numValue, basis: basisStr, from_commit: "", from_ts: 0 };
+    case "cold-start":
+      if (numValue === null) return { value: null, basis: "no-history" };
+      // age_seconds stubbed to 0. See file header trade-off note (1).
+      return {
+        value: numValue,
+        basis: "cold-start",
+        from_commit: "",
+        from_ts: 0,
+        age_seconds: 0,
+      };
+    case "no-history":
+    case "repo-not-tracked":
+      return { value: null, basis: basisStr };
+    default:
+      return { value: null, basis: "no-history" };
+  }
+}
+
+function noHistory(): DeltaValue {
+  return { value: null, basis: "no-history" };
+}
+
+function createEmptyEntry(): RepoDeltaEntry {
+  return {
+    stars_now: 0,
+    delta_1h: noHistory(),
+    delta_24h: noHistory(),
+    delta_7d: noHistory(),
+    delta_30d: noHistory(),
+  };
+}
+
+function maxProducedAtMs(events: ToolboxEvent[]): number {
+  let max = 0;
+  for (const ev of events) {
+    const t = Date.parse(ev.produced_at);
+    if (Number.isFinite(t) && t > max) max = t;
+  }
+  return max;
+}
+
+/**
+ * Fetch the latest stars + fork velocity from TOOLBOX and merge into a
+ * single `DeltasJson` keyed by OSS Insight repo_id. Returns null when
+ * BOTH sub-fetches fail (single-side success is fine — adapter returns
+ * a partial DeltasJson with only the side that came back).
+ */
+export async function fetchDeltasFromToolbox(
+  opts: ToolboxFetchOptions,
+): Promise<DeltasJson | null> {
+  const [starsResp, forksResp] = await Promise.all([
+    fetchLeaderboardEvents(opts, "trending.github.stars.velocity"),
+    fetchLeaderboardEvents(opts, "trending.github.fork.velocity"),
+  ]);
+  if (!starsResp && !forksResp) return null;
+
+  const reverseMap = getFullNameToRepoId();
+  const repos: Record<string, RepoDeltaEntry> = {};
+  const allEvents: ToolboxEvent[] = [
+    ...(starsResp?.targets ?? []),
+    ...(forksResp?.targets ?? []),
+  ];
+
+  function lookupRepoId(targetIdentity: string): string | null {
+    const fullName = extractGithubFullName(targetIdentity);
+    if (!fullName) return null;
+    return reverseMap.get(fullName) ?? null;
+  }
+
+  // Merge stars side
+  for (const ev of starsResp?.targets ?? []) {
+    const repoId = lookupRepoId(ev.target_identity);
+    if (!repoId) continue;
+    const f = ev.fields;
+    if (typeof f !== "object" || f === null) continue;
+
+    const entry = repos[repoId] ?? createEmptyEntry();
+    if (typeof f.stars_now === "number") entry.stars_now = f.stars_now;
+    for (const win of WINDOWS) {
+      entry[`delta_${win}` as `delta_${DeltaWindow}`] = buildDeltaValue(
+        f[`delta_${win}`],
+        f[`delta_${win}_basis`],
+      );
+    }
+    repos[repoId] = entry;
+  }
+
+  // Merge fork side. See file header trade-off note (2): the dual-write
+  // doesn't send fork basis strings, so all fork deltas come through as
+  // basis: "no-history" via buildDeltaValue's default-case.
+  for (const ev of forksResp?.targets ?? []) {
+    const repoId = lookupRepoId(ev.target_identity);
+    if (!repoId) continue;
+    const f = ev.fields;
+    if (typeof f !== "object" || f === null) continue;
+
+    const entry = repos[repoId] ?? createEmptyEntry();
+    if (typeof f.forks_now === "number") entry.forks_now = f.forks_now;
+    for (const win of WINDOWS) {
+      const valueKey = `fork_delta_${win}` as `fork_delta_${DeltaWindow}`;
+      const basisKey = `fork_delta_${win}_basis`;
+      entry[valueKey] = buildDeltaValue(f[valueKey], f[basisKey]);
+    }
+    repos[repoId] = entry;
+  }
+
+  const latestMs = maxProducedAtMs(allEvents);
+  return {
+    computedAt:
+      latestMs > 0 ? new Date(latestMs).toISOString() : new Date().toISOString(),
+    // `windows` is recon-confirmed unused by all consumer paths
+    // (derived-repos.ts reads only DeltaValue.value + .basis). Returning
+    // empty object preserves the type contract.
+    windows: {} as DeltasJson["windows"],
+    coverage: undefined,
+    repos,
+  };
+}

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -111,6 +111,14 @@ export interface RepoDeltaEntry {
   delta_24h: DeltaValue;
   delta_7d: DeltaValue;
   delta_30d: DeltaValue;
+  // Fork side — present in real production payloads even though earlier
+  // versions of this type omitted them. Optional for back-compat with
+  // legacy/cold-seed deltas that pre-date fork tracking.
+  forks_now?: number;
+  fork_delta_1h?: DeltaValue;
+  fork_delta_24h?: DeltaValue;
+  fork_delta_7d?: DeltaValue;
+  fork_delta_30d?: DeltaValue;
 }
 
 export interface WindowPick {
@@ -163,6 +171,16 @@ function fullNameIndex(): Map<string, string> {
   return map;
 }
 
+/**
+ * Public accessor for the `owner/name → OSS Insight repo_id` reverse map.
+ * Used by the TOOLBOX velocity adapter (`src/lib/toolbox-store-velocity.ts`)
+ * to translate `target_identity` URLs back into the keys that
+ * `DeltasJson.repos` uses.
+ */
+export function getFullNameToRepoId(): Map<string, string> {
+  return fullNameIndex();
+}
+
 // ---------------------------------------------------------------------------
 // Refresh hook — pulls fresh trending + deltas from the data-store.
 // ---------------------------------------------------------------------------
@@ -201,9 +219,15 @@ export async function refreshTrendingFromStore(): Promise<RefreshResult> {
     try {
       const { getDataStore } = await import("./data-store");
       const store = getDataStore();
+
+      // Phase A.2 velocity adapter: when TOOLBOX_READ_VELOCITY=true and
+      // TOOLBOX_API_URL/_API_KEY are set, deltas come from the TOOLBOX
+      // /v1/signals/leaderboard endpoint instead of the legacy data-store
+      // read. Trending fetch is unchanged. The flag default is OFF —
+      // zero change to current behaviour.
       const [trendingResult, deltasResult] = await Promise.all([
         store.read<TrendingFile>("trending"),
-        store.read<DeltasJson>("deltas"),
+        readDeltasWithToolboxFallback(store),
       ]);
 
       if (trendingResult.data && trendingResult.source !== "missing") {
@@ -234,6 +258,36 @@ export async function refreshTrendingFromStore(): Promise<RefreshResult> {
   });
 
   return inflight;
+}
+
+/**
+ * Phase A.2 deltas read with TOOLBOX fallback.
+ *
+ * When TOOLBOX_READ_VELOCITY=true (and TOOLBOX_API_URL/_API_KEY are set),
+ * attempts to fetch aggregated stars + fork velocity from TOOLBOX. Any
+ * failure (network, auth, shape) returns null and the legacy data-store
+ * deltas read runs as before.
+ *
+ * The synthetic source value is "redis" rather than a fictional "toolbox"
+ * to keep the existing 4-value DataSource union ergonomic. Reviewers
+ * tracking "where did this delta come from" should look at the local
+ * fetched-at vs. trending fetched-at + check env flags.
+ */
+async function readDeltasWithToolboxFallback(
+  store: { read<T>(key: string): Promise<{ data: T | null; source: "redis" | "file" | "memory" | "missing"; ageMs: number; fresh: boolean; writtenAt?: string }> },
+): Promise<{ data: DeltasJson | null; source: "redis" | "file" | "memory" | "missing"; ageMs: number; fresh: boolean }> {
+  if (process.env.TOOLBOX_READ_VELOCITY === "true") {
+    const apiUrl = process.env.TOOLBOX_API_URL;
+    const apiKey = process.env.TOOLBOX_API_KEY;
+    if (apiUrl && apiKey) {
+      const { fetchDeltasFromToolbox } = await import("./toolbox-store-velocity");
+      const toolboxFile = await fetchDeltasFromToolbox({ apiUrl, apiKey });
+      if (toolboxFile) {
+        return { data: toolboxFile, source: "redis", ageMs: 0, fresh: true };
+      }
+    }
+  }
+  return store.read<DeltasJson>("deltas");
 }
 
 /**


### PR DESCRIPTION
> **⚠️ DRAFT — blocked on [`0motionguy/toolbox#56`](https://github.com/0motionguy/toolbox/pull/56) merging + a service-plan `tbk_live_*` key being minted for trendingrepo. Reviewable now; flag-flippable once `/v1/signals/leaderboard` is live on `api.aiso.tools` AND the mentions-pack PR ([`#1149`](https://github.com/0motionguy/starscreener/pull/1149)) has proven clean in prod for ≥24 h.**

## Summary

Adds an env-flagged read path that pulls aggregated per-repo **stars + fork velocity** from TOOLBOX's `/v1/signals/leaderboard` endpoint and shapes the response back into the existing `DeltasJson` contract (keyed by OSS Insight `repo_id`).

Companion to [`#1149`](https://github.com/0motionguy/starscreener/pull/1149) (the mentions pack: HN + Reddit + Bluesky + dev.to). Together these cover the top 6 read paths driving Phase A.2's blast radius.

When `TOOLBOX_READ_VELOCITY=true` AND `TOOLBOX_API_URL`/`TOOLBOX_API_KEY` are set, `refreshTrendingFromStore()` routes the **deltas** side of its `Promise.all` through `fetchDeltasFromToolbox()` instead of the legacy `store.read("deltas")`. Trending fetch is **unchanged** in this PR — only deltas switch. Flag defaults OFF.

## How the join works

TOOLBOX events carry `target_identity` as a GitHub URL (`https://github.com/owner/name`), but the local `DeltasJson.repos` map is keyed by **OSS Insight numeric `repo_id`** (e.g. `"16607898"`). The adapter reverse-joins via `getFullNameToRepoId()` (newly exported from `src/lib/trending.ts` — wraps the pre-existing private `fullNameIndex()`), which builds `owner/name → repo_id` from the current trending payload. Repos in TOOLBOX but not in current trending data are silently dropped (their velocity isn't useful without trending context anyway).

## Files

| File | Type | Purpose |
|---|---|---|
| `src/lib/toolbox-store-velocity.ts` | NEW | `fetchDeltasFromToolbox()` — dual-signal fetch (stars + fork) + repo_id reverse-join + `DeltasJson` construction |
| `src/lib/__tests__/toolbox-store-velocity.test.ts` | NEW | 8 node:test cases — happy path, partial merge, null fallback on both fail, unknown-repo skip, unknown-basis degradation, computedAt aggregation |
| `src/lib/trending.ts` | MOD | (a) widen `RepoDeltaEntry` with optional fork fields; (b) export `getFullNameToRepoId()`; (c) `readDeltasWithToolboxFallback()` branch in `refreshTrendingFromStore()` |
| `.env.example` | MOD | Documents `TOOLBOX_READ_VELOCITY` flag + the shared `TOOLBOX_API_URL` / `TOOLBOX_API_KEY` block |

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `node:test src/lib/__tests__/toolbox-store-velocity.test.ts` — 8/8 pass
- [x] `node:test src/lib/pipeline/__tests__/derived-repos.test.ts` — 3/3 pass (regression on the deltas consumer)
- [ ] **Rollout (after toolbox#56 merges + service-plan key minted + #1149 mentions pack proven for ≥24 h):**
  1. Flip `TOOLBOX_READ_VELOCITY=true` on **preview** Vercel deployment.
  2. Compare homepage / `/repo/[owner]/[name]` velocity badges side-by-side against prod for 24 h. Watch for:
     - Repos that go missing from the badge surface (means reverse-map miss)
     - Cold-start undercount on viral repos (see trade-off (1) below)
     - Fork velocity rows showing as `0` (means basis is missing — see trade-off (2))
  3. If clean → flip on prod.
- [ ] Roll back: unset `TOOLBOX_READ_VELOCITY` (instantaneous; legacy data-store deltas resume on next ISR window).

## Documented semantic trade-offs

Both are noted inline at the top of `src/lib/toolbox-store-velocity.ts`:

**(1) Cold-start `age_seconds` stub.** The dual-write at `scripts/_toolbox-ingest.mjs:557-565` doesn't transmit `age_seconds` (or `from_commit` / `from_ts`). The local `DeltaValue` discriminated union requires `age_seconds: number` on the cold-start variant. This adapter stubs `age_seconds: 0` / `from_commit: ""` / `from_ts: 0`. Runtime semantic is preserved — `derived-repos.ts:119-120` `isRealDelta` only reads `.value` + `.basis`, so consumers correctly fall back. The lost metadata isn't read by any consumer path observed during recon. Upstream fix queued: emit `age_seconds` for cold-start basis.

**(2) Fork basis is LOST in transit.** The dual-write at `scripts/_toolbox-ingest.mjs:580-596` sends fork deltas as just `fork_delta_<win>` (the value) — it does NOT send a corresponding `fork_delta_<win>_basis` field, unlike the stars side. This adapter therefore treats all fork deltas as `basis: "no-history"` → `isRealDelta` returns false → consumers fall back. **Upstream fix queued**: add `pushNormalized(forkNormalized, \`fork_delta_${win}_basis\`, d.basis, 1.0)` in the dual-write. After that ships + TOOLBOX has a re-scrape, this adapter will emit real basis strings without change.

## What's deliberately NOT in this PR

- **Trending list read switch** (`trending.github.repos` signal type) — kept on legacy `store.read("trending")` for this PR. The velocity adapter depends on the reverse-map built from the trending cache, so switching trending to TOOLBOX in the same PR doubles the surface area. Queue for a follow-up after this proves clean.
- **Reddit-all-posts second hook** — separate adapter slot in PR #1149's description.
- **Any consumer-side changes** — the adapter preserves the legacy `DeltasJson` shape, so `derived-repos.ts` projection + Repo card rendering are unchanged.

## Related

- TOOLBOX endpoint PR: [`0motionguy/toolbox#56`](https://github.com/0motionguy/toolbox/pull/56)
- Mentions pack adapters: [`0motionguy/starscreener#1149`](https://github.com/0motionguy/starscreener/pull/1149)
- Pre-recon design plan: `~/.claude/plans/phase-a2-velocity-design-2026-05-13.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)