### PR TITLE
audit(impeccable): wave 8 — P1 mechanical sweep (13 findings closed)

### DIFF
--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -120,7 +120,10 @@ function formatAge(value: string): string {
 }
 
 function sourceName(source: string): string {
-  return SOURCE_LABELS[source] ?? source.replaceAll("-", " ");
+  if (SOURCE_LABELS[source]) return SOURCE_LABELS[source];
+  return source
+    .replaceAll("-", " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function roundName(signal: FundingSignal): string {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2132,14 +2132,6 @@ body::before {
   line-height: 1.2 !important;
 }
 
-.feat-card .desc {
-  display: none;
-}
-
-.feat-card .why {
-  display: none;
-}
-
 .feat-card .badge {
   font-size: var(--font-size-xs) !important;
 }

--- a/src/app/hackernews/trending/page.tsx
+++ b/src/app/hackernews/trending/page.tsx
@@ -181,7 +181,6 @@ function WindowedHnFeed({ allStories }: { allStories: HnStory[] }) {
       table24h={<HnStoryFeed stories={w24h} />}
       table7d={<HnStoryFeed stories={w7d} />}
       table30d={<HnStoryFeed stories={w30d} />}
-      defaultWindow="7d"
     />
   );
 }

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -437,7 +437,7 @@ function TrendingThisWeek({ movers, totalRows }: TrendingThisWeekProps) {
         marginBottom: 16,
         border: "1px solid var(--v4-line-200)",
         background: "var(--v4-bg-050)",
-        borderRadius: 4,
+        borderRadius: 2,
       }}
     >
       <header
@@ -514,7 +514,7 @@ function TrendingThisWeek({ movers, totalRows }: TrendingThisWeekProps) {
                     gap: 10,
                     padding: "8px 10px",
                     border: "1px solid var(--v4-line-200)",
-                    borderRadius: 3,
+                    borderRadius: 2,
                     background: "var(--v4-bg-100)",
                     textDecoration: "none",
                     color: "var(--v4-ink-100)",
@@ -566,7 +566,7 @@ function TrendingThisWeek({ movers, totalRows }: TrendingThisWeekProps) {
                       fontFamily: "var(--font-geist-mono), monospace",
                       fontSize: 11,
                       fontWeight: 600,
-                      color: "var(--v4-up, #4ade80)",
+                      color: "var(--v4-money)",
                       flexShrink: 0,
                     }}
                     title={`+${deltaLabel} ${unitLabel} · 7d`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -862,7 +862,7 @@ export default async function HomePage() {
 
         <MetricGrid columns={6}>
           <Metric label="coverage" value={formatCompact(repos.length)} sub="tracked repos" />
-          <Metric label="stars today" value={formatCompact(total24h)} delta="+ live" tone="positive" />
+          <Metric label="stars today" value={formatCompact(total24h)} sub="24h aggregate" tone="positive" />
           <Metric label="weekly stars" value={formatCompact(total7d)} sub="7d window" />
           <Metric label="consensus now" value={consensusRepos.length} sub="top multi-source" tone="consensus" />
           <Metric label="breakouts now" value={breakoutRepos.length} sub="above baseline" tone="accent" />

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -542,9 +542,9 @@ export default async function SignalsPage({ searchParams }: SignalsPageProps) {
             role="status"
             style={{
               padding: "10px 14px",
-              border: "1px solid var(--color-border, rgba(255,255,255,0.08))",
-              borderRadius: 8,
-              color: "var(--color-muted, #888)",
+              border: "1px solid var(--color-border-default)",
+              borderRadius: 2,
+              color: "var(--color-text-subtle)",
               fontFamily: "var(--font-geist-mono), monospace",
               fontSize: 12,
               letterSpacing: "0.06em",

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -642,7 +642,7 @@ function ListTaxonomyTabs({
               alignItems: "baseline",
               gap: 6,
               padding: "5px 10px",
-              borderRadius: 3,
+              borderRadius: 2,
               textTransform: "uppercase",
               letterSpacing: "0.08em",
               textDecoration: "none",

--- a/src/components/funding/WindowedFundingBoard.tsx
+++ b/src/components/funding/WindowedFundingBoard.tsx
@@ -30,6 +30,8 @@ export function WindowedFundingBoard({
 }: Props) {
   const [win, setWin] = useState<FundingWindow>(defaultWindow);
   const rows = win === "24h" ? rows24h : win === "30d" ? rows30d : rows7d;
+  const tabId = (w: FundingWindow) => `funding-window-tab-${w}`;
+  const panelId = (w: FundingWindow) => `funding-window-panel-${w}`;
 
   return (
     <>
@@ -42,9 +44,11 @@ export function WindowedFundingBoard({
         {(["24h", "7d", "30d"] as const).map((w) => (
           <button
             key={w}
+            id={tabId(w)}
             type="button"
             role="tab"
             aria-selected={win === w}
+            aria-controls={panelId(w)}
             className={`tab${win === w ? " on" : ""}`}
             onClick={() => setWin(w)}
           >
@@ -55,9 +59,6 @@ export function WindowedFundingBoard({
           <span
             className="muted"
             style={{
-              fontFamily: "var(--v4-mono)",
-              letterSpacing: "0.14em",
-              textTransform: "uppercase",
               fontSize: "9.5px",
               fontVariantNumeric: "tabular-nums",
             }}
@@ -66,7 +67,12 @@ export function WindowedFundingBoard({
           </span>
         </span>
       </div>
-      <section className="board funding-board">
+      <section
+        id={panelId(win)}
+        role="tabpanel"
+        aria-labelledby={tabId(win)}
+        className="board funding-board"
+      >
         {rows.length === 0 ? (
           <div
             style={{

--- a/src/components/signals-terminal/SourceFeedPanel.tsx
+++ b/src/components/signals-terminal/SourceFeedPanel.tsx
@@ -332,7 +332,7 @@ function TweetFeed({ items, source }: { items: TweetItem[]; source: SourceKey })
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  border: "1.5px solid var(--color-bg-shell)",
+                  border: "1px solid var(--color-bg-shell)",
                 }}
               >
                 <SourceMark source={source} size={8} monochrome />

--- a/src/components/signals-terminal/SourceFilterBar.tsx
+++ b/src/components/signals-terminal/SourceFilterBar.tsx
@@ -258,6 +258,7 @@ export function SourceFilterBar({
         prefetch={false}
         className={`signals-chip${isAllOn ? " signals-chip-on" : ""}`}
         aria-pressed={isAllOn}
+        aria-label="All sources"
       >
         ALL
       </Link>
@@ -365,6 +366,7 @@ export function SourceFilterBar({
           topic === null ? " signals-chip-on" : ""
         }`}
         aria-pressed={topic === null}
+        aria-label="All topics"
       >
         ALL
       </Link>


### PR DESCRIPTION
## Summary

Cherry-picks 13 P1 (and 1 closely-coupled P0) mechanical fixes from the 9 existing audit reports (waves 2/4/6) that survive cross-cutting closures from waves 5/7. Each fix is 1-3 lines, audit-prescribed, surgical. Stacks on origin/main.

## Fixes (13 total)

| # | Surface | File:line | Defect | Fix |
|---|---|---|---|---|
| 1 | /funding | page.tsx:122 | sourceName fallback returns lowercased kebab text | Title-case the fallback |
| 2 | /funding | WindowedFundingBoard.tsx:36-69 | tablist missing tabpanel association (SR can't tie selection to panel) | Wire id + aria-controls + role="tabpanel" + aria-labelledby |
| 3 | /funding | WindowedFundingBoard.tsx:55-66 | Redundant inline fontFamily/letterSpacing/textTransform (parent already sets) | Drop the three redundant declarations |
| 4 | /signals | SourceFilterBar.tsx:260 | source-filter ALL chip missing aria-label (only visible text is "ALL") | Add aria-label="All sources" |
| 5 | /signals | SourceFilterBar.tsx:367 | topic-filter ALL chip missing aria-label | Add aria-label="All topics" |
| 6 | /signals | page.tsx:545 | KpiStrip empty-state uses var(--color-border, rgba(...)) fallback + borderRadius 8 + var(--color-muted, #888) | Canonical tokens (--color-border-default, --color-text-subtle) + borderRadius 2 |
| 7 | /signals | SourceFeedPanel.tsx:335 | Off-ladder 1.5px avatar border | 1px (canonical --border-width-hairline) |
| 8 | /mcp (P0) | page.tsx:569 | Undefined var(--v4-up, #4ade80) — breaks theme-skin | var(--v4-money) (canonical positive-delta token) |
| 9 | /mcp | page.tsx:440 | Hero borderRadius 4 (violates 2px card spec) | borderRadius 2 |
| 10 | /mcp | page.tsx:517 | Mover-row borderRadius 3 (violates 2px spec) | borderRadius 2 |
| 11 | /skills | page.tsx:645 | Tab link borderRadius 3 (--radius-button is 2px) | borderRadius 2 |
| 12 | / (home) | globals.css:2135-2141 | Dead .feat-card .desc / .why display:none rules (component never emits these classes) | Delete the two rules |
| 13 | / (home) | page.tsx:865 | Metric stars-today has delta="+ live" fake green pill | Replace with sub="24h aggregate" |
| 14 | /hackernews/trending | page.tsx:184 | Dead defaultWindow="7d" prop (component default already "7d") | Remove the prop |

(Counting #8 as the bonus P0 — it's a 1-LOC token swap, audit-prescribed, no design judgment.)

## Selection criteria

Mechanical (1-3 LOC), no design judgment, no prop threading, file:line ref still valid post-waves-5/7, independent. Skipped ambiguous P1s and "operator-pick-direction" items.

### Skipped P1s (and why)

- **funding tab 44px tap target** — closed by wave-7a `.tabs .tab` cross-cutting fix (PR #1175)
- **HN LiveDot label / cold-state copy / HN_ORANGE token** — closed by waves 7a/7c (PRs #1174/#1175)
- **twitter formatClock / LiveDot pulse / tab tap target** — closed by waves 5/7a/7e (PRs #1169/#1175/#1177)
- **repo-detail v2-live-dot box-shadow / OrganizationCard try/catch / avatar gradient** — closed by wave-5 (PR #1169)
- **reddit/trending hover + radii + dead code** — closed by waves 7b/7d (PRs #1173/#1176)
- **Honest-chrome LIVE callsites on /home (HeroPanel/BubbleMap/LiveTopTable)** — design call: requires per-source lastFetchedAt threading from page envelopes, not 1-3 LOC. Deferred.
- **`/signals` LIVE on SourceFeedPanel/VolumeAreaChart** — design call: requires verdictBySource lookup threading through the page. Deferred.
- **repo-detail 11x border-radius 3px → 2px sweep** — crosses 11 files, deferred to dedicated radius-sweep PR.
- **Tab tabpanel ARIA on `/twitter` and `/hackernews`** — would require state-machine refactor beyond 3 LOC.
- **All "Design call" findings** in every audit — skipped per the selection criteria.

## Test plan
- [x] Each fix verified: re-grep audit ref → defect closed
- [x] `npx impeccable detect --json` clean on all 10 changed files (globals.css has 1 pre-existing `side-tab` finding for functional border-left rails which CLAUDE.md explicitly allows — verified unchanged from baseline)
- [x] `npm run lint:guards` green
- [x] `npm run typecheck` green
- [ ] (recommended) visual smoke each surface at 375px post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)