### PR TITLE
audit(impeccable): wave 10c — /tierlist remaining P0s

### DIFF
--- a/src/app/tierlist/page.tsx
+++ b/src/app/tierlist/page.tsx
@@ -49,7 +49,7 @@ export default function TierListEditorPage() {
         </div>
         <div className="clock">
           <span className="big">S / F</span>
-          <span className="live">share-ready</span>
+          <span>share-ready</span>
         </div>
       </section>
 
@@ -64,7 +64,7 @@ export default function TierListEditorPage() {
           <span className="t-num">02</span>
           <span className="t-h">Tier list</span>
           <span className="t-d">Rank repos into a shareable board.</span>
-          <span className="t-foot"><span className="live">live</span><span className="ar">-&gt;</span></span>
+          <span className="t-foot"><span>editor</span><span className="ar">-&gt;</span></span>
         </Link>
         <Link className="tool" href="/compare">
           <span className="t-num">03</span>


### PR DESCRIPTION
## Summary

Per wave-8 [tierlist-audit.md](https://github.com/0motionguy/starscreener/blob/audit/imp-wave-8-audits/docs/audits/impeccable/tierlist-audit.md). Wave-9d (PR #1193) already closed the keyboard a11y P0. This wave closes the 2 mechanical chrome-honesty P0s:

- **P0 #1 — page.tsx:52**: Dropped `className=\"live\"` from the clock's \"share-ready\" badge. `/tierlist` is a static client-side editor with no live data feed; the `.live` class (globals.css L1657-1673) renders `--sig-green` + 6px dot + `--shadow-live` glow — the LiveDot pattern reserved for live feeds. Per `feedback_freshness_chrome_must_be_honest`, this is chrome dishonesty. Parent `.page-head .clock` already styles plain spans mono uppercase `--ink-300`.

- **P0 #2 — page.tsx:67**: Same fix on the active tool card's `t-foot` eyebrow. Swapped text \"live\" → \"editor\" + dropped `className=\"live\"`. Matches the neighboring inactive tools (\"model\", \"analysis\", \"chart\"). Parent `.tool .t-foot` styles plain children `--ink-400` uppercase mono.

### Deferred P0 #4

Audit lists a 4th P0 (tier-letter row missing sr-only color cue at TierBoard.tsx:118-124), but tags it `**Design call** (operator: confirm sr-only copy pattern)`. The existing `aria-label=\"Rename tier ${label}\"` already exposes the **tier rank** to screen readers — which is the semantic anchor for the row (color is decorative + user-chosen). Color naming (\"salmon\", \"coral\", ...) is subjective and needs operator approval before shipping. Flagging for next wave if operator wants it.

### Not in scope

TIER_COLORS theme-awareness is a P1 (not P0) in the audit and is itself a \"Design call\" (operator: confirm /tierlist is dark-only vs theme-aware). Other P1s (tap targets, font-sans→mono drift, Avatar `#F56E0F`, etc.) → future wave.

## Verification

- `npx impeccable@latest detect src/app/tierlist/ src/components/tier-list/` — 1 finding, the pre-existing `bg-black` modal scrim in MobileTierPicker.tsx:117 documented as a known FP in the audit (\"What's working well\" section). No new findings introduced.
- `npm run lint:guards` — all 3 sub-checks pass (check-img-lazy, check-collector-keep-last-50, check-routes-config).
- `npm run typecheck` — clean.

## Test plan

- [ ] Vercel preview: visit `/tierlist`, confirm \"share-ready\" no longer renders green dot/glow.
- [ ] Same preview: confirm the \"Tier list\" tool card eyebrow reads \"editor\" with no green dot, visually consistent with sibling tool cards (\"model\", \"analysis\", \"chart\").
- [ ] No regression in `.live` rendering on actual live-data surfaces (e.g. `/`, `/dashboard`, `/tabs`-using pages).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>