### PR TITLE
refactor(lib): extract toolbox-store-common.ts (B.10)

### DIFF
--- a/src/lib/toolbox-store-common.ts
+++ b/src/lib/toolbox-store-common.ts
@@ -1,0 +1,95 @@
+// TOOLBOX read adapter — shared primitives
+//
+// Common types + fetch wrapper + helpers used by per-signal adapters in
+// toolbox-store.ts (mentions: hn/reddit/bluesky/devto) and
+// toolbox-store-velocity.ts (stars + fork velocity). New adapters
+// (huggingface variants, producthunt, openai-rss, etc.) import from here
+// instead of duplicating the boilerplate.
+//
+// Each adapter still owns its own row-shaping logic (mapping TOOLBOX
+// events to the legacy file shape that the UI layer expects); only the
+// transport + identity-extraction live here.
+
+import "server-only";
+
+export const DEFAULT_LIMIT = 500;
+export const DEFAULT_TIMEOUT_MS = 8_000;
+
+export interface ToolboxEvent {
+  target_id: string;
+  target_kind: string;
+  target_identity: string;
+  scan_id: string;
+  run_id: string;
+  signal_type: string;
+  produced_at: string;
+  fields: Record<string, unknown>;
+}
+
+export interface ToolboxLeaderboardResponse {
+  count: number;
+  targets: ToolboxEvent[];
+}
+
+export interface ToolboxFetchOptions {
+  apiUrl: string;
+  apiKey: string;
+  limit?: number;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export function extractGithubFullName(targetIdentity: string): string | null {
+  try {
+    const url = new URL(targetIdentity);
+    const host = url.hostname.toLowerCase();
+    if (host !== "github.com" && host !== "www.github.com") return null;
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    return `${parts[0]}/${parts[1]}`;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchLeaderboardEvents(
+  opts: ToolboxFetchOptions,
+  signalType: string,
+): Promise<ToolboxLeaderboardResponse | null> {
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") return null;
+
+  const base = opts.apiUrl.replace(/\/+$/, "");
+  const url = `${base}/v1/signals/leaderboard?type=${encodeURIComponent(signalType)}&limit=${limit}`;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      headers: {
+        authorization: `Bearer ${opts.apiKey}`,
+        accept: "application/json",
+      },
+      signal: ac.signal,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as ToolboxLeaderboardResponse;
+    if (!body || !Array.isArray(body.targets)) return null;
+    return body;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function maxProducedAtMs(events: ToolboxEvent[]): number {
+  let max = 0;
+  for (const ev of events) {
+    const t = Date.parse(ev.produced_at);
+    if (Number.isFinite(t) && t > max) max = t;
+  }
+  return max;
+}

--- a/src/lib/toolbox-store-velocity.ts
+++ b/src/lib/toolbox-store-velocity.ts
@@ -28,79 +28,14 @@ import "server-only";
 
 import type { DeltasJson, DeltaValue, RepoDeltaEntry } from "./trending";
 import { getFullNameToRepoId } from "./trending";
+import type { ToolboxEvent, ToolboxFetchOptions } from "./toolbox-store-common";
+import {
+  extractGithubFullName,
+  fetchLeaderboardEvents,
+  maxProducedAtMs,
+} from "./toolbox-store-common";
 
-const DEFAULT_LIMIT = 500;
-const DEFAULT_TIMEOUT_MS = 8_000;
-
-interface ToolboxEvent {
-  target_id: string;
-  target_kind: string;
-  target_identity: string;
-  scan_id: string;
-  run_id: string;
-  signal_type: string;
-  produced_at: string;
-  fields: Record<string, unknown>;
-}
-
-interface ToolboxLeaderboardResponse {
-  count: number;
-  targets: ToolboxEvent[];
-}
-
-export interface ToolboxFetchOptions {
-  apiUrl: string;
-  apiKey: string;
-  limit?: number;
-  timeoutMs?: number;
-  fetchImpl?: typeof fetch;
-}
-
-function extractGithubFullName(targetIdentity: string): string | null {
-  try {
-    const url = new URL(targetIdentity);
-    const host = url.hostname.toLowerCase();
-    if (host !== "github.com" && host !== "www.github.com") return null;
-    const parts = url.pathname.split("/").filter(Boolean);
-    if (parts.length < 2) return null;
-    return `${parts[0]}/${parts[1]}`;
-  } catch {
-    return null;
-  }
-}
-
-async function fetchLeaderboardEvents(
-  opts: ToolboxFetchOptions,
-  signalType: string,
-): Promise<ToolboxLeaderboardResponse | null> {
-  const limit = opts.limit ?? DEFAULT_LIMIT;
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
-  if (typeof fetchImpl !== "function") return null;
-
-  const base = opts.apiUrl.replace(/\/+$/, "");
-  const url = `${base}/v1/signals/leaderboard?type=${encodeURIComponent(signalType)}&limit=${limit}`;
-
-  const ac = new AbortController();
-  const timer = setTimeout(() => ac.abort(), timeoutMs);
-  try {
-    const res = await fetchImpl(url, {
-      headers: {
-        authorization: `Bearer ${opts.apiKey}`,
-        accept: "application/json",
-      },
-      signal: ac.signal,
-    });
-    if (!res.ok) return null;
-    const body = (await res.json()) as ToolboxLeaderboardResponse;
-    if (!body || !Array.isArray(body.targets)) return null;
-    return body;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
-}
+export type { ToolboxFetchOptions };
 
 const WINDOWS = ["1h", "24h", "7d", "30d"] as const;
 type DeltaWindow = (typeof WINDOWS)[number];
@@ -150,15 +85,6 @@ function createEmptyEntry(): RepoDeltaEntry {
     delta_7d: noHistory(),
     delta_30d: noHistory(),
   };
-}
-
-function maxProducedAtMs(events: ToolboxEvent[]): number {
-  let max = 0;
-  for (const ev of events) {
-    const t = Date.parse(ev.produced_at);
-    if (Number.isFinite(t) && t > max) max = t;
-  }
-  return max;
 }
 
 /**

--- a/src/lib/toolbox-store.ts
+++ b/src/lib/toolbox-store.ts
@@ -43,46 +43,14 @@ import type {
   RedditPost,
   RedditRepoMention,
 } from "./reddit";
+import type { ToolboxEvent, ToolboxFetchOptions } from "./toolbox-store-common";
+import {
+  extractGithubFullName,
+  fetchLeaderboardEvents,
+  maxProducedAtMs,
+} from "./toolbox-store-common";
 
-const DEFAULT_LIMIT = 500;
-const DEFAULT_TIMEOUT_MS = 8_000;
-
-interface ToolboxEvent {
-  target_id: string;
-  target_kind: string;
-  target_identity: string;
-  scan_id: string;
-  run_id: string;
-  signal_type: string;
-  produced_at: string;
-  fields: Record<string, unknown>;
-}
-
-interface ToolboxLeaderboardResponse {
-  count: number;
-  targets: ToolboxEvent[];
-}
-
-export interface ToolboxFetchOptions {
-  apiUrl: string;
-  apiKey: string;
-  limit?: number;
-  timeoutMs?: number;
-  fetchImpl?: typeof fetch;
-}
-
-function extractGithubFullName(targetIdentity: string): string | null {
-  try {
-    const url = new URL(targetIdentity);
-    const host = url.hostname.toLowerCase();
-    if (host !== "github.com" && host !== "www.github.com") return null;
-    const parts = url.pathname.split("/").filter(Boolean);
-    if (parts.length < 2) return null;
-    return `${parts[0]}/${parts[1]}`;
-  } catch {
-    return null;
-  }
-}
+export type { ToolboxFetchOptions };
 
 function slugIdFromFullName(fullName: string): string {
   return String(fullName)
@@ -90,48 +58,6 @@ function slugIdFromFullName(fullName: string): string {
     .replace(/\//g, "--")
     .replace(/\./g, "-")
     .replace(/[^a-z0-9-]/g, "");
-}
-
-async function fetchLeaderboardEvents(
-  opts: ToolboxFetchOptions,
-  signalType: string,
-): Promise<ToolboxLeaderboardResponse | null> {
-  const limit = opts.limit ?? DEFAULT_LIMIT;
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
-  if (typeof fetchImpl !== "function") return null;
-
-  const base = opts.apiUrl.replace(/\/+$/, "");
-  const url = `${base}/v1/signals/leaderboard?type=${encodeURIComponent(signalType)}&limit=${limit}`;
-
-  const ac = new AbortController();
-  const timer = setTimeout(() => ac.abort(), timeoutMs);
-  try {
-    const res = await fetchImpl(url, {
-      headers: {
-        authorization: `Bearer ${opts.apiKey}`,
-        accept: "application/json",
-      },
-      signal: ac.signal,
-    });
-    if (!res.ok) return null;
-    const body = (await res.json()) as ToolboxLeaderboardResponse;
-    if (!body || !Array.isArray(body.targets)) return null;
-    return body;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-function maxProducedAtMs(events: ToolboxEvent[]): number {
-  let max = 0;
-  for (const ev of events) {
-    const t = Date.parse(ev.produced_at);
-    if (Number.isFinite(t) && t > max) max = t;
-  }
-  return max;
 }
 
 function isoFromMaxOrNow(maxMs: number): string {


### PR DESCRIPTION
Dedupes ~80 lines between toolbox-store.ts + toolbox-store-velocity.ts. Unblocks B.9 (5 new mention adapters). 30/30 tests pass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)