### PR TITLE
audit(impeccable): wave 10b — /breakouts honest chrome + OG fix (2 P0)

### DIFF
--- a/src/app/breakouts/page.tsx
+++ b/src/app/breakouts/page.tsx
@@ -4,7 +4,9 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { getDerivedRepos } from "@/lib/derived-repos";
-import { lastFetchedAt } from "@/lib/trending";
+import { getLastFetchedAt, refreshTrendingFromStore } from "@/lib/trending";
+import { refreshRedditMentionsFromStore } from "@/lib/reddit-data";
+import { refreshHackernewsMentionsFromStore } from "@/lib/hackernews";
 import { getChannelStatus } from "@/lib/pipeline/cross-signal";
 import { formatNumber } from "@/lib/utils";
 import type { Repo } from "@/lib/types";
@@ -17,17 +19,21 @@ import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { FreshnessChip } from "@/components/shared/FreshnessChip";
 
-export const dynamic = "force-static";
+// ISR cadence — match sibling surfaces (/mcp, /agent-repos, /). 60s keeps
+// FreshnessBadge + FreshnessChip + VerdictRibbon "refreshed live" stamp
+// honest: each window re-runs the data-store refresh hooks and rebuilds
+// from the post-refresh in-memory cache.
+export const revalidate = 60;
 
 export const metadata: Metadata = {
   title: "Cross-Signal Breakouts",
   description:
-    "Repos firing across multiple signal channels right now — GitHub stars, Reddit, Hacker News, Bluesky, dev.to, and X/Twitter — surfaced before they go mainstream.",
+    "Repos firing across multiple signal channels right now — GitHub stars, Reddit submissions, and Hacker News — surfaced before they go mainstream.",
   alternates: { canonical: "/breakouts" },
   openGraph: {
     title: "Cross-Signal Breakouts — TrendingRepo",
     description:
-      "Repos firing across multiple signal channels at once. The earliest cross-source breakout view.",
+      "Repos firing across GitHub stars, Reddit, and Hacker News at once. The earliest cross-source breakout view.",
     url: "/breakouts",
     type: "website",
   },
@@ -35,7 +41,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Cross-Signal Breakouts — TrendingRepo",
     description:
-      "Repos firing across multiple signal channels at once. The earliest cross-source breakout view.",
+      "Repos firing across GitHub stars, Reddit, and Hacker News at once. The earliest cross-source breakout view.",
   },
 };
 
@@ -76,6 +82,18 @@ export default async function BreakoutsPage({
   const params = await searchParams;
   const filter = parseFilter(params.filter);
   const nowMs = Date.now();
+
+  // Hydrate the stores the three rendered channels read from so each ISR
+  // window resolves a real "now" timestamp and live channel status rather
+  // than build-time-frozen values. Per CLAUDE.md "data reads MUST go
+  // through the data-store."
+  await Promise.all([
+    refreshTrendingFromStore(),
+    refreshRedditMentionsFromStore(),
+    refreshHackernewsMentionsFromStore(),
+  ]);
+
+  const lastFetchedAt = getLastFetchedAt();
 
   const annotated = getDerivedRepos().map((repo) => ({
     ...repo,


### PR DESCRIPTION
## Summary

Closes 2 P0 defects from wave-8 `breakouts-audit.md`.

### P0 #1 — `force-static` + "refreshed live" chrome lie
Page was `export const dynamic = "force-static"` while `<FreshnessBadge>`, per-row `<FreshnessChip>`, and the `VerdictRibbon` sub-stamp all claimed live freshness. The imported `lastFetchedAt` was a captured-at-import-time constant (see `src/lib/trending.ts:57`), so all three chrome elements reported build-time age forever.

**Fix (direction A):**
- `force-static` -> `revalidate = 60`, matching sibling surfaces (`/mcp`, `/agent-repos`, home).
- Added `await Promise.all([refreshTrendingFromStore(), refreshRedditMentionsFromStore(), refreshHackernewsMentionsFromStore()])` at handler entry so each ISR window pulls fresh Redis payloads through the data-store. The three refreshes correspond exactly to the three channels `visibleFiring`/`getChannelStatus` reads (GH stars, Reddit, HN).
- Swapped `import { lastFetchedAt }` -> `import { getLastFetchedAt }`. The page now binds `const lastFetchedAt = getLastFetchedAt()` after the refreshes, so `<FreshnessBadge>` and `<FreshnessChip>` render the post-refresh timestamp.
- 60s cadence chosen because refresh hooks already self-rate-limit at 30s; shorter would no-op, longer would lag siblings.

### P0 #2 — OG description mismatch (6 sources promised, 3 delivered)
`metadata.description` and both `openGraph` / `twitter` descriptions claimed "GitHub stars, Reddit, Hacker News, Bluesky, dev.to, and X/Twitter" — but `visibleFiring` only sums github+reddit+hn, the rank columns render three pips, and the page lede already correctly says "Three signal sources."

**Fix (direction A):** rewrote all three description fields to match the rendered three-channel reality. Honest is winning per PRODUCT.md.

## Files changed
- `src/app/breakouts/page.tsx` (+23, -5)

## Verification
- `npx --yes impeccable@latest detect src/app/breakouts/ src/components/breakouts/` — exit 0, clean
- `npm run lint:guards` — green
- `npm run typecheck` — green
- `npm run build` — green; `/breakouts` no longer emits `.html` (was static, is now ISR)

## Out of scope
Wave-8 audit also lists P0-3 (`.badge.cons` semantic-color fix — shipped in PR #1192 per wave-9c), plus P1/P2/P3 defects (column header rename, ChannelHeatStrip wiring, FreshnessBadge `source="mcp"` mismatch, tap target a11y, avatar slice, etc.) — leave to follow-up waves.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>