### PR TITLE
chore(ci): migrate 16 refresh-* cron workflows to self-hosted runner (B.1.d batch 2)

### DIFF
--- a/.github/workflows/refresh-collection-rankings.yml
+++ b/.github/workflows/refresh-collection-rankings.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/refresh-hotness-snapshot.yml
+++ b/.github/workflows/refresh-hotness-snapshot.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-mcp-dependents.yml
+++ b/.github/workflows/refresh-mcp-dependents.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-mcp-smithery-rank.yml
+++ b/.github/workflows/refresh-mcp-smithery-rank.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-mcp-usage-snapshot.yml
+++ b/.github/workflows/refresh-mcp-usage-snapshot.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-npm-downloads.yml
+++ b/.github/workflows/refresh-npm-downloads.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-pypi-downloads.yml
+++ b/.github/workflows/refresh-pypi-downloads.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-reddit-baselines.yml
+++ b/.github/workflows/refresh-reddit-baselines.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/refresh-skill-claude.yml
+++ b/.github/workflows/refresh-skill-claude.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-derivatives.yml
+++ b/.github/workflows/refresh-skill-derivatives.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-forks-snapshot.yml
+++ b/.github/workflows/refresh-skill-forks-snapshot.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-skill-install-snapshot.yml
+++ b/.github/workflows/refresh-skill-install-snapshot.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-skill-lobehub.yml
+++ b/.github/workflows/refresh-skill-lobehub.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-skillsmp.yml
+++ b/.github/workflows/refresh-skill-skillsmp.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-smithery.yml
+++ b/.github/workflows/refresh-skill-smithery.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-star-activity.yml
+++ b/.github/workflows/refresh-star-activity.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   append:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
16 refresh-* cron workflows migrated from ubuntu-latest to [self-hosted, linux, x64]. Pattern matches scrape-* batch (PR #1196). Same runner gabagool-ams. 🤖 Generated with [Claude Code](https://claude.com/claude-code)