### PR TITLE
audit(impeccable): wave 6 — /twitter + /reddit/trending + /hackernews/trending audits (43 findings)

### DIFF
--- a/docs/audits/impeccable/hackernews-trending-audit.md
+++ b/docs/audits/impeccable/hackernews-trending-audit.md
@@ -1,0 +1,131 @@
+# /hackernews/trending audit — 2026-05-13
+
+## Files audited
+- [src/app/hackernews/trending/page.tsx](../../../src/app/hackernews/trending/page.tsx) — RSC page entry, KpiBand snapshot, WindowedHnFeed wrapper, HnStoryFeed table.
+- [src/app/hackernews/trending/loading.tsx](../../../src/app/hackernews/trending/loading.tsx) — pulse skeleton.
+- [src/app/hackernews/trending/error.tsx](../../../src/app/hackernews/trending/error.tsx) — boundary fallback.
+- [src/components/feed/WindowedFeedTable.tsx](../../../src/components/feed/WindowedFeedTable.tsx) — 24h/7d/30d window switcher (consumed in legacy mode).
+- [src/components/feed/TerminalFeedTable.tsx](../../../src/components/feed/TerminalFeedTable.tsx) — shared dense table (consumed).
+- [src/components/templates/SourceFeedTemplate.tsx](../../../src/components/templates/SourceFeedTemplate.tsx) — page shell (consumed).
+- [src/components/ui/KpiBand.tsx](../../../src/components/ui/KpiBand.tsx), [src/components/ui/LiveDot.tsx](../../../src/components/ui/LiveDot.tsx) — chrome primitives.
+- [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx) — sanctioned freshness pattern (**NOT used on this surface**).
+- [src/lib/news/freshness.ts](../../../src/lib/news/freshness.ts) — `hackernews` NewsSource exists at L20 / L44 (fast threshold), ready to wire.
+- [src/app/globals.css#L2296-2337](../../../src/app/globals.css) — `.tabs` / `.tab` chrome (consumed by legacy WindowedFeedTable).
+
+## P0 findings (dishonest / broken / a11y blocker)
+
+### P0-1 — Hardcoded `<LiveDot label="LIVE · 24H">` with no `FreshnessBadge`
+[page.tsx:116](../../../src/app/hackernews/trending/page.tsx#L116). `<LiveDot label={`LIVE · ${trendingFile.windowHours}H`} />` in the PageHead clock slot, no tone prop → defaults to `money` which renders a green pulse via [LiveDot.tsx:20-32](../../../src/components/ui/LiveDot.tsx#L20). It fires green pulse even when the HN scraper is hours / days stale, identical to the defect waves 3a/3b/3c closed on `/`, `/signals`, `/funding`. `FreshnessBadge` is never imported on this route despite `freshness.ts` already shipping a `hackernews` threshold.
+
+Fix: keep `LiveDot` as a tone slot (acceptable visual anchor) **only** when paired with `<FreshnessBadge source="hackernews" lastUpdatedAt={trendingFile.fetchedAt} />` immediately after — exactly the lobsters pattern at [lobsters/page.tsx:217-218](../../../src/app/lobsters/page.tsx#L217). Better: drop the hardcoded `LiveDot` and let `FreshnessBadge` own the verdict. **Mechanical.**
+
+### P0-2 — Window-toggle tabs render `<button>` 28px tall — sub-44 mobile tap target
+[WindowedFeedTable.tsx:148-159](../../../src/components/feed/WindowedFeedTable.tsx#L148) + [globals.css:2305-2314](../../../src/app/globals.css#L2305). `.tabs .tab` is `padding: 9px 14px; font-size: var(--font-size-lg)` (10px from terminal sub-scale) → measured height ≈ 28px. Three tabs sit side-by-side as the only window switcher on this surface; missing the right one on touch is the primary scan-flow error mode. PRODUCT.md "Mobile posture" mandates 44×44 minimums; WCAG 2.5.5 (Level AAA) and 2.5.8 (Level AA, Target Size Minimum) both fail.
+
+Fix: bump `.tabs .tab` to `min-height: 44px; padding: 12px 14px; display: inline-flex; align-items: center` (or scope under `@media (max-width: 767px)` if desktop density is sacred). This is consumed by /hackernews/trending, /lobsters, /devto, /bluesky, /reddit — a shared win. **Mechanical.**
+
+### P0-3 — Cold-state branch drops the PageHead clock + freshness entirely
+[page.tsx:79-94](../../../src/app/hackernews/trending/page.tsx#L79). When `allStories.length === 0`, the cold branch renders `SourceFeedTemplate` with `crumb + title + lede` but no `clock` slot — and a `ColdState` section underneath whose copy says "the scraper hasn't run yet" with a literal `npm run scrape:hn` command. (1) no `FreshnessBadge` even in cold, so a user can't tell whether the surface is genuinely empty vs the Redis envelope returned [] vs the scraper is down. (2) operator copy (`<code>npm run scrape:hn</code>`) leaks to the public surface — identical anti-pattern to the wave-2 twitter audit P1 "Cold-state lede leaks internal API endpoint." Honest-by-default voice says "HN scan is cold — fresh data lands hourly," not "run this CLI."
+
+Fix: (a) render `<FreshnessBadge source="hackernews" lastUpdatedAt={trendingFile.fetchedAt} />` in the clock slot even in the cold branch — it'll render `COLD · Nd` honestly; (b) replace the `<code>npm run scrape:hn</code>` copy with public-friendly "HN scan is cold — fresh data lands hourly." and gate the dev hint behind `process.env.NODE_ENV === "development"`. **Mechanical.**
+
+## P1 findings (visible regression)
+
+### P1-1 — `HN_ORANGE = "#ff6600"` hardcoded RGB instead of the source token
+[page.tsx:55](../../../src/app/hackernews/trending/page.tsx#L55) `const HN_ORANGE = "#ff6600"` is reused on rank ≤10 ([L198](../../../src/app/hackernews/trending/page.tsx#L198)), FP badge bg ([L256](../../../src/app/hackernews/trending/page.tsx#L256)), score ≥100 ([L273](../../../src/app/hackernews/trending/page.tsx#L273)), cold-state h2 ([L339](../../../src/app/hackernews/trending/page.tsx#L339)), TerminalFeedTable accent ([L316](../../../src/app/hackernews/trending/page.tsx#L316)). DESIGN.md "Source brand colors" defines `--source-hackernews: #ff7a3d` and the V4 alias `--v4-src-hn: #ff7a3d` ([globals.css:176, 6226](../../../src/app/globals.css#L176)). The page's `#ff6600` (true classic HN orange) and the system token `#ff7a3d` (perceptually-tuned brand orange) are two different oranges; the surface drifts from the OG card / heatmap tile renders that consume the token. KpiBand already uses `var(--v4-src-hn)` correctly at [L126](../../../src/app/hackernews/trending/page.tsx#L126) — the rest of the file should match.
+
+Fix: replace the literal with `const HN_ORANGE = "var(--v4-src-hn)"` (or just inline `"var(--v4-src-hn)"` everywhere). **Mechanical.**
+
+### P1-2 — Title cell loses its `linkedRepo` chip on mobile because the parent uses `flex` without wrap
+[page.tsx:209-244](../../../src/app/hackernews/trending/page.tsx#L209). `<div className="flex min-w-0 items-center gap-2">` holds `EntityLogo` + truncated `<a>` title + `↳ owner/repo` chip. On 375px after the `.home-surface` 16px padding × 2, the rank col (44px) + score col (70px), the title column is ~210px wide. With a 20px logo + 8px gap + truncated title, the `↳ linkedRepo` chip frequently sits zero-width or scroll-clipped. The `linkedRepo` chip is the cross-source value-add of this surface — losing it on mobile kills the "HN story → linked GH repo" pivot.
+
+Fix: either (a) wrap the chip to a new line with `flex-wrap` + `basis-full` on `<a>` so the chip drops below the title at <640px, or (b) hide the chip in the title cell on mobile and re-render it as a tappable row-accordion. **Design call.**
+
+### P1-3 — `WindowedFeedTable` legacy mode ships 3× HTML payload + missing `tabpanel` association
+[WindowedFeedTable.tsx:127-167](../../../src/components/feed/WindowedFeedTable.tsx#L127). Page wires legacy mode (`table24h/7d/30d` props at [page.tsx:181-183](../../../src/app/hackernews/trending/page.tsx#L181)), so all three pre-rendered tables — up to 50 rows × full row markup × 3 — ship in the initial HTML even though only one is visible. The component's own JSDoc ([WindowedFeedTable.tsx:11-15](../../../src/components/feed/WindowedFeedTable.tsx#L11)) explicitly recommends the opt-in `?win=` mode for the perf path. Separately, the tab strip uses `role="tablist"` + `role="tab"` + `aria-selected` correctly, but the table itself isn't wrapped in `role="tabpanel"` / `aria-labelledby` so screen readers can't tie selection to content. Same defect wave-3d /skills closed.
+
+Fix: migrate the page to the `?win=` opt-in mode (also requires dropping `export const revalidate = 300` → `export const dynamic = "force-dynamic"` for the param to pick up — already dynamic-ish at 5min ISR, the cost is small). Add `id` to each `role="tab"` and wrap the rendered table in `<section role="tabpanel" aria-labelledby={selectedTabId}>`. **Design call** for the dynamic-route trade-off; **mechanical** for the aria fix.
+
+### P1-4 — Row stagger animation overrides `prefers-reduced-motion`
+[TerminalFeedTable.tsx:156-158](../../../src/components/feed/TerminalFeedTable.tsx#L156) sets `animation: slide-up 0.35s cubic-bezier(0.2, 0.8, 0.2, 1) both; animation-delay: ${stagger}ms` as inline style. The global `prefers-reduced-motion` rule at [globals.css:1103](../../../src/app/globals.css#L1103) zeroes animation-duration via class selectors, but inline styles win over class rules unless the class is set with `!important`. Up to 50 rows × 50ms stagger (capped at 6 = 300ms) on initial paint for reduced-motion users. Same defect as wave-2 twitter audit P1-row-stagger.
+
+Fix: move the animation into a class (`.v2-row` already exists — apply via `data-stagger="${rowIndex}"` + CSS `--stagger-delay` + class-level animation), so the reduced-motion override actually applies. **Mechanical.**
+
+### P1-5 — `formatClock` cold path returns `"warming"` — same warm/scraped lie as /twitter
+[page.tsx:64-67](../../../src/app/hackernews/trending/page.tsx#L64). When `trendingFile.fetchedAt` is undefined, the clock cell reads `warming · UTC · SCRAPED · LIVE · 24H` — a five-token honest-looking telemetry line that's actually wholly fabricated. Wave-2 twitter audit P0-2 named this defect explicitly. The cold branch already protects against `allStories.length === 0`, but if `fetchedAt` is missing while stories exist (Redis envelope half-populated), the clock lies.
+
+Fix: return `"OFFLINE"` or `"—"` and let `FreshnessBadge` (per P0-1) own the COLD verdict. **Mechanical.**
+
+### P1-6 — KpiBand "FRONT PAGE" tone="money" greens up a non-freshness signal
+[page.tsx:135-141](../../../src/app/hackernews/trending/page.tsx#L135). `FRONT PAGE` cell uses `tone: "money"` and `pip: "var(--v4-money)"` — green. Per DESIGN.md color semantics, `--color-money` / `--v4-money` is reserved for monetary / fresh-now / positive-delta semantics. "Stories that ever hit FP" is a tier signal, not a freshness or money signal. Reads as "this many fresh stories" on first glance.
+
+Fix: switch to `tone="acc"` + pip `--v4-src-hn` (HN orange — matches the FP badge in-row at [L256](../../../src/app/hackernews/trending/page.tsx#L256)). **Design call.**
+
+### P1-7 — Reading rank highlight uses two oranges across one column
+[page.tsx:196-202](../../../src/app/hackernews/trending/page.tsx#L196). The `#` cell colors rank <10 with `HN_ORANGE` ("#ff6600") and rank ≥10 with `--v4-ink-400`. Five rows later the FP badge ([L256](../../../src/app/hackernews/trending/page.tsx#L256)) renders the *same* `HN_ORANGE` as a filled background, and the score cell ([L273](../../../src/app/hackernews/trending/page.tsx#L273)) repeats it for `score ≥ 100`. Three orange semantics in one row: rank-tier, FP-hit, score-tier — all encoded with the same hue. Reader can't tell which signal is which without checking column headers.
+
+Fix: keep `HN_ORANGE` (post-P1-1, → `--v4-src-hn`) for the FP badge (source identity) and the rank ≤10 highlight (tier signal); switch the `score ≥ 100` cell to `--v4-money` or bold-weight ink-000 so the three semantics decouple visually. **Design call.**
+
+## P2 findings (polish / drift)
+
+### P2-1 — `LiveDot role="status" aria-live="polite"` fires on every render
+[LiveDot.tsx:30-39](../../../src/components/ui/LiveDot.tsx#L30). The dot is decorative (always-on), but the `role="status"` + `aria-live="polite"` on the wrapper means screen readers re-announce "LIVE · 24H" on every component render. Honest-chrome aside, the SR experience is noisy.
+
+Fix: drop `role="status"` + `aria-live` — the freshness verdict belongs on `FreshnessBadge` (which itself doesn't `aria-live` for the same reason). **Mechanical.**
+
+### P2-2 — Tabs caption "rows · {win}" uses muted ink — fails 4.5:1 contrast
+[WindowedFeedTable.tsx:160-162](../../../src/components/feed/WindowedFeedTable.tsx#L160) + [globals.css:2331-2336](../../../src/app/globals.css#L2331). `.tabs .right` is `color: var(--ink-400)` against `var(--bg-025)` (`#0c0d10` ish). Mono 12px small caps at ink-400 measures ~3.2:1 contrast. WCAG AA needs 4.5:1 for text under 18px.
+
+Fix: switch to `var(--ink-300)` (matches `.tab` rest state). **Mechanical.**
+
+### P2-3 — Cold-state border is dashed; populated branch is solid — inconsistent affordance
+[page.tsx:328-358](../../../src/app/hackernews/trending/page.tsx#L328) cold-state uses `border: 1px dashed var(--v4-line-100)` + `borderRadius: 2`; populated TerminalFeedTable uses `border: 1px solid var(--v3-line-200)` ([TerminalFeedTable.tsx:110-112](../../../src/components/feed/TerminalFeedTable.tsx#L110)). The dashed border on empty state is the "placeholder" pattern from the DESIGN.md "no series" idiom, but the rest of the project uses dashed only for *true* empty cells, not full surface empty-state. Reads as "this UI is unfinished," not "this data is empty."
+
+Fix: use `border: 1px solid var(--v3-line-100)` for the cold-state container and let the headline ink-color do the empty-state lift. **Design call.**
+
+### P2-4 — `EntityLogo` at 20px square uses `shape="square"` — drifts from DESIGN.md radii
+[page.tsx:212-217](../../../src/app/hackernews/trending/page.tsx#L212). `shape="square"` is fine, but DESIGN.md radii ladder caps at 2px for cards; a 20px source-logo with `shape="square"` ends up perfectly sharp-cornered next to the 2px-rounded `↳ linkedRepo` chip ([L235-237](../../../src/app/hackernews/trending/page.tsx#L235)). Tiny inconsistency.
+
+Fix: `shape="rounded"` (2px) or leave both sharp — pick one. **Design call.**
+
+### P2-5 — `WindowedFeedTable` default `defaultWindow="7d"` but page also passes `defaultWindow="7d"` — dead prop
+[page.tsx:184](../../../src/app/hackernews/trending/page.tsx#L184). Component default at [WindowedFeedTable.tsx:56](../../../src/components/feed/WindowedFeedTable.tsx#L56) is already `"7d"`. Dead.
+
+Fix: drop the prop. **Mechanical.**
+
+## What's working well
+
+- **Per-window pre-computation is server-side** — `sortByScore` + `inWindow` ([page.tsx:162-175](../../../src/app/hackernews/trending/page.tsx#L162)) runs in RSC; client only swaps which pre-rendered tree mounts. No client-side filtering = no flash of unfiltered content.
+- **`hideBelow="sm"` on FP column + `hideBelow="md"` on Cmts/Age** ([page.tsx:251, 284, 299](../../../src/app/hackernews/trending/page.tsx#L251)) hides non-essential columns at narrow breakpoints — title + score + rank survive at 375px, which is exactly the right priority for the scan question.
+- **`hnItemHref` opens in new tab with `rel="noopener noreferrer"`** ([page.tsx:218-222](../../../src/app/hackernews/trending/page.tsx#L218)) — correct security posture for external links.
+- **Score-color tier (≥100 → orange)** is honest semantic encoding — high-score stories visibly stand out.
+- **KpiBand `--v4-src-hn` pip on TRACKED** ([page.tsx:126](../../../src/app/hackernews/trending/page.tsx#L126)) — correct source-token use; this is the canonical pattern other cells should match (per P1-1, P1-6).
+- **Sentry-wired error boundary** ([error.tsx:13-17](../../../src/app/hackernews/trending/error.tsx#L13)) captures rendering failures honestly; honest copy "this surface failed to render" beats most app-router defaults.
+- **Caption on table** ([page.tsx:317](../../../src/app/hackernews/trending/page.tsx#L317)) — `<caption>` is screen-reader visible inside `TerminalFeedTable`; meaningful description.
+
+## Verify-in-context
+
+- **P0-1 honest-chrome lie is the same shape as the lobsters / devto / twitter siblings** — the LiveDot pattern was authored once and ships across 5 source-feed routes. Fixing it here unblocks a one-liner sweep across the family.
+- **P0-2 tap-target is shared** — `.tabs .tab` is consumed by /hackernews/trending, /lobsters, /devto, /bluesky, /reddit. One CSS edit closes 5 routes' P0 simultaneously.
+- **P0-3 cold-state operator-copy leak** matches twitter-audit P1 "internal API endpoint" — same anti-pattern, different surface; fix once + grep for siblings.
+- **HN data is currently working per OPERATOR notes (hourly scrape, `data/hackernews-trending.json`)** — none of the P0s are masking real data degradation; they're chrome lies on healthy data.
+- 6 of 7 P1s + 3 of 5 P2s are mechanical fixes touching ≤5 lines each.
+
+## Mechanical fixes ready to ship
+
+1. **Honest-chrome on the clock slot** — replace `<LiveDot label={...} />` at [page.tsx:116](../../../src/app/hackernews/trending/page.tsx#L116) with `<FreshnessBadge source="hackernews" lastUpdatedAt={trendingFile.fetchedAt} />` (drop `LiveDot` import) — closes P0-1.
+2. **Tab tap target 44×44** — `.tabs .tab { min-height: 44px; padding: 12px 14px; display: inline-flex; align-items: center; }` at [globals.css:2305](../../../src/app/globals.css#L2305) — closes P0-2 across 5 routes.
+3. **Cold-state freshness + dev-only operator copy** — add `clock` slot in cold branch with `FreshnessBadge`; swap `<code>npm run scrape:hn</code>` block behind `NODE_ENV === "development"` — closes P0-3.
+4. **`HN_ORANGE` → `--v4-src-hn`** at [page.tsx:55](../../../src/app/hackernews/trending/page.tsx#L55) — closes P1-1.
+5. **`formatClock` cold path** — return `"OFFLINE"` instead of `"warming"` at [page.tsx:67](../../../src/app/hackernews/trending/page.tsx#L67) — closes P1-5.
+6. **KpiBand FRONT PAGE tone** — `tone: "money"` → `tone: "acc"` + `pip: "var(--v4-src-hn)"` at [page.tsx:139-140](../../../src/app/hackernews/trending/page.tsx#L139) — closes P1-6.
+7. **Drop dead `defaultWindow` prop** at [page.tsx:184](../../../src/app/hackernews/trending/page.tsx#L184) — closes P2-5.
+8. **LiveDot SR noise** — drop `role="status"` + `aria-live` at [LiveDot.tsx:34-35](../../../src/components/ui/LiveDot.tsx#L34) — closes P2-1 globally.
+9. **Tabs `.right` contrast** — `color: var(--ink-300)` at [globals.css:2332](../../../src/app/globals.css#L2332) — closes P2-2.
+
+## Counts
+
+- P0: 3
+- P1: 7
+- P2: 5
+- Total: 15

--- a/docs/audits/impeccable/reddit-trending-audit.md
+++ b/docs/audits/impeccable/reddit-trending-audit.md
@@ -1,0 +1,213 @@
+# /reddit/trending audit — 2026-05-13
+
+> Impeccable design audit on `/reddit/trending`. Project rules applied: honest freshness chrome is non-negotiable; functional `border-l-*` color-keys on tier rows are NOT side-tab slop; card radii are 2px; cards are shadow-free; Reddit collector is currently degraded (RSS fallback writes `score=0`).
+
+## Files audited
+
+- [src/app/reddit/trending/page.tsx](../../../src/app/reddit/trending/page.tsx) — RSC route with bundled-JSON fallback + SSR empty-tab redirect
+- [src/components/reddit-trending/AllTrendingTabs.tsx](../../../src/components/reddit-trending/AllTrendingTabs.tsx) — client tab strip + filters + EmptyWindow
+- [src/components/reddit-trending/PostListPanel.tsx](../../../src/components/reddit-trending/PostListPanel.tsx) — full post-row chunk
+- [src/components/reddit-trending/SubredditGroupPanel.tsx](../../../src/components/reddit-trending/SubredditGroupPanel.tsx) — by-subreddit compact rows
+- [src/components/reddit-trending/trending-helpers.ts](../../../src/components/reddit-trending/trending-helpers.ts) — tier classes, color-key
+- [src/components/reddit-trending/SubredditMindshareCanvas.tsx](../../../src/components/reddit-trending/SubredditMindshareCanvas.tsx) — dead, unimported
+- [src/components/reddit-trending/SubredditHeatMapCanvas.tsx](../../../src/components/reddit-trending/SubredditHeatMapCanvas.tsx) — dead, unimported
+- [src/components/reddit-trending/TopicMindshareCanvas.tsx](../../../src/components/reddit-trending/TopicMindshareCanvas.tsx) — dead, unimported
+- [src/components/reddit/ContentTagChips.tsx](../../../src/components/reddit/ContentTagChips.tsx) — chip filter row
+- [src/components/reddit/BaselinePill.tsx](../../../src/components/reddit/BaselinePill.tsx)
+- [src/components/reddit/VelocityIndicator.tsx](../../../src/components/reddit/VelocityIndicator.tsx)
+- [src/components/ui/InventoryBand.tsx](../../../src/components/ui/InventoryBand.tsx)
+
+## P0 findings
+
+### 1. Three large dead-code map components ship to disk but are unimported — confusion + audit liability
+
+- **Files**: [SubredditHeatMap.tsx](../../../src/components/reddit-trending/SubredditHeatMap.tsx), [SubredditHeatMapCanvas.tsx](../../../src/components/reddit-trending/SubredditHeatMapCanvas.tsx) (660 LOC), [SubredditMindshareMap.tsx](../../../src/components/reddit-trending/SubredditMindshareMap.tsx), [SubredditMindshareCanvas.tsx](../../../src/components/reddit-trending/SubredditMindshareCanvas.tsx) (928 LOC), [TopicMindshareMap.tsx](../../../src/components/reddit-trending/TopicMindshareMap.tsx), [TopicMindshareCanvas.tsx](../../../src/components/reddit-trending/TopicMindshareCanvas.tsx) (~450 LOC)
+- **Mechanical**: `rg "SubredditHeatMap\|TopicMindshareMap\|SubredditMindshareMap"` returns only their own internal references — `page.tsx` no longer renders any of them. The wave-1 fix for `bg-black` in `SubredditHeatMapCanvas.tsx:387` is technically still there, but the file is now unreachable code. Auditors flag findings in files the user never sees.
+- **Fix**: Delete the three Map + Canvas pairs OR mount the heat map back on the page above `<AllTrendingTabs>`. Picking one or the other is a product decision; either way, stop carrying both. Recommend keep `SubredditHeatMap` + delete the bubble physics pair (Topic + SubredditMindshare) — the heat map was the explicit replacement per file header.
+- **Design call**: design — product needs to pick whether the heatmap returns or stays dead. Mechanical part is the deletion sweep.
+
+### 2. Post rows render bouncy hover (translate + scale + arbitrary orange shadow) — violates "no card shadows" + "non-bouncy motion"
+
+- **File**: [PostListPanel.tsx:66-72](../../../src/components/reddit-trending/PostListPanel.tsx#L66), same pattern in [SubredditGroupPanel.tsx:47-53](../../../src/components/reddit-trending/SubredditGroupPanel.tsx#L47)
+- **Mechanical**: `motion-safe:hover:-translate-y-0.5 motion-safe:hover:scale-[1.005]` + `hover:shadow-[0_8px_24px_-8px_rgba(245,110,15,0.25)]`. DESIGN.md is explicit: `--shadow-card: none` is enforced; "no card shadows at all, ever. Shadows reserved for focus, LIVE, overlay, popover, glow." A 24px orange drop-shadow on every row hover is a card-elevation shadow. Plus 1.005× scale on every hover is the "hover lift" anti-pattern DESIGN.md called out as drifted from V2 (the canonical hover is `--shadow-row-hover: inset 3px 0 0 functional`).
+- **Fix**: Replace hover with the sanctioned `--shadow-row-hover` inset-rail. Drop `translate` + `scale`. Border-color hover (`hover:border-brand/40`) can stay — it's the honest hover signal.
+- **Design call**: design — touches every Reddit post row. Same anti-pattern probably lurks elsewhere; worth a global sweep follow-up.
+
+### 3. Card radii drift — `rounded-xl` (10px) on rows + nested cards contradict the 2px `--radius-card`
+
+- **File**: [PostListPanel.tsx:66](../../../src/components/reddit-trending/PostListPanel.tsx#L66) (`rounded-xl`), [SubredditGroupPanel.tsx:47](../../../src/components/reddit-trending/SubredditGroupPanel.tsx#L47) (`rounded-xl`), [SubredditGroupPanel.tsx:171](../../../src/components/reddit-trending/SubredditGroupPanel.tsx#L171) (`rounded-md`, 4px), inner stat block at [PostListPanel.tsx:152](../../../src/components/reddit-trending/PostListPanel.tsx#L152) (`rounded-lg`, 6px).
+- **Mechanical**: globals.css resolves `--radius-card: 0.125rem` (2px). `rounded-xl` maps to `--radius-xl: 10px`. DESIGN.md "terminal density. Sharp corners are intentional. Don't round things to 12px — that reads as a marketing site, not a screener." `/reddit/trending` rows are softer than any other surface in the codebase.
+- **Fix**: `rounded-xl` → `rounded-card` (or `rounded-[2px]`) on row + compact row. Sub-group header card (`rounded-md`) → `rounded-card`. Inner inset stat block (`rounded-lg`) → `rounded` (3px) or `rounded-card`. Keep the BaselinePill at `rounded-md` (it's a pill chip, not a card).
+- **Design call**: design — every Reddit user lands on a 10px-radius row. This is the "looks like a marketing site" smell the brand explicitly rejects.
+
+## P1 findings
+
+### 4. `bg-black` still present on heatmap container (wave-1 fix never landed in wave6)
+
+- **File**: [SubredditHeatMapCanvas.tsx:387](../../../src/components/reddit-trending/SubredditHeatMapCanvas.tsx#L387)
+- **Mechanical**: `<div ref={containerRef} className="relative w-full bg-black rounded-md overflow-hidden border border-border-primary">`. Wave-1 audit baseline expected this swapped to `bg-bg-canvas` and PR #1146 claimed the fix; the wave6 worktree still has `bg-black`. Untinted neutral violates DESIGN.md surface tokens: "Never use bare `bg-black` — use `bg-bg-canvas` or the overlay token."
+- **Fix**: `bg-black` → `bg-bg-canvas`. Drops to P2 if the dead-code purge in #1 deletes this file outright.
+- **Design call**: mechanical (one token swap), gated on #1.
+
+### 5. Mid-tier active-state colors hardcode `accent-green` tint — should route through brand tokens
+
+- **File**: [SubredditHeatMapCanvas.tsx:355, 374](../../../src/components/reddit-trending/SubredditHeatMapCanvas.tsx#L355) — `bg-accent-green/20 text-accent-green` on the window/sort toggle.
+- **Mechanical**: Functional-green is correct semantic for "active/toggle-on" per DESIGN.md (`--color-functional: #22c55e`), but the wider codebase uses `bg-brand` for active tabs (see [AllTrendingTabs.tsx:340](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L340) and [SubredditMindshareCanvas.tsx:805](../../../src/components/reddit-trending/SubredditMindshareCanvas.tsx#L805)). Within the same `/reddit/trending` family the active-state hue swaps between brand-orange and accent-green depending on which sub-component you're in. Drift.
+- **Fix**: Pick one. Recommend brand for primary tabs, functional-green only for row-hover + toggle-on states. Apply across the three control clusters.
+- **Design call**: design — single decision propagates.
+
+### 6. Subreddit chip on each post row uses HSL-from-name color hash — fails contrast guarantees + reads "random pastel" not "data"
+
+- **File**: [trending-helpers.ts:95-100](../../../src/components/reddit-trending/trending-helpers.ts#L95) (`subredditColorHash`), consumed at [PostListPanel.tsx:80](../../../src/components/reddit-trending/PostListPanel.tsx#L80), [SubredditGroupPanel.tsx:176](../../../src/components/reddit-trending/SubredditGroupPanel.tsx#L176)
+- **Mechanical**: `hsl(<hue>, 60%, 65%)` against `bg-bg-card` (`#101418`, oklch 0.189). HSL 60% saturation × 65% lightness on dark surfaces produces pastels that nominally pass 4.5:1 contrast but read as "fun party theme" not "Bloomberg-terminal serious". Hue is quantized to 30° (12 buckets), so r/MachineLearning and r/Python may collide. Worse: the color tells the user nothing about the sub — purely identity, no momentum/tier signal.
+- **Fix**: Two options: (a) drop the random hash, render `r/{sub}` in `text-text-primary` and let the avatar carry identity color (LetterAvatar already does); (b) keep deterministic color but pin saturation lower (e.g. `hsl(hue, 40%, 75%)`) and use a 6-hue palette pinned to DESIGN.md tokens. Recommend (a) — color budget on this page is already crowded (per-tier border, brand-orange CTAs, baseline-tier pills).
+- **Design call**: design — every row reads slightly different. The "serious, fast-scan" feel takes a hit.
+
+### 7. Subreddit chip + inline `↗` external-link arrow taps below 44×44
+
+- **File**: [PostListPanel.tsx:76-94](../../../src/components/reddit-trending/PostListPanel.tsx#L76)
+- **Mechanical**: `<button>` chip for `r/{sub}` is text-only (`text-sm font-mono` line-height collapses to ~18px), no `min-h-11`. Adjacent `↗` external-link is `text-xs leading-none -ml-1`, hit-target ~12×12. PRODUCT.md is explicit: "44×44 minimum tap targets on every interactive element." Two taps stacked on mobile guaranteed to mis-fire.
+- **Fix**: Wrap chip in `min-h-11 inline-flex items-center` and pad the `↗` to `h-11 w-11 inline-flex items-center justify-center -my-3 -mx-1` (use negative margin so it still reads inline visually but the hit-target spans the row height).
+- **Design call**: mechanical with a design tilt — easy fix, high mobile-CX impact.
+
+### 8. SubredditHeatMapCanvas tooltip uses viewport `clientX/Y` math but never handles touch — no mobile reflow
+
+- **File**: [SubredditHeatMapCanvas.tsx:287-318](../../../src/components/reddit-trending/SubredditHeatMapCanvas.tsx#L287)
+- **Mechanical**: tooltip pinned to cursor via pointer events. On mobile, no `tap-to-reveal` fallback, and the 280px tooltip clamped to viewport leaves <16px on a 375px screen. Cells smaller than ~50×30 on mobile are unreadable (no text fits per `typographyFor()`).
+- **Fix**: On viewports ≤640px, swap the treemap for a vertical list of top-15 cells with the same per-cell content (name, big number, momentum delta, sparkline). Treemap's strength is dense-grid pan-scan — wasted on a phone.
+- **Design call**: design — gated on #1 keeping the heatmap alive.
+
+### 9. KPI band shows "Top score" + "GH-linked" even when collector is degraded — no honest signal that scores are zero
+
+- **File**: [page.tsx:248-321](../../../src/app/reddit/trending/page.tsx#L248)
+- **Mechanical**: When Reddit RSS fallback fires (the documented degraded state where `score=0, numComments=0` for 80%+ of posts), `topScore` will compute to `0` and "GH-linked" tiles read `0`. Page renders four big tabular `0`s with no explanation. The `InventoryBand` zero-engagement count says "RSS-fallback artifacts" but the KPI band is silent.
+- **Fix**: When `stats.totalPosts > 0` AND `topScore === 0`, render a small sub-label "RSS fallback — scores unavailable" under the TOP SCORE / GH-LINKED cells, OR collapse those two cells when degraded. The page already detects engagement via `postsZeroEngagement`; piggyback the same condition.
+- **Design call**: design — partial chrome lie. P1 because the FreshnessBadge already reads COLD honestly, but the KPI band is the loudest signal on the surface.
+
+### 10. ContentTagChips active-state has `bg-black/25` inner count badge — same untinted-black violation
+
+- **File**: [ContentTagChips.tsx:270](../../../src/components/reddit/ContentTagChips.tsx#L270)
+- **Mechanical**: `bg-black/25 text-white/95` on the count badge when a chip is active. DESIGN.md again: never bare `bg-black`. The 25% alpha tames the visual hit but lints fail the rule.
+- **Fix**: `bg-black/25` → `bg-bg-canvas/40` or `bg-bg-overlay/25`.
+- **Design call**: mechanical.
+
+## P2 findings
+
+### 11. Three coexisting font-size scales used inside one component
+
+- **File**: [PostListPanel.tsx:78-191](../../../src/components/reddit-trending/PostListPanel.tsx#L78)
+- **Mechanical**: A single post row mixes `text-sm` (Tailwind `--text-sm: 12px`), `text-xs` (11px), `text-[11px]` (arbitrary literal), `text-[10px]` (arbitrary). DESIGN.md flagged "rationalize 3 coexisting type scales" as an open follow-up. Hardcoded `text-[11px]` literals bypass the token system.
+- **Fix**: Replace `text-[11px]` → `text-xs`, `text-[10px]` → `text-2xs`. Either expand the global ladder or use the existing tokens. Defer the cross-scale rationalization to the DESIGN.md follow-up sweep.
+- **Design call**: design — small, additive cleanup.
+
+### 12. `EmptyWindow` uses `rounded-md` (4px) — drift vs 2px card spec
+
+- **File**: [AllTrendingTabs.tsx:453](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L453)
+- **Mechanical**: Dashed-border empty-state at 4px. EmptyState in `cold-page` uses the `EmptyState` primitive which is correct; this in-tab empty is a one-off.
+- **Fix**: `rounded-md` → `rounded-card`.
+- **Design call**: mechanical.
+
+### 13. `PanelSkeleton` placeholders at `rounded-xl` (10px) — same drift as the rows they're standing in for
+
+- **File**: [AllTrendingTabs.tsx:155](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L155)
+- **Mechanical**: Skeleton block at `h-[120px] rounded-xl`. When the rows fix lands in #3, the skeleton will visibly contradict the real rows.
+- **Fix**: Carry whatever radius #3 chooses through to the skeleton.
+- **Design call**: mechanical, gated on #3.
+
+### 14. Pointer-up tooltip pattern uses `transition: stroke-width 120ms` then a separate `transition: r 180ms` on overlapping circles — non-uniform motion
+
+- **File**: [TopicMindshareCanvas.tsx:141, 149](../../../src/components/reddit-trending/TopicMindshareCanvas.tsx#L141)
+- **Mechanical**: Two SVG circles in the same group animate `r` (180ms) and `stroke-width` (120ms) independently on the same drag/active. They visibly desync on slow devices. Wave-1 flagged `transition: width` here as layout-jank candidate; current code uses `transition: r` (an SVG attribute, not a CSS box-model layout property) — that's actually fine for composited animation. Flagging the duration mismatch instead.
+- **Fix**: Unify both to `var(--motion-duration-base)` (180ms) with `var(--motion-ease-standard)`. Dead-code purge in #1 would moot this.
+- **Design call**: design, gated on #1.
+
+### 15. SubredditGroupPanel sub-header uses hash color for `r/{sub}` text — same as #6 but on the group label
+
+- **File**: [SubredditGroupPanel.tsx:174-178](../../../src/components/reddit-trending/SubredditGroupPanel.tsx#L174)
+- **Mechanical**: Same `subredditColorHash` pastel applied to the group title. Same fix flows from #6.
+- **Design call**: rolls into #6.
+
+## What's working well (reference patterns to propagate)
+
+1. **Honest FreshnessBadge wiring** ([page.tsx:286-289](../../../src/app/reddit/trending/page.tsx#L286)) — `<FreshnessBadge source="reddit" lastUpdatedAt={allPostsFetchedAt} />` is exemplary. No hardcoded "FRESH · 1H" anywhere. Comment block at L281-285 calls out the honest-chrome rule by name. This page is the reference for honest chrome on the codebase — `/signals` should copy this shape.
+2. **Bundled-JSON SSR fallback** ([page.tsx:79-101, 144-169](../../../src/app/reddit/trending/page.tsx#L79)) — the "never less than what we have" rule from 2026-05-08 is well-implemented: cold detect → bundled file → engagement-filter → graceful degrade. Pattern should travel to `/funding` and other degraded sources.
+3. **EmptyWindow + SSR-side tab redirect** ([page.tsx:179-214, AllTrendingTabs.tsx:295-310](../../../src/app/reddit/trending/page.tsx#L179)) — never strand the user on an empty tab. Both server-side redirect AND client-side `router.replace` as belt-and-braces. Strong UX.
+4. **Functional `border-l-4 border-l-[#ff6600]` tier color-key** ([trending-helpers.ts:33,66](../../../src/components/reddit-trending/trending-helpers.ts#L33)) — wave-1 baseline correctly tagged these as functional, not decorative. Reddit-orange on hyperviral rows is identity-keyed; do not strip.
+5. **`defaultFilterWouldHideAll` auto-degrade** ([AllTrendingTabs.tsx:209-215](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L209)) — when the default `value_score >= 1` would zero out the page (RSS degraded state), the filter falls through. Honest user-facing graceful degrade.
+6. **Velocity p50/p90 percentile gating** ([AllTrendingTabs.tsx:75-99](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L75)) — chevrons + velocity-bar color only fire on the top decile of the visible feed, so they stay rare and meaningful. Worth borrowing for `/twitter`.
+7. **Lazy-loaded tab panels** ([AllTrendingTabs.tsx:32-39](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L32)) — `dynamic(... ssr:false, loading: <PanelSkeleton/>)` is the right shape; first paint ships just the strip.
+8. **`content-visibility: auto` on rows** ([PostListPanel.tsx:60-64](../../../src/components/reddit-trending/PostListPanel.tsx#L60)) — cheap virtualization, full SSR compat, no react-window. Pattern note in DESIGN.md follow-ups.
+9. **InventoryBand making the degraded state visible** ([page.tsx:251-267](../../../src/app/reddit/trending/page.tsx#L251)) — "Zero-engagement: RSS-fallback artifacts" is the explicit, honest disclosure the brand requires.
+
+## Verify-in-context
+
+- **Reddit collector degraded state** (per CLAUDE.md anti-patterns + PRODUCT.md "honest reliability state"): when the Apify-less fallback runs, `score=0` rows dominate. The page handles this on three layers — bundled-JSON splice, `defaultFilterWouldHideAll`, sortTrending fallback to chronological. KPI band is the one place that still doesn't reflect the degraded state (#9).
+- **Motion tokens**: `transition-colors duration-150` on tab chips matches `--motion-duration-fast: 120ms` within tolerance (Tailwind's `duration-150` = 150ms; the design token is 120ms but a 30ms divergence is invisible). No bouncy easing in the active component tree — Framer's `[0.22, 1, 0.36, 1]` ease on heatmap cells matches the project's non-bouncy `cubic-bezier(0.2, 0.8, 0.2, 1)` shape closely. Acceptable.
+- **A11y**: tab strip has `role="tablist"` + `role="tab"` + `aria-selected` ([AllTrendingTabs.tsx:321, 332](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L321)). HeatMapCanvas window/sort toggles use plain `<button>` without `role="tab"` ([SubredditHeatMapCanvas.tsx:347-381](../../../src/components/reddit-trending/SubredditHeatMapCanvas.tsx#L347)) — sister TopicMindshareCanvas and SubredditMindshareCanvas DO use `role="tab"`. Inconsistency, but moot if #1 deletes the file.
+- **Wave-1 baseline `TopicMindshareCanvas.tsx:149` "transition: width"**: now reads `transition: stroke-width 120ms`. `stroke-width` is an SVG attribute compositable on the GPU, not a layout property — wave-1's concern was correct for `width: <px>` on HTML elements; it does not apply here. **Cleared.**
+- **Wave-1 baseline `SubredditHeatMapCanvas.tsx:387` "bg-black"**: still present in wave6 (#4). PR #1146 either didn't merge or didn't reach this worktree.
+
+## Mechanical fixes ready to ship
+
+1. **Dead-code purge** (#1): `git rm src/components/reddit-trending/{SubredditMindshareMap,SubredditMindshareCanvas,TopicMindshareMap,TopicMindshareCanvas}.tsx` and keep `SubredditHeatMap*` only if product wants the heatmap mounted; otherwise drop those too. Confirm no other file imports any of them first.
+2. **PostListPanel.tsx:66 / SubredditGroupPanel.tsx:47** (#2 + #3): remove `motion-safe:hover:-translate-y-0.5 motion-safe:hover:scale-[1.005]` and the arbitrary `hover:shadow-[0_8px_24px_-8px_rgba(245,110,15,0.25)]`; change `rounded-xl` → `rounded-card`. Replace with `hover:shadow-row-hover` (or define a 1px brand-border hover).
+3. **PostListPanel.tsx:152** (#3): `rounded-lg` → `rounded`.
+4. **SubredditGroupPanel.tsx:171** (#3): `rounded-md` → `rounded-card`.
+5. **AllTrendingTabs.tsx:155, 453** (#12, #13): `rounded-xl` / `rounded-md` → `rounded-card`.
+6. **SubredditHeatMapCanvas.tsx:387** (#4): `bg-black` → `bg-bg-canvas` (skip if file deleted in #1).
+7. **ContentTagChips.tsx:270** (#10): `bg-black/25` → `bg-bg-canvas/40`.
+8. **PostListPanel.tsx:76-94** (#7): wrap `r/{sub}` button in `min-h-11`, expand `↗` link to 44×44 hit-target with negative margins.
+9. **trending-helpers.ts:95-100** (#6, #15): drop `subredditColorHash`, recolor `r/{sub}` callers to `text-text-primary`.
+
+## Quick-fix patches (optional)
+
+### Patch A — kill the row anti-patterns
+
+```tsx
+// PostListPanel.tsx (row className)
+className={cn(
+  "group relative block border border-border-primary rounded-card bg-bg-card p-4 sm:p-5",
+  "transition-colors duration-150 motion-reduce:transition-none",
+  "hover:border-brand/40",
+  tc.row,            // keeps the functional border-l-* tier key
+  tc.contentOpacity,
+)}
+```
+
+### Patch B — KPI band honest sub-label when degraded
+
+```tsx
+// page.tsx KpiBand cells, in the TOP SCORE + GH-LINKED cells
+{
+  label: "TOP SCORE",
+  value: topScore.toLocaleString("en-US"),
+  sub: postsWithEngagement === 0 ? "RSS fallback — scores unavailable" : "velocity peak",
+  tone: "acc",
+  pip: "var(--v4-acc)",
+},
+```
+
+### Patch C — dedupe sub-color
+
+```tsx
+// trending-helpers.ts
+export function subredditColorHash(_seed: string): string {
+  return "var(--color-text-primary)";
+}
+// or delete and remove the import + style at call sites
+```
+
+---
+
+**Audit health score (estimated)**
+
+| # | Dimension | Score | Key finding |
+|---|---|---|---|
+| 1 | Hierarchy & scannability | 3 | 4-KPI band + lede reads in <3s; sub-color hash adds confusing pastel noise |
+| 2 | Honest chrome | 4 | FreshnessBadge wired correctly; KPI band silent on RSS-fallback degraded state |
+| 3 | Information density | 4 | Excellent — rows, chips, sparklines, baseline pills all earn their keep |
+| 4 | Accessibility & responsive | 2 | <44px sub-chip tap target; heatmap canvas has no mobile reflow; pastel contrast borderline |
+| 5 | Motion & interaction | 2 | Bouncy `translate + scale + 24px orange drop-shadow` row hover violates DESIGN.md no-card-shadow + non-bouncy rules |
+| **Total** | | **15/25** | **Solid — the honest-chrome cluster `/signals` failed on is fully fixed here. Remaining defects are mechanical drift (radii, dead code, hover anti-pattern).** |
+
+The page is one of the better surfaces in the codebase: honest chrome, bundled-JSON fallback, empty-tab redirect, auto-degrade filter — all done correctly. The P0s are not chrome lies (rare for trendingrepo); they're dead-code accumulation (3 unimported maps) and template-SaaS hover patterns leaked through. One pattern fix on row hover lands across both list panels, one purge across three Map files, one radius sweep across four call sites — three small PRs total.

--- a/docs/audits/impeccable/twitter-audit.md
+++ b/docs/audits/impeccable/twitter-audit.md
@@ -1,0 +1,128 @@
+# /twitter audit — 2026-05-13
+
+## Files audited
+- [src/app/twitter/page.tsx](../../../src/app/twitter/page.tsx)
+- [src/app/twitter/TwitterTabSwitcher.tsx](../../../src/app/twitter/TwitterTabSwitcher.tsx)
+- [src/app/twitter/loading.tsx](../../../src/app/twitter/loading.tsx)
+- [src/app/twitter/error.tsx](../../../src/app/twitter/error.tsx)
+- [src/components/twitter/TwitterMentionBadge.tsx](../../../src/components/twitter/TwitterMentionBadge.tsx)
+- [src/components/twitter/TwitterSignalPanel.tsx](../../../src/components/twitter/TwitterSignalPanel.tsx) (lives under /twitter but consumed by `/repo/[owner]/[name]`)
+- [src/components/twitter/XSignalBadge.tsx](../../../src/components/twitter/XSignalBadge.tsx)
+- [src/components/templates/SourceFeedTemplate.tsx](../../../src/components/templates/SourceFeedTemplate.tsx) (consumed)
+- [src/components/ui/PageHead.tsx](../../../src/components/ui/PageHead.tsx) (consumed)
+- [src/components/ui/KpiBand.tsx](../../../src/components/ui/KpiBand.tsx) (consumed)
+- [src/components/ui/InventoryBand.tsx](../../../src/components/ui/InventoryBand.tsx) (consumed)
+- [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx) (consumed)
+- [src/lib/news/freshness.ts](../../../src/lib/news/freshness.ts) (threshold source)
+- [src/app/globals.css#L5691-5697](../../../src/app/globals.css) (`.v2-live-dot` definition)
+
+## P0 findings (dishonest / broken / a11y blocker)
+
+- **Hardcoded `v2-live-dot` green pulse on the X signal panel** — [TwitterSignalPanel.tsx:38](../../../src/components/twitter/TwitterSignalPanel.tsx#L38). The terminal-bar renders `<span className="block h-1.5 w-1.5 rounded-full v2-live-dot" />` (CSS = `var(--v2-sig-green)` + 6px green glow, [globals.css:5691](../../../src/app/globals.css#L5691)) regardless of `panel.summary.lastScannedAt`. The next slot at line 58 honestly reports `REFRESHED {getRelativeTime(...)}`, so the green pulse is permanently green while the timestamp says "4 hours ago". This is the exact `feedback_freshness_chrome_must_be_honest` defect cleaned out of `/`, `/signals`, `/funding` in waves 3a/3b/3c. Component renders only on `/repo/[owner]/[name]`, but it lives on the /twitter audit perimeter and is owned by this surface. Fix: drop the `v2-live-dot` class and let the `REFRESHED …` slot encode age — or swap that header slot for `<FreshnessBadge source="twitter" lastUpdatedAt={panel.summary.lastScannedAt} />`. **Mechanical.**
+- **`"warming"` masquerades as a UTC clock** — [page.tsx:67, 330, 390](../../../src/app/twitter/page.tsx#L67). When `stats.lastScannedAt` is null/missing, `formatClock` returns the string `"warming"` and is rendered in the `.big` slot of the PageHead clock column under a `UTC · SCRAPED` muted line. The visible read is `warming · UTC · SCRAPED` — operator-friendly debug copy that reads "data is about to land" when reality is the source is OFFLINE or the bucket was never populated. Identical pattern to wave-3c funding-audit P0 #2. Fix: render `"—"` or `"OFFLINE"` and let `<FreshnessBadge>` own the COLD verdict. **Mechanical.**
+
+## P1 findings (visible regression)
+
+- **Tab `<button>` 40px min-height — sub-44 tap target** — [TwitterTabSwitcher.tsx:46-48](../../../src/app/twitter/TwitterTabSwitcher.tsx#L46) `min-h-[40px]`. WCAG 2.5.5 + project mobile rule require 44×44. Fix: bump `min-h-[40px]` → `min-h-[44px]` and add `align-items: center`. Same drift in the unused server-side `TwitterTabNav` at [page.tsx:275](../../../src/app/twitter/page.tsx#L275). **Mechanical.**
+- **Tab `<button role>` and panel association missing** — [TwitterTabSwitcher.tsx:36-55](../../../src/app/twitter/TwitterTabSwitcher.tsx#L36). The `<nav aria-label="Twitter leaderboard tabs">` contains plain buttons with `aria-pressed` but no `role="tablist"` / `role="tab"` / `aria-controls`, and no surrounding `role="tabpanel"` / `aria-labelledby` around the rendered table. Screen readers can't tie selection to panel content. Same defect closed in wave-3d /skills audit. Fix: convert to `role="tab"` with `id`s + wrap `{activeTab === "global" ? globalTable : trendingTable}` in `<section role="tabpanel" aria-labelledby={selectedTabId}>`. **Mechanical.**
+- **RepoActionLinks buttons are 24×24** — [page.tsx:131, 147, 159](../../../src/app/twitter/page.tsx#L131). `inline-flex h-6 w-6 items-center justify-center rounded-full` on the X / GitHub / website link triplet. Each row has three; on mobile they form a 96px-wide cluster of sub-44 tap targets sitting inside a 12.5em row. Fix: bump to `h-9 w-9` (36×36) at minimum, or to `h-11 w-11` (44×44) on touch viewports via `[@media(pointer:coarse)]`. **Mechanical.**
+- **MentionAuthorBubbles 20×20 avatar links overlap (-ml-1.5)** — [page.tsx:204-206](../../../src/app/twitter/page.tsx#L204). Each `<Link>` is `h-5 w-5` with `-ml-1.5` overlap; the second through fifth bubbles have ~6px of independent click area before the next bubble eclipses them. Active tap targets are far below 44px. Fix: enlarge to `h-7 w-7` with `-ml-2` overlap, OR render the stack as a single button that opens the strongest author and downgrade the rest to decorative. **Design call** (mobile interaction pattern).
+- **Cold-state lede leaks internal API endpoint to the public surface** — [page.tsx:670-674](../../../src/app/twitter/page.tsx#L670). `<code>/api/internal/signals/twitter/v1/ingest</code>` rendered to anyone hitting /twitter when the dataset is cold. Operator copy on a user-facing surface. Fix: replace with "Twitter scan is cold — fresh data lands every 3 hours." and gate the dev hint behind `process.env.NODE_ENV === "development"`. **Mechanical.**
+- **`<MarkVisited routeKey="twitter">` references `stats.reposWithMentions` not row count** — [page.tsx:319, 378](../../../src/app/twitter/page.tsx#L319). In the cold branch the count is whatever the lifetime aggregate is, even though no rows render. Side-effect: the global "new since last visit" badge in the nav under-reads true freshness on /twitter. Fix: pass `rows.length` (the visible count) so the visit indicator reflects what the user actually saw. **Design call** (semantics of "visited" — operator confirms whether the marker tracks lifetime or surface-visible volume).
+- **Row stagger animation ignores `prefers-reduced-motion`** — [page.tsx:529-531](../../../src/app/twitter/page.tsx#L529) `animation: slide-up 0.35s cubic-bezier(0.2, 0.8, 0.2, 1) both; animationDelay: stagger`. 200 rows × 50ms stagger capped at 6 = up to 300ms of staggered motion on initial paint with no reduced-motion guard. Fix: wrap the `animation` inline-style in a media-query class (`@media (prefers-reduced-motion: reduce) { .v2-row { animation: none !important; } }` already broadly applies if the row uses a class, but the inline style here overrides). Move the animation into a class so the reduce-motion rule applies. **Mechanical.**
+
+## P2 findings (polish / drift)
+
+- **Author-bubble tones are 5 hardcoded RGBA palettes — drift from OKLCH tokens** — [page.tsx:70-96](../../../src/app/twitter/page.tsx#L70). Per DESIGN.md the production palette uses `--v3-*` / `--v4-*` tokens. These hash-keyed tones bypass the token system and the runtime accent picker — switching accent from Lava to Cyan won't ripple into the author bubbles. Fix: source the 5 tones from `var(--v4-src-x)`, `var(--v4-money)`, `var(--v4-magenta)`, `var(--v4-amber)`, `var(--v4-violet)` (or commit the 5 palette tones as new tokens). **Design call.**
+- **KPI pip colors mix source vs accent vs money vs blue** — [page.tsx:409, 416, 422, 429](../../../src/app/twitter/page.tsx#L409). TWEETS pip = `--v4-src-x` (X blue), TOP LIKES pip = `--v4-acc` (Liquid Lava), KOLS pip = `--v4-money` (green), FRESH NOW pip = `--v4-blue`. Functional sense (source / activity / unique / freshness) is plausible, but the FRESH NOW pip is `--v4-blue` not `--v4-money` — green is the freshness semantic everywhere else (FreshnessBadge `live`, InventoryBand `fresh`). Fix: FRESH NOW pip → `--v4-money` for consistency. **Design call.**
+- **Mobile compact summary uses `|` separator without `aria-hidden`** — [page.tsx:586-590](../../../src/app/twitter/page.tsx#L586). The `<span className="md:hidden">…likes | rts | score</span>` row reads to a screen reader as "X likes pipe Y rts pipe Z score". Mostly aesthetic — pipes are usually ignored by SR — but worth swapping for `·` to match the rest of the surface, or wrapping pipes in `<span aria-hidden>`. **Mechanical.**
+- **`badgeState === "x_fire"` hardcoded RGBA fills** — [page.tsx:508-510](../../../src/app/twitter/page.tsx#L508). `rgba(245, 110, 15, 0.4)` / `rgba(245, 110, 15, 0.1)` are inlined; if the accent picker switches from Lava to Cyan, the X-FIRE badge stays orange. Fix: `color-mix(in oklab, var(--v4-acc) 40%, transparent)` derivations. **Mechanical.**
+- **Row hover lacks focus-visible state** — [page.tsx:524, globals.css:4382](../../../src/app/twitter/page.tsx#L524). `.v2-row:hover` sets background but no `:focus-within` for the row when keyboard-tabbing through the repo link or action chips. Keyboard users can't see which row contains the focused element. Fix: add `.v2-row:focus-within { background: var(--bg-050); }`. **Mechanical.**
+
+## What's working well
+
+- **FreshnessBadge wired correctly in both branches** — [page.tsx:337-340, 396-399](../../../src/app/twitter/page.tsx#L337). The comment block at 332-336 explicitly documents the prior LiveDot defect and why FreshnessBadge replaced it — exactly the honest-chrome contract.
+- **`buildTwitterInventoryStats` closes the "23 of 6,000" gap** — [page.tsx:362-374, InventoryBand.tsx:145-178](../../../src/app/twitter/page.tsx#L362). Tweets observed / Repos with buzz / Fresh now / Stale tiles make the collected-vs-rendered delta legible.
+- **Cold-state branch is real** — [page.tsx:314-346](../../../src/app/twitter/page.tsx#L314). No "fake empty grid" pattern; the surface actually swaps to a `// no X findings yet` block with the badge attached.
+- **Initial-letter fallback behind the avatar img** — [page.tsx:212-228](../../../src/app/twitter/page.tsx#L212). Comment explains the rationale (unavatar.io 429); robust against image failures.
+- **`export const dynamic = "force-static"` + 5-min ISR** — [page.tsx:41-42](../../../src/app/twitter/page.tsx#L41). Matches the 3h scrape cadence with appropriate slack; not over-revalidated.
+- **`aria-label` on every interactive Link** — RepoActionLinks (X, GitHub, website), MentionAuthorBubbles, repo title link all carry descriptive `aria-label`s.
+
+## Verify-in-context
+
+- The two P0 honest-chrome lies are cousins of the funding-audit / signals-audit / home-audit findings already closed in waves 3a–3c.
+- 4 of 6 P1s are mechanical fixes touching ≤3 lines each.
+- No mobile-reflow ENOENT issues at 375px — fixed-col grid math (244px + 32px padding = 276px) leaves ~100px for the 1fr column, tight but renders.
+
+## Mechanical fixes ready to ship
+
+1. **TwitterSignalPanel honest chrome** — drop `v2-live-dot` at [TwitterSignalPanel.tsx:38](../../../src/components/twitter/TwitterSignalPanel.tsx#L38), replace the terminal-bar timestamp slot with `<FreshnessBadge source="twitter" lastUpdatedAt={panel.summary.lastScannedAt} />`.
+2. **`formatClock` cold path** — return `"OFFLINE"` instead of `"warming"` at [page.tsx:67](../../../src/app/twitter/page.tsx#L67).
+3. **Tab tap targets** — `min-h-[40px]` → `min-h-[44px]` at [TwitterTabSwitcher.tsx:48](../../../src/app/twitter/TwitterTabSwitcher.tsx#L48) and [page.tsx:275](../../../src/app/twitter/page.tsx#L275).
+4. **Tab a11y** — add `role="tab"` + `id` + `aria-controls`, wrap panels in `role="tabpanel"` / `aria-labelledby`.
+5. **RepoActionLinks tap targets** — `h-6 w-6` → `h-9 w-9` (or `h-11 w-11` on coarse pointer) at [page.tsx:131, 147, 159](../../../src/app/twitter/page.tsx#L131).
+6. **Cold lede copy** — replace `<code>/api/internal/signals/twitter/v1/ingest</code>` with operator-neutral copy at [page.tsx:670-674](../../../src/app/twitter/page.tsx#L670).
+7. **Row reduce-motion** — promote inline `animation:` to a class so the global reduced-motion rule applies.
+8. **KPI FRESH NOW pip** — `--v4-blue` → `--v4-money` at [page.tsx:429](../../../src/app/twitter/page.tsx#L429).
+9. **X_FIRE badge token mapping** — swap inline `rgba(245, 110, 15, …)` to `color-mix(in oklab, var(--v4-acc) …, transparent)` at [page.tsx:508-510](../../../src/app/twitter/page.tsx#L508).
+10. **Row focus-visible** — add `.v2-row:focus-within { background: var(--bg-050); }` at [globals.css:4411](../../../src/app/globals.css#L4411).
+
+## Quick-fix patches (optional)
+
+### P0 #1 — TwitterSignalPanel honest chrome
+
+Before ([TwitterSignalPanel.tsx:37-60](../../../src/components/twitter/TwitterSignalPanel.tsx#L37)):
+```tsx
+<span aria-hidden className="flex items-center gap-1.5">
+  <span className="block h-1.5 w-1.5 rounded-full v2-live-dot" />
+  ...
+</span>
+<span className="flex-1 truncate" style={{ color: "var(--v2-ink-200)" }}>
+  {"// X · SIGNAL · 24H"}
+</span>
+<span className="v2-stat shrink-0" style={{ color: "var(--v2-ink-300)" }}>
+  REFRESHED {getRelativeTime(panel.summary.lastScannedAt).toUpperCase()}
+</span>
+```
+
+After:
+```tsx
+<span aria-hidden className="flex items-center gap-1.5">
+  <span className="block h-1.5 w-1.5 rounded-full" style={{ background: "var(--v2-line-200)" }} />
+  ... // two more neutral dots
+</span>
+<span className="flex-1 truncate" style={{ color: "var(--v2-ink-200)" }}>
+  {"// X · SIGNAL · 24H"}
+</span>
+<FreshnessBadge source="twitter" lastUpdatedAt={panel.summary.lastScannedAt} />
+```
+
+### P0 #2 — formatClock cold path
+
+Before ([page.tsx:65-68](../../../src/app/twitter/page.tsx#L65)):
+```tsx
+function formatClock(iso: string | undefined | null): string {
+  if (!iso) return "warming";
+  return new Date(iso).toISOString().slice(11, 19);
+}
+```
+
+After:
+```tsx
+function formatClock(iso: string | undefined | null): string {
+  if (!iso) return "OFFLINE";
+  return new Date(iso).toISOString().slice(11, 19);
+}
+```
+
+### P1 #1 — tab tap targets
+
+Before ([TwitterTabSwitcher.tsx:48](../../../src/app/twitter/TwitterTabSwitcher.tsx#L48)):
+```tsx
+className="v2-mono inline-flex min-h-[40px] shrink-0 items-center gap-2 px-3 ..."
+```
+
+After:
+```tsx
+className="v2-mono inline-flex min-h-[44px] shrink-0 items-center gap-2 px-3 ..."
+```


### PR DESCRIPTION
## Summary

Wave-6 audits on 3 high-traffic momentum surfaces not covered by wave-2. Stacks on main, read-only (markdown reports only — no source mutation).

## Findings — 43 total (8 P0 / 20 P1 / 15 P2)

| Surface | P0 | P1 | P2 | Report |
|---|---|---|---|---|
| `/twitter` | 2 | 6 | 5 | [twitter-audit.md](docs/audits/impeccable/twitter-audit.md) |
| `/reddit/trending` | 3 | 7 | 5 | [reddit-trending-audit.md](docs/audits/impeccable/reddit-trending-audit.md) |
| `/hackernews/trending` | 3 | 7 | 5 | [hackernews-trending-audit.md](docs/audits/impeccable/hackernews-trending-audit.md) |

## Cross-cutting meta-findings (highest-leverage fixes uncovered yet)

1. **`.tabs .tab` is shared CSS across 5+ source-feed routes** — one CSS edit closes the 28px tap-target P0 family-wide.
2. **`LiveDot` has `aria-live=\"polite\"`** — screen readers re-announce \"LIVE\" on every re-render. Single component fix lands a11y win across every consumer.
3. **HN brand color drift** — `HN_ORANGE = \"#ff6600\"` hardcoded next to canonical `--v4-src-hn: #ff7a3d`.
4. **Lobsters already pairs `LiveDot` with `FreshnessBadge`** — canonical pattern exists, propagate to HN + others.

## Notable surprises

- **`/reddit/trending` is HONEST** (clean FreshnessBadge wiring with prior-defect code comments). The P0s are structural: ~2000 LOC of dead-code heatmaps (`SubredditHeatMap*`, `SubredditMindshareMap*`, `TopicMindshareMap*`) on disk but unimported. The wave-1 `bg-black` CLI finding lived in **unreachable code**.
- **`/twitter` page.tsx is also already honest** — but the v2-live-dot defect lives in `TwitterSignalPanel.tsx` which actually renders on `/repo/[owner]/[name]`. Wave-5 (#1169) closed v2-live-dot globally so this finding may already be resolved; verify post-merge.
- **HN has no momentum chart** — task hint was speculative; the surface is KpiBand + window-tabs + dense table.
- **`/reddit/trending` row hover is bouncy** — `translate-y + scale + 24px orange drop-shadow` violates DESIGN.md \"no card shadows\" + \"non-bouncy\" rules.

## What's NOT in this PR

Read-only audits. **Mechanical fixes from these reports get their own follow-up PRs.** Recommended next wave priority order (by leverage):

1. **Wave-7a (cross-cutting CSS fix)** — bump `.tabs .tab` to `min-height: 44px` on mobile. Closes a P0 across 5+ routes in one CSS edit.
2. **Wave-7b (cross-cutting a11y)** — drop `aria-live` from `LiveDot` OR scope it so SR doesn't re-announce. Touches one component, lands globally.
3. **Wave-7c (HN page)** — swap hardcoded `LiveDot label=\"LIVE · 24H\"` for `<FreshnessBadge source=\"hackernews\" lastUpdatedAt={fetchedAt} />`. Same pattern as wave-3a /signals.
4. **Wave-7d (cleanup)** — delete the ~2000 LOC dead code on `/reddit/trending`. Pure removal, no functional change.

## Test plan
- [x] Reports written and reviewable
- [ ] (next wave) Apply fixes
- [ ] (eventually) Visual smoke each surface at 375px + 1280px post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)