### PR TITLE
audit(impeccable): wave 9a — HuggingFace honest chrome + brand token (4 P0)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,6 +191,8 @@
   --source-openai-oklch: oklch(0.801 0.114 179.5);
   --source-claude: var(--color-warning);
   --source-claude-oklch: oklch(0.824 0.149 73.3);
+  --source-huggingface: #FFD21E;
+  --source-huggingface-oklch: oklch(0.879 0.169 92.5);
 
   /* ── Fonts (V2: Geist primary, V1 stack as fallback) ────────────────────── */
   --font-sans: var(--font-geist), var(--font-inter), "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
@@ -6233,7 +6235,7 @@ body::before {
   --v4-silver: var(--color-silver);
   --v4-bronze: #cd7f32;
 
-  /* Source channel colors (8 sources) */
+  /* Source channel colors (9 sources) */
   --v4-src-hn: #ff7a3d;
   --v4-src-gh: #c8d3df;
   --v4-src-x: #7aa7ff;
@@ -6255,6 +6257,7 @@ body::before {
   --v4-src-npm: #cb3837;
   --v4-src-npm-30: rgba(203, 56, 55, 0.30);
   --v4-src-npm-05: rgba(203, 56, 55, 0.05);
+  --v4-src-hf: #FFD21E;
 
   /* Funding source palette (8 sources) */
   --v4-fund-cb: #3a4a8e;

--- a/src/app/huggingface/datasets/page.tsx
+++ b/src/app/huggingface/datasets/page.tsx
@@ -27,12 +27,13 @@ import { huggingFaceLogoUrl, huggingFaceAuthorLogoUrl } from "@/lib/logos";
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { PageHead } from "@/components/ui/PageHead";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { MarkVisited } from "@/components/layout/MarkVisited";
 import { HfNavTabs } from "@/components/huggingface/HfNavTabs";
 import { HuggingFaceIcon } from "@/components/brand/BrandIcons";
 
-const HF_ACCENT_BAR = "#FFD21E"; // HF brand yellow
+// HF brand yellow — tokenized via --v4-src-hf (defined in globals.css).
+const HF_ACCENT_BAR = "var(--v4-src-hf)";
 
 export const dynamic = "force-static";
 export const revalidate = 1800; // 30 min
@@ -131,7 +132,7 @@ export default async function HuggingFaceDatasetsPage() {
               <>
                 <span className="big">{formatClock(file.fetchedAt)}</span>
                 <span className="muted">UTC · SCRAPED</span>
-                <LiveDot label="FRESH · 3H" />
+                <FreshnessBadge source="huggingface" lastUpdatedAt={file.fetchedAt} />
               </>
             }
           />

--- a/src/app/huggingface/spaces/page.tsx
+++ b/src/app/huggingface/spaces/page.tsx
@@ -26,12 +26,13 @@ import { huggingFaceLogoUrl, huggingFaceAuthorLogoUrl } from "@/lib/logos";
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { PageHead } from "@/components/ui/PageHead";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { MarkVisited } from "@/components/layout/MarkVisited";
 import { HfNavTabs } from "@/components/huggingface/HfNavTabs";
 import { HuggingFaceIcon } from "@/components/brand/BrandIcons";
 
-const HF_YELLOW = "#FFD21E";
+// HF brand yellow — tokenized via --v4-src-hf (defined in globals.css).
+const HF_YELLOW = "var(--v4-src-hf)";
 
 export const dynamic = "force-static";
 export const revalidate = 1800; // 30 min
@@ -130,7 +131,7 @@ export default async function HuggingFaceSpacesPage() {
               <>
                 <span className="big">{formatClock(file.fetchedAt)}</span>
                 <span className="muted">UTC · SCRAPED</span>
-                <LiveDot label="FRESH · 3H" />
+                <FreshnessBadge source="huggingface" lastUpdatedAt={file.fetchedAt} />
               </>
             }
           />

--- a/src/app/huggingface/trending/page.tsx
+++ b/src/app/huggingface/trending/page.tsx
@@ -25,14 +25,13 @@ import { huggingFaceLogoUrl, huggingFaceAuthorLogoUrl } from "@/lib/logos";
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { PageHead } from "@/components/ui/PageHead";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { MarkVisited } from "@/components/layout/MarkVisited";
 import { HfNavTabs } from "@/components/huggingface/HfNavTabs";
 import { HuggingFaceIcon } from "@/components/brand/BrandIcons";
 
-// HF "yellow" — no `--v4-src-hf` token exists; hardcoded once on the pip,
-// rest of the page stays tokenized via var(--v4-*).
-const HF_YELLOW = "#FFD21E";
+// HF brand yellow — tokenized via --v4-src-hf (defined in globals.css).
+const HF_YELLOW = "var(--v4-src-hf)";
 
 export const dynamic = "force-static";
 export const revalidate = 1800; // 30 min
@@ -141,7 +140,7 @@ export default async function HuggingFaceTrendingPage() {
               <>
                 <span className="big">{formatClock(file.fetchedAt)}</span>
                 <span className="muted">UTC · SCRAPED</span>
-                <LiveDot label="FRESH · 3H" />
+                <FreshnessBadge source="huggingface" lastUpdatedAt={file.fetchedAt} />
               </>
             }
           />

--- a/src/lib/news/freshness.ts
+++ b/src/lib/news/freshness.ts
@@ -27,7 +27,8 @@ export type NewsSource =
   | "mcp"
   | "skills"
   | "arxiv"
-  | "repos";
+  | "repos"
+  | "huggingface";
 
 export type FreshnessStatus = "live" | "warn" | "cold";
 
@@ -35,6 +36,10 @@ const TWITTER_STALE_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 // arXiv scraper runs every 3h; data cadence is daily-ish.
 // 12h budget = 3h cron + 9h grace before the badge goes cold.
 const ARXIV_STALE_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+// HF scrapers (models / datasets / spaces) run every 3h on staggered crons
+// (:13 / :25 / :35). 8h = one cron tick + 5h grace; warn fires at 4h (one
+// missed tick).
+const HUGGINGFACE_STALE_THRESHOLD_MS = 8 * 60 * 60 * 1000;
 
 /**
  * Mapping from NewsSource → stale threshold in ms. We treat the *stale*
@@ -68,6 +73,10 @@ export const SOURCE_STALE_MS: Record<NewsSource, number> = {
   // stalled trending refresh trips amber/cold honestly, but day-old "fresh"
   // data doesn't keep the home page lit green.
   repos: TWITTER_STALE_THRESHOLD_MS,
+  // HF models/datasets/spaces share the same 3h cron cadence — 8h budget
+  // (one tick + 5h grace) keeps the badge honest without firing on a
+  // single skipped run.
+  huggingface: HUGGINGFACE_STALE_THRESHOLD_MS,
 };
 
 /** Soft warn threshold = 50% of the stale threshold. Past it the badge


### PR DESCRIPTION
## Summary

Closes the /huggingface P0 cluster (4 findings) from the wave-8 audit. All 3 HF sub-pages (/trending, /datasets, /spaces) were rendering hardcoded \`<LiveDot label=\"FRESH · 3H\" />\` outside FreshnessBadge and using the literal \`#FFD21E\` in four files.

The fix was blocked because:

- NewsSource union had no \`\"huggingface\"\` entry
- No \`--source-huggingface\` / \`--v4-src-hf\` token existed

This PR closes both gaps and applies the wave-3a-style honest-chrome swap.

## Changes

1. **\`src/lib/news/freshness.ts\`** — adds \`\"huggingface\"\` to NewsSource union and \`HUGGINGFACE_STALE_THRESHOLD_MS = 8h\` (3h cron + 5h grace; warn at 4h = one missed tick). Modeled on the staggered HF crons (models :13, datasets :25, spaces :35).
2. **\`src/app/globals.css\`** — adds \`--source-huggingface: #FFD21E\` + \`--source-huggingface-oklch: oklch(0.879 0.169 92.5)\` to the \`--source-*\` block, and \`--v4-src-hf: #FFD21E\` to the v4 source palette block.
3. **\`src/app/huggingface/{trending,datasets,spaces}/page.tsx\`** — replace \`<LiveDot label=\"FRESH · 3H\" />\` with \`<FreshnessBadge source=\"huggingface\" lastUpdatedAt={file.fetchedAt} />\`; drop \`LiveDot\` import; repoint local \`HF_YELLOW\` / \`HF_ACCENT_BAR\` from \`\"#FFD21E\"\` literal to \`\"var(--v4-src-hf)\"\` so every downstream consumer site (pips, rank color, momentum bar, cold-state heading) flips to the token.

## Verification

- \`grep -rn \"LiveDot.*FRESH.*3H\|#FFD21E\" src/app/huggingface/\` → 0 matches
- \`npm run typecheck\` → green (enum change compiles)
- \`npm run lint:guards\` → green
- \`npx impeccable detect ...\` → no new findings (1 pre-existing finding in \`globals.css:1501\` unrelated to this diff)

## Test plan

- [ ] Vercel preview: visit \`/huggingface/trending\`, \`/huggingface/datasets\`, \`/huggingface/spaces\`
- [ ] Confirm the badge reads \`FRESH · Xh\` / \`STALE · Xh\` / \`COLD · Xd\` (not \`FRESH · 3H\` literal)
- [ ] Confirm the yellow brand color still renders (pips, rank top-10, momentum bar, cold-state heading)
- [ ] Hover the badge — tooltip should reveal the underlying \`fetchedAt\` ISO

🤖 Generated with [Claude Code](https://claude.com/claude-code)