### PR TITLE
audit(impeccable): wave 7a — cross-cutting CSS + a11y + token fixes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2313,6 +2313,13 @@ body::before {
   text-transform: uppercase;
 }
 
+@media (max-width: 640px) {
+  .tabs .tab {
+    min-height: 44px;
+    padding-block: 12px;
+  }
+}
+
 .tabs .tab.on {
   border-bottom-color: var(--acc);
   color: var(--ink-000);

--- a/src/app/hackernews/trending/page.tsx
+++ b/src/app/hackernews/trending/page.tsx
@@ -52,7 +52,7 @@ export const metadata: Metadata = {
   },
 };
 
-const HN_ORANGE = "#ff6600";
+const HN_ORANGE = "var(--source-hackernews)";
 
 function formatAgeHours(ageHours: number | undefined): string {
   if (ageHours === undefined || !Number.isFinite(ageHours)) return "—";

--- a/src/components/ui/LiveDot.tsx
+++ b/src/components/ui/LiveDot.tsx
@@ -31,7 +31,6 @@ export function LiveDot({ tone = "money", label, className }: LiveDotProps) {
     <span
       className={cn("v4-live-dot", `v4-live-dot--${tone}`, className)}
       role="status"
-      aria-live="polite"
     >
       <i className="v4-live-dot__pip" aria-hidden="true" />
       {label ? <span className="v4-live-dot__label">{label}</span> : null}

--- a/src/components/ui/__tests__/v4-chrome.test.tsx
+++ b/src/components/ui/__tests__/v4-chrome.test.tsx
@@ -45,11 +45,15 @@ describe("LiveDot", () => {
     expect(container.querySelector(".v4-live-dot__label")).toBeNull();
   });
 
-  it("renders an accessible status role", () => {
+  it("renders an accessible status role without aria-live", () => {
     const { container } = render(<LiveDot label="LIVE" />);
     const root = container.querySelector(".v4-live-dot");
     expect(root?.getAttribute("role")).toBe("status");
-    expect(root?.getAttribute("aria-live")).toBe("polite");
+    // aria-live intentionally absent per wave-7a audit decision: LiveDot is
+    // decorative; screen readers pick up freshness state via FreshnessBadge
+    // and surrounding text. The prior aria-live="polite" caused SRs to re-
+    // announce "LIVE" on every render across every consumer (P2 a11y noise).
+    expect(root?.getAttribute("aria-live")).toBeNull();
   });
 
   it("renders the label when provided", () => {


### PR DESCRIPTION
## Summary

Bundle of 3 single-file changes with global blast radius, per the /goal plan. Stacks on origin/main, independent of waves 1-6.

## Fixes

| Fix | File | Change | Blast radius |
|---|---|---|---|
| A | src/app/globals.css | Mobile-only `.tabs .tab` 44x44 tap target | 5+ source-feed routes |
| B | src/components/ui/LiveDot.tsx | Drop `aria-live="polite"` | Every LiveDot consumer (screen reader noise) |
| C | src/app/hackernews/trending/page.tsx | `HN_ORANGE = "#ff6600"` -> `var(--source-hackernews)` | HN brand color enters the themeable accent system |

## Why media-query (Fix A) over unconditional 44px

Desktop visual baseline unchanged. Minimal-sufficient rule per /goal plan.

## Test plan
- [x] impeccable detect clean on changed files (1 pre-existing finding at globals.css:1499 unrelated to this PR)
- [x] lint:guards green
- [x] typecheck green
- [ ] (recommended) visual smoke /hackernews/trending at 375px

Generated with Claude Code