### PR TITLE
audit(impeccable): wave 7d — /reddit/trending hover + radii polish (2 P0)

### DIFF
--- a/src/components/reddit-trending/PostListPanel.tsx
+++ b/src/components/reddit-trending/PostListPanel.tsx
@@ -63,10 +63,10 @@ function PostRow({ post: p, velocityP90, velocityStats, onSubClick }: PostRowPro
         containIntrinsicSize: "0 160px",
       }}
       className={cn(
-        "group relative block border border-border-primary rounded-xl bg-bg-card shadow-card p-4 sm:p-5",
-        "transition-[border-color,box-shadow,background-color,transform] duration-200 motion-reduce:transition-none",
-        "motion-safe:hover:-translate-y-0.5 motion-safe:hover:scale-[1.005]",
-        "hover:border-brand/40 hover:shadow-[0_8px_24px_-8px_rgba(245,110,15,0.25)]",
+        "group relative block border border-border-primary rounded-sm bg-bg-card p-4 sm:p-5",
+        "transition-[border-color,background-color,transform] duration-200 motion-reduce:transition-none",
+        "motion-safe:hover:-translate-y-px",
+        "hover:border-brand/40",
         tc.row,
         tc.contentOpacity,
       )}


### PR DESCRIPTION
## Summary

Closes 2 polish P0s on /reddit/trending per wave-6 audit. Stacks on origin/main.

## Fixes

| # | Severity | Defect | Fix |
|---|---|---|---|
| 1 | P0 | Post-row hover: translate-y + scale + 24px drop-shadow (bouncy + violates "no card shadows" rule) | Dropped scale + drop-shadow; kept translate-y: -1px subtle lift |
| 2 | P0 | Post-row `rounded-xl` (10px) — violates 2px --radius-card spec | `rounded-xl` → `rounded-sm` (3px) |

## Hover direction decision (per /goal STOP RULES)

The audit identified the defect but left the replacement direction open. Picked **"drop scale + drop-shadow, keep translate-y: -1px"** as highest-confidence proposal:
- Removes both DESIGN.md violations (no card shadows; non-bouncy)
- Preserves hover affordance (-1px lift signals interactivity)
- Matches existing terminal-feel hover patterns

## Test plan
- [x] impeccable detect clean
- [x] lint:guards green
- [x] typecheck green
- [ ] (recommended) visual smoke /reddit/trending at 375px + 1280px — confirm hover still feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)