### PR TITLE
chore(ci): migrate ci.yml to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   classify:
     name: Classify PR paths
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     outputs:
       data_only: ${{ steps.paths.outputs.data_only }}
@@ -82,7 +82,7 @@ jobs:
   gate:
     name: Typecheck, guards, tests, build, e2e
     needs: classify
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     steps:
       - name: Data-only fast path
@@ -142,9 +142,11 @@ jobs:
       # Cold-compile dev mode would blow the 30s test timeout in
       # playwright.config.ts on the first hit per route — production builds
       # serve every page sub-second, which is what the timeout assumes.
+      # Self-hosted runner has playwright deps pre-installed (apt 2026-05-13).
+      # --with-deps removed: needs root, ghrunner doesn't have passwordless sudo.
       - name: Install Playwright (chromium)
         if: needs.classify.outputs.data_only != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Seed Playwright repo fixtures
         if: needs.classify.outputs.data_only != 'true'
@@ -190,11 +192,14 @@ jobs:
           # TRENDINGREPO_* names during the brand migration.
           TRENDINGREPO_ALLOW_MISSING_ENV: "true"
           STARSCREENER_ALLOW_MISSING_ENV: "true"
+        # Port 13023 (not 3023) because the VPS self-hosted runner host already
+        # binds 127.0.0.1:3023 → toolbox-trendingrepo-1 container (production
+        # trendingrepo). Use 13023 to avoid the conflict during CI test runs.
         run: |
-          STARSCREENER_BASE_URL=http://localhost:3023 npx next start -p 3023 &
+          STARSCREENER_BASE_URL=http://localhost:13023 npx next start -p 13023 &
           echo $! > .next-pid
           for i in $(seq 1 60); do
-            if curl -sSf http://localhost:3023/ >/dev/null 2>&1; then
+            if curl -sSf http://localhost:13023/ >/dev/null 2>&1; then
               echo "server up after ${i}s"
               exit 0
             fi
@@ -209,7 +214,7 @@ jobs:
       - name: Playwright smokes
         if: needs.classify.outputs.data_only != 'true'
         env:
-          STARSCREENER_BASE_URL: http://localhost:3023
+          STARSCREENER_BASE_URL: http://localhost:13023
         # Gate the functional smoke specs. The visual screenshot suite under
         # tests/e2e/visual needs committed Linux baselines before it can run
         # reliably on a clean CI worker.
@@ -231,7 +236,7 @@ jobs:
     name: MCP server build
     needs: classify
     if: needs.classify.outputs.data_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Migrates all 3 jobs in \`ci.yml\` (classify, gate, mcp-build) from \`ubuntu-latest\` to \`[self-hosted, linux, x64]\`. The runner is \`gabagool-ams\` (id=21) on the Vultr Amsterdam VPS — pre-flighted earlier this session via PR chore/test-self-hosted-runner (docker access ok, labels resolve, fast cold start).

## Two adaptations vs upstream

1. **Drop \`--with-deps\` from playwright install.** System deps (libnss3, libgbm1, libnspr4, libasound2, et al — 16 packages total) pre-installed on VPS as of 2026-05-13 via \`apt-get install\`. \`ghrunner\` has no passwordless sudo, so \`--with-deps\` would fail. If a future Playwright version needs a new dep, install it via root SSH: \`apt-get install <pkg>\`.

2. **CI \`next start\` port 3023 → 13023.** Production \`toolbox-trendingrepo-1\` already binds \`127.0.0.1:3023\` on the VPS host. CI test runs would conflict. Port 13023 is free.

## Why now

Per the next-session handover §2.A.2, GHA-hosted quota has been forcing \`--admin --squash\` bypasses on every PR. This blocked the branch-protection signal we get from \"green CI = mergeable\". Now that the toolbox sibling PR #59 (verify.yml migration) is merged and proven, doing the same for the canonical starscreener CI gate gets us back to clean PR workflow.

## Verification

This PR's own CI run = the verification. If green, we know:
- \`actions/setup-node@v4\` works on self-hosted
- \`npm ci\` for the monorepo lockfile works
- \`npm run typecheck\`, \`lint:guards\`, \`check-v3-token-budget.mjs\`, \`test:hooks\` (93 vitest), \`test\` (node:test suite) all pass
- Playwright chromium runs without \`--with-deps\` (deps pre-installed)
- \`next start -p 13023\` doesn't conflict with prod trendingrepo on 3023
- \`mcp-build\` job builds the sibling MCP package

## Risk + rollback

- Risk: a missing playwright dep emerges → CI fails at the Playwright step. Fix: \`apt-get install <missing-pkg>\` on VPS, re-run CI.
- Risk: 13023 is somehow occupied at test time → \`next start\` fails. Pick a different port and push.
- Rollback: revert this PR; ubuntu-latest resumes; admin-merge pattern continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)