### PR TITLE
feat(ingest): emit fork_delta_basis + *_age_seconds in velocity dual-write (B.4)

### DIFF
--- a/scripts/__tests__/toolbox-ingest.test.mjs
+++ b/scripts/__tests__/toolbox-ingest.test.mjs
@@ -435,6 +435,52 @@ test("deltasToEvents — emits fork-velocity event when forks_now present", () =
   assert.ok(keys.includes("fork_delta_24h"));
 });
 
+test("deltasToEvents — emits fork_delta_<win>_basis when basis is present", () => {
+  const payload = {
+    repos: {
+      "10270250": {
+        stars_now: 100,
+        forks_now: 50,
+        fork_delta_24h: { value: 5, basis: "exact" },
+        fork_delta_7d: { value: 30, basis: "nearest" },
+      },
+    },
+  };
+  const events = deltasToEvents(payload, FAKE_REPO_METADATA);
+  const fork = events.find((e) => e.signal_type === "trending.github.fork.velocity");
+  const byKey = Object.fromEntries(fork.normalized.map((n) => [n.key, n.value]));
+  assert.equal(byKey.fork_delta_24h_basis, "exact");
+  assert.equal(byKey.fork_delta_7d_basis, "nearest");
+});
+
+test("deltasToEvents — emits *_age_seconds for cold-start basis", () => {
+  const payload = {
+    repos: {
+      "10270250": {
+        stars_now: 100,
+        forks_now: 50,
+        delta_24h: { value: 4, basis: "cold-start", age_seconds: 3600 },
+        fork_delta_24h: { value: 5, basis: "cold-start", age_seconds: 7200 },
+      },
+    },
+  };
+  const events = deltasToEvents(payload, FAKE_REPO_METADATA);
+  const stars = events.find((e) => e.signal_type === "trending.github.stars.velocity");
+  const fork = events.find((e) => e.signal_type === "trending.github.fork.velocity");
+  const starsByKey = Object.fromEntries(stars.normalized.map((n) => [n.key, n.value]));
+  const forkByKey = Object.fromEntries(fork.normalized.map((n) => [n.key, n.value]));
+  assert.equal(starsByKey.delta_24h_age_seconds, 3600);
+  assert.equal(forkByKey.fork_delta_24h_age_seconds, 7200);
+});
+
+test("deltasToEvents — omits *_age_seconds when basis is exact/nearest (no age field)", () => {
+  // FAKE_DELTAS_PAYLOAD has basis="exact" / "nearest" with no age_seconds.
+  const events = deltasToEvents(FAKE_DELTAS_PAYLOAD, FAKE_REPO_METADATA);
+  const stars = events.find((e) => e.signal_type === "trending.github.stars.velocity");
+  const keys = stars.normalized.map((n) => n.key);
+  assert.ok(!keys.some((k) => k.endsWith("_age_seconds")));
+});
+
 test("deltasToEvents — returns empty on missing payload or metadata", () => {
   assert.deepEqual(deltasToEvents(null, FAKE_REPO_METADATA), []);
   assert.deepEqual(deltasToEvents(FAKE_DELTAS_PAYLOAD, null), []);

--- a/scripts/_toolbox-ingest.mjs
+++ b/scripts/_toolbox-ingest.mjs
@@ -553,6 +553,8 @@ export function deltasToEvents(payload, repoMetadata) {
 
     // Stars-velocity event. Use pushNormalized to skip null delta values
     // (basis="repo-not-tracked" / "no-history" entries); jsonb NOT NULL.
+    // `_age_seconds` is emitted only for cold-start basis, where
+    // compute-deltas.mjs populates `age_seconds = now - picked_ts`.
     const starsNormalized = [];
     pushNormalized(starsNormalized, "stars_now", deltas.stars_now ?? 0, 1.0);
     for (const win of ["1h", "24h", "7d", "30d"]) {
@@ -561,6 +563,9 @@ export function deltasToEvents(payload, repoMetadata) {
         const conf = d.basis === "exact" ? 1.0 : d.basis === "nearest" ? 0.7 : 0.5;
         pushNormalized(starsNormalized, `delta_${win}`, d.value, conf);
         pushNormalized(starsNormalized, `delta_${win}_basis`, d.basis, 1.0);
+        if (typeof d.age_seconds === "number") {
+          pushNormalized(starsNormalized, `delta_${win}_age_seconds`, d.age_seconds, 1.0);
+        }
       }
     }
     if (starsNormalized.length > 0) {
@@ -575,6 +580,10 @@ export function deltasToEvents(payload, repoMetadata) {
     }
 
     // Fork-velocity event — only when forks_now is present (future-proof).
+    // Mirror the stars-velocity shape: emit value + basis + age_seconds so
+    // toolbox-store-velocity.ts can resolve the discriminated DeltaValue
+    // union without stubbing (kills the trade-off notes 1 and 2 in that
+    // file's header).
     if (typeof deltas.forks_now === "number") {
       const forkNormalized = [];
       pushNormalized(forkNormalized, "forks_now", deltas.forks_now, 1.0);
@@ -582,6 +591,10 @@ export function deltasToEvents(payload, repoMetadata) {
         const d = deltas[`fork_delta_${win}`];
         if (d && typeof d === "object") {
           pushNormalized(forkNormalized, `fork_delta_${win}`, d.value, 0.7);
+          pushNormalized(forkNormalized, `fork_delta_${win}_basis`, d.basis, 1.0);
+          if (typeof d.age_seconds === "number") {
+            pushNormalized(forkNormalized, `fork_delta_${win}_age_seconds`, d.age_seconds, 1.0);
+          }
         }
       }
       if (forkNormalized.length > 0) {


### PR DESCRIPTION
## Summary

Closes the 2 documented trade-offs in [src/lib/toolbox-store-velocity.ts](src/lib/toolbox-store-velocity.ts) by transmitting the missing fork basis + cold-start age_seconds from \`scripts/_toolbox-ingest.mjs\` to TOOLBOX.

## Changes

\`scripts/_toolbox-ingest.mjs\`:
- **Stars-velocity event** (lines ~557-565): emit \`delta_<win>_age_seconds\` when present (cold-start basis only). compute-deltas.mjs sets this via \`now - picked_ts\` in [line 190](scripts/compute-deltas.mjs).
- **Fork-velocity event** (lines ~580-596): emit \`fork_delta_<win>_basis\` (was missing entirely) AND \`fork_delta_<win>_age_seconds\` for cold-start.
- Both guarded by \`typeof d.age_seconds === "number"\` so exact/nearest (no age field) skip the push and stay compatible with the existing JSONB-NOT-NULL discipline.

\`scripts/__tests__/toolbox-ingest.test.mjs\` (3 new tests):
- Fork basis emitted when present.
- \`*_age_seconds\` emitted for cold-start (both stars + forks).
- \`*_age_seconds\` omitted when basis is exact/nearest.

All 30 tests pass locally (\`node --test scripts/__tests__/toolbox-ingest.test.mjs\`).

## Why

The velocity reader adapter [src/lib/toolbox-store-velocity.ts](src/lib/toolbox-store-velocity.ts) documents these in its file header:

1. \"Cold-start \`age_seconds\` stub\" — currently the adapter stubs \`age_seconds: 0\` because the dual-write doesn't send it.
2. \"Fork basis is LOST in transit\" — every fork delta currently lands as \`basis: \"no-history\"\` via buildDeltaValue's default-case.

After this PR + the next cron-velocity refresh, the new fields land in \`tb_signals.value\`. A follow-up PR will update \`buildDeltaValue\` in the adapter to consume them — that's when the stubs go away.

## Risk + rollback

- Risk: the new emitted fields could surprise the TOOLBOX validation. Mitigation: the new keys (\`*_basis\`, \`*_age_seconds\`) follow the existing \`pushNormalized\` pattern and JSONB normalized array shape — no schema change.
- Risk: tb_signals.value grows ~30 bytes per velocity event due to the new fields. Negligible.
- Rollback: revert the PR; the adapter continues stubbing as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)