### PR TITLE
audit(impeccable): wave 9e — /collections honest chrome (2 P0)

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -14,6 +14,7 @@ import {
   getCollectionRankingsFetchedAt,
   refreshCollectionRankingsFromStore,
 } from "@/lib/collection-rankings";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { absoluteUrl, SITE_NAME } from "@/lib/seo";
 
 export const revalidate = 600;
@@ -80,7 +81,8 @@ export default async function CollectionsIndexPage() {
         </div>
         <div className="clock">
           <span className="big">{cards.length}</span>
-          <span className="live">collections live</span>
+          <span>total</span>
+          <FreshnessBadge source="mcp" lastUpdatedAt={collectionRankingsFetchedAt} />
         </div>
       </section>
 
@@ -89,7 +91,7 @@ export default async function CollectionsIndexPage() {
           <div className="panel-head">
             <span className="key">{"// COLLECTION RANKINGS"}</span>
             <span className="right">
-              <span className="live">Updated {freshness}</span>
+              <FreshnessBadge source="mcp" lastUpdatedAt={collectionRankingsFetchedAt} />
             </span>
           </div>
         </section>


### PR DESCRIPTION
## Summary

Closes the 2 P0 honest-chrome findings from wave-8 `collections-audit.md`:

- **P0** Hardcoded `<span className="live">` at `page.tsx:83` and `:92` rendered a green-pulse halo regardless of rankings age. When `getCollectionRankingsFetchedAt()` returned `null`, the page literally rendered "Updated never" with a green pulse.
- **P0** `/collections` was the only audited top surface that didn't render the canonical `<FreshnessBadge>` — no machine-classified verdict (live/warn/cold).

## Fix

- Import `FreshnessBadge` from `@/components/shared/FreshnessBadge`
- Replace both lying `<span className="live">` blocks with `<FreshnessBadge source="mcp" lastUpdatedAt={collectionRankingsFetchedAt} />`
- Reword "collections live" → "total" (P2 copy fix bundled with the chrome fix per audit)

## NewsSource: `mcp`

`collection-rankings` is a slow-cron Redis-published feed on a 6h cadence (`cadenceMin: 360` in `worker/health/route.ts`). Threshold matches `NPM_STALE_THRESHOLD_MS` exactly — same family as MCP/Skills. Sibling pages `/breakouts`, `/agent-repos`, `/categories`, `/papers`, `/star-history` all use `source="mcp"` for the same reason. The audit's quick-fix patch explicitly suggests this value.

Same pattern wave-3a (PR #1150) shipped for `/signals`.

## Verification

- `npm run typecheck` — green
- `npm run lint:guards` — green
- `npx impeccable detect src/app/collections/` — clean (exit 0, zero findings)
- `grep -n 'className="live"\|<LiveDot' src/app/collections/page.tsx` — zero matches

## Test plan

- [ ] Vercel preview loads `/collections` with no green-pulse halo
- [ ] FreshnessBadge renders FRESH/STALE/COLD verdict next to the count
- [ ] When `collection-rankings` is cold/null, badge renders COLD (not "Updated never · green")
- [ ] No regression on other audited surfaces using `source="mcp"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)