### PR TITLE
audit(impeccable): wave 10a — close 4 P0s on /compare

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -48,7 +48,7 @@ export default function ComparePage() {
               <CompareSelectedCount />
             </Suspense>
           </span>
-          <span className="live">series selected</span>
+          <span className="t-d">series selected</span>
         </div>
       </section>
 
@@ -60,7 +60,7 @@ export default function ComparePage() {
             Compare momentum curves across repos and export the chart.
           </span>
           <span className="t-foot">
-            <span className="live">live</span>
+            <span>live</span>
             <span className="ar">-&gt;</span>
           </span>
         </Link>

--- a/src/components/compare/CompareSelector.tsx
+++ b/src/components/compare/CompareSelector.tsx
@@ -237,7 +237,8 @@ export function CompareSelector() {
                 type="button"
                 onClick={() => removeRepo(id)}
                 className={cn(
-                  "p-0.5 rounded-full hover:bg-bg-card-hover transition-colors cursor-pointer",
+                  "p-2 -my-2 -mr-1 rounded-full hover:bg-bg-card-hover transition-colors cursor-pointer",
+                  "min-w-[44px] min-h-[44px] flex items-center justify-center",
                   "text-text-tertiary hover:text-text-primary",
                 )}
                 aria-label={`Remove ${name}`}

--- a/src/components/compare/CompareWaveTop.tsx
+++ b/src/components/compare/CompareWaveTop.tsx
@@ -8,6 +8,7 @@ import { CompareSelector } from "./CompareSelector";
 import { CompareStatStrip } from "./CompareStatStrip";
 import { CompareSharePanel } from "./CompareSharePanel";
 import { StarterPackRow } from "./StarterPackRow";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 // Inline minimal Repo stub so we don't drag node:fs/node:path from
 // @/lib/collections into this client component. Mirrors buildCuratedStub
 // shape for the no-data case the chart already handles.
@@ -215,6 +216,18 @@ export function CompareWaveTop() {
     () => buildMindsharePctByFullName(payloads),
     [payloads],
   );
+  // Max payload.updatedAt across all resolved series — drives an honest
+  // freshness verdict in the panel head. Per-payload Redis-published cadence
+  // is ~6h, so `mcp` NewsSource (12h budget) is the closest threshold.
+  // Null collapses the badge to "unknown" (no payloads yet / empty state).
+  const maxUpdatedAt = useMemo<string | null>(() => {
+    let max: string | null = null;
+    for (const p of Object.values(payloads)) {
+      if (!p.updatedAt) continue;
+      if (!max || p.updatedAt > max) max = p.updatedAt;
+    }
+    return max;
+  }, [payloads]);
 
   const [metric, setMetric] = useState<StarActivityMetric>("stars");
   const [chartWindow, setChartWindow] = useState<StarActivityWindow>("all");
@@ -261,7 +274,7 @@ export function CompareWaveTop() {
         <div className="panel-head">
           <span className="key">{`// STAR HISTORY / CHART / ${repoIds.length} SERIES`}</span>
           <span className="right">
-            <span className="live">Live</span>
+            <FreshnessBadge source="mcp" lastUpdatedAt={maxUpdatedAt} />
           </span>
         </div>
         <div className="panel-body compare-control-body">


### PR DESCRIPTION
## Summary

Closes the 4 P0 findings from the wave-8 [compare-audit.md](https://github.com/0motionguy/starscreener/blob/audit/imp-wave-8-audits/docs/audits/impeccable/compare-audit.md).

- **P0 #1** (`page.tsx:51`) — Dropped `.live` from the `series selected` counter. UI state, not data freshness — the green pulse was a lie. (Option B per task spec.)
- **P0 #2** (`page.tsx:63`) — Dropped `.live` from the Star History tool-card foot. Sibling tiles (Signals / Top 10 / Tier List) don't have it; consistency wins over a never-wired freshness claim. (Option B.)
- **P0 #3** (`CompareWaveTop.tsx:264`) — Replaced static `<span className="live">Live</span>` with `<FreshnessBadge source="mcp" lastUpdatedAt={maxUpdatedAt} />`. Wired to the max `updatedAt` across resolved `StarActivityPayload`s; `mcp` NewsSource (12h budget) matches the slow-cron Redis-published payload cadence per `SOURCE_STALE_MS`. (Option A — this panel does display data with a real timestamp.)
- **P0 #4** (`CompareSelector.tsx:236-245`) — Pill X tap-target was ~16×16, failed the 44×44 mobile minimum. Applied audit-prescribed approach: `min-w-[44px] min-h-[44px] p-2 -my-2 -mr-1 flex items-center justify-center`. Visual pill stays compact via negative margin; real hit area is 44×44. Destructive-action a11y restored.

3 files changed, 18 insertions, 4 deletions.

## Test plan

- [x] `npx impeccable@latest detect src/app/compare/ src/components/compare/` — zero `live` / freshness / tap-target findings remain (only pre-existing P1/P2 `borderLeft: 3px` repo-identity stripes, called out as functional in the audit).
- [x] `npm run lint:guards` — green.
- [x] `npm run typecheck` — clean.
- [x] `npx vitest run src/components/compare/ src/hooks/__tests__/useCompareRepos.test.tsx` — 6/6 pass; no compare-touching tests assert on the old shape.
- [ ] Preview: pull `/compare` with no `?repos=` param — counter no longer pulses green, no "live" dots, "FRESH/STALE/COLD" badge appears only when chart payloads are loaded.
- [ ] Mobile devtools 375px: pill X remove button is tappable with thumb-sized target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)