### PR TITLE
chore(ci): migrate 27 remaining workflows to self-hosted (B.1.d batch 4)

### DIFF
--- a/.github/workflows/aiso-self-scan.yml
+++ b/.github/workflows/aiso-self-scan.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   self-scan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Trigger scan + capture event

--- a/.github/workflows/audit-freshness.yml
+++ b/.github/workflows/audit-freshness.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   auto-merge:
     if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/backfill-meta.yml
+++ b/.github/workflows/backfill-meta.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   backfill:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/check-nitter.yml
+++ b/.github/workflows/check-nitter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/check-profile-completion.yml
+++ b/.github/workflows/check-profile-completion.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   collect:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   collect:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/data-pr-validate.yml
+++ b/.github/workflows/data-pr-validate.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   validate:
     name: Validate data PR
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/enrich-arxiv.yml
+++ b/.github/workflows/enrich-arxiv.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   enrich:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/enrich-repo-profiles.yml
+++ b/.github/workflows/enrich-repo-profiles.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   enrich:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/health-watch.yml
+++ b/.github/workflows/health-watch.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ping-mcp-liveness.yml
+++ b/.github/workflows/ping-mcp-liveness.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   ping:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     env:
       BASE_URL: https://trendingrepo.com

--- a/.github/workflows/probe-reddit.yml
+++ b/.github/workflows/probe-reddit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   probe:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/promote-unknown-mentions.yml
+++ b/.github/workflows/promote-unknown-mentions.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   promote:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run-shadow-scoring.yml
+++ b/.github/workflows/run-shadow-scoring.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   shadow:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       REDIS_URL: ${{ secrets.REDIS_URL }}
       UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   gitleaks:
     name: Gitleaks workspace scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/sentry-fix-bot.yml
+++ b/.github/workflows/sentry-fix-bot.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   dispatch-agent:
     if: github.event.label.name == 'sentry-error'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Plant @claude prompt with stack-trace context
         env:

--- a/.github/workflows/snapshot-consensus.yml
+++ b/.github/workflows/snapshot-consensus.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   snapshot:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     # Hard cap so a hung Redis read can't burn the GH Actions 6h budget.
     # Belt; suspenders is the ioredis commandTimeout in src/lib/data-store.ts.
     timeout-minutes: 15

--- a/.github/workflows/snapshot-top10-sparklines.yml
+++ b/.github/workflows/snapshot-top10-sparklines.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   snapshot:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     # Hard cap so a hung Redis read can't burn the GH Actions 6h budget.
     timeout-minutes: 15
     steps:

--- a/.github/workflows/snapshot-top10.yml
+++ b/.github/workflows/snapshot-top10.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   snapshot:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     # Hard cap so a hung Redis read can't burn the GH Actions 6h budget.
     timeout-minutes: 15
     steps:

--- a/.github/workflows/sweep-cross-source-mentions.yml
+++ b/.github/workflows/sweep-cross-source-mentions.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   sweep:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/sweep-staleness.yml
+++ b/.github/workflows/sweep-staleness.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   sweep:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/sync-trustmrr.yml
+++ b/.github/workflows/sync-trustmrr.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/trendingrepo-worker.yml
+++ b/.github/workflows/trendingrepo-worker.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   ping:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 3
     strategy:
       fail-fast: false


### PR DESCRIPTION
Final batch of cron/utility migration. 27 files; only backup-redis-snapshot.yml stays on ubuntu-latest (needs sudo). Pattern matches batches 1-3. 🤖 Generated with [Claude Code](https://claude.com/claude-code)