### PR TITLE
audit(impeccable): wave 5 — close 3 /repo/[owner]/[name] P0s

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5693,7 +5693,9 @@ body::before {
   height: 6px;
   border-radius: 50%;
   background: var(--v2-sig-green);
-  box-shadow: 0 0 6px var(--v2-sig-green);
+  /* No box-shadow / pulse — honest chrome rule. The class is kept as a
+     static color-keyed indicator only; freshness is signalled at the page
+     boundary via <FreshnessBadge> driven by classifyFreshness(). */
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/components/repo-detail/OrganizationCard.tsx
+++ b/src/components/repo-detail/OrganizationCard.tsx
@@ -19,7 +19,20 @@ interface OrganizationCardProps {
 export async function OrganizationCard({
   owner,
 }: OrganizationCardProps): Promise<JSX.Element> {
-  const profile = await fetchGithubUserProfile(owner);
+  // Cold-miss synthesized repos may resolve owners that the GitHub user
+  // API cannot return (rate-limit, 5xx, deleted user). An uncaught throw
+  // here bubbles past the parent — which is rendered inline in
+  // page.tsx:517 outside an ErrorBoundary — and 500s the whole page.
+  // Same regression class as the d81856ad bug PR #1159 closed at the
+  // page boundary. Defensive try/catch keeps the panel best-effort and
+  // degrades to the existing empty state.
+  let profile: Awaited<ReturnType<typeof fetchGithubUserProfile>> | null = null;
+  try {
+    profile = await fetchGithubUserProfile(owner);
+  } catch (err) {
+    console.warn("[organization-card] profile resolver failed", err);
+    profile = null;
+  }
 
   if (!profile) {
     return (

--- a/src/components/repo-detail/RepoIdHero.tsx
+++ b/src/components/repo-detail/RepoIdHero.tsx
@@ -329,7 +329,7 @@ export function RepoIdHero({
           justify-content: center;
           border: 1px solid var(--v3-line-200);
           border-radius: 4px;
-          background: linear-gradient(135deg, #6366f1, #8b5cf6);
+          background: linear-gradient(135deg, var(--v4-acc), var(--v4-acc-dim));
           color: #fff;
           font-family: var(--font-geist-mono, monospace);
           font-size: 24px;


### PR DESCRIPTION
## Summary

Closes the 3 P0s identified by the wave-4 `/repo/[owner]/[name]` audit ([PR #1161 report](https://github.com/0motionguy/starscreener/pull/1161)). Stacks on main, independent of the wave-3 stack.

## Fixes

| # | Severity | File | Fix |
|---|---|---|---|
| 1 | P0 | src/app/globals.css | drop permanent `.v2-live-dot` glow — closes P0 across 3 components (CrossSignalBreakdown, ProjectSurfaceMap, WhyTrending) and benefits 13 callsites globally |
| 2 | P0 | src/components/repo-detail/OrganizationCard.tsx | wrap `fetchGithubUserProfile` await in try/catch — defensive pattern matches d81856ad-class regression closed in #1159 |
| 3 | P0 | src/components/repo-detail/RepoIdHero.tsx | replace hardcoded `linear-gradient(135deg, #6366f1, #8b5cf6)` avatar with `var(--v4-acc)` / `var(--v4-acc-dim)` — respects all 5 theme accent hues |

## Why fix #1 is the highest leverage

Single CSS rule. Lands honest chrome across `CrossSignalBreakdown`, `ProjectSurfaceMap`, `WhyTrending` simultaneously — 3-for-1 ROI as stated in the audit. The class is preserved as a static color-keyed indicator so all 13 global callsites continue to render; only the permanent pulse glow that violated `feedback_freshness_chrome_must_be_honest` is removed.

## Why fix #2 matters

Same regression class as the production 500 PR #1159 just closed at the page boundary. `fetchGithubUserProfile` on cold-miss synthesized repos hits the public GitHub user API with no fallback path; an upstream rate-limit, 5xx, or deleted-user condition = uncaught throw = 500. The parent `<OrganizationCard>` is rendered inline at `page.tsx:517` outside any ErrorBoundary, so the throw bubbles past the page-level harness. Wrapped the await in try/catch matching the existing defensive pattern at `page.tsx:271-280`; on failure, the existing `org-card-empty` state renders.

## Why fix #3 matters

Liquid Lava orange (`#fb923c`) is the V4 brand. Every repo on the page rendered with a generic indigo→purple avatar before the user could read the name — the strongest pre-textual brand cue was wrong on every cold path. Now respects all 5 accent hues (orange, blue, yellow, green, etc.) via the `--v4-acc` token, so theme-switching propagates correctly.

## Test plan
- [x] impeccable detect on `src/app/globals.css` and `src/components/repo-detail/` — no new findings (pre-existing `.side-tab` finding at globals.css:1499 is out of scope)
- [x] `lint:guards` green
- [x] `typecheck` green
- [ ] (recommended) visual smoke `/repo/<any-cold-miss-repo>` at 375px + 1280px to confirm avatar + org panel

Generated with [Claude Code](https://claude.com/claude-code)