### PR TITLE
fix(repo-detail): close /repo/* 500 on cold-miss path (production P0)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Wait for deploy propagation
         run: sleep 30
 
-      - name: Synthetic curl checks (16 critical routes)
+      - name: Synthetic curl checks (17 critical routes)
         id: smoke
         shell: bash
         run: |
@@ -30,6 +30,14 @@ jobs:
           # the pre-existing /repo/* 500 P0 (since d81856ad) bled for days
           # because no smoke probe covered detail pages. vercel/next.js is
           # a long-stable canonical sample; rotate if it ever moves.
+          #
+          # /repo/anthropics/anthropic-cookbook added 2026-05-13. The
+          # vercel/next.js probe alone only covers the curated-derived-set
+          # path; the cold-miss / live-fetch fallback (synthesized repo
+          # shape) has its own crash surface — Next.js's static-to-dynamic
+          # detector + the GitHub upstream resolver. We pin a long-tail
+          # but stable repo here so any future regression on that branch
+          # surfaces in CI within a deploy, not by a user 4 days later.
           routes=(
             "/"
             "/signals"
@@ -45,6 +53,7 @@ jobs:
             "/agent-commerce"
             "/agent-commerce/facilitator"
             "/repo/vercel/next.js"
+            "/repo/anthropics/anthropic-cookbook"
             "/api/health?soft=1"
           )
 

--- a/src/lib/__tests__/github-live.test.ts
+++ b/src/lib/__tests__/github-live.test.ts
@@ -1,0 +1,91 @@
+// StarScreener — github-live regression tests.
+//
+// Focused on the 2026-05-13 P0 fix: the live-repo cold-miss path on
+// /repo/[owner]/[name] threw "Page changed from static to dynamic at runtime"
+// because githubFetch defaulted to `cache: "no-store"` inside an ISR page.
+// These tests pin the fetch options so a future refactor that drops the
+// cache hint regresses straight to a failing test instead of bleeding to a
+// production 500.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { synthesizeRepoFromGitHub } from "../github-live";
+
+// ---------------------------------------------------------------------------
+// 1. synthesizeRepoFromGitHub shape — every consumer of the cold-miss path
+//    reads from this shape, so this test guards against a missing field
+//    silently degrading a future page section to undefined-access.
+// ---------------------------------------------------------------------------
+
+test("synthesizeRepoFromGitHub produces all fields the detail page reads", () => {
+  const synthetic = synthesizeRepoFromGitHub({
+    full_name: "facebook/react",
+    name: "react",
+    owner: { login: "facebook", avatar_url: "https://avatars/face.png" },
+    description: "A library for the web",
+    html_url: "https://github.com/facebook/react",
+    homepage: "https://react.dev",
+    language: "JavaScript",
+    topics: ["ui", "library"],
+    stargazers_count: 234_000,
+    forks_count: 49_000,
+    open_issues_count: 800,
+    pushed_at: "2026-05-12T10:00:00Z",
+    created_at: "2013-05-24T16:15:54Z",
+  });
+  // Cross-source signal fields must be present (zero or null) so the
+  // page renders the "tracking started" banner against an empty shape
+  // rather than crashing on undefined access.
+  assert.equal(synthetic.fullName, "facebook/react");
+  assert.equal(synthetic.stars, 234_000);
+  assert.equal(synthetic.starsDelta24h, 0);
+  assert.equal(synthetic.starsDelta24hMissing, true);
+  assert.equal(synthetic.starsDelta7dMissing, true);
+  assert.equal(synthetic.starsDelta30dMissing, true);
+  assert.equal(synthetic.momentumScore, 0);
+  assert.deepEqual(synthetic.sparklineData, []);
+  assert.equal(synthetic.mentions, null);
+  assert.equal(synthetic.hasMovementData, false);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The cold-miss fetch must opt INTO Next.js's data cache so the page stays
+//    statically renderable. Specifically: it must NOT inherit the
+//    github-fetch helper's default cache: "no-store", and must set a finite
+//    revalidate. This guards the 2026-05-13 regression by reading the source
+//    directly — ESM modules are immutable so swapping the imported reference
+//    at runtime isn't an option, but the call site is short enough that a
+//    source-level check is reliable.
+// ---------------------------------------------------------------------------
+
+test("live-repo fetch passes cache hints that keep the ISR page renderable", async () => {
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const src = await fs.readFile(
+    path.resolve(here, "..", "github-live.ts"),
+    "utf8",
+  );
+  // Locate the fetchFromGitHub function body — every other githubFetch caller
+  // in the codebase routes through different helpers; this is the only one
+  // on the ISR-rendered /repo/[owner]/[name] path.
+  const match = src.match(
+    /async function fetchFromGitHub[\s\S]*?await githubFetch\([\s\S]*?\);/,
+  );
+  assert.ok(match, "expected fetchFromGitHub to call githubFetch");
+  const callSite = match[0];
+  // The two regression markers — drop either of these and prod 500s on the
+  // cold-miss path because Next.js 15 throws "static to dynamic at runtime".
+  assert.match(
+    callSite,
+    /cache:\s*"force-cache"/,
+    'cache: "force-cache" must be set — bare default is "no-store" which breaks ISR',
+  );
+  assert.match(
+    callSite,
+    /next:\s*\{\s*revalidate:\s*\d+/,
+    "next.revalidate must be set so the fetch participates in Next data cache",
+  );
+});

--- a/src/lib/github-live.ts
+++ b/src/lib/github-live.ts
@@ -55,7 +55,21 @@ async function fetchFromGitHub(
   const path = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
   let result;
   try {
-    result = await githubFetch(path, { operation: "live-repo-fetch" });
+    // CRITICAL: must use `next: { revalidate }` instead of the helper's default
+    // `cache: "no-store"`. This fetch runs inside the /repo/[owner]/[name] page
+    // (ISR, revalidate=300). With `no-store` Next.js 15 throws
+    // "Page changed from static to dynamic at runtime" the moment the cold-miss
+    // path tries to upstream — every uncurated repo 500s on production despite
+    // every other await being try/catch-wrapped. The error is thrown by the
+    // static-to-dynamic detector at the render boundary, OUTSIDE user code, so
+    // the surrounding try/catch never sees it. Letting this fetch participate
+    // in Next's data cache (matched to our own 1h Redis TTL) keeps the page on
+    // its ISR path. Discovered 2026-05-13 via Vercel runtime logs.
+    result = await githubFetch(path, {
+      operation: "live-repo-fetch",
+      cache: "force-cache",
+      next: { revalidate: 3600 },
+    });
   } catch (err) {
     console.error("[github-live] fetch failed", owner, name, err);
     return null;


### PR DESCRIPTION
## Summary

Closes the pre-existing P0 from commit `d81856ad` (2026-05-08): `/repo/[owner]/[name]` returns HTTP 500 for any repo not in the curated derived set. Production verification 2026-05-13 showed 9 of 10 sampled repos failing; only the bundled `vercel/next.js` worked.

## Root cause

The cold-miss path calls `fetchGitHubRepoLiveWithinBudget` → `githubFetch` → `fetch(..., { cache: "no-store" })`. Inside an ISR-rendered page (`revalidate = 300`), Next.js 15 throws `Page changed from static to dynamic at runtime` the moment that uncached upstream `fetch()` runs. The throw originates at the framework's static-to-dynamic detector — **outside** the awaited code path — so the surrounding `try/catch` (added in #830 / #1078) never sees it.

The framework bubbles to `/_error`, which is why the response looks like a Pages-Router 500 page despite the route living under App Router. Vercel runtime log confirming the diagnosis:

```
Error: Page changed from static to dynamic at runtime /repo/facebook/react,
reason: revalidate: 0 fetch https://api.github.com/repos/facebook/react
/repo/[owner]/[name]
```

This is why every previous defensive guard reduced surface but couldn't close it — the throw happens at a layer above where the guards reach.

## Fix

At the `live-repo-fetch` call site only (not the global `githubFetch` helper — admin dashboard etc. still want `no-store`), opt into Next.js's data cache:

```ts
result = await githubFetch(path, {
  operation: "live-repo-fetch",
  cache: "force-cache",
  next: { revalidate: 3600 },
});
```

The 1h TTL matches our existing Redis cache TTL (`LIVE_REPO_TTL_SECONDS = 3600`) on the same payload, so layering is consistent: Next caches for 1h, our Redis caches for 1h, GitHub upstream gets hit at most once per hour per `(owner, name)`. The page stays on its ISR path; cold-miss repos render the "Tracking just started" banner against the synthesized minimal `Repo` as designed.

## Verification

- [x] 5 cold-miss repos (facebook/react, anthropics/anthropic-cookbook, openai/openai-cookbook, sst/sst, sindresorhus/ky) now render 200 + "Tracking just started" banner locally
- [x] vercel/next.js (derived-store repo) still renders 200 — no regression
- [x] `npm run typecheck` green
- [x] `npm run lint:guards` green (all 5 sub-checks)
- [x] `impeccable detect src/lib/github-live.ts` clean
- [x] New regression test `src/lib/__tests__/github-live.test.ts` pins both required markers (`cache: "force-cache"` + `next.revalidate`) and was verified to **fail** when the cache hint is removed.
- [ ] (post-merge) production verification via the 5-cold-miss probe

## Smoke test gap closed

Added `/repo/anthropics/anthropic-cookbook` to the post-deploy smoke probe list. The existing `/repo/vercel/next.js` probe only covers the derived-store branch — the cold-miss / live-fetch fallback has its own crash surface (Next's static-to-dynamic detector + the GitHub upstream resolver). Without a cold-miss probe, the next regression on this branch would bleed for days again. Probe step name updated 16 → 17 routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)