### PR TITLE
audit(impeccable): wave 8 — 5 more surface audits (/compare /breakouts /huggingface /collections /tierlist, ~99 findings)

### DIFF
--- a/docs/audits/impeccable/breakouts-audit.md
+++ b/docs/audits/impeccable/breakouts-audit.md
@@ -1,0 +1,142 @@
+# Impeccable Audit — `/breakouts`
+
+**Scope:** `src/app/breakouts/{page,loading,error}.tsx`, `src/components/breakouts/ChannelHeatStrip.tsx`, plus the `.board` / `.lb-row` / `.chip` chrome in `src/app/globals.css`.
+**Surface:** Cross-Signal Breakouts leaderboard — high-traffic, public.
+**Date:** 2026-05-13 · Wave 8.
+
+---
+
+## Headline
+
+`/breakouts` lies about its own freshness in three places and ships a green-coded "consensus" badge on rows whose 24h delta is **negative**. The leaderboard's six-column grid mislabels its own columns ("Channels" carries only GitHub; "Signals" carries Reddit+HN), and the page advertises six signal sources in the OG description but renders only three. Chrome is in place (PageHead + VerdictRibbon + FreshnessBadge + FreshnessChip), but the wiring is incorrect: `force-static` + the build-frozen `lastFetchedAt` import constant means the badge reports build-time age forever. The standalone `ChannelHeatStrip` primitive — explicitly designed for this route per its own header comment — is unused. Filter chips are 24px tall (fail 44×44 mobile).
+
+**Counts:** 4 P0 · 5 P1 · 4 P2 · 2 P3.
+
+---
+
+## P0 — Honest chrome / correctness
+
+### P0-1 — `force-static` + `lastFetchedAt` constant freezes freshness at build time
+**File:** `src/app/breakouts/page.tsx:20`, `:7`, `:112`, `:240`
+**Evidence:** `export const dynamic = "force-static"` + `import { lastFetchedAt } from "@/lib/trending"`. `lastFetchedAt` is exported as a captured-at-import-time constant (`src/lib/trending.ts:57`), not the live getter `getLastFetchedAt()`. The badge and per-row chip will read the data file's `fetchedAt` from whenever the build ran — usable for hours/days. There is no ISR `revalidate` either.
+**Fix:** Either (a) switch to `dynamic = "force-dynamic"` + call `await refreshTrendingFromStore()` and use `getLastFetchedAt()`, or (b) add `export const revalidate = 1800` and still use the getter so each ISR window reads the in-memory cache post-refresh. Per CLAUDE.md "data reads MUST go through the data-store."
+**Call:** Mechanical.
+
+### P0-2 — VerdictRibbon stamp asserts "refreshed live" on a force-static page
+**File:** `src/app/breakouts/page.tsx:122`
+**Evidence:** `sub: \`of ${totalFiring} firing · ${allThree} all-three · refreshed live\``. The page is `force-static`; nothing is live. This is a hardcoded LIVE-class assertion outside `<FreshnessBadge>` / `classifyFreshness()` — the exact pattern the project rules name as P0.
+**Fix:** Replace with a derived age (e.g. `\`updated ${ageLabel}\`` computed from `getLastFetchedAt()`), or drop the phrase entirely. Let the FreshnessBadge in the clock slot carry the verdict.
+**Call:** Design + mechanical.
+
+### P0-3 — `.badge.cons` renders ALL delta24 values in green, including negatives
+**File:** `src/app/breakouts/page.tsx:255-258`; CSS `src/app/globals.css:5371-5376`
+**Evidence:** Row badge is hardcoded `className="badge cons"` with the consensus token (`--b-cons` → `--color-positive`, green). `deltaLabel` can be `-500` when `delta24 < 0` (line 220), but the badge stays green. A negative momentum number tinted green is misleading numeric encoding on a momentum surface.
+**Fix:** Branch the modifier by sign: `cn("badge", delta24 > 0 && "cons", delta24 < 0 && "div", delta24 === 0 && "single")` — the divergence (amber) and single (neutral) tokens already exist at `globals.css:5385-5403`. Optionally suppress the badge entirely when `delta24 === 0`.
+**Call:** Mechanical (semantic bug).
+
+### P0-4 — OG / meta description promises six sources, surface delivers three
+**File:** `src/app/breakouts/page.tsx:24-39`
+**Evidence:** metadata.description = "GitHub stars, Reddit, Hacker News, Bluesky, dev.to, and X/Twitter". `visibleFiring()` (line 55-58) sums only `github`, `reddit`, `hn` from `getChannelStatus`. The page renders three rank columns, the SEO claim says six. Public-page truthfulness rule.
+**Fix:** Either align the description to the rendered three-channel reality, or extend `getChannelStatus`/`visibleFiring` to include the four missing channels. Lede on line 107 already correctly says "Three signal sources" — copy that into metadata.
+**Call:** Mechanical.
+
+---
+
+## P1 — Hierarchy & honesty
+
+### P1-1 — Column headers "Channels" + "Signals" don't match content split
+**File:** `src/app/breakouts/page.tsx:207-214`, `:248-254`
+**Evidence:** Header row declares 6 columns: `# · Repository · Score · Channels · Signals · 24h`. Body row puts ONLY GH under "Channels" and Reddit+HN under "Signals". There's no semantic distinction — all three are channels and signals. Scanning a row, the reader can't reconcile "GH appears under Channels but R/HN appear under Signals."
+**Fix:** Merge into a single "Channels" cell containing all three pips (GH | R | HN) in a 3-grid, drop the second column, and rebalance the grid template (`42px 1fr 92px 130px 100px`).
+**Call:** Design.
+
+### P1-2 — `ChannelHeatStrip` exists, is documented for this route, and is unused
+**File:** `src/components/breakouts/ChannelHeatStrip.tsx:1-17` (header comment: "24-cell hourly heatmap used in sub-pages.html § /breakouts polish"); `src/app/breakouts/page.tsx` (no import)
+**Evidence:** The breakout surface ranks repos by momentum but shows no temporal shape — a reader can't tell whether a `+1.2k` delta is one spike or a steady climb. The primitive built for exactly this gap is sitting unused.
+**Fix:** Compute per-repo hourly bucket from existing signal timestamps (derive in `getDerivedRepos`) and render `<ChannelHeatStrip hours={...}>` inside `.lb-row .repo` under the description line. Falls back to invisible if hours unavailable.
+**Call:** Design.
+
+### P1-3 — FreshnessBadge wired with `source="mcp"` on a breakout/cross-signal page
+**File:** `src/app/breakouts/page.tsx:112`
+**Evidence:** `<FreshnessBadge source="mcp" lastUpdatedAt={lastFetchedAt} />`. The `mcp` threshold is set for slow-cron MCP feeds; the breakout source is the trending pipeline (refreshed by /api collectors + Redis). Picking the wrong `NewsSource` mis-classifies live/warn/cold — a 90-min-old payload could read FRESH on the slow MCP threshold when it is actually STALE for trending.
+**Fix:** Use the matching source. If `classifyFreshness` lacks a "trending" or "github-cron" key, add it; otherwise use the closest cadence (3h cron → roughly the `skills` or a new `trending` band).
+**Call:** Mechanical.
+
+### P1-4 — `FreshnessChip updatedAt={lastFetchedAt}` on every row reuses page-level timestamp
+**File:** `src/app/breakouts/page.tsx:240`
+**Evidence:** All 50 rows render the same chip value (the page-wide `lastFetchedAt`). The chip's purpose per its header comment is "per-row freshness companion" — one value for every row makes it ornamental noise that defeats the chip's purpose and adds 50× redundant token weight.
+**Fix:** Either (a) drop the per-row chip and let the page-level FreshnessBadge carry it, or (b) wire per-repo signal-last-seen (e.g. `repo.lastSignalAt` from `getDerivedRepos`) so the chip actually differs row-to-row.
+**Call:** Design.
+
+### P1-5 — Score "conf-bar" caps at 100% but `crossSignalScore` is unbounded
+**File:** `src/app/breakouts/page.tsx:223`
+**Evidence:** `score = Math.max(4, Math.min(100, Math.round((repo.crossSignalScore ?? 0) * 32)))`. The 32× multiplier and 100 clamp encode an assumption that the score lives in `[0, 3.125]`. A repo at score 5.0 (top hit) shows the same 100% bar as a repo at 3.125 (mid-pack). The bar stops differentiating the highest scorers — the exact rows the page exists to surface.
+**Fix:** Normalize against the page's actual max: `score = Math.round((repo.crossSignalScore / topScore) * 96) + 4` (topScore is already computed at line 89). Keeps a 4% floor for legibility, scales the rest honestly.
+**Call:** Mechanical.
+
+---
+
+## P2 — Information density, accessibility
+
+### P2-1 — Filter chips 24px tall — fail 44×44 mobile tap target
+**File:** `src/app/breakouts/page.tsx:188-198`; CSS `src/app/globals.css:5220-5229`
+**Evidence:** `.chip` is `height: 24px`. The three filter chips ("All firing" / "2+ channels" / "3 channels") are the primary mobile interaction on the page. At 375px width with 16px gutters, they sit in a row alongside the "Filter" label and the "N repos" right-counter — finger targets ~24×60.
+**Fix:** Add a mobile-only override: `@media (max-width: 640px) { .filter-bar .chip { min-height: 44px; padding: 0 14px; } }`. Don't bloat desktop.
+**Call:** Mechanical (a11y).
+
+### P2-2 — `.rb us` / `.rb gh` / `.rb hf` class names are semantically scrambled
+**File:** `src/app/breakouts/page.tsx:249-253`
+**Evidence:** GitHub uses `rb us`, Reddit uses `rb gh`, Hacker News uses `rb hf`. The `.us` class makes the value orange (`.rb.us .v` → `--acc`), `.hf` makes it amber. Class names are inherited from a prior route incarnation and now lie about their content; any future maintainer reading "GH" and a class of "us" will lose 10 minutes.
+**Fix:** Rename to `rb rb-github` / `rb rb-reddit` / `rb rb-hn` with matching CSS aliases, deprecate the old class names. Surgical CSS rename.
+**Call:** Mechanical.
+
+### P2-3 — "NOISE" KPI tile has no filter affordance
+**File:** `src/app/breakouts/page.tsx:160-166`, `:188-198`
+**Evidence:** KpiBand cell labelled "NOISE" with `oneChannel` count exists, but the three filter chips offer "all / multi / three" only — no "noise / single channel" toggle. The reader is told "32 single-channel" but cannot click to inspect them.
+**Fix:** Add a fourth filter key `"single"` → `r._firing === 1`, and a chip "1 channel".
+**Call:** Design.
+
+### P2-4 — Score column splits `(score)` from `(conf-bar)` but no width for narrow rows
+**File:** `src/app/breakouts/page.tsx:244-247`; CSS `src/app/globals.css:6018-6035`
+**Evidence:** `.score` is `align-items: flex-end; gap: 3px`, conf-bar is `width: 78px; height: 3px`. On 901-1100px viewport, grid is `42px 1fr 92px 102px 96px 100px` — the 92px score column hosts a 78px bar plus the score text plus right-align padding. Bar and score number stack vertically inside a 92px cell; at the breakpoint just before 900px collapse, the bar bumps against the next column.
+**Fix:** Either widen the grid column (`110px`) or shrink the bar (`width: 64px`).
+**Call:** Mechanical.
+
+---
+
+## P3 — Polish
+
+### P3-1 — Repo avatar shows two uppercase letters of `fullName`, includes the `/`
+**File:** `src/app/breakouts/page.tsx:234`
+**Evidence:** `repo.fullName.slice(0, 2).toUpperCase()` — for "vercel/next.js" produces "VE", for "a/b" produces "A/". The slash-edge case is real on short org names.
+**Fix:** `repo.owner.slice(0, 2).toUpperCase()` — owner is already split on the Repo type.
+**Call:** Mechanical.
+
+### P3-2 — Empty-state copy is bare; no recovery affordance
+**File:** `src/app/breakouts/page.tsx:201-204`
+**Evidence:** `"No repos match this filter right now."` — no link back to a looser filter. User who landed on `?filter=three` and saw 0 has to discover the filter chips above.
+**Fix:** Add a "Try '2+ channels' →" recovery link inside the empty state, defaulting to the next-looser filter.
+**Call:** Design.
+
+---
+
+## What's already right
+
+- PageHead + VerdictRibbon + KpiBand + SectionHead all primitives-correct.
+- 2px radii (`rounded-[2px]` in loading, no shadows applied).
+- Side-tab `border-left: 2px solid var(--acc)` on `.lb-row.first` is the canonical "leader" rail — keep.
+- Loading skeleton mirrors the rendered layout (4-col KPI band, 12 row strips).
+- Mobile collapse at 900px stacks score/badge/gauge/ranks into column 2 — sound.
+- `scroll={false}` on filter Links prevents jarring scroll resets.
+
+---
+
+## Mechanical vs Design split
+
+| Class | Count | Where it lives |
+|---|---|---|
+| Mechanical | 9 | P0-1, P0-3, P0-4, P1-3, P1-5, P2-1, P2-2, P2-4, P3-1 |
+| Design | 5 | P0-2 (also mech), P1-1, P1-2, P1-4, P2-3, P3-2 |
+| Both | 1 | P0-2 |
+
+Mechanical = code/wiring fixes touching the page and the data-store integration. Design = visual hierarchy and component-composition decisions that move the surface from "leaderboard chrome" to "breakout-first scanning instrument."

--- a/docs/audits/impeccable/collections-audit.md
+++ b/docs/audits/impeccable/collections-audit.md
@@ -1,0 +1,128 @@
+## /collections audit — 2026-05-13
+
+Focus: the collections index (`/collections`) plus the slug detail (`/collections/[slug]`) it links into. Curated AI-repo lists ranked live against the trending index, attributed to OSS Insight (Apache 2.0).
+
+## Files audited
+
+- [src/app/collections/page.tsx](../../../src/app/collections/page.tsx) — index
+- [src/app/collections/[slug]/page.tsx](../../../src/app/collections/[slug]/page.tsx) — slug detail (V4 ProfileTemplate)
+- [src/app/collections/layout.tsx](../../../src/app/collections/layout.tsx) — imports `compare.css` + `categories.css`
+- [src/app/collections/loading.tsx](../../../src/app/collections/loading.tsx) — skeleton
+- [src/app/collections/error.tsx](../../../src/app/collections/error.tsx) — error boundary
+- [src/lib/collections.ts](../../../src/lib/collections.ts) — `formatFreshness`, `summarizeCollection`
+- [src/components/categories/categories.css](../../../src/components/categories/categories.css) — `.collection-card`, `.collection-freshness`, `.collection-foot`
+- [src/app/globals.css](../../../src/app/globals.css) — `.page-head .clock .live`, `.panel-head .right .live`, `.tool`
+- [src/components/ui/v4.css](../../../src/components/ui/v4.css) — `.v4-collection-activity`, `.v4-collection-rail-list`
+
+## P0 findings (honest-chrome + canonical-badge)
+
+- **[P0] Hardcoded green-pulse `<span className="live">` violates honest-chrome rule (2 sites on index)** — [page.tsx:83](../../../src/app/collections/page.tsx#L83) renders `<span className="live">collections live</span>` inside `.page-head .clock`; [page.tsx:92](../../../src/app/collections/page.tsx#L92) renders `<span className="live">Updated {freshness}</span>` inside `.panel-head .right`. Both inherit the `.live` style at [globals.css:1657-1673](../../../src/app/globals.css#L1657) / [globals.css:4134-4150](../../../src/app/globals.css#L4134) which sets `color: var(--sig-green)` plus a 5–6px green ::before dot with `box-shadow: var(--shadow-live)`. The pulse fires unconditionally — when `getCollectionRankingsFetchedAt()` returns null, `formatFreshness` returns "never" and the page literally renders "Updated never" with a green-pulse halo. This is the exact pattern memory `feedback_freshness_chrome_must_be_honest` flags: bypassing `<FreshnessBadge>` / `classifyFreshness()` and inlining a hardcoded LIVE/green-pulse. **Mechanical fix.**
+
+- **[P0] Page never renders the canonical `<FreshnessBadge>`** — [page.tsx](../../../src/app/collections/page.tsx) imports `formatFreshness` from `@/lib/collections` but never imports `FreshnessBadge` from `@/components/shared/FreshnessBadge`. Every other audited surface (`/mcp`, `/skills`, `/news`) wires the badge next to the page-head clock so the verdict (`fresh`/`stale`/`cold`) routes through one classifier. Without it, /collections is the only top-level data surface whose freshness has no machine-classified verdict — a user can't tell 1h-fresh from 7d-stale rankings. Fix: import `FreshnessBadge`, add `<FreshnessBadge source="<closest enum>" lastUpdatedAt={collectionRankingsFetchedAt} />` next to the clock, and delete the `.live` chrome around `formatFreshness`. **Mechanical fix once a `NewsSource` enum value is picked.**
+
+## P1 findings (mobile + radius drift on the slug detail)
+
+- **[P1] `.v4-collection-rail-list__link` fails 44×44 mobile tap target** — [v4.css:2711-2721](../../../src/components/ui/v4.css#L2711). Padding `8px 12px` + 11px font ≈ 27px tall. The right-rail "Related collections" list is a primary cross-nav (each row links to another collection), and it's well below the 375px minimum height rule. Fix: `padding: 12px 14px; min-height: 44px;` (matches the `/mcp` `.fchip` fix shape from wave-2).
+
+- **[P1] Card radius drift on the [slug] detail — 4px tiles inside a 2px-card system** — [[slug]/page.tsx:446](../../../src/app/collections/[slug]/page.tsx#L446) inline `borderRadius: 4` on the identity-strip 2-letter tile; [v4.css:2620](../../../src/components/ui/v4.css#L2620), [v4.css:2661](../../../src/components/ui/v4.css#L2661), [v4.css:2702](../../../src/components/ui/v4.css#L2702) all set `border-radius: 4px` on the activity feed, rail card, and rail list. DESIGN.md cards = 2px (`--radius-card: 0.125rem`). Topic chips on the same component correctly use `borderRadius: 2` at [[slug]/page.tsx:501](../../../src/app/collections/[slug]/page.tsx#L501) — so the inconsistency is visible within a single eyeful. Fix: swap all four hits to `2px` / `var(--radius-card)`. **Mechanical.**
+
+- **[P1] Loading skeleton diverges from the rendered grid** — [loading.tsx:21](../../../src/app/collections/loading.tsx#L21) renders `grid-cols-1 sm:grid-cols-2 md:grid-cols-3` with 9 cards. The real `.collections-grid` is `repeat(3, ...)` ≥1100px, `repeat(2, ...)` 640–1100px, `1fr` <640px ([categories.css:108-119](../../../src/components/categories/categories.css#L108)) — so at the 768–1099px window the skeleton shows 3 columns while the real page shows 2, producing a visible layout jolt on hand-off. Also 9 cards understates the 28 collections currently shipping. Fix: align breakpoints (`md:grid-cols-2 xl:grid-cols-3`), bump skeleton to 12 cards. **Mechanical.**
+
+## P2 findings (motion, empty-state copy, attribution position)
+
+- **[P2] `.tool:hover` has no transition — border-color snaps instantly** — [globals.css:3588-3590](../../../src/app/globals.css#L3588). Card hover swaps `--line-200` → `--line-400` with no `transition: border-color 150ms ease`. DESIGN.md wants 120–180ms non-bouncy on hover. Affects every `/collections` card + every other `.tool` consumer in the app. Single-property fix on `.tool`. **Mechanical.**
+
+- **[P2] Empty-state copy leaks implementation detail (mirrors /mcp wave-2 finding)** — [page.tsx:103](../../../src/app/collections/page.tsx#L103) reads `"Collections are curated via data/collections/*.yml."` This is a build-time invariant the user never sees (28 YAMLs ship in the repo), and surfaces a filesystem path. Same anti-pattern wave-2 caught on `/mcp` ("the cron writes to Redis at 03:30 UTC..."). Fix: either delete the section entirely (unreachable in practice) or rewrite as user-facing copy: `"// no collections yet · check back soon"`. **Design call** — operator may want to keep the path for transparency.
+
+- **[P2] Index has no sort or filter for 28 collections** — [page.tsx:106-130](../../../src/app/collections/page.tsx#L106). Cards render alphabetically by slug; no chip to filter by `moving > 0`, no sort by `live` count, no search. With 28 cards at 178px min-height that's a 1900px+ scroll on mobile. Collections with breakouts get buried below `agent-skills.yml`. Lowest-effort fix: a single "MOVING NOW" toggle chip above the grid using the existing `.live-top-filters .fchip` primitive (already in `globals.css`). **Design call.**
+
+- **[P2] Curator attribution buried in the footer** — [page.tsx:132-142](../../../src/app/collections/page.tsx#L132). Every card represents OSS Insight curation, but the attribution sits 1900px below the grid in a footer the user almost certainly never reaches. The [slug] page handles this correctly with `CURATOR_NAME` in the identity strip + the right-rail About card. Fix: hoist a one-line attribution into `.page-head` ("Curated by OSS Insight") or into the `.collection-freshness` panel-head. **Design call.**
+
+- **[P2] Clock "X collections live" overloads "live"** — [page.tsx:81-84](../../../src/app/collections/page.tsx#L81). The count is correct, but pairing the number with the word "live" + green pulse implies real-time data. Collections are static YAMLs; only the rankings refresh. Copy nit: "X total" or "X curated lists" with the data-freshness verdict moved to the (canonical) `<FreshnessBadge>`. Bundled with the P0 honest-chrome fix.
+
+- **[P2] `compare-empty-state` reused for collections index empty-state — wrong domain class** — [page.tsx:99](../../../src/app/collections/page.tsx#L99). The CSS lives under `.compare-*` and is imported via `compare.css` in the layout. The class name is misleading and any future `/compare` change accidentally affects `/collections`. Move the empty-state to a `.collections-empty-state` selector or use a shared `.empty-state` primitive. **Mechanical refactor.**
+
+## What's working well — keep
+
+- **Cards uphold the 2px-radius / no-shadow contract on the index.** `.tool` uses border-only (`var(--line-200)`), `.collection-card` adds a 2px top border without per-card color-keys — no side-tab AI-slop. ([categories.css:13](../../../src/components/categories/categories.css#L13))
+- **Honest stub-data discipline.** `summarizeCollection` only counts repos with `movementStatus` set; `liveCountFor` only counts items present in the live index. No fabricated "moving now" counts on quiet collections. ([collections.ts:204-226](../../../src/lib/collections.ts#L204))
+- **Mobile reflow is clean.** Grid steps 3→2→1 at 1100/640. Page-head stacks at 767. No horizontal-scroll risk at 375px.
+- **Error boundary uses canonical V4 tokens + Sentry capture** ([error.tsx](../../../src/app/collections/error.tsx)).
+- **Detail page wires the `RelatedRepoCard` shared primitive + V4 `ProfileTemplate`** — the [slug] avoids ad-hoc layouts.
+
+## Verify-in-context
+
+Before shipping fixes:
+- `npm run dev` → load `http://localhost:3023/collections` at 375px and 1440px.
+- Wipe `collectionRankingsFetchedAt` (set Redis key to null OR cold-boot): confirm the page does NOT render "Updated never" with a green pulse — should render the COLD verdict via `<FreshnessBadge>`.
+- Tab through the `.collection-card` grid → confirm focus ring; hover one → confirm transition is 120–180ms.
+- Open a slug page at 375px → confirm `.v4-collection-rail-list__link` is ≥44px tap target.
+
+## Mechanical fixes ready to ship
+
+1. **P0** [page.tsx:81-95](../../../src/app/collections/page.tsx#L81) — replace both `<span className="live">…</span>` blocks with a single `<FreshnessBadge>` next to the clock; reword "collections live" → "total".
+2. **P1** [v4.css:2716](../../../src/components/ui/v4.css#L2716) — `padding: 8px 12px` → `padding: 12px 14px; min-height: 44px;` on `.v4-collection-rail-list__link`.
+3. **P1** [[slug]/page.tsx:446](../../../src/app/collections/[slug]/page.tsx#L446), [v4.css:2620](../../../src/components/ui/v4.css#L2620), [v4.css:2661](../../../src/components/ui/v4.css#L2661), [v4.css:2702](../../../src/components/ui/v4.css#L2702) — `border-radius: 4px` → `2px` (or `var(--radius-card)` where available).
+4. **P1** [loading.tsx:21](../../../src/app/collections/loading.tsx#L21) — `sm:grid-cols-2 md:grid-cols-3` → `md:grid-cols-2 xl:grid-cols-3`; bump skeleton from 9 → 12 cards.
+5. **P2** [globals.css:3588](../../../src/app/globals.css#L3588) — add `transition: border-color 150ms ease;` to `.tool`.
+6. **P2** [page.tsx:99-104](../../../src/app/collections/page.tsx#L99) + sibling CSS — rename `.compare-empty-state` usage to a `.collections-empty-state` or shared `.empty-state` primitive; rewrite copy.
+
+## Quick-fix patches
+
+### P0 — kill green-pulse, wire canonical badge
+
+```diff
+- import { Layers } from "lucide-react";
++ import { Layers } from "lucide-react";
++ import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+
+  <div className="clock">
+    <span className="big">{cards.length}</span>
+-   <span className="live">collections live</span>
++   <span>total</span>
++   <FreshnessBadge source="mcp" lastUpdatedAt={collectionRankingsFetchedAt} />
+  </div>
+
+- {freshness && (
+-   <section className="panel collection-freshness">
+-     <div className="panel-head">
+-       <span className="key">{"// COLLECTION RANKINGS"}</span>
+-       <span className="right">
+-         <span className="live">Updated {freshness}</span>
+-       </span>
+-     </div>
+-   </section>
+- )}
+```
+
+(The panel-head block becomes redundant once the badge ships next to the clock. If keeping for visual rhythm, drop the `.live` className on the `<span>`.)
+
+### P1 — tap-target on rail list
+
+```diff
+  .v4-collection-rail-list__link {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+-   padding: 8px 12px;
++   padding: 12px 14px;
++   min-height: 44px;
+```
+
+### P2 — hover transition on `.tool`
+
+```diff
+  .tool {
+    position: relative;
+    ...
+    padding: 14px;
+    color: inherit;
+    text-decoration: none;
++   transition: border-color 150ms ease;
+  }
+```
+
+---
+
+**Surface verdict:** /collections is structurally honest — the data layer, summarization, and stub handling all respect the project's no-fabrication rule. The chrome lies. Two `<span className="live">` strings turn the page-head into a perpetual green-pulse regardless of rankings age, and the canonical `<FreshnessBadge>` is missing. Fix those two clusters and the surface is shippable.

--- a/docs/audits/impeccable/compare-audit.md
+++ b/docs/audits/impeccable/compare-audit.md
@@ -1,0 +1,166 @@
+# /compare audit — 2026-05-13
+
+Surface: `/compare` (Compare Repos · Canonical Signals)
+Audited under the impeccable rubric: hierarchy, honest chrome, density, a11y/responsive, motion.
+
+## Files audited
+
+- [src/app/compare/page.tsx](../../../src/app/compare/page.tsx)
+- [src/app/compare/layout.tsx](../../../src/app/compare/layout.tsx)
+- [src/app/compare/loading.tsx](../../../src/app/compare/loading.tsx)
+- [src/app/compare/error.tsx](../../../src/app/compare/error.tsx)
+- [src/components/compare/CompareClient.tsx](../../../src/components/compare/CompareClient.tsx)
+- [src/components/compare/CompareProfileGrid.tsx](../../../src/components/compare/CompareProfileGrid.tsx)
+- [src/components/compare/CompareWaveTop.tsx](../../../src/components/compare/CompareWaveTop.tsx)
+- [src/components/compare/CompareSelector.tsx](../../../src/components/compare/CompareSelector.tsx)
+- [src/components/compare/CompareSharePanel.tsx](../../../src/components/compare/CompareSharePanel.tsx)
+- [src/components/compare/CompareStatStrip.tsx](../../../src/components/compare/CompareStatStrip.tsx)
+- [src/components/compare/CompareChart.tsx](../../../src/components/compare/CompareChart.tsx)
+- [src/components/compare/CompareHeatmap.tsx](../../../src/components/compare/CompareHeatmap.tsx)
+- [src/components/compare/RepoBannerCard.tsx](../../../src/components/compare/RepoBannerCard.tsx)
+- [src/components/compare/RepoProfileColumn.tsx](../../../src/components/compare/RepoProfileColumn.tsx)
+- [src/components/compare/ContributorGrid.tsx](../../../src/components/compare/ContributorGrid.tsx)
+- [src/components/compare/MomentumRow.tsx](../../../src/components/compare/MomentumRow.tsx)
+- [src/components/compare/WinnerChips.tsx](../../../src/components/compare/WinnerChips.tsx)
+- [src/components/compare/StarterPackRow.tsx](../../../src/components/compare/StarterPackRow.tsx)
+- [src/components/compare/compare.css](../../../src/components/compare/compare.css)
+
+## P0 findings
+
+**P0-1 — Dishonest LIVE chrome on `series selected` counter.** [page.tsx:51](../../../src/app/compare/page.tsx). The selected-series count is wrapped in `<span className="live">` which globals.css `.page-head .clock .live` paints sig-green + adds a pulsing live-dot `::before` with `box-shadow: var(--shadow-live)`. The chrome reads as "live data signal" but is just a static count. Violates the freshness-chrome rule.
+Fix: drop the `live` class — render `<span className="t-d" style={{color:"var(--ink-300)"}}>series selected</span>`. **Mechanical (1 line).**
+
+**P0-2 — Dishonest LIVE chrome on tool-card foot.** [page.tsx:63](../../../src/app/compare/page.tsx). `<span className="live">live</span>` inside the "Star History" tool foot is never wired to a freshness verdict — it always renders green-glowing regardless of underlying data staleness. Three other tool cards (Signals/Top10/Tier List) on the same row do NOT use `.live`, so the inconsistency reads as a freshness claim, not a label.
+Fix: replace with `<FreshnessBadge>` driven by `classifyFreshness()` on the chart payload's max `lastUpdatedAt`, OR drop to a neutral `<span>live</span>` styled via `.t-foot` token (no green dot, no glow). **Design call** (does this tile need a freshness signal, or just consistency with siblings?).
+
+**P0-3 — Dishonest LIVE chrome on chart panel head.** [CompareWaveTop.tsx:264](../../../src/components/compare/CompareWaveTop.tsx). `<span className="live">Live</span>` in the `panel-head .right` slot of the "// STAR HISTORY / CHART / N SERIES" panel. globals.css `.panel-head .right .live` paints sig-green dot + `--shadow-live-small` glow. Hardcoded — never reflects the actual age of `payloads` or `repos` data.
+Fix: replace with `<FreshnessBadge data-source="star-activity">` driven by the latest `lastUpdatedAt` of the resolved payloads, or remove the badge entirely (the chart `<title>` already says "Star Activity (30 days)" which carries window context). **Design call.**
+
+**P0-4 — Pill remove button under tap-target minimum.** [CompareSelector.tsx:236-245](../../../src/components/compare/CompareSelector.tsx). The X button is `p-0.5` + 12px icon → ~16×16 hit area. Project rule: 44×44 minimum on mobile, especially for destructive actions. Same issue applies to the dropdown rows being 32px-ish per item — but the bigger problem is the per-pill X.
+Fix: wrap the X icon in a button with `min-w-[44px] min-h-[44px] p-2` and use `-mr-2 -my-2` negative margin to keep visual pill compact while preserving real hit area. **Mechanical (2 lines).**
+
+## P1 findings
+
+**P1-1 — Duplicate breadcrumbs on the page.** Both [page.tsx:37-39](../../../src/app/compare/page.tsx) (`<div className="crumb"><b>Tools</b> / compare</div>`) and [CompareProfileGrid.tsx:296-308](../../../src/components/compare/CompareProfileGrid.tsx) (`<nav aria-label="Breadcrumb">Home / Compare</nav>`) render breadcrumb-like UI. Screen readers will announce both navigation landmarks; visual scan sees redundant location chrome.
+Fix: keep the page-level `crumb` (it carries the canonical "Tools" parent) and remove the `PageHeader` `<nav>` inside `CompareProfileGrid` since the surrounding panel-head + page-head already establish location. **Mechanical (delete ~10 lines).**
+
+**P1-2 — Contributor avatars under tap target.** [ContributorGrid.tsx:43](../../../src/components/compare/ContributorGrid.tsx). Each contributor avatar is a `size-8` (32×32) anchor — under 44px. Up to 20 avatars per repo column, packed `gap-1` (4px). On mobile, fingers will overlap multiple avatars.
+Fix: keep visual size 32px but expand hit zone via `relative` + `::before { content:""; position:absolute; inset:-6px; }` pseudo-target. Or stack as a clickable list on mobile breakpoints. **Design call.**
+
+**P1-3 — Chart toggle buttons under tap target.** [CompareChart.tsx:535-549](../../../src/components/compare/CompareChart.tsx). ToggleButton uses `px-2 py-1 text-[10px]` → ~24×20px hit area. Five toggle groups (Theme / Metric / Window / Scale / Mode) stack into the chart toolbar — on 375px mobile, this is a finger-frustrating row of micro-buttons.
+Fix: bump to `px-2.5 py-2 text-[11px]` on desktop, `px-3 py-2.5 min-h-[36px] text-[12px]` on mobile (still falls under 44 but at least usable). Real fix is a mobile drawer/sheet for chart options. **Design call.**
+
+**P1-4 — Heatmap row label-overflow on narrow viewports.** [CompareHeatmap.tsx:225-232](../../../src/components/compare/CompareHeatmap.tsx). The `<div className="flex flex-wrap items-center gap-2 mb-2">` header packs avatar + fullName + "N commits (30d) · M total (52w)" on one row. On 375px the totals get pushed below the fullName with no separator, looking like an orphan.
+Fix: hide the 52w-total on `<sm` (`hidden sm:inline`) or stack the meta vertically below the name when truncated. **Mechanical.**
+
+**P1-5 — CompareStatStrip drops mindshare/rank on mobile.** [CompareStatStrip.tsx:39](../../../src/components/compare/CompareStatStrip.tsx). 2-col on mobile means the per-card meta row (`+1.2k 24H · #4 · MS 18%`) gets `flex-wrap`, pushing rank + mindshare onto a second line — readable but the "MS —" placeholder dominates when data is missing. Plus the grid is `gap-3` which at 2 cols leaves cards uncomfortably wide.
+Fix: switch mobile to single-column `flex-col gap-2 sm:grid sm:grid-cols-2`, or reduce padding on mobile (`px-2 py-2 sm:px-3 sm:py-2.5`). **Design call.**
+
+**P1-6 — Per-repo border-left + per-component border-left visual stutter.** Every `RepoBannerCard`, `PulseCard`, `RepoSubHeader`, `RepoProfileColumn`, and `HeatRow` independently applies `borderLeft: 3px solid {accent}`. Across the page that's ~5 different vertical-bar strokes per repo — five places the "repo identity" is repeated. Functional per the in-prompt note, but the *accumulation* through the long scroll makes the page feel like a tagged form, not a comparison dashboard.
+Fix: keep accent stripes on RepoBannerCard + RepoProfileColumn (the "anchor" cards) and demote to a 2px top stripe or accent-dot on the secondary panels (Pulse / Tech Stack / Contributors / Heatmap). **Design call.**
+
+## P2 findings
+
+**P2-1 — `bg-black` not used, but theme leak.** [CompareChart.tsx:295](../../../src/components/compare/CompareChart.tsx) uses `splitLineColor = "#1f1f1f"` for light theme — fine. No `bg-black` violations found. But [CompareChart.tsx:830](../../../src/components/compare/CompareChart.tsx) `var(--color-text-muted, var(--color-text-tertiary))` is a fallback to a non-existent token — degrades to `text-tertiary`. Cosmetic.
+
+**P2-2 — Skeleton uses `--v3-bg-*` legacy tokens.** [loading.tsx:11,14,17,27,34,42](../../../src/app/compare/loading.tsx) all use `var(--v3-bg-050)` / `var(--v3-bg-100)`. These are pre-token-system holdovers. Modern compare components use `bg-bg-secondary` / `bg-bg-card` etc.
+Fix: migrate to current surface tokens (`var(--color-bg-raised)` / `var(--color-bg-muted)`). **Mechanical.**
+
+**P2-3 — Error page uses `--v2-*` legacy tokens.** [error.tsx:24,31,42,47,49](../../../src/app/compare/error.tsx) — same legacy-token issue across `--v2-sig-red`, `--v2-ink-000`, `--v2-ink-300`, `--v2-ink-400`. **Mechanical.**
+
+**P2-4 — Inline `<style>`-style props instead of utility classes.** [error.tsx:28-36](../../../src/app/compare/error.tsx) and [CompareChart.tsx:693-696, 700-704](../../../src/components/compare/CompareChart.tsx) hand-roll style objects for color/fontSize. Drifts from the rest of compare which uses tailwind tokens. **Mechanical.**
+
+**P2-5 — `formatRelativeDate` rolls its own; `getRelativeTime` exists in utils.** [CompareClient.tsx:110-123](../../../src/components/compare/CompareClient.tsx) reimplements relative-time formatting; [RepoBannerCard.tsx:170-174](../../../src/components/compare/RepoBannerCard.tsx) uses the shared `getRelativeTime`. Output drifts between the two surfaces (e.g. "today" vs "Xh ago"). **Mechanical.**
+
+**P2-6 — Empty-state copy mismatch.** [CompareClient.tsx:308-312](../../../src/components/compare/CompareClient.tsx) says "Select at least 2 repos to compare their momentum, stars, and activity"; [CompareProfileGrid.tsx:250-253](../../../src/components/compare/CompareProfileGrid.tsx) says "Select at least 2 repos to compare their momentum, signals, and revenue". Different feature lists.
+Fix: align on one canonical empty-state copy. **Mechanical.**
+
+**P2-7 — CompareSharePanel uses `rounded-card`, gets overridden anyway.** [CompareSharePanel.tsx:165](../../../src/components/compare/CompareSharePanel.tsx) sets `rounded-card`; `compare.css:131-136` then strips `border-radius` back to `--radius-none`. The class is dead intent — confusing for future maintainers. **Mechanical.**
+
+**P2-8 — `WinnerChips` `rounded-full` pill on a flat-radii page.** [WinnerChips.tsx:98-99](../../../src/components/compare/WinnerChips.tsx) renders chips as `rounded-full`. But `compare.css` doesn't override `rounded-full` — so these read as warm pills on an otherwise flat-cornered terminal page. Inconsistency.
+Fix: either expose `rounded-full` overrides in `compare.css` OR change chips to `rounded-[3px]`/`rounded-none`. **Design call.**
+
+**P2-9 — `border-l 3px` per-row on heatmap eats horizontal space.** [CompareHeatmap.tsx:223](../../../src/components/compare/CompareHeatmap.tsx). The 3px stripe + 12px card padding leaves 15px of "non-data" on the left of the 52-week strip. On a 375px viewport the heatmap squares shrink to ~6px each.
+Fix: drop the heatmap row's `borderLeft` and rely on the avatar+accent-dot in the header for repo identity (matches the impeccable hint that border-stripes are functional but can be demoted). **Design call.**
+
+**P2-10 — `space-y-8` rhythm between section headings creates lots of scroll.** [CompareClient.tsx:475](../../../src/components/compare/CompareClient.tsx) `EmbeddedShell` uses `space-y-8` (32px). Combined with the ~14 sections (banner / chart / heatmap / pulse / tech / contrib / wins) the page is a long scroll. Could tighten to `space-y-6` (24px) and let `label-section` headings carry hierarchy. **Design call.**
+
+## What's working well
+
+- **Per-repo accent system is internally consistent.** `COMPARE_PALETTE` is the single source of truth shared by selector pills, banner stripes, chart strokes, heatmap series, language bars, and winner chips. The 5-slot palette indexing keeps each repo's identity readable across the entire page.
+- **Diff-tone highlighting is restrained.** `computeDiffFlags` in `CompareProfileGrid` only colors the extremes when spread > threshold — exactly the right call. Avoids the rainbow-everything trap.
+- **Skeleton geometry matches final geometry.** `BannerSkeleton`, `HeatmapSkeleton` (52×7 grid), `PulseSkeleton`, `SectionRowSkeleton`, `WinnerSkeleton` all preserve final layout dimensions — no layout shift on hydration.
+- **Empty / fallback discipline.** `fallbackBundle()` synthesizes ok:false envelopes so one failed repo never blanks its siblings. Grid keeps all selected slots populated even on `/api/compare` errors.
+- **URL-driven sharing works.** `CompareWaveTop` syncs `?repos=` via `router.replace({scroll:false})` so the back button doesn't accumulate noise on every pill add/remove.
+- **Compare-page CSS overrides flatten radii to 0.** `compare.css:131-136` enforces the terminal look across `v2-card`, `rounded-card`, `rounded-md`, `rounded-badge` — exactly aligned with the project's terminal-feel tokens.
+- **Chart end-of-line labels.** `CompareChart.buildLineData` puts the series label at the right end of each line. Far better than a separate legend lookup — answers "which line is which repo" instantly.
+
+## Verify-in-context
+
+- LIVE chrome (P0-1/2/3) is visible without data — load `/compare` with no `?repos=` param: the "series selected" pulse + tool-card live dot + chart-panel "Live" badge all render against the empty-state. They are LIVE chrome with no live data backing them.
+- Tap-target (P0-4) is provable on devtools mobile 375px — try to remove a pill with a thumb-sized target on the iPhone 13 emulator; the 16px X is below pointer accuracy.
+- Duplicate breadcrumbs (P1-1) audible with VoiceOver: two "navigation, Breadcrumb" landmarks announced.
+
+## Mechanical fixes ready to ship
+
+Ordered by impact-per-line:
+
+1. **P0-1** — Drop `className="live"` on `page.tsx:51`. 1 char delta.
+2. **P0-2** — Drop `className="live"` on `page.tsx:63` (or replace with FreshnessBadge — design call).
+3. **P0-3** — Drop `className="live"` on `CompareWaveTop.tsx:264` (or replace with FreshnessBadge).
+4. **P0-4** — Add `min-w-[44px] min-h-[44px] -m-2 p-2` to the pill-X button.
+5. **P1-1** — Delete the `PageHeader` `<nav>` block in `CompareProfileGrid.tsx:295-308`.
+6. **P2-2/2-3/2-4** — Sweep `--v2-*` / `--v3-*` legacy tokens to current `--color-*` tokens.
+7. **P2-6** — Unify the two empty-state copies on one canonical message.
+
+## Quick-fix patches (optional)
+
+```tsx
+// page.tsx:51 — drop dishonest "live" pulse
+- <span className="live">series selected</span>
++ <span className="t-d">series selected</span>
+```
+
+```tsx
+// page.tsx:63 — same; the foot "live" tag is a freshness claim that's never wired
+- <span className="live">live</span>
++ <span>live</span>
+```
+
+```tsx
+// CompareWaveTop.tsx:263-265 — replace static Live with FreshnessBadge or remove
+- <span className="right">
+-   <span className="live">Live</span>
+- </span>
++ <span className="right">
++   <FreshnessBadge slug="star-activity" />
++ </span>
+```
+
+```tsx
+// CompareSelector.tsx:236-245 — expand hit zone without growing pill
+   <button
+     type="button"
+     onClick={() => removeRepo(id)}
+     className={cn(
+-      "p-0.5 rounded-full hover:bg-bg-card-hover transition-colors cursor-pointer",
++      "p-2 -my-2 -mr-1 rounded-full hover:bg-bg-card-hover transition-colors cursor-pointer",
++      "min-w-[44px] min-h-[44px] flex items-center justify-center",
+       "text-text-tertiary hover:text-text-primary",
+     )}
+     aria-label={`Remove ${name}`}
+   >
+     <X size={12} />
+   </button>
+```
+
+```tsx
+// CompareProfileGrid.tsx:295-308 — remove duplicate breadcrumb
+- function PageHeader() {
+-   return (
+-     <nav aria-label="Breadcrumb" ...>...</nav>
+-   );
+- }
+- ...
+- <PageHeader />
+```

--- a/docs/audits/impeccable/huggingface-audit.md
+++ b/docs/audits/impeccable/huggingface-audit.md
@@ -1,0 +1,174 @@
+# /huggingface audit — 2026-05-13
+
+> Impeccable design audit on `/huggingface` and its three sub-surfaces (`/trending` = Models, `/datasets`, `/spaces`). Project rules applied: honest freshness chrome non-negotiable; HF has THREE independent sources (models / datasets / spaces) each with its own cron cadence — freshness must reflect each surface's actual state; HF brand yellow `#FFD21E` is the functional source color but **no `--source-hf` / `--v4-src-hf` token exists**, so the value is currently hardcoded across four files.
+
+## Files audited
+
+- [src/app/huggingface/page.tsx](../../../src/app/huggingface/page.tsx) — 5-line redirect alias to `/huggingface/models`
+- [src/app/huggingface/models/page.tsx](../../../src/app/huggingface/models/page.tsx) — 1-line re-export from `../trending/page`
+- [src/app/huggingface/trending/page.tsx](../../../src/app/huggingface/trending/page.tsx) — Models feed (host page; canonical `/huggingface` per metadata)
+- [src/app/huggingface/datasets/page.tsx](../../../src/app/huggingface/datasets/page.tsx) — Datasets feed
+- [src/app/huggingface/spaces/page.tsx](../../../src/app/huggingface/spaces/page.tsx) — Spaces feed
+- [src/app/huggingface/{trending,datasets,spaces}/loading.tsx](../../../src/app/huggingface/) — 3 identical skeleton stubs
+- [src/app/huggingface/{trending,datasets,spaces}/error.tsx](../../../src/app/huggingface/) — 3 identical error boundaries
+- [src/components/huggingface/HfNavTabs.tsx](../../../src/components/huggingface/HfNavTabs.tsx) — tab strip across all 3 sub-surfaces
+- Cross-refs: [src/components/shared/FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx), [src/lib/news/freshness.ts](../../../src/lib/news/freshness.ts), [src/components/ui/LiveDot.tsx](../../../src/components/ui/LiveDot.tsx)
+
+## P0 findings
+
+### 1. Hardcoded `<LiveDot label="FRESH · 3H" />` on all 3 sub-pages — honest-chrome violation × 3
+
+- **Files**: [trending/page.tsx:144](../../../src/app/huggingface/trending/page.tsx#L144), [datasets/page.tsx:134](../../../src/app/huggingface/datasets/page.tsx#L134), [spaces/page.tsx:133](../../../src/app/huggingface/spaces/page.tsx#L133)
+- **Mechanical**: All three pages render `<LiveDot label="FRESH · 3H" />` inside the PageHead clock slot with **no relation to actual `fetchedAt`**. `LiveDot` defaults to `tone="money"` (green, pulsing). The string is a static literal — the dot pulses green even when the underlying payload is hours stale, the Redis store is dark, or the scraper is broken. This is the exact pattern called out in [feedback_freshness_chrome_must_be_honest](C:\Users\mirko\.claude\projects\c--dev-trendingrepo\memory\feedback_freshness_chrome_must_be_honest.md): "Never inline hardcoded 'FRESH · 1H' / green-pulse LiveDot. Wire `lastUpdatedAt` to `FreshnessBadge` via `classifyFreshness()`."
+- **Fix**: Replace each `<LiveDot label="FRESH · 3H" />` with `<FreshnessBadge source="huggingface" lastUpdatedAt={file.fetchedAt} />`. **Gated on #2**: `huggingface` is not yet a `NewsSource` union member — must add it (with `oldestRecordAt` stamping per the B4 pattern) before the badge can compile. Per-surface threshold likely matches `npm`/`mcp` (6h cron + 6h grace = 12h stale budget), since HF scrapers run on a slow cadence similar to MCP. Keep the static UTC clock text + `// UTC · SCRAPED` muted label — those are honest.
+- **Design call**: mechanical with a tiny design tilt — 3 line-level swaps + 1 freshness.ts entry. The "lie" is identical on all three pages so the fix is identical.
+
+### 2. `NewsSource` union has no `huggingface` entry — no freshness budget defined for any HF surface
+
+- **File**: [src/lib/news/freshness.ts:18-29](../../../src/lib/news/freshness.ts#L18), `SOURCE_STALE_MS` at [L42-59](../../../src/lib/news/freshness.ts#L42)
+- **Mechanical**: The `NewsSource` discriminated union lists `reddit | hackernews | bluesky | devto | lobsters | producthunt | twitter | npm | mcp | skills` — no `huggingface`. Means: even if an engineer tried to wire `FreshnessBadge` correctly (per #1), TypeScript would reject `source="huggingface"`. The page rules require **honest** chrome on all three HF surfaces; the badge can't exist until the type allows it.
+- **Fix**: Add `"huggingface"` to `NewsSource` and `SOURCE_STALE_MS["huggingface"] = NPM_STALE_THRESHOLD_MS` (12h budget, matching slow-cron Redis publishers like `mcp`/`skills`). Consider three sub-keys (`huggingface-models`, `huggingface-datasets`, `huggingface-spaces`) if the cron cadences diverge — verify-in-context against `scripts/scrape-huggingface*.mjs` cadences before committing to one vs. three keys. Recommend **one key** unless cadence reading shows >2× spread.
+- **Design call**: mechanical, **blocks #1**.
+
+### 3. Three HF scrapers can be in three different freshness states — the page assumes they're identical
+
+- **Files**: [trending/page.tsx:84](../../../src/app/huggingface/trending/page.tsx#L84) (`getHfTrendingFile().fetchedAt`), [datasets/page.tsx:75](../../../src/app/huggingface/datasets/page.tsx#L75) (`getHfDatasetsFile().fetchedAt`), [spaces/page.tsx:74](../../../src/app/huggingface/spaces/page.tsx#L74) (`getHfSpacesFile().fetchedAt`)
+- **Mechanical**: Each sub-page reads its own `file.fetchedAt` and renders its own static `FRESH · 3H` label. There's no cross-surface awareness: a user landing on `/huggingface/spaces` cannot tell that `/datasets` may be 18h stale (cold) while spaces is 1h fresh. The nav tab strip ([HfNavTabs.tsx](../../../src/components/huggingface/HfNavTabs.tsx)) renders all three tabs at identical visual weight — no per-tab freshness signal. This is the cross-source honest-chrome corollary: when a single host page fans out to 3 collectors, the tab strip is the right place to surface per-source state.
+- **Fix**: After #1 + #2, optionally add per-tab freshness dots in `HfNavTabs.tsx`: each tab shows a 6×6 dot in `var(--v4-money)` / `--v4-amber)` / `--v4-red)` derived from `classifyFreshness("huggingface", <perSourceFetchedAt>)`. Read all three file timestamps server-side once and thread them down as `tabBar={<HfNavTabs activeHref=... freshness={{models, datasets, spaces}} />}`. Without this, the user has no signal that switching tabs may show stale data.
+- **Design call**: design — net-new affordance, three-source coordination. Lower urgency than #1+#2 but the highest-leverage fix for the "3 independent sources" rule called out in the audit brief.
+
+### 4. `#FFD21E` HF brand yellow is hardcoded in 4 files — color budget drift; no `--source-hf` token
+
+- **Files**: [trending/page.tsx:35](../../../src/app/huggingface/trending/page.tsx#L35) (`const HF_YELLOW = "#FFD21E"`), [datasets/page.tsx:35](../../../src/app/huggingface/datasets/page.tsx#L35) (`const HF_ACCENT_BAR = "#FFD21E"`), [spaces/page.tsx:34](../../../src/app/huggingface/spaces/page.tsx#L34) (`const HF_YELLOW`), [HfNavTabs.tsx:31-33](../../../src/components/huggingface/HfNavTabs.tsx#L31) (`#FFD21E` literal × 3 in style)
+- **Mechanical**: Comment at `trending/page.tsx:34` admits the gap: "HF 'yellow' — no `--v4-src-hf` token exists; hardcoded once on the pip". The rest of the codebase has `--source-{github,hackernews,x,reddit,producthunt,bluesky,dev,openai,claude}` ([globals.css:174-191](../../../src/app/globals.css#L174)) and the V4 mirror `--v4-src-{hn,gh,x,reddit,bsky,dev,claude,openai}` ([globals.css:6226-6233](../../../src/app/globals.css#L6226)). HF is the largest-LOC source page family without a token. Drift risk: datasets uses `HF_ACCENT_BAR`, trending+spaces use `HF_YELLOW` for the same color — already two names for one value. The `#FFD21E` literal also leaks into inline `rgba(255, 210, 30, 0.08)` in HfNavTabs.tsx:33 (the 0.08 alpha tint) — another magic value tied to the same brand.
+- **Fix**: Add `--source-hf: #FFD21E` + `--source-hf-oklch: oklch(...)` to `:root` block in globals.css (matching the pattern at L174-191), and `--v4-src-hf: #FFD21E` to the V4 mirror block at L6226-6233. Replace the four literal sites with `var(--v4-src-hf)`. Drop both `HF_YELLOW` and `HF_ACCENT_BAR` const declarations; pass the CSS var directly to the table `accent` prop and the inline styles. The HfNavTabs.tsx 0.08-alpha active background becomes `color-mix(in oklch, var(--v4-src-hf) 8%, transparent)` — survives token-switching, no magic alpha.
+- **Design call**: design — small token addition, then mechanical literal-to-token sweep across 4 files. Sister fix to the openai/claude token additions.
+
+## P1 findings
+
+### 5. `huggingFaceLogoUrl` imported but never used in all three pages
+
+- **Files**: [trending/page.tsx:22](../../../src/app/huggingface/trending/page.tsx#L22), [datasets/page.tsx:24](../../../src/app/huggingface/datasets/page.tsx#L24), [spaces/page.tsx:23](../../../src/app/huggingface/spaces/page.tsx#L23)
+- **Mechanical**: Each page imports `{ huggingFaceLogoUrl, huggingFaceAuthorLogoUrl }` but only consumes `huggingFaceAuthorLogoUrl` — `grep huggingFaceLogoUrl\(` returns zero call-sites under `src/app/huggingface/`. Dead imports across three pages signal copy-paste shaped from an earlier draft that rendered a top-level brand logo (now replaced by `<HuggingFaceIcon />` from `brand/BrandIcons`). Lint is presumably suppressing `no-unused-vars` here.
+- **Fix**: Drop `huggingFaceLogoUrl` from the destructure in all three pages.
+- **Design call**: mechanical — three identical 1-symbol edits.
+
+### 6. ColdState fallback is duplicated near-verbatim across all three pages
+
+- **Files**: [trending/page.tsx:358-393](../../../src/app/huggingface/trending/page.tsx#L358), [datasets/page.tsx:328-363](../../../src/app/huggingface/datasets/page.tsx#L328), [spaces/page.tsx:363-405](../../../src/app/huggingface/spaces/page.tsx#L363)
+- **Mechanical**: Three `function ColdState()` definitions, each ~35 LOC, differ only in the embedded `npm run` / `node scripts/...` hint and the `data/huggingface-*.json` filename. Same inline styles, same `// no data yet` heading, same `border-radius: 2`. Duplicate triplet means a fix to one (e.g. updating the cold-state copy when the scraper changes name) doesn't propagate. The codebase already has an `EmptyState` primitive used elsewhere (see `/reddit/trending` cold path) — HF is the outlier.
+- **Fix**: Extract `HfColdState({ source: "models" | "datasets" | "spaces" })` co-located under `src/components/huggingface/HfColdState.tsx`. Wire the scraper hint via a switch on `source`. Saves ~70 LOC and gives the three pages one shape to maintain.
+- **Design call**: mechanical — straight extraction.
+
+### 7. `MomentumBar` defined three times verbatim — same drift surface as #6
+
+- **Files**: [trending/page.tsx:321-352](../../../src/app/huggingface/trending/page.tsx#L321), [datasets/page.tsx:291-322](../../../src/app/huggingface/datasets/page.tsx#L291), [spaces/page.tsx:326-357](../../../src/app/huggingface/spaces/page.tsx#L326)
+- **Mechanical**: Three identical `function MomentumBar({ value, accent }: { value: number; accent: string })` declarations. ~30 LOC each. Magic numbers in all three: `height: 6`, `borderRadius: 1` (note: not 2; the row-level bar uses 1px corners while every other card uses `--radius-card: 2px` — minor radius drift). `boxShadow: 0 0 6px ${accent}66` is the same trick. Triplet duplication.
+- **Fix**: Extract `<MomentumBar value={..} accent={..} />` to `src/components/huggingface/MomentumBar.tsx`. Already accepts `accent` so it's source-agnostic. Same drop pattern propagates if other source pages adopt the same bar later. Pin `borderRadius` to a token while extracting.
+- **Design call**: mechanical — straight extraction; the radius drift is a 1-char fix that rides along.
+
+### 8. Loading skeleton uses `var(--v3-bg-050)` / `var(--v3-bg-100)` — drift vs surrounding `--v4-*` tokens
+
+- **Files**: [trending/loading.tsx:10,14,18,23,30,38](../../../src/app/huggingface/trending/loading.tsx#L10), [datasets/loading.tsx:10,14,18,23,30,38](../../../src/app/huggingface/datasets/loading.tsx#L10), [spaces/loading.tsx:10,14,18,23,30,38](../../../src/app/huggingface/spaces/loading.tsx#L10)
+- **Mechanical**: Three identical skeleton files all reference `--v3-bg-*` tokens. globals.css L426-427 + L6176-6177 confirm v3 and v4 alias the same `--color-bg-raised` / `--color-bg-muted` so the visual outcome is identical TODAY, but the v3 → v4 sweep is intentional and these are the only three files under `src/app/huggingface/` still on v3. Sister loading.tsx files in newer sources use v4 directly.
+- **Fix**: `--v3-bg-050` → `--v4-bg-050`, `--v3-bg-100` → `--v4-bg-100`. Three files × 6 lines each = trivial mechanical sweep.
+- **Design call**: mechanical.
+
+### 9. Error boundaries reference `--v2-*` tokens — same drift, older generation
+
+- **Files**: [trending/error.tsx:23,32,42,49,52](../../../src/app/huggingface/trending/error.tsx#L23), [datasets/error.tsx:23,32,42,49,52](../../../src/app/huggingface/datasets/error.tsx#L23), [spaces/error.tsx:23,32,42,49,52](../../../src/app/huggingface/spaces/error.tsx#L23)
+- **Mechanical**: Three identical error pages all use `--v2-sig-red`, `--v2-ink-000`, `--v2-ink-300`, `--v2-ink-400`. The `--v2-*` family is two generations behind. globals.css L507-508 aliases v2 to v3 to v4 so it renders correctly, but the chain is fragile.
+- **Fix**: Sweep `--v2-sig-red` → `--v4-red`, `--v2-ink-*` → `--v4-ink-*`. Three files, 15 token swaps total. Less urgent than #8 because error states are rare.
+- **Design call**: mechanical.
+
+### 10. Tab strip is a `<nav>` with `<Link>` chips — missing `role="tablist"` + `role="tab"` for the 3-source pattern
+
+- **File**: [HfNavTabs.tsx:13-43](../../../src/components/huggingface/HfNavTabs.tsx#L13)
+- **Mechanical**: The component renders `<nav aria-label="Hugging Face sections">` with `<Link>` children carrying `aria-current="page"` for active. Semantically defensible (it's navigation between three routes, not a tab control), but the visual pattern is the same as `/reddit/trending`'s `role="tablist"` strip ([AllTrendingTabs.tsx:321](../../../src/components/reddit-trending/AllTrendingTabs.tsx#L321)) which DOES use the ARIA pattern. Screen-reader users get different affordances for visually-identical patterns. Pick one.
+- **Fix**: Two options: (a) keep `<nav>` semantics — explicitly correct since each tab routes; document in a code comment that this is intentional (consistency with sidebar routing); (b) switch to `role="tablist"` + `role="tab"` for consistency with reddit-trending's intra-page tab pattern. Recommend (a) — `HfNavTabs` truly navigates routes and `aria-current="page"` is the right shape. The 90% similar visual is acceptable.
+- **Design call**: design — needs the project-wide rule on "when is a tab strip a tablist vs a route nav".
+
+### 11. Tab strip uses `rounded-sm` (2px) + `border` (1px) — radii are correct, but the active state shifts `background` AND `borderColor` AND `color` simultaneously
+
+- **File**: [HfNavTabs.tsx:30-34](../../../src/components/huggingface/HfNavTabs.tsx#L30)
+- **Mechanical**: Active state changes three properties at once: `borderColor` (line → `#FFD21E`), `color` (ink-300 → `#FFD21E`), `background` (bg-050 → `rgba(255, 210, 30, 0.08)`). The `transition-colors` Tailwind utility only animates color/background/border-color (which is fine), but the simultaneous triple-shift on hover and active feels heavier than the single-axis active states elsewhere. PageHead clock is the visual anchor; tabs should be quieter when active.
+- **Fix**: Keep the active background tint and active text-color, **drop the active border-color change**. The 1px border stays at `var(--v4-line-200)` in both states; the active state communicates via the 8% bg + bolder text. Sibling: `transition-colors duration-120` (matches `--motion-duration-fast`) — currently the duration is implicit (browser default ~150ms).
+- **Design call**: design — small tonal call, propagates to the tab feel.
+
+### 12. `formatClock(file.fetchedAt)` returns 8-char UTC time but the page never tells the user WHEN today
+
+- **Files**: [trending/page.tsx:68-71](../../../src/app/huggingface/trending/page.tsx#L68), [datasets/page.tsx:68-71](../../../src/app/huggingface/datasets/page.tsx#L68), [spaces/page.tsx:67-70](../../../src/app/huggingface/spaces/page.tsx#L67)
+- **Mechanical**: Helper slices `.toISOString().slice(11, 19)` → e.g. `"14:32:08"`. No date. If the user lands on the page at 09:00 UTC the day AFTER a scrape, the clock reads `"22:14:53"` with no date qualifier; combined with the (broken) `FRESH · 3H` LiveDot the user is told "live, 22:14:53" while actually viewing 30-hour-old data. Honest-chrome adjacent.
+- **Fix**: Once #1 lands, `FreshnessBadge` carries the `title` tooltip with the full ISO (it already does: `Last updated ${iso} · ${verdict.status} · stale after ...`). The clock can stay as time-only because the badge owns the truth. Optionally tag the muted sub-label `UTC · SCRAPED` with the date when `ageMs > 24h`.
+- **Design call**: design — gated on #1.
+
+### 13. Cold-state hint references `npm run scrape:huggingface` for trending but `node scripts/scrape-huggingface-{datasets,spaces}.mjs` for the others — inconsistent runner
+
+- **Files**: [trending/page.tsx:383](../../../src/app/huggingface/trending/page.tsx#L383), [datasets/page.tsx:353](../../../src/app/huggingface/datasets/page.tsx#L353), [spaces/page.tsx:394](../../../src/app/huggingface/spaces/page.tsx#L394)
+- **Mechanical**: Trending tells operators `npm run scrape:huggingface`; datasets tells them `node scripts/scrape-huggingface-datasets.mjs`; spaces tells them `node scripts/scrape-huggingface-spaces.mjs`. CLAUDE.md lists `npm run scrape:huggingface` / `scrape:huggingface-spaces` as the canonical runners. The two raw `node …mjs` hints leak implementation; the operator-facing copy should match the documented runner.
+- **Fix**: Verify in `package.json` whether `scrape:huggingface-datasets` / `:huggingface-spaces` scripts exist; if yes, use them. If not, propose adding them in a follow-up and update the cold-state hints. Will fold cleanly into #6 (shared `HfColdState`).
+- **Design call**: mechanical — gated on `package.json` script check.
+
+## P2 findings
+
+### 14. `tone="acc"` and `tone="money"` props passed to KpiBand but cell color also passed as `pip="var(--v4-acc)"` — possible double-paint
+
+- **Files**: [trending/page.tsx:152-178](../../../src/app/huggingface/trending/page.tsx#L152), [datasets/page.tsx:141-168](../../../src/app/huggingface/datasets/page.tsx#L141), [spaces/page.tsx:140-167](../../../src/app/huggingface/spaces/page.tsx#L140)
+- **Mechanical**: Each KpiBand cell sets BOTH `tone: "acc"` and `pip: "var(--v4-acc)"` (or `money`/`v4-money`, etc.). Not necessarily a bug — `tone` likely scopes the value-row text color while `pip` is the small accent dot — but the same color is being threaded through two props for the same visual outcome. Without reading KpiBand internals it's a minor smell; if `tone="acc"` already implies the pip color, the explicit `pip` prop is redundant.
+- **Fix**: Read [src/components/ui/KpiBand.tsx](../../../src/components/ui/KpiBand.tsx) to confirm whether `tone` alone covers the pip. If yes, drop the redundant `pip` prop across all 12 cells (3 pages × 4 cells). If no (i.e. pip is independent), keep both — currently doing no harm.
+- **Design call**: mechanical, verify-in-context.
+
+### 15. Models feed Type column renders `pipelineTag ?? libraryName ?? null` with same chrome — collapsed semantics
+
+- **File**: [trending/page.tsx:236-253](../../../src/app/huggingface/trending/page.tsx#L236)
+- **Mechanical**: Pipeline tag (e.g. `text-generation`) and library name (e.g. `transformers`) are different facets — one is the task, one is the runtime. The column header reads "Type" and uses the same `border + bg-100 + ink-300` chip for both. The `title={tag}` tooltip is the only disambiguation; on small screens (`hideBelow: "sm"`) the column hides entirely. Information conflation.
+- **Fix**: Two options: (a) keep one column, tweak chip color: pipelineTag → `var(--v4-blue)`-tinted, libraryName → `var(--v4-ink-400)`-tinted, with the chip carrying a subtle outline color indicating which facet rendered; (b) split into two columns "Task" + "Lib" but at most 3 chars each. (a) preserves layout; (b) is more honest. Recommend (a) for now.
+- **Design call**: design — small honest-information improvement.
+
+### 16. Spaces "Models" column tooltip shows newline-joined model IDs via `\n` in title attribute — won't render
+
+- **File**: [spaces/page.tsx:256-274](../../../src/app/huggingface/spaces/page.tsx#L256)
+- **Mechanical**: `tooltip = s.models.slice(0, 3).join("\n") + (count > 3 ? "\n… +${count - 3} more" : "")` and set as `title={tooltip}`. HTML `title` attributes treat `\n` as whitespace — most browsers render the entire string on one line; some collapse the newlines entirely. The user sees a wall of text.
+- **Fix**: Either (a) replace `\n` with ` · ` for a single-line `title` (browser-native, accessible), or (b) replace with a real tooltip popover. (a) is the K2-simplicity-first move.
+- **Design call**: mechanical — one-line fix.
+
+### 17. `momentum` value rendered as `Math.round(pct)` next to a 6px-tall bar — 24px-wide text reservation is wider than needed
+
+- **Files**: [trending/page.tsx:344-348](../../../src/app/huggingface/trending/page.tsx#L344), datasets + spaces have the same render
+- **Mechanical**: `<span ... width: 24, textAlign: "right">{Math.round(pct)}</span>` — max value is 100 (3 chars). At `text-[10px]` mono, 3 chars is ~18px. 24px is fine, but the bar is `flex-1` which means it stretches available width minus the 24px label. On the narrowest momentum-column width (120px → 96px available for bar after label + gap), the label dominates relative to the data.
+- **Fix**: Either widen the column to 140px to give the bar 110px or replace the literal `width: 24` with `min-width: 24` and let it shrink for 2-digit values. Mechanical, gated on the extraction in #7.
+- **Design call**: mechanical, low-impact.
+
+### 18. Cold-state heading is uppercase `// NO DATA YET` mono with letter-spacing 0.18em — louder than the page H1
+
+- **Files**: [trending/page.tsx:368-378](../../../src/app/huggingface/trending/page.tsx#L368), datasets/spaces equivalent
+- **Mechanical**: H1 is sans 30px, weight 500, ink-000 — quiet. Cold-state H2 uses `v2-mono` + `fontWeight: 700` + `textTransform: "uppercase"` + `letterSpacing: "0.18em"` + 18px in HF yellow. On a cold page (no data) the loudest type on the screen is the empty-state banner — the H1 is muted by comparison. Inversion of hierarchy.
+- **Fix**: Drop the HF-yellow tint on the heading; keep mono treatment but in `var(--v4-ink-300)` and `fontWeight: 600` to match the page lede tier. The empty-state should read as a subdued aside, not as the loudest element.
+- **Design call**: design — small hierarchy correction, propagates via #6 extraction.
+
+### 19. `MomentumBar` `boxShadow: 0 0 6px ${accent}66` is a glow — within DESIGN.md "glow reserved for focus/LIVE/overlay/popover/glow"
+
+- **Files**: [trending/page.tsx:340](../../../src/app/huggingface/trending/page.tsx#L340), datasets/spaces equivalent
+- **Mechanical**: 6px glow at 40% alpha on the momentum fill. DESIGN.md (per project rules) says no card shadows but allows glows for "focus, LIVE, overlay, popover, glow". A momentum bar is data viz, not a glow surface. Reads as a marketing-y touch on what should be tabular data.
+- **Fix**: Drop the `boxShadow` line entirely. The accent fill on its own is plenty. Pairs cleanly with #7's extraction.
+- **Design call**: design — single-line removal, restraint matters on a 100-row table.
+
+## What's working well (reference patterns to propagate)
+
+1. **Cold-state graceful degrade** ([trending/page.tsx:87-111](../../../src/app/huggingface/trending/page.tsx#L87), datasets + spaces same shape) — when `allModels.length === 0`, the page still renders PageHead + tab strip and only the body switches to ColdState. User never lands on a blank surface. Pattern matches `/reddit/trending` cold handling.
+2. **Card radii honor the spec** — `borderRadius: 2` on type chips, sdk chips, cold-state container. No `rounded-md`/`xl` drift.
+3. **No card shadows** — momentum-bar glow notwithstanding (#19), the page is clean: no `shadow-lg`, no `hover:shadow-*` on rows.
+4. **Functional accent-color signaling** — top-10 rank colored HF yellow ([trending/page.tsx:200](../../../src/app/huggingface/trending/page.tsx#L200)), high-download rows tinted ([L264](../../../src/app/huggingface/trending/page.tsx#L264)), 3+ underlying models on a Space tinted ([spaces/page.tsx:266](../../../src/app/huggingface/spaces/page.tsx#L266)). All are information color-keys, not decoration. Do not strip.
+5. **Tab `border-l`-equivalent functional color-key** — `HfNavTabs.tsx` active state uses HF yellow for border + text + bg-tint. This IS the functional color-key the rules call out — keep, just push through `var(--v4-src-hf)` per #4.
+6. **`force-static` + `revalidate = 1800`** — ISR cache aligns with the home `revalidate=1800`. Honest cache contract.
+7. **`MarkVisited routeKey="hfModels|hfDatasets|hfSpaces"`** — three distinct routeKeys mean the sidebar "fresh count" indicator is per-surface. Good per-source granularity.
+8. **`SourceFeedTemplate` consumer pattern** — all three pages follow the same shape (head + snapshot + tabBar + list). Template usage is consistent.
+
+## Verify-in-context
+
+- **HF cron cadence**: project memory says HF scrapers exist but doesn't pin the exact cadence; the inline `FRESH · 3H` label suggests scrapers run every 3h, which would mean a 12h budget (3h cadence × 2 grace × 2 cron-cadence = matches `npm`/`mcp`). Confirm against `.github/workflows/scrape-huggingface*.yml` before pinning the `SOURCE_STALE_MS["huggingface"]` value in #2.
+- **`oldestRecordAt` stamping**: `freshness.ts:findOldestRecordAt` looks for `lastRefreshedAt` strings in nested objects. Verify `scripts/scrape-huggingface*.mjs` writes per-record `lastRefreshedAt` — if yes, thread it through the `refreshHfModelsFromStore()` → page hook so `FreshnessBadge` gets the strongest signal. If no, the page-level `fetchedAt` alone is acceptable but the COLD-force escape hatch (per-record floor at `staleAfterMs × 2`) won't fire.
+- **`HfNavTabs` accessibility**: confirmed `aria-current="page"` is set correctly; `role="tablist"` is intentionally absent because these are route links, not in-page tabs (per #10).
+- **MarkVisited route keys** (`hfModels`, `hfDatasets`, `hfSpaces`): grep`ed in sidebar-content; routeKey strings match. Confirms the 3-surface independence is plumbed through to the sidebar fresh-count badge.
+- **`force-static` + the cold-state `<ColdState />`**: cold rendering inside a `force-static` page means the ISR snapshot can be cached cold. When the scraper recovers, the page won't re-render until the next 30-min revalidate window. Acceptable for HF cadence, but worth a comment so future operators don't think the cold state is sticky.
+- **No `bg-black` violations** detected on any HF surface. Audit-rule clean here.

--- a/docs/audits/impeccable/tierlist-audit.md
+++ b/docs/audits/impeccable/tierlist-audit.md
@@ -1,0 +1,132 @@
+# /tierlist audit — 2026-05-13
+
+## Files audited
+- [src/app/tierlist/page.tsx](../../../src/app/tierlist/page.tsx)
+- [src/app/tierlist/loading.tsx](../../../src/app/tierlist/loading.tsx)
+- [src/app/tierlist/error.tsx](../../../src/app/tierlist/error.tsx)
+- [src/components/tier-list/TierListEditor.tsx](../../../src/components/tier-list/TierListEditor.tsx)
+- [src/components/tier-list/TierBoard.tsx](../../../src/components/tier-list/TierBoard.tsx)
+- [src/components/tier-list/MobileTierPicker.tsx](../../../src/components/tier-list/MobileTierPicker.tsx)
+- [src/components/tier-list/RepoSearchBox.tsx](../../../src/components/tier-list/RepoSearchBox.tsx)
+- [src/components/tier-list/ShareBar.tsx](../../../src/components/tier-list/ShareBar.tsx)
+- [src/components/tier-list/TemplatePicker.tsx](../../../src/components/tier-list/TemplatePicker.tsx)
+- [src/components/tier-list/TopSharePngButton.tsx](../../../src/components/tier-list/TopSharePngButton.tsx)
+- [src/components/tier-list/Avatar.tsx](../../../src/components/tier-list/Avatar.tsx)
+- [src/components/tier-list/tier-list.css](../../../src/components/tier-list/tier-list.css)
+- [src/lib/tier-list/constants.ts](../../../src/lib/tier-list/constants.ts) (TIER_COLORS palette)
+- [src/lib/tier-list/client-store.ts](../../../src/lib/tier-list/client-store.ts) (state)
+- [src/app/globals.css#L1657-1673, L3634-3648](../../../src/app/globals.css) `.page-head .clock .live` + `.tool .t-foot .live`
+
+## P0 findings (dishonest / broken / a11y blocker)
+
+- **Hardcoded green-pulse `<span className="live">share-ready</span>` in page clock** — [page.tsx:52](../../../src/app/tierlist/page.tsx#L52). The `.live` class at [globals.css#L1657-1673](../../../src/app/globals.css#L1657) renders `--sig-green` text + a 6px green dot with `--shadow-live` glow — i.e. the LiveDot pattern reserved for live data feeds. `/tierlist` is a static, client-side editor with no underlying feed. Per `feedback_freshness_chrome_must_be_honest` this is a chrome lie. Fix: drop the `.live` class on this label (it's a static descriptor, not a freshness signal). Render as plain mono text or use the neutral eyebrow style. **Mechanical.**
+- **Hardcoded green-pulse `<span className="live">live</span>` on the active tool card** — [page.tsx:67](../../../src/app/tierlist/page.tsx#L67). Same pattern as above via `.tool .t-foot .live` at [globals.css#L3634-3648](../../../src/app/globals.css#L3634). The active tile gets a green-dot "LIVE" eyebrow even though "Tier list" is a static editor, not a live-data surface. Worse: the same green-dot meaning is reused on *non-active* tool cards elsewhere in the file pattern, so the visual reads inconsistently. Fix: replace the `.live` chip with a neutral `active` / `now` eyebrow that doesn't borrow the freshness vocabulary. **Mechanical.**
+- **Drag-to-tier has zero keyboard a11y for placement** — [TierBoard.tsx:42-45](../../../src/components/tier-list/TierBoard.tsx#L42). `useSensor(KeyboardSensor)` is wired, but the draggable cell ([TierBoard.tsx:261-269](../../../src/components/tier-list/TierBoard.tsx#L261)) only exposes the `listeners` on a button labelled "Drag handle for X" that is `hidden md:inline-flex` — desktop-only. There is no keyboard-reachable "place into S/A/B/..." control on desktop (the `<select>` at [TierBoard.tsx:284-302](../../../src/components/tier-list/TierBoard.tsx#L284) is hidden until `group-hover` / `group-focus-within` — but the hidden state means `select` is `display: none` and unreachable via Tab in keyboard-only nav). Net effect: keyboard users can't move an item into a tier on desktop. dnd-kit announcements alone don't solve placement; you need a visible drop-target list. Fix: render the per-item `<select>` permanently (or always-visible on focus, not on hover) so keyboard users can place items without a pointer. **Mechanical.**
+- **Tier letter editable input is reachable but unlabelled by screen reader for color context** — [TierBoard.tsx:118-124](../../../src/components/tier-list/TierBoard.tsx#L118). The input has `aria-label="Rename tier ${label}"` but the surrounding `<div className="tier-letter" style={{ backgroundColor: color }}>` ([TierBoard.tsx:117](../../../src/components/tier-list/TierBoard.tsx#L117)) carries the tier's identity (color is the *only* affordance distinguishing S/A/B/C). Color-blind users tabbing into the row hear "Rename tier S" but get no semantic color cue. Plus the four chrome buttons (color, remove, up, down) only become visible on `group-hover` / `focus-visible:opacity-100` — keyboard users *do* see them on tab-focus, but the affordance order (color → remove → up → down) is unannounced. Fix: keep `aria-label` but add a `<span class="sr-only">` describing tier rank + color name; ensure focus-order makes sense. **Design call** (operator: confirm sr-only copy pattern).
+
+## P1 findings (visible regression)
+
+- **Tap targets fail 44×44** — multiple sites in [tier-list.css](../../../src/components/tier-list/tier-list.css):
+  - `.tier-row-chrome` `18×18` ([L267-268](../../../src/components/tier-list/tier-list.css#L267))
+  - `.tier-color-picker button` `18×18` ([L310-311](../../../src/components/tier-list/tier-list.css#L310))
+  - `.ico-btn` `min-height: 28px` ([L189](../../../src/components/tier-list/tier-list.css#L189)) — "+ Add row" / "Reset" / "Share PNG"
+  - `.tier-result` `min-height: 38px` ([L128](../../../src/components/tier-list/tier-list.css#L128))
+  - `.tier-item` `height: 34px` ([L345](../../../src/components/tier-list/tier-list.css#L345))
+  Per project mobile rule (44×44 baseline, 375px viewport) all of these are tap-target failures. Fix: lift `.ico-btn` to `min-height: 44px`, `.tier-result` to `48px`, color-picker swatches to `28×28` with `8px` hit padding via `::before` so visual size stays compact. **Mechanical.**
+- **Tier label typography inconsistent: sans on desktop, mono on mobile** — desktop [tier-list.css:245-262](../../../src/components/tier-list/tier-list.css#L245) uses `font-family: var(--font-sans)` for `.tier-letter` and `.tier-letter-input`; mobile picker swatch [MobileTierPicker.tsx:221](../../../src/components/tier-list/MobileTierPicker.tsx#L221) uses `font-mono font-bold`. Per audit context ("Tier label typography — uppercase + mono per data convention") and the rest of this codebase's terminal-feel data type (every other `.key` / eyebrow uses mono), the desktop tier letters should be mono too. Same character ("S") reads as Inter on desktop and SF Mono on the bottom-sheet — visual drift. Fix: switch `.tier-letter` / `.tier-letter-input` to `font-family: var(--font-mono)`. **Design call** (operator: confirm mono is intended — current sans choice may be deliberate "Hanrahan" plan callout per [constants.ts:5](../../../src/lib/tier-list/constants.ts#L5)).
+- **`confirm("Clear the whole list?")` is a browser-native modal** — [TierListEditor.tsx:103](../../../src/components/tier-list/TierListEditor.tsx#L103). Inconsistent with the rest of the product (`ConfirmDialog.tsx` exists at `src/components/ui/ConfirmDialog.tsx` per the wave-1 PUNCH-LIST). Native confirm() has unstyled chrome, breaks visual continuity, and isn't keyboard-trappable in the same way. Fix: replace with the project's `ConfirmDialog`. **Mechanical.**
+- **No focus-visible outline on draggables, search results, color picker swatches, or chrome buttons** — only `.ico-btn:focus-visible` ([tier-list.css:205](../../../src/components/tier-list/tier-list.css#L205)) has a focus treatment. `.tier-item` (drag cell), `.tier-result` (search row), `.tier-color-picker button`, `.tier-row-chrome` all rely on browser-default focus rings which are often suppressed by `outline: 0` upstream. Tab through the editor and you can lose the focus indicator entirely. Fix: add `:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }` to each. **Mechanical.**
+- **Tier S/A/B/C/D/E/F palette is not theme-aware** — [constants.ts:7-15](../../../src/lib/tier-list/constants.ts#L7). Seven hardcoded hexes (`#FF7676`...`#FF8AC4`) baked in. The comment claims WCAG-AA against `#151419` only — but the project supports a light theme (per `--color-bg-*` token system in `globals.css`). On a light theme the saturated pastels lose contrast against `#0a0a0a` label text *and* against light backgrounds. Fix: define `--tier-color-1..7` tokens in `globals.css` that flip per `[data-theme]`, then have `TIER_COLORS` reference the tokens at render time. Otherwise document explicitly that /tierlist is dark-only. **Design call.**
+- **Search results `role="listbox"` lacks `aria-activedescendant` + keyboard navigation** — [RepoSearchBox.tsx:88-117](../../../src/components/tier-list/RepoSearchBox.tsx#L88). The `<div role="listbox">` contains buttons with `role="option"` + `aria-selected={false}` (always false — never tracks the focused option), and the input doesn't `aria-controls` / `aria-activedescendant` the listbox. Keyboard users can Tab into the listbox but lose typeahead's "down-arrow to select" expectation. Fix: wire arrow-key handling on the input that moves a `activeIndex` state, set `aria-activedescendant={resultId}` on the input, and `aria-selected={i === activeIndex}` on each option. **Mechanical.**
+- **`Avatar.tsx` monogram fallback hardcodes `#F56E0F` background** — [Avatar.tsx:51-52](../../../src/components/tier-list/Avatar.tsx#L51). Not theme-aware. Should be `var(--acc)` (the brand accent token). Same hardcode also fails when the brand color shifts seasonally. Fix: replace `backgroundColor: "#F56E0F"` with `backgroundColor: "var(--acc)"`. **Mechanical.**
+
+## P2 findings (polish / drift)
+
+- **Loading skeleton uses `--v3-bg-050` / `--v3-bg-100`** — [loading.tsx:11, 15, 18, 27](../../../src/app/tierlist/loading.tsx#L11). The shipped page renders under `.tierlist-page` which uses `--bg-*` / `--v4-*` tokens. Generation mismatch (skeleton on V3 tokens, page on V4) means a swap-in flash during navigation. **Design call.**
+- **Error page mixes V2 tokens (`--v2-sig-red`, `--v2-ink-*`) with V4 surface** — [error.tsx:23, 33, 42](../../../src/app/tierlist/error.tsx#L23). Same drift as loading.tsx — three different token generations live in one route. **Design call.**
+- **`.tier-item` is `cursor: grab` even on touch where it's a `<button>`** — [tier-list.css:351](../../../src/components/tier-list/tier-list.css#L351) sets `cursor: grab` on the wrapper, but on mobile the desktop drag handle is `hidden` and a *separate* button (the tap-to-open-picker variant) is shown. So mobile users see a grab cursor (if anything) on a button that doesn't drag. Cosmetic on touch but signals drag-not-supported elsewhere. Fix: scope `cursor: grab` to `.tier-item:has(button.cursor-grab)` or move it to the drag-handle button itself. **Mechanical.**
+- **`.tier-item .nm` max-width 220px** ([tier-list.css:358](../../../src/components/tier-list/tier-list.css#L358)) — a long owner/repo (`huggingface/transformers`) gets ellipsized. The owner segment carries the brand association ("which org wrote this") so the ellipsis hits the part users want to read. Consider showing only `repo.name` once `displayName` is in `itemMeta` (already populated at [RepoSearchBox.tsx:23-26](../../../src/components/tier-list/RepoSearchBox.tsx#L23)). **Design call.**
+- **`.tier-pool` border is `dashed`** ([tier-list.css:397](../../../src/components/tier-list/tier-list.css#L397)) — dashed borders typically signal "placeholder / inactive". The pool is the primary input region. A solid 1px `--line-300` reads as "real container", not "WIP zone". **Design call.**
+- **Hint section renders even when there's no real interaction yet** — [TierListEditor.tsx:117-138](../../../src/components/tier-list/TierListEditor.tsx#L117). The `Hint` panel ships full 4-step instructions in a `.tier-side` aside. After first-time use it's clutter. Fix: dismiss-once + localStorage flag, or fold into a small `?` toggle. **Design call.**
+- **`tier-toolbar .lbl` "Pool" + "Templates"** are uppercase mono eyebrows ([tier-list.css:84-89](../../../src/components/tier-list/tier-list.css#L84)) but `tier-title-meta` uses the same look at the same vertical band ([tier-list.css:67-73](../../../src/components/tier-list/tier-list.css#L67)). Two eyebrows that close to each other compete for attention. Drop the toolbar labels (the controls are self-explanatory). **Design call.**
+- **`MobileTierPicker.tsx:264` `text-[var(--v4-red)]`** uses raw CSS-var-in-Tailwind escape — the rest of the file uses theme tokens. Drift; works but inconsistent. **Polish.**
+- **`onDragEnd` doesn't validate `MAX_ITEMS_PER_TIER`** — [TierBoard.tsx:47-56](../../../src/components/tier-list/TierBoard.tsx#L47) hands off to `moveItem` which silently no-ops at the tier cap ([client-store.ts:158](../../../src/lib/tier-list/client-store.ts#L158)). User drags an item, drops it on a full tier, nothing happens, no toast. Fix: surface a `toast.error("Tier full — 10 items max")`. **Mechanical.**
+
+## What's working well
+
+- **No `<FreshnessBadge>` misuse** — the page is correctly NOT claiming a freshness budget (it's a static editor, not a feed). The honest-chrome violation is only at the `.live` decoration, not at the badge level.
+- **MobileTierPicker is a model implementation**: CSS-only transitions, `prefers-reduced-motion` bypass, Escape-to-close, body scroll lock, `role="dialog" aria-modal="true"`, modal scrim at `bg-black/60` (the documented FP). The 220ms duration sits inside the 120-180ms-to-non-bouncy band's tolerance for sheet-style transitions.
+- **Drag-drop pattern uses dnd-kit correctly** — `PointerSensor` with `distance: 4` activation constraint (prevents accidental drag on click), `KeyboardSensor` registered (even though placement keyboard a11y has a separate hole — see P0 #3).
+- **Mobile fallback exists**: `MobileTierPicker` is a deliberate "tap-to-place" alternative to long-press drag, with the cited NN/g rationale in the file header.
+- **Tier color picker is keyboard reachable**: `setPickerOpen` toggles + focus on Tab via `focus-visible:opacity-100` ([TierBoard.tsx:129, 139, 150, 161](../../../src/components/tier-list/TierBoard.tsx#L129)).
+- **Mobile-specific tap target exists**: separate `inline-flex md:hidden` button at [TierBoard.tsx:270-277](../../../src/components/tier-list/TierBoard.tsx#L270) opens the bottom sheet — touch users don't have to discover the drag handle.
+- **Tier removal preserves items**: `removeTier` re-buckets the items back into the unranked pool ([client-store.ts:244](../../../src/lib/tier-list/client-store.ts#L244)) instead of silently deleting.
+- **2px radii respected** — `rounded-[2px]`, `rounded-[3px]` (loading + picker buttons + tier-item swatch). No card shadows; `--shadow-card` resolves to `none` ([globals.css#L326](../../../src/app/globals.css#L326)) so the `box-shadow: var(--shadow-card)` on `.tier-results` ([tier-list.css:120](../../../src/components/tier-list/tier-list.css#L120)) is effectively a no-op (defensive, fine).
+- **CLI baseline FP recalibration honored**: the `bg-black/60` at [MobileTierPicker.tsx:117](../../../src/components/tier-list/MobileTierPicker.tsx#L117) is a documented modal scrim — not flagged as new per wave-1 punch list.
+- **Outbound `Share on X` opens in new tab** with `noopener,noreferrer` ([ShareBar.tsx:111](../../../src/components/tier-list/ShareBar.tsx#L111)). Honest outbound contract.
+- **`MAX_ITEMS_TOTAL = 70`** + `MAX_ITEMS_PER_TIER = 10` caps prevent unbounded state — defensive design.
+
+## Verify-in-context
+- **Tier palette theme-awareness** (P1 #5) — operator to confirm: is /tierlist intentionally dark-only, or should the seven hexes become CSS-var tokens that flip per `[data-theme]`?
+- **Tier letter typography** (P1 #2) — sans vs mono. Current desktop sans choice may be deliberate per `~/.claude/plans/trendingrepo-tier-typed-hanrahan.md` plan callout. Confirm intent before changing.
+- **`Hint` panel** (P2 #6) — keep or auto-dismiss after first interaction?
+
+## Mechanical fixes ready to ship
+
+1. P0 #1 — drop `.live` class from `<span>share-ready</span>` at [page.tsx:52](../../../src/app/tierlist/page.tsx#L52).
+2. P0 #2 — drop `.live` class from `<span>live</span>` at [page.tsx:67](../../../src/app/tierlist/page.tsx#L67); pick a neutral `active` eyebrow.
+3. P0 #3 — make `.tier-item-controls` always-visible (or visible on `:focus-within`) so keyboard users can reach the per-item placement `<select>`.
+4. P1 #1 — bump tap targets: `.ico-btn → min-height: 44px`, `.tier-result → 48px`, `.tier-color-picker button → 28×28 + 8px padded hit area`, `.tier-row-chrome → 28×28`.
+5. P1 #3 — swap `confirm(...)` for `<ConfirmDialog>` at [TierListEditor.tsx:103](../../../src/components/tier-list/TierListEditor.tsx#L103).
+6. P1 #4 — add `:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }` to `.tier-item`, `.tier-result`, `.tier-color-picker button`, `.tier-row-chrome`.
+7. P1 #7 — replace hardcoded `#F56E0F` in `Avatar.tsx` with `var(--acc)`.
+8. P2 #6 — wire `toast.error` on `moveItem` no-op (when target tier is at cap).
+
+## Quick-fix patches
+
+### P0 #1 + #2 — drop hardcoded `.live` chrome
+
+Before ([page.tsx:50-53, 67](../../../src/app/tierlist/page.tsx#L50)):
+```tsx
+<div className="clock">
+  <span className="big">S / F</span>
+  <span className="live">share-ready</span>
+</div>
+...
+<span className="t-foot"><span className="live">live</span><span className="ar">-&gt;</span></span>
+```
+
+After:
+```tsx
+<div className="clock">
+  <span className="big">S / F</span>
+  <span className="muted">share-ready</span>
+</div>
+...
+<span className="t-foot"><span className="muted">editor</span><span className="ar">-&gt;</span></span>
+```
+
+(or invent a neutral `.eyebrow-static` class in globals.css if a dedicated style is wanted — the rule is: only `<FreshnessBadge>` may render LiveDot chrome).
+
+### P1 #1 — 44×44 tap targets
+
+```css
+.ico-btn { min-height: 44px; padding: 0 14px; }
+.tier-result, .tier-result-empty { min-height: 48px; }
+.tier-row-chrome { width: 28px; height: 28px; }
+.tier-color-picker button { width: 28px; height: 28px; }
+```
+
+### P1 #7 — themed Avatar fallback
+
+Before ([Avatar.tsx:51-52](../../../src/components/tier-list/Avatar.tsx#L51)):
+```ts
+backgroundColor: "#F56E0F",
+color: "#0a0a0a",
+```
+
+After:
+```ts
+backgroundColor: "var(--acc)",
+color: "var(--ink-on-acc, #0a0a0a)",
+```


### PR DESCRIPTION
## Summary

5 LLM audits on diverse public surfaces. Read-only (markdown reports only). Stacks on origin/main.

## Findings — ~99 total

| Surface | P0 | P1 | P2 | P3 | Report |
|---|---|---|---|---|---|
| `/compare` | 4 | 6 | 10 | — | [compare-audit.md](docs/audits/impeccable/compare-audit.md) |
| `/breakouts` | 4 | 5 | 4 | 2 | [breakouts-audit.md](docs/audits/impeccable/breakouts-audit.md) |
| `/huggingface` | 4 | 9 | 6 | — | [huggingface-audit.md](docs/audits/impeccable/huggingface-audit.md) |
| `/collections` | 2 | 3 | 6 | — | [collections-audit.md](docs/audits/impeccable/collections-audit.md) |
| `/tierlist` | 4 | 7 | 9 | — | [tierlist-audit.md](docs/audits/impeccable/tierlist-audit.md) |
| **Totals** | **18** | **30** | **35** | **2** | |

## Headline findings per surface

- **`/compare`** — 3 hardcoded `<span class=live>` sites pulse green on static counters + chart head. Tap-target P0 on the pill X (~16×16).
- **`/breakouts`** — `force-static` page labels itself "refreshed live" — FreshnessBadge + FreshnessChip both report build-time age forever. `.badge.cons` tints negative 24h deltas green. `ChannelHeatStrip` primitive is built but **not imported** by the page.
- **`/huggingface`** — All three sub-pages (`/trending`, `/datasets`, `/spaces`) hardcode `LiveDot label="FRESH · 3H"`. Blocked from wave-3a-style fix because `NewsSource` union has no `huggingface` entry yet. `#FFD21E` hardcoded in 4 files (no `--v4-src-hf` token).
- **`/collections`** — Two hardcoded green-pulse spans render "Updated never" with a green halo. **Only audited top surface without `FreshnessBadge`**.
- **`/tierlist`** — 2 hardcoded `.live` pulses on a STATIC editor. **Keyboard-a11y blocker**: per-item placement select is `display: none` until `group-hover` — keyboard users can't move items on desktop.

## Pleasant surprises

- `MobileTierPicker` is well-built (Escape, scroll lock, reduced-motion, NN/g rationale documented).
- `HfNavTabs` active state correctly uses HF yellow as functional color-key.
- `/compare` preserves per-repo accent stripes as functional color-keys per project rules.

## What's NOT in this PR

Read-only audits. **Fixes land in wave-9+.** Pairs with PR #1189 (wave-8 P1 mechanical sweep, 13 P1 fixes shipped from existing audits).

## Test plan
- [x] All 5 reports written and reviewable
- [ ] (next wave) Apply mechanical fixes from these reports
- [ ] (cross-cutting fix candidate) Add `huggingface` to the NewsSource enum so `/huggingface` honest-chrome can ship same-pattern as wave-7c
- [ ] (cross-cutting fix candidate) Add `--v4-src-hf` token; cascade through `/huggingface` consumers same-shape as wave-7a's HN_ORANGE swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)