### PR TITLE
audit(impeccable): wave 11b — reconcile chart palette drift (orange-first canonical)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,11 +147,13 @@
 
   /* ── Chart series — 5-slot rotating palette for compare/heatmap/multi-line.
      Slot order matches the compare-page selector pills + repo-profile columns
-     so chart strokes, banner accents, and column headers line up by index. */
-  --color-series-1: var(--color-positive);  /* green  — slot 0 */
-  --color-series-2: var(--color-blue);  /* blue   — slot 1 */
-  --color-series-3: var(--color-violet);  /* purple — slot 2 */
-  --color-series-4: var(--color-warning);  /* amber  — slot 3 */
+     so chart strokes, banner accents, and column headers line up by index.
+     Unified with tokens.ts SERIES_PALETTE (orange-first, brand-accent lead)
+     in wave-11b. ECharts theme + CSS sparklines now show identical slot-0. */
+  --color-series-1: var(--color-accent);    /* orange — slot 0 (lead) */
+  --color-series-2: var(--color-positive);  /* green  — slot 1 */
+  --color-series-3: var(--color-cyan);      /* cyan   — slot 2 */
+  --color-series-4: var(--color-warning);   /* amber  — slot 3 */
   --color-series-5: var(--color-negative);  /* red    — slot 4 (compare cap bumped 4→5 in W3) */
 
   /* ── Terminal surfaces ─────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Resolves the chart palette drift documented in DESIGN.md (wave-1 PR #1146) and flagged in /signals audit (wave-2). Stacks on main.

## The drift

globals.css `--color-series-*` was green-first; tokens.ts `SERIES_PALETTE` (the actual ECharts theme) is orange-first. Side-by-side renders (CSS sparkline + ECharts viz) showed different first-series colors.

## Canonical choice: orange-first

Aligns globals.css to tokens.ts because:
1. tokens.ts is what ECharts actually consumes in every chart render
2. Brand-accent orange leading = "lead story reads as brand-themed"
3. /signals ConsensusRadar already deliberately uses `CHART_TOKENS.accent` (orange) as top polygon for brand-accent leadership
4. globals.css `--color-series-*` is the SECONDARY consumer — minimal blast radius to align it

## Verified consumers

`grep -rln "color-series-[1-5]" src/` — 1 consumer file (`src/components/compare/palette.ts` exporting `COMPARE_PALETTE`), used by 4 /compare components (`CompareChart`, `CompareClient`, `CompareStatStrip`, `RepoProfileColumn`). All four index positionally (`palette[i]`) by user-selection slot — no slot carries semantic meaning. First-selected repo's banner accent + chart stroke shifts from green to orange; this is a brand alignment, not a semantic break. /compare page tested mentally with the swap — no broken meaning.

## Follow-up

DESIGN.md \"Chart series palette — NOTE: drift\" section needs the drift note removed after wave-1 PR #1146 merges. Documented in commit message. (DESIGN.md does not exist on main — it lives on PR #1146 only, so the cleanup must happen there post-merge.)

## Test plan
- [x] impeccable detect clean (only pre-existing `[side-tab]` finding at line 1501 remains, unrelated to this change at line 151)
- [x] lint:guards green
- [x] typecheck green
- [ ] (post-merge) visual check chart-rendering surface (e.g., /signals ConsensusRadar) — palette should be unchanged (it was already orange via tokens.ts); /compare CSS consumers (`--color-series-*`) now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)