### PR TITLE
audit(impeccable): wave 9c — .badge.cons semantic-color fix (1 P0)

### DIFF
--- a/src/app/breakouts/page.tsx
+++ b/src/app/breakouts/page.tsx
@@ -252,7 +252,11 @@ export default async function BreakoutsPage({
                     <span className="rb gh"><span className="lab">R</span><span className="v">{channelRank(repo, nowMs, "reddit")}</span></span>
                     <span className="rb hf"><span className="lab">HN</span><span className="v">{channelRank(repo, nowMs, "hn")}</span></span>
                   </span>
-                  <span className="badge cons">
+                  <span
+                    className={`badge ${
+                      delta24 > 0 ? "cons" : delta24 < 0 ? "div" : "single"
+                    }`}
+                  >
                     <span className="pip" aria-hidden="true" />
                     {deltaLabel}
                   </span>


### PR DESCRIPTION
## Summary

- Fix wave-8 breakouts-audit P0-3: `.badge.cons` tinted ALL 24h delta values green on `/breakouts`, including negatives — falling momentum read as positive movement (semantic-color lie).
- Component-level branching: badge modifier now follows the sign of `delta24h`.

## Fix shape (Option A — component-level)

`src/app/breakouts/page.tsx` row body, was:
```tsx
<span className="badge cons">
  <span className="pip" aria-hidden="true" />
  {deltaLabel}
</span>
```
now:
```tsx
<span
  className={`badge ${
    delta24 > 0 ? "cons" : delta24 < 0 ? "div" : "single"
  }`}
>
  <span className="pip" aria-hidden="true" />
  {deltaLabel}
</span>
```

The three modifier rules already exist in `globals.css:5371-5403`:
- `.badge.cons`  → `--b-cons`  → `--color-positive` (green) — for `delta24 > 0`
- `.badge.div`   → `--b-div`   → `--color-warning` (amber, divergence) — for `delta24 < 0`
- `.badge.single`→ `--b-single`→ neutral grey via `--line-300` — for `delta24 === 0`

All semantic tokens; theme-aware; zero new CSS.

## Verification

- [x] `npm run typecheck` — green
- [x] `npm run lint:guards` — green (0 missing budgets, 0 orphans)
- [x] `npx impeccable@latest detect src/app/globals.css src/app/breakouts/ src/components/breakouts/` — no new findings introduced (1 pre-existing side-tab finding at globals.css:1499 unrelated to this fix)

## Files changed

- `src/app/breakouts/page.tsx` (+5 / -1)

Refs: wave-8 `docs/audits/impeccable/breakouts-audit.md` P0-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)