### PR TITLE
audit(impeccable): wave 7e — /twitter formatClock honest fallback (1 P0)

### DIFF
--- a/src/app/twitter/page.tsx
+++ b/src/app/twitter/page.tsx
@@ -63,8 +63,10 @@ function parseTwitterTab(raw: string | string[] | undefined): TwitterTab {
 }
 
 function formatClock(iso: string | undefined | null): string {
-  if (!iso) return "warming";
-  return new Date(iso).toISOString().slice(11, 19);
+  if (!iso) return "—";
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime()) || parsed.getTime() === 0) return "—";
+  return parsed.toISOString().slice(11, 19);
 }
 
 const AUTHOR_BUBBLE_TONES = [


### PR DESCRIPTION
## Summary

Closes 1 P0 on /twitter per wave-6 audit. Stacks on origin/main.

## Fix

`src/app/twitter/page.tsx:65` — `formatClock(iso)` returned literal `"warming"` when `iso` was null. Rendered on the page-head as a clock face value — operator copy masquerading as live time. Same pattern wave-3c (PR #1152) closed for /funding.

```diff
 function formatClock(iso: string | undefined | null): string {
-  if (!iso) return "warming";
-  return new Date(iso).toISOString().slice(11, 19);
+  if (!iso) return "—";
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime()) || parsed.getTime() === 0) return "—";
+  return parsed.toISOString().slice(11, 19);
 }
```

Also guards against invalid Date + epoch-zero (matches the funding fix shape).

## Wave-6 P0 #1 (v2-live-dot on TwitterSignalPanel) — closed by wave-5

The wave-6 twitter audit's first P0 (`TwitterSignalPanel.tsx:38` hardcoded `v2-live-dot` pulse) is effectively closed by **wave-5 PR #1169**, which dropped the `.v2-live-dot` `box-shadow` rule globally in `globals.css`. The class remains as a static color-keyed dot; the pulse lie is gone. No additional action in wave-7e.

## Test plan
- [x] impeccable detect clean
- [x] lint:guards green
- [x] typecheck green
- [ ] (recommended) visual smoke /twitter at 375px + 1280px with null/missing lastScannedAt

🤖 Generated with [Claude Code](https://claude.com/claude-code)