### PR TITLE
chore(ci): migrate cron-* workflows to self-hosted runner (B.1.d batch 3)

### DIFF
--- a/.github/workflows/cron-agent-commerce.yml
+++ b/.github/workflows/cron-agent-commerce.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/cron-aiso-drain.yml
+++ b/.github/workflows/cron-aiso-drain.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: POST /api/cron/aiso-drain

--- a/.github/workflows/cron-digest-weekly.yml
+++ b/.github/workflows/cron-digest-weekly.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: POST /api/cron/digest/weekly

--- a/.github/workflows/cron-freshness-check.yml
+++ b/.github/workflows/cron-freshness-check.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/cron-llm.yml
+++ b/.github/workflows/cron-llm.yml
@@ -41,7 +41,7 @@ jobs:
     if: |
       github.event_name == 'schedule' && github.event.schedule == '10 * * * *'
       || (github.event_name == 'workflow_dispatch' && inputs.job == 'aggregate')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: GET /api/cron/llm/aggregate
@@ -71,7 +71,7 @@ jobs:
     if: |
       github.event_name == 'schedule' && github.event.schedule == '15 2 * * *'
       || (github.event_name == 'workflow_dispatch' && inputs.job == 'sync-models')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: GET /api/cron/llm/sync-models

--- a/.github/workflows/cron-mcp-usage-rotate.yml
+++ b/.github/workflows/cron-mcp-usage-rotate.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: POST /api/cron/mcp/rotate-usage

--- a/.github/workflows/cron-pipeline-cleanup.yml
+++ b/.github/workflows/cron-pipeline-cleanup.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: POST /api/pipeline/cleanup

--- a/.github/workflows/cron-pipeline-ingest.yml
+++ b/.github/workflows/cron-pipeline-ingest.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: POST /api/pipeline/ingest

--- a/.github/workflows/cron-pipeline-persist.yml
+++ b/.github/workflows/cron-pipeline-persist.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: POST /api/pipeline/persist

--- a/.github/workflows/cron-pipeline-rebuild.yml
+++ b/.github/workflows/cron-pipeline-rebuild.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     # Rebuild can take substantially longer than an incremental ingest —
     # give it 30 min before the action runner hard-kills us. If a real
     # rebuild needs more, bump here rather than lowering the cadence.

--- a/.github/workflows/cron-reddit-daily.yml
+++ b/.github/workflows/cron-reddit-daily.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     # Bumped 15→30 min 2026-05-08 for Apify residential-proxy provider:
     # 45 subs × ~25-35s per sub (actor cold-start + scroll-paginate) ≈ 22 min
     # at steady state; 30 min gives headroom for Apify queue spikes.

--- a/.github/workflows/cron-twitter-outbound.yml
+++ b/.github/workflows/cron-twitter-outbound.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   fire:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Pick endpoint from schedule

--- a/.github/workflows/cron-warmup.yml
+++ b/.github/workflows/cron-warmup.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   warmup:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -72,7 +72,7 @@ jobs:
 
   summarize:
     needs: warmup
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     if: always()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cron-webhooks-flush.yml
+++ b/.github/workflows/cron-webhooks-flush.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: POST /api/cron/webhooks/scan


### PR DESCRIPTION
Batch 3 of cron migration. All cron-* workflows to self-hosted. Pattern matches batches 1+2 (PRs #1196 #1197). 🤖 Generated with [Claude Code](https://claude.com/claude-code)