### PR TITLE
chore(ci): migrate 14 scrape-* cron workflows to self-hosted runner (B.1.d batch 1)

### DIFF
--- a/.github/workflows/scrape-arxiv.yml
+++ b/.github/workflows/scrape-arxiv.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-awesome-skills.yml
+++ b/.github/workflows/scrape-awesome-skills.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-bluesky.yml
+++ b/.github/workflows/scrape-bluesky.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-claude-rss.yml
+++ b/.github/workflows/scrape-claude-rss.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-devto.yml
+++ b/.github/workflows/scrape-devto.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-huggingface-datasets.yml
+++ b/.github/workflows/scrape-huggingface-datasets.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-huggingface-spaces.yml
+++ b/.github/workflows/scrape-huggingface-spaces.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-huggingface.yml
+++ b/.github/workflows/scrape-huggingface.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-lobsters.yml
+++ b/.github/workflows/scrape-lobsters.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-npm-daily.yml
+++ b/.github/workflows/scrape-npm-daily.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-npm.yml
+++ b/.github/workflows/scrape-npm.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-openai-rss.yml
+++ b/.github/workflows/scrape-openai-rss.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-producthunt.yml
+++ b/.github/workflows/scrape-producthunt.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Migrates 14 scrape-* cron workflows from ubuntu-latest to [self-hosted, linux, x64]. First batch of B.1.d. Same gabagool-ams runner as ci.yml. Single-line edit per file; pattern is checkout → setup-node → npm ci → run script → git-commit-data. Crons fire on schedule and queue when runner is busy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)