### PR TITLE
audit(impeccable): wave 7c — /hackernews/trending honest chrome + copy (2 P0)

### DIFF
--- a/src/app/hackernews/trending/page.tsx
+++ b/src/app/hackernews/trending/page.tsx
@@ -25,7 +25,7 @@ import { repoLogoUrl } from "@/lib/logos";
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 
 // ISR (5min) so the page picks up hourly Redis refreshes from
 // scrape-trending.yml. `force-static` was baking whatever data was
@@ -113,7 +113,16 @@ export default async function HackerNewsTrendingPage() {
           <>
             <span className="big">{formatClock(trendingFile.fetchedAt)}</span>
             <span className="muted">UTC · SCRAPED</span>
-            <LiveDot label={`LIVE · ${trendingFile.windowHours}H`} />
+            {/* W4-FRESHBADGE / wave-7c P0 #6. Replaced hardcoded
+                <LiveDot label={`LIVE · ${windowHours}H`}/> which fired
+                a green pulse regardless of fetchedAt — same brand-killing
+                lie wave-3a fixed on /signals (PR #1150) and wave-7
+                fixed on /reddit/trending. lib/news/freshness.ts already
+                ships `hackernews` as a NewsSource. */}
+            <FreshnessBadge
+              source="hackernews"
+              lastUpdatedAt={trendingFile.fetchedAt ?? null}
+            />
           </>
         }
         snapshot={
@@ -345,14 +354,16 @@ function ColdState() {
       >
         {"// no data yet"}
       </h2>
+      {/* wave-7c P0 #7. Previous copy leaked `npm run scrape:hn` and a
+          data/*.json path to a public surface — operator-doc in the user
+          position. Rewritten to honest user-facing copy: this branch
+          fires when the entire trending file is empty (collector hasn't
+          published yet or Redis is cold-starting), not just when the
+          24h window has nothing. */}
       <p style={{ marginTop: 12, maxWidth: "32rem", fontSize: 13, color: "var(--v4-ink-300)" }}>
-        The Hacker News scraper hasn&apos;t run yet. Run{" "}
-        <code style={{ color: "var(--v4-ink-100)" }}>npm run scrape:hn</code>{" "}
-        locally to populate{" "}
-        <code style={{ color: "var(--v4-ink-100)" }}>
-          data/hackernews-trending.json
-        </code>
-        , then refresh this page.
+        The Hacker News signal feed is warming up. Our hourly sweep usually
+        catches up within minutes — refresh the page shortly to see the
+        top stories ranked by velocity-weighted trending score.
       </p>
     </section>
   );


### PR DESCRIPTION
## Summary

Closes 2 P0s on /hackernews/trending per wave-6 audit. Stacks on origin/main.

## Fixes

| # | Severity | Defect | Fix |
|---|---|---|---|
| 1 | P0 | Hardcoded LiveDot pulse — FreshnessBadge never imported | Wired FreshnessBadge with `source="hackernews"` + `lastUpdatedAt={fetchedAt}` |
| 2 | P0 | Empty-state leaked `npm run scrape:hn` to public surface | Rewrote copy to user-facing |

Same honest-chrome pattern wave-3a (#1150) shipped on /signals.

## Test plan
- [x] impeccable detect clean
- [x] lint:guards green
- [x] typecheck green
- [ ] (recommended) visual smoke /hackernews/trending at 375px + 1280px, both populated and cold-branch states

🤖 Generated with [Claude Code](https://claude.com/claude-code)