### PR TITLE
audit(impeccable): wave 4 — close 2 residual /home P0s

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -491,18 +491,25 @@ function HeroPanel({
 
 const SOURCE_ICONS: ReadonlyArray<{
   key: string;
+  channel: "github" | "hn" | "reddit" | "bluesky" | "devto";
   label: string;
   Icon: (props: { size?: number; className?: string }) => React.ReactElement;
 }> = [
-  { key: "gh", label: "GitHub", Icon: GithubIcon },
-  { key: "hn", label: "Hacker News", Icon: HackerNewsIcon },
-  { key: "r", label: "Reddit", Icon: RedditIcon },
-  { key: "b", label: "Bluesky", Icon: BlueskyIcon },
-  { key: "d", label: "dev.to", Icon: DevtoIcon },
+  { key: "gh", channel: "github", label: "GitHub", Icon: GithubIcon },
+  { key: "hn", channel: "hn", label: "Hacker News", Icon: HackerNewsIcon },
+  { key: "r", channel: "reddit", label: "Reddit", Icon: RedditIcon },
+  { key: "b", channel: "bluesky", label: "Bluesky", Icon: BlueskyIcon },
+  { key: "d", channel: "devto", label: "dev.to", Icon: DevtoIcon },
 ];
 
 function ConsensusRow({ repo, index }: { repo: Repo; index: number }) {
   const channels = Math.max(1, sourceCount(repo));
+  // Render only icons for sources that are actually firing on this repo.
+  // Falls back to the first N entries when channelStatus isn't attached
+  // (legacy / degraded payload) so the row never collapses to empty.
+  const firingSources = repo.channelStatus
+    ? SOURCE_ICONS.filter(({ channel }) => repo.channelStatus?.[channel])
+    : SOURCE_ICONS.slice(0, channels);
   return (
     <a className={`cons-row ${index === 0 ? "first" : ""}`} href={`/repo/${repo.owner}/${repo.name}`}>
       <div className="cons-top">
@@ -526,8 +533,8 @@ function ConsensusRow({ repo, index }: { repo: Repo; index: number }) {
         </span>
       </div>
       <div className="cons-bot">
-        <span className="srcs" aria-label={`${channels} sources firing`}>
-          {SOURCE_ICONS.slice(0, channels).map(({ key, label, Icon }) => (
+        <span className="srcs" aria-label={`${firingSources.length} sources firing`}>
+          {firingSources.map(({ key, label, Icon }) => (
             <span
               key={key}
               className={`sd sd-${key}`}
@@ -944,10 +951,14 @@ export default async function HomePage() {
           <CardHeader right={<span className="live">LIVE</span>} showCorner>
             {"// TR-100 Index"}
           </CardHeader>
+          {/*
+            Removed three decorative <span class="tg"> "tabs" (Index / Share /
+            Categories). They looked clickable but had no onClick / role /
+            keyboard handler — affordance lie (WCAG 2.4.3 + 4.1.2). The chart
+            below only renders the Index view, so the toggle was unreachable
+            by design. Keep only the right-aligned 30d summary, which is real.
+          */}
           <div className="chart-toggle">
-            <span className="tg on">Index</span>
-            <span className="tg">Share</span>
-            <span className="tg">Categories</span>
             <span className="right">30d / <b>{formatCompact(total30d)}</b></span>
           </div>
           {(() => {


### PR DESCRIPTION
## Summary

Closes the 2 residual P0s on `/` deferred from wave-3b (PR #1153). Stacks on main (independent of the wave-3 stack — these are different files).

## What changed

| # | Severity | File | Fix |
|---|---|---|---|
| 1 | P0 | `src/app/page.tsx` (ConsensusRow, ~L504-552) | Filter `SOURCE_ICONS` against `repo.channelStatus` keys instead of slicing the array by `sourceCount()`. A repo with `[github, twitter]` firing no longer renders `[github, hackernews]`. Falls back to the prior slice when `channelStatus` is absent so degraded payloads keep working. |
| 2 | P0 | `src/app/page.tsx` (TR-100 chart-toggle, ~L947) | Removed three non-interactive `<span class="tg">` "tabs" (Index / Share / Categories) — no `onClick`, no `role`, no keyboard handler (WCAG 2.4.3 + 4.1.2 affordance lie). Kept the real `30d / <total>` summary. Building Share/Categories views was out of scope; downgraded the UI element rather than ship more fake state. |

## Test plan
- [x] `npm run typecheck` green
- [x] `npm run lint:guards` green (11 sub-checks)
- [x] `npx impeccable@latest detect src/app/page.tsx src/components/home/ src/components/terminal/` clean
- [ ] (recommended) visual smoke at 375px and 1280px on the Vercel preview

Out of scope (per task brief):
- The 3 hardcoded LIVE strings are wave-3b's job (PR #1153).
- P0-4 (44×44 tap target) and P0-5 (breakout spark color) live in `LiveTopTable.tsx` / `BreakoutRow` and are tracked separately — the wave-4 brief explicitly limits this PR to the 2 deferred items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)