### PR TITLE
audit(impeccable): wave 11a — 5 more surface audits (/devto /producthunt /bluesky-trending /npm /arxiv, ~67 findings)

### DIFF
--- a/docs/audits/impeccable/arxiv-audit.md
+++ b/docs/audits/impeccable/arxiv-audit.md
@@ -1,0 +1,107 @@
+# Impeccable design audit — `/arxiv/trending`
+
+**Surface**: `/arxiv/trending` (no separate `/arxiv` landing — directory only contains `trending/`).
+**Date**: 2026-05-13 · **Worktree**: `wave11a` · **Branch**: `audit/imp-wave-11a-audits`
+**Counts**: P0 × 2 · P1 × 3 · P2 × 4 · P3 × 3
+
+**Headline**: Two P0 honest-chrome violations. A hardcoded `<LiveDot label="FRESH · 3H" />` pulses green every render regardless of `file.fetchedAt`, on a feed whose cadence is daily-ish + scraped on a 3h cron — and the cold branch strips freshness chrome entirely. arXiv brand `#B22234` (Cornell crimson) collides visually with `--v4-red` (loss semantics) on rank numerals + momentum bar. NewsSource enum has no `arxiv` member, so `FreshnessBadge` cannot drop in without a one-line enum extension (mechanical).
+
+---
+
+## P0 — Ship-stopping
+
+### P0-1 · Hardcoded green-pulse "FRESH · 3H" outside FreshnessBadge
+- [`src/app/arxiv/trending/page.tsx:125`](../../../src/app/arxiv/trending/page.tsx#L125) — `<LiveDot label="FRESH · 3H" />` resolves to default `tone="money"` ([`LiveDot.tsx:29`](../../../src/components/ui/LiveDot.tsx#L29)) → `v4-live-dot--money` green pulse via `var(--v4-shadow-pulse-money)` at `var(--v4-duration-pulse)` ([`v4.css:100-107`](../../../src/components/ui/v4.css#L100-L107)). Pulse fires on every render with **zero coupling to `file.fetchedAt`**. arXiv enrichment is daily-ish; the scraper cron is 3h. Either way the label is a fixed string baked into JSX, not derived from `classifyFreshness()`.
+- **Why P0**: direct violation of project rule (`feedback_freshness_chrome_must_be_honest.md`): "Never inline hardcoded `FRESH · 1H` / green-pulse `LiveDot`. Wire `lastUpdatedAt` to `FreshnessBadge` via `classifyFreshness()`."
+- **Fix**: (a) Add `arxiv` to `NewsSource` + `SOURCE_STALE_MS` in [`src/lib/news/freshness.ts:18-28,42-59`](../../../src/lib/news/freshness.ts#L18-L59). Cadence guidance: arXiv scraper runs every 3h, so reuse `NPM_STALE_THRESHOLD_MS` (50h) for the slow-cron daily-ish profile, or define `ARXIV_STALE_THRESHOLD_MS = 12 * 60 * 60 * 1000`. (b) Swap line 125 to `<FreshnessBadge lastUpdatedAt={file.fetchedAt} source="arxiv" />`.
+- **Call**: **Mechanical** — one enum entry + one primitive swap.
+
+### P0-2 · Cold-state strips all freshness chrome
+- [`src/app/arxiv/trending/page.tsx:84-100`](../../../src/app/arxiv/trending/page.tsx#L84-L100) — when `cold` is true, the `SourceFeedTemplate` is rendered with no `clock` slot at all. User sees title + lede + the `ColdState` panel but no badge distinguishing "never scraped" from "scraped 14 days ago, source down".
+- **Why P0**: cold is exactly when honest chrome matters most. `file.fetchedAt` is present even when `papers.length === 0` (only `count` is zero); the page is throwing away a signal that would tell the user whether to wait 30 minutes or contact an operator.
+- **Fix**: pass `clock={<FreshnessBadge lastUpdatedAt={file.fetchedAt} source="arxiv" />}` to the cold branch's `SourceFeedTemplate`. After P0-1's enum patch this drops in.
+- **Call**: **Mechanical**.
+
+---
+
+## P1 — Significant
+
+### P1-1 · Brand red collides with `--v4-red` negative-delta semantics
+- [`src/app/arxiv/trending/page.tsx:36`](../../../src/app/arxiv/trending/page.tsx#L36), [`:252`](../../../src/app/arxiv/trending/page.tsx#L252), [`:363`](../../../src/app/arxiv/trending/page.tsx#L363), [`:412`](../../../src/app/arxiv/trending/page.tsx#L412), [`:443`](../../../src/app/arxiv/trending/page.tsx#L443)
+- `ARXIV_BRAND = "#B22234"` (Cornell crimson) is painted on: rank numerals 01–10, the momentum-bar fill + glow `boxShadow: 0 0 6px ${accent}66`, the ColdState H2 header, the enrichment banner `// HEADS-UP` prefix. The file header (lines 32-36) is honest about why — `--v4-red` is reserved for negative deltas — but the comment doesn't solve the perceptual collision: rank-1 crimson + a future drop arrow (`var(--v4-red)`) in the same row reads as the same signal.
+- The code header explicitly anticipates this: "No `--v4-src-arxiv` token exists yet, so hardcode the brand color rather than fall back to the generic `--v4-red` (which is reserved for negative-delta semantics)." Verified absent in [`globals.css:6226-6233`](../../../src/app/globals.css#L6226-L6233) — only `hn / gh / x / reddit / bsky / dev / claude / openai` exist.
+- **Fix**: Tokenize once: add `--v4-src-arxiv: #B22234` and `--v4-src-arxiv-glow: rgba(178, 34, 52, 0.4)` to [`src/components/ui/v4.css`](../../../src/components/ui/v4.css) (alongside the other `--v4-src-*` tokens). Replace the 5 inline `ARXIV_BRAND` references with `var(--v4-src-arxiv)`. Bonus: rank-2 through rank-10 demote to `var(--v4-ink-100)` so only rank-1 carries the brand mark — same hierarchy, half the red density.
+- **Call**: **Design** (tokenization + density call).
+
+### P1-2 · `defaultWindow="7d"` doesn't match the "trending today" reading
+- [`src/app/arxiv/trending/page.tsx:195`](../../../src/app/arxiv/trending/page.tsx#L195) — `WindowedFeedTable defaultWindow="7d"`. The KpiBand surfaces `NEW THIS WEEK` (line 145) implying 7d is the headline window; that's fine for a weekly digest, but the page title says "trending" and the lede says "Domain-scored arXiv paper feed" — neither anchors to a window. A first-load reader sees 7d already implied by the KPI, and the tab strip is the only signal that 24h/30d even exist.
+- **Fix**: Either (a) Move the active window into the URL via the opt-in `tableActive` + `activeWindow` mode already supported by [`WindowedFeedTable.tsx:64-93`](../../../src/components/feed/WindowedFeedTable.tsx#L64-L93) (page becomes dynamic, shareable links), or (b) Promote the active count to the KpiBand title (`PAPERS · 7D`) so the answer-in-3s question — "which papers are trending in this window?" — has a window labeled on the snapshot. Option (b) is the surgical fix.
+- **Call**: **Design**.
+
+### P1-3 · `ColdState` leaks operator runbook to public route
+- [`src/app/arxiv/trending/page.tsx:452-458`](../../../src/app/arxiv/trending/page.tsx#L452-L458) — ColdState tells the visitor: "The arXiv scraper hasn't run yet. Run `npm run scrape:arxiv` locally to populate `data/arxiv-recent.json`, then refresh this page." This is a dev-only runbook on a public URL. Same pattern as the `/bluesky/trending` P1-3 audit finding.
+- **Fix**: User-facing copy ("Feed warming. arXiv refreshes every 3h — check back shortly.") and move the runbook into the admin/ops surface.
+- **Call**: **Design**.
+
+---
+
+## P2 — Polish
+
+### P2-1 · `tab` buttons miss the 44×44 mobile target
+- [`src/components/feed/WindowedFeedTable.tsx:148-159`](../../../src/components/feed/WindowedFeedTable.tsx#L148-L159) (legacy mode used by `/arxiv/trending`) — `<button className="tab">24h|7d|30d</button>` inherits `.tabs .tab` from [`globals.css:2305-2314`](../../../src/app/globals.css#L2305-L2314): `padding: 9px 14px` ≈ ~36–40 px tall depending on font metrics, ~52 px wide for "24h". Height ≤40 px — 4 px shy of the 44 × 44 rule at 375 px.
+- **Fix**: Add `min-h: 44px` to `.tabs .tab` in globals.css (touches every feed table, not just arxiv) OR bump padding to `12px 14px`. The first is the right cross-feed fix.
+- **Call**: **Mechanical**.
+
+### P2-2 · Enrichment banner `border-radius: 2` correct, but lives on the wrong surface level
+- [`src/app/arxiv/trending/page.tsx:204-220`](../../../src/app/arxiv/trending/page.tsx#L204-L220) — banner uses `background: var(--v4-bg-025)` + `border: 1px dashed var(--v4-line-200)`. It's the only chrome between the KpiBand and the feed table, so it ought to step UP from the snapshot row, not match it. Both KpiBand (template inheritance) and this banner land near `--v4-bg-025/050`; the user's eye has no surface-step cue saying "the table starts here". The 6-surface-level rule is meant to ladder; this collapses two.
+- **Fix**: Bump banner background to `var(--v4-bg-075)` and keep the dashed border for the "advisory" semantic. Adds one of the missing 6 levels.
+- **Call**: **Design**.
+
+### P2-3 · Inline `↳ linked-repo` pill below 44 × 44 tap target & not a link
+- [`src/app/arxiv/trending/page.tsx:296-309`](../../../src/app/arxiv/trending/page.tsx#L296-L309) — pill is `px-1.5 py-0.5 text-[9px]` ≈ ~24 × 18 px. It's also rendered as a `<span>` (not an anchor) even though the data exposes `linkedRepos[0].fullName`. A user who scans the feed for "paper linked to a repo" (the explicit success criterion of this audit) can SEE the pill but can't click it.
+- **Fix**: Render as `<a href={`https://github.com/${linkedRepo}`} target="_blank" rel="noopener noreferrer">↳ {linkedRepo}</a>`, bump padding to `px-2 py-1.5` and add `min-h-[28px]` (touch target sits inside the row's clickable space, so 28 is the local minimum here, 44 is across the row).
+- **Call**: **Design**.
+
+### P2-4 · `loading.tsx` references stale `--v3-*` tokens
+- [`src/app/arxiv/trending/loading.tsx:9-41`](../../../src/app/arxiv/trending/loading.tsx#L9-L41) — skeletons use `var(--v3-bg-050)` / `var(--v3-bg-100)`. Page lives in V4. Same defect as the `/npm` audit P2-4.
+- **Fix**: Swap to `var(--v4-bg-050)` / `var(--v4-bg-075)`.
+- **Call**: **Mechanical**.
+
+---
+
+## P3 — Nice-to-have
+
+### P3-1 · `LiveDot` announces "FRESH · 3H" via `aria-live="polite"`
+- [`src/components/ui/LiveDot.tsx:35`](../../../src/components/ui/LiveDot.tsx#L35), [`src/app/arxiv/trending/page.tsx:125`](../../../src/app/arxiv/trending/page.tsx#L125) — screen readers announce the literal string "FRESH · 3H" on page load regardless of actual freshness. Resolves automatically once P0-1 lands (FreshnessBadge announces verdict in `title`, not via `aria-live`).
+- **Fix**: Falls out of P0-1.
+- **Call**: **Mechanical**.
+
+### P3-2 · `formatClock` returns `HH:MM:SS` for daily-cadence data
+- [`src/app/arxiv/trending/page.tsx:72-75`](../../../src/app/arxiv/trending/page.tsx#L72-L75) — `.slice(11, 19)` renders seconds precision on a feed whose cadence is 3h. Implies live-tick freshness the data doesn't support. Identical defect to `/npm` audit P3-2.
+- **Fix**: `.slice(11, 16)` → `HH:MM`.
+- **Call**: **Design**.
+
+### P3-3 · `EntityLogo size={20}` paired with hostname favicon at 32px request resolution
+- [`src/app/arxiv/trending/page.tsx:236-237,272-278`](../../../src/app/arxiv/trending/page.tsx#L236-L278) — `paperFaviconUrl(p.absUrl, 32)` requests a 32 px favicon but `EntityLogo size={20}` renders it at 20 px. Wastes ~36% of the bytes per row × 100 rows. With reduced motion off, the staggered table entrance animation amplifies the visual cost.
+- **Fix**: Pass `size={20}` to `paperFaviconUrl` to match render size; google s2 supports 16 px the most common arxiv.org case.
+- **Call**: **Mechanical**.
+
+---
+
+## Out of scope but noted
+
+- The `momentum` bar at [`page.tsx:393-424`](../../../src/app/arxiv/trending/page.tsx#L393-L424) renders a `boxShadow: 0 0 6px ${accent}66` halo on a fill bar — that's an effect not a card, so the "no card shadows" rule doesn't apply. Read it carefully if the rule is later expanded to "no shadows of any kind on V4 content surfaces"; currently scoped to cards.
+- `error.tsx` references `var(--v2-sig-red)` + `var(--v2-ink-*)` tokens — same V2/V4 mix as the `/npm` audit's parallel finding. Tracked under the V4-token-sweep meta issue.
+- Citation column header says `"Cits"` (line 341) but every value is 0 in the MVP — the enrichment banner already explains this. After enrichment lands the column will earn its keep; until then it could be hidden, but the explicit banner makes the trade legible. Keep.
+
+---
+
+## Verification checklist for the fix PR
+
+- [ ] `arxiv` added to `NewsSource` + `SOURCE_STALE_MS` in `src/lib/news/freshness.ts`.
+- [ ] `<LiveDot>` removed from `/arxiv/trending`; only `<FreshnessBadge source="arxiv">` carries freshness state.
+- [ ] Cold branch renders the same `FreshnessBadge` in its `clock` slot.
+- [ ] `--v4-src-arxiv` token added to `v4.css`; 5 inline `ARXIV_BRAND` references swapped.
+- [ ] Linked-repo pill is an `<a>` to the GitHub repo, with `min-h-[28px]`.
+- [ ] No `--v3-*` token reference remains under `src/app/arxiv/`.
+- [ ] `.tabs .tab` has `min-h: 44px` at 375 px viewport (cross-feed fix).

--- a/docs/audits/impeccable/bluesky-trending-audit.md
+++ b/docs/audits/impeccable/bluesky-trending-audit.md
@@ -1,0 +1,107 @@
+# Impeccable design audit — `/bluesky/trending`
+
+**Surface**: `/bluesky/trending` (no separate `/bluesky` landing exists — directory only contains `trending/`).
+**Date**: 2026-05-13 · **Worktree**: `wave11a` · **Branch**: `audit/imp-wave-11a-audits`
+**Headline**: Two P0 honest-chrome violations. Hardcoded green-pulse `LIVE · 24H` ignores `fetchedAt` on a surface the OPERATOR doc flags as degradation-prone, and the COLD fallback strips the freshness chrome entirely instead of rendering an honest `COLD` badge. Brand token drift (`#0085FF` instead of `--source-bluesky: #3aa4ff`) on 6 inline-style sites. Mobile tap targets on inline `↳ repo` pill below 44 px.
+
+---
+
+## P0 — Ship-stopping
+
+### P0-1 · Hardcoded green-pulse LIVE label ignores freshness signal
+- [`src/app/bluesky/trending/page.tsx:114-120`](../../../src/app/bluesky/trending/page.tsx) — `<LiveDot label="LIVE · 24H" />` defaults to `money` tone → pulsing green ([`LiveDot.tsx:29`](../../../src/components/ui/LiveDot.tsx), [`v4.css:103-107`](../../../src/components/ui/v4.css)). Pulse fires on every render regardless of `trendingFile.fetchedAt` age.
+- **Why P0**: violates `feedback_freshness_chrome_must_be_honest.md`. OPERATOR note: bluesky scraper has prior cron drift; rendering green-pulse on stale data is the exact failure mode the memory warns about.
+- **Fix**: replace with `<FreshnessBadge lastUpdatedAt={trendingFile.fetchedAt} source="bluesky" />` ([`FreshnessBadge.tsx:28`](../../../src/components/shared/FreshnessBadge.tsx)). The `bluesky` NewsSource is already wired in `SOURCE_STALE_MS` ([`src/lib/news/freshness.ts:45`](../../../src/lib/news/freshness.ts)).
+- **Call**: **Mechanical** — drop-in primitive swap.
+
+### P0-2 · Cold-state strips all freshness chrome
+- [`src/app/bluesky/trending/page.tsx:79-94`](../../../src/app/bluesky/trending/page.tsx) — when `blueskyCold || allPosts.length === 0`, the `SourceFeedTemplate` renders with no `clock` slot at all. User sees title + lede + `ColdState` panel but no badge telling them this is COLD with age.
+- **Why P0**: cold is exactly when honest chrome matters most. Currently the page reads "warming/no data" copy without surfacing the actual `getBlueskyFetchedAt()` ISO that distinguishes "never scraped" (epoch-zero) from "scraped 14 days ago".
+- **Fix**: pass `clock={<FreshnessBadge lastUpdatedAt={getBlueskyFetchedAt()} source="bluesky" />}` to the cold branch's `SourceFeedTemplate`. Badge renders `COLD · <age>` via [`FreshnessBadge.tsx:22-26`](../../../src/components/shared/FreshnessBadge.tsx).
+- **Call**: **Mechanical**.
+
+---
+
+## P1 — Significant
+
+### P1-1 · Brand color drift: `#0085FF` vs canonical `--source-bluesky: #3aa4ff`
+- [`src/app/bluesky/trending/page.tsx:50`](../../../src/app/bluesky/trending/page.tsx) — `const BSKY_BLUE = "#0085FF"` (Bluesky's old hex). Project tokens declare `--source-bluesky: #3aa4ff` ([`src/app/globals.css:184`](../../../src/app/globals.css)) and `--v4-src-bsky: #3aa4ff` ([`src/app/globals.css:6230`](../../../src/app/globals.css)). The KpiBand correctly references `var(--v4-src-bsky)` (line 128) but the inline rank, topic-chip, like-threshold, and ColdState header all use the local const → side-by-side rendering mismatches the brand pip in the KPI cell.
+- **Used at**: page.tsx lines 200, 287, 288, 289, 316, 375, 398. Six divergent surfaces.
+- **Fix**: delete `BSKY_BLUE`, swap to `"var(--v4-src-bsky)"` (or `"var(--source-bluesky)"`).
+- **Call**: **Mechanical**.
+
+### P1-2 · Inline `↳ repo` pill below 44 × 44 mobile tap target
+- [`src/app/bluesky/trending/page.tsx:253-266`](../../../src/app/bluesky/trending/page.tsx) — anchor `px-1.5 py-0.5 text-[10px]` ≈ 26 × 18 px hit area. Mobile thumbs miss it; sits inline beside a longer post anchor with overlapping target zones.
+- **Fix**: bump padding to `px-2 py-1.5` and add `min-h-[28px]` minimum; or hoist into row-wide context-menu pattern.
+- **Call**: **Design** — touches density vs. tap-target tradeoff.
+
+### P1-3 · `ColdState` shipping-code reveal leaks dev-only copy to prod
+- [`src/app/bluesky/trending/page.tsx:407-416`](../../../src/app/bluesky/trending/page.tsx) — ColdState tells the visitor to "Run `npm run scrape:bsky` locally". This is an internal runbook leak on a public route. Users see a 6-line shell instruction.
+- **Fix**: rephrase to user-facing copy ("Feed warming. Refresh shortly.") and route the runbook to an admin-only surface.
+- **Call**: **Design**.
+
+---
+
+## P2 — Polish
+
+### P2-1 · WindowedFeedTable lacks `tabpanel` semantics
+- [`src/components/feed/WindowedFeedTable.tsx:140-166`](../../../src/components/feed/WindowedFeedTable.tsx) — `role="tablist"` + `role="tab"` + `aria-selected` but no `role="tabpanel"` wrapper around `{table}` and no `aria-labelledby` linkage. Screen readers announce tabs but not what they control.
+- **Fix**: wrap `{table}` in `<div role="tabpanel" id="win-{win}" aria-labelledby="tab-{win}">` and give each tab `id="tab-{win}"`.
+- **Call**: **Mechanical**.
+
+### P2-2 · Tab strip uses `.tab.on` CSS class for active state but no keyboard arrow rotation
+- [`src/components/feed/WindowedFeedTable.tsx:148-159`](../../../src/components/feed/WindowedFeedTable.tsx) — buttons rely on tab key only; APG tablist pattern wants Left/Right arrows. Missing `onKeyDown` handler + `tabIndex={isActive ? 0 : -1}` rotation.
+- **Call**: **Mechanical**.
+
+### P2-3 · Stagger animation duration 350 ms > 120–180 ms motion budget
+- [`src/components/feed/TerminalFeedTable.tsx:156`](../../../src/components/feed/TerminalFeedTable.tsx) — `slide-up 0.35s cubic-bezier(0.2,0.8,0.2,1)` applied to up to 6 rows × 50 ms stagger = 600 ms total intro on a feed page. Non-bouncy curve so not jarring, but blows the token.
+- **Fix**: shorten to 0.16s; keep curve.
+- **Call**: **Design** — shared component, ripples to 5+ other source feeds.
+
+### P2-4 · Clock slot stacks UTC time + "SCRAPED" + LiveDot without single hierarchy
+- [`src/app/bluesky/trending/page.tsx:114-120`](../../../src/app/bluesky/trending/page.tsx) — three fragments compete: big HH:MM:SS, muted "UTC · SCRAPED", green LiveDot. After honest-chrome fix lands, simplify to: `<FreshnessBadge … />` only. Removes 3 visual elements for 1.
+- **Call**: **Design**.
+
+### P2-5 · KPI cell `TOPICS` value = matched query family count without anchor
+- [`src/app/bluesky/trending/page.tsx:138-143`](../../../src/app/bluesky/trending/page.tsx) — number floats without sub-context ("matched query families" sub only). Pair with chip preview ("agents · LLMs · MCP · …") so "what's trending" answers in <3 s.
+- **Call**: **Design**.
+
+---
+
+## P3 — Nice-to-have
+
+### P3-1 · `EntityLogo` 20 px + 13 px snippet creates 20-px hit zone on logo
+- [`src/app/bluesky/trending/page.tsx:218-228`](../../../src/app/bluesky/trending/page.tsx) — logo isn't a link, but sits inside row alongside the anchored snippet; users tap the logo expecting a deep link. Consider wrapping `<a>` around the whole flex container.
+- **Call**: **Design**.
+
+### P3-2 · Topic chip uses `${BSKY_BLUE}4D` (30 % alpha) border on dim chip background
+- [`src/app/bluesky/trending/page.tsx:284-301`](../../../src/app/bluesky/trending/page.tsx) — once brand color flips to `#3aa4ff` (P1-1), retest contrast; chip text on `${BSKY_BLUE}0D` background may dip below 3:1.
+- **Call**: **Design**.
+
+### P3-3 · `metadata.alternates.canonical` set to `/bluesky/trending`
+- [`src/app/bluesky/trending/page.tsx:36`](../../../src/app/bluesky/trending/page.tsx) — correct now, but there's no `/bluesky` landing; if you add one later, canonical needs to reflect.
+- **Call**: **N/A** noted.
+
+---
+
+## Surprises
+
+1. **`export const dynamic = "force-static"`** ([line 30](../../../src/app/bluesky/trending/page.tsx)) on a "live"-labelled feed. Static = no re-render; the green pulse is **architecturally** lying — the page is cached for ISR, so "LIVE · 24H" is the build-time fetch. P0-1 is even worse than first read.
+2. **`blueskyCold` is module-init**, not request-time ([`bluesky.ts:164`](../../../src/lib/bluesky.ts)). The runtime path calls `isBlueskyCold()` (line 172) but the page reads the static export. Cold-state may render after the first refresh succeeds, until next deploy.
+3. **OPERATOR.md lists this route as GREEN** ([`docs/OPERATOR.md:325`](../../OPERATOR.md)) — contradicts the prompt's "currently degraded" framing. The honest-chrome P0s stand regardless: green-pulse on static output is dishonest by construction.
+4. No `bg-black`, card radii are 2 px throughout, no card shadows — those constraints already met.
+5. The page never imports `FreshnessBadge` despite the lib being available and `bluesky` already in `NewsSource` enum.
+
+---
+
+## Summary
+
+| Severity | Count | Themes |
+|---|---|---|
+| P0 | 2 | Honest chrome (LIVE pulse hardcoded; cold-state strips chrome) |
+| P1 | 3 | Brand drift, mobile tap target, internal copy leak |
+| P2 | 5 | A11y tabs, motion budget, KPI density |
+| P3 | 3 | Polish, contrast retest, canonical |
+| **Total** | **13** | — |
+
+Mechanical : Design = **6 : 7**. The two P0s are both mechanical drop-ins that can land in one commit using primitives already in the codebase.

--- a/docs/audits/impeccable/devto-audit.md
+++ b/docs/audits/impeccable/devto-audit.md
@@ -1,0 +1,152 @@
+# Impeccable Design Audit — `/devto`
+
+Branch: `audit/imp-wave-11a-audits` · Worktree: `wave11a` · Date: 2026-05-13
+
+## Files audited
+
+- [src/app/devto/page.tsx](../../../src/app/devto/page.tsx)
+- [src/app/devto/loading.tsx](../../../src/app/devto/loading.tsx)
+- [src/app/devto/error.tsx](../../../src/app/devto/error.tsx)
+- [src/components/devto/DevtoBadge.tsx](../../../src/components/devto/DevtoBadge.tsx)
+- Shared: [SourceFeedTemplate](../../../src/components/templates/SourceFeedTemplate.tsx), [KpiBand](../../../src/components/ui/KpiBand.tsx), [LiveDot](../../../src/components/ui/LiveDot.tsx), [FreshnessBadge](../../../src/components/shared/FreshnessBadge.tsx), [TerminalFeedTable](../../../src/components/feed/TerminalFeedTable.tsx), [WindowedFeedTable](../../../src/components/feed/WindowedFeedTable.tsx)
+
+## Counts
+
+| Sev | Count |
+|---|---|
+| P0 | 3 |
+| P1 | 5 |
+| P2 | 4 |
+
+---
+
+## P0 — must-fix before next ship
+
+### P0-1 · Honest chrome: hardcoded `<LiveDot label="LIVE · 7D">` outside `<FreshnessBadge>`
+**File:** [src/app/devto/page.tsx:141](../../../src/app/devto/page.tsx#L141)
+**Finding:** `<LiveDot label={\`LIVE · ${trendingFile.windowDays}D\`} />` is rendered unconditionally in the PageHead clock slot. The default `tone="money"` triggers `v4-pulse` animation, so the page reads "FRESH" green even when `fetchedAt` is 4d old (the 24h tab already renders 0 rows and a "Last scrape Xh ago" empty-state hint, which is exactly the dishonest-chrome scenario the rule names). Three sister pages (`/agent-repos`, `/breakouts`, `/categories`) already route through `<FreshnessBadge source="..." lastUpdatedAt={...} />`.
+**Fix:** Replace `<LiveDot …/>` with `<FreshnessBadge source="devto" lastUpdatedAt={trendingFile.fetchedAt} />`. `NewsSource` already includes `"devto"` and `SOURCE_STALE_MS.devto` = `DEVTO_STALE_THRESHOLD_MS`.
+**Mechanical vs Design:** **Mechanical** — swap the import + the JSX expression.
+
+### P0-2 · Brand-color drift: `DEVTO_BLUE = "#6699ff"` contradicts `--source-dev: #b08bff`
+**File:** [src/app/devto/page.tsx:38](../../../src/app/devto/page.tsx#L38)
+**Finding:** Page hardcodes blue `#6699ff` for the table accent (line 410) and rank top-10 (line 286), but the KPI band on the same page uses `var(--v4-src-dev)` purple (line 151), and `DevtoBadge.tsx` uses `var(--source-dev)` purple. Three colors claiming to be "dev.to" on a single route. Per DESIGN rule "dev.to brand purple/violet (`--source-dev: #b08bff`)". The side-tab/column-key signal becomes incoherent because top-10 ranks and table accent disagree with the per-source color-key everywhere else.
+**Fix:** Delete `DEVTO_BLUE`. Use `var(--source-dev)` (or `var(--v4-src-dev)`) for `accent={…}` and the rank-color ternary. Keep KpiBand pip as-is — it's already correct.
+**Mechanical vs Design:** **Mechanical** — one constant, two call sites.
+
+### P0-3 · `DevtoBadge.DEVTO_BRAND_COLOR` exports `#0a0a0a` (black) as the "channel-dot" source of truth
+**File:** [src/components/devto/DevtoBadge.tsx:36,93](../../../src/components/devto/DevtoBadge.tsx#L36)
+**Finding:** Component comment says "channel-dot indicator can use the same source-of-truth without drifting on a brand refresh" — but the constant is `#0a0a0a`, not the purple already used three lines below for fill/border. Any downstream consumer that imports this gets pitch-black instead of `--source-dev`. Future drift guaranteed.
+**Fix:** Set `DEVTO_BRAND_COLOR = "#b08bff"` (or, better, re-export a token like `"var(--source-dev)"` and let consumers resolve at render).
+**Mechanical vs Design:** **Mechanical**.
+
+---
+
+## P1 — should-fix this sprint
+
+### P1-1 · Cold-state path also missing freshness chrome
+**File:** [src/app/devto/page.tsx:97-119](../../../src/app/devto/page.tsx#L97)
+**Finding:** When `cold === true`, the SourceFeedTemplate renders with no `clock` slot at all — yet `trendingFile.fetchedAt` IS available and is passed to `EmptyState.lastSuccessAt`. The user sees no badge telling them *how* cold cold is.
+**Fix:** Render `<FreshnessBadge source="devto" lastUpdatedAt={trendingFile.fetchedAt} />` in `clock={…}` even on the cold branch — that's the single most useful signal at that moment.
+**Mechanical vs Design:** **Mechanical**.
+
+### P1-2 · Mobile reflow: `<span class="big">` UTC clock + `LiveDot` collide at 375px
+**File:** [src/app/devto/page.tsx:137-143](../../../src/app/devto/page.tsx#L137); CSS [v4.css:378-396](../../../src/components/ui/v4.css#L378)
+**Finding:** PageHead media query collapses clock under headline at ≤640px, but the clock slot still renders three children (`<span class="big">`, `<span class="muted">`, `<LiveDot>`) inline with no explicit wrap/gap on mobile. On a 375px iPhone SE column the LiveDot pip + label wraps awkwardly, producing a 4-line clock stack that competes visually with the H1.
+**Fix:** Wrap the three spans in `display:flex; flex-wrap:wrap; gap:6px` (or a `v4-page-head__clock-stack` class). Once P0-1 collapses LiveDot into FreshnessBadge, this still applies to the badge layout.
+**Mechanical vs Design:** **Design** — needs a small layout primitive.
+
+### P1-3 · Top-row tap target = 28px ('Cmts' header on mobile)
+**File:** [src/app/devto/page.tsx:354-365](../../../src/app/devto/page.tsx#L354)
+**Finding:** Hidden ≥md only (`hideBelow: "md"`), but the visible columns on mobile — title link (`text-[13px]`) and reactions chip — sit in `px-3 py-2.5` cells (line 164 of TerminalFeedTable) yielding ~36–40px row heights. The article-title `<a>` is the primary tap and clips at ~36px on the densest rows. Rule: 44×44 mobile tap targets.
+**Fix:** Bump row vertical padding to `py-3` at ≤md, OR add `min-height: 44px` to `<tr>` at mobile breakpoint.
+**Mechanical vs Design:** **Mechanical**.
+
+### P1-4 · `EntityLogo size={20}` author avatar fails 44px touch contract on mobile
+**File:** [src/app/devto/page.tsx:310](../../../src/app/devto/page.tsx#L310)
+**Finding:** 20×20 avatar — fine for icon density but the whole row's only avatar-sized interactive cluster is the title link. Avatar is decorative (`alt=""`) and not clickable; but the visual density makes mobile users unsure if the avatar is itself a tap target.
+**Fix:** Either bump to 24px and keep decorative, or make the avatar tap-route to the author profile (then bump to 32px with a wrapping `<a aria-label="@username">`).
+**Mechanical vs Design:** **Design** — interaction-contract decision.
+
+### P1-5 · Tag chip lacks `aria-label`; first tag only is exposed
+**File:** [src/app/devto/page.tsx:371-388](../../../src/app/devto/page.tsx#L371)
+**Finding:** Tag chip renders `#{tag}` with `title={a.tags.join(", ")}` — tooltip is mouse-only. Screen readers get `#nextjs` and never learn the other tags. Static chip with no `role` either.
+**Fix:** Add `aria-label={\`tag ${tag}\${a.tags.length > 1 ? \`, plus \${a.tags.length - 1} more\` : ''}\`}`. Keep `title` for sighted hover.
+**Mechanical vs Design:** **Mechanical**.
+
+---
+
+## P2 — polish
+
+### P2-1 · Loading skeleton drifts from real layout
+**File:** [src/app/devto/loading.tsx](../../../src/app/devto/loading.tsx)
+**Finding:** Renders 4 KPI cells + 10 row skeletons, but real page renders the KPI band + tab-strip (3 windows) + 50 row table. The tab strip is unrepresented, so the layout shifts ~32px when content arrives.
+**Fix:** Add a 36px-tall skeleton block between the KPI grid and the row stack.
+**Mechanical vs Design:** **Mechanical**.
+
+### P2-2 · `formatClock()` shows `HH:MM:SS` UTC but never ticks (static after SSR)
+**File:** [src/app/devto/page.tsx:76-79](../../../src/app/devto/page.tsx#L76)
+**Finding:** "11:32:04 UTC · SCRAPED" with a LIVE pulse pip next to it implies live wall-clock. The value is frozen at SSR + ISR cache time. Either it's not "live" (drop the pulse — already covered by P0-1) or use `<LiveClock/>` like sister pages.
+**Fix:** Subsumed by P0-1; once FreshnessBadge replaces LiveDot the "SCRAPED" semantic is honest.
+**Mechanical vs Design:** **Design**.
+
+### P2-3 · Motion: row stagger uses `0.35s` — outside 120-180ms band
+**File:** [src/app/devto/page.tsx:504](../../../src/app/devto/page.tsx#L504); [TerminalFeedTable.tsx:156](../../../src/components/feed/TerminalFeedTable.tsx#L156)
+**Finding:** `slide-up 0.35s cubic-bezier(0.2,0.8,0.2,1)` row-entry animation. Easing curve matches the spec but duration is 2x the 180ms ceiling. Reduced-motion media query in globals.css zeroes it out, so the only impact is "feels heavy" for users without that preference.
+**Fix:** Drop to `0.18s` (or pull the duration into a `--v4-duration-feed-row` token shared across feed tables — this lives in the TerminalFeedTable shared component so any fix lands across HN/Lobsters/Bluesky/Reddit/Devto at once).
+**Mechanical vs Design:** **Design** — touches shared primitive, needs design-system call.
+
+### P2-4 · `LiveDot` ARIA on cold state mislabels
+**File:** [src/components/ui/LiveDot.tsx:33-35](../../../src/components/ui/LiveDot.tsx#L33)
+**Finding:** Component always sets `role="status" aria-live="polite"` — so a `<LiveDot tone="none">` still announces as a status region. Not a /devto-specific bug but relevant once we route LiveDot through FreshnessBadge anyway.
+**Fix:** Out-of-scope for this audit; flag for shared-component sprint.
+**Mechanical vs Design:** **Design**.
+
+---
+
+## Working well
+
+- KPI band uses `var(--v4-src-dev)` correctly for the TRACKED pip — proves the page knows the right color.
+- 24h-empty failure mode handled gracefully via `emptyHint(activeWindow)` — names scrape-lag in minutes/hours/days and routes user to the populated window. This is exactly the "honest empty state" pattern the project rules call for.
+- `<EntityLogo>` fallback chain documented inline (lines 297-308) explaining why `dev.to/<user>.png` was dropped (CORB) — good forensic comment.
+- Reactions ≥50 highlighted in `--v4-money` — single-glance signal density done well.
+- `dynamic = "force-static"` + ISR `revalidate=300` is the right cache-contract choice.
+- Tab strip server-renders all 3 windows but uses `WindowedFeedTable`'s legacy mode — fine for top-50 capped rows.
+
+## Verify-in-context (run with Vercel preview)
+
+- Visit `/devto` at 375px width — confirm clock-region wrap behaviour and that title-cell tap zone hits 44px.
+- Throttle `data/devto-trending.json` `fetchedAt` to >2 days ago — confirm LIVE pulse correctly degrades to STALE/COLD (proves P0-1 is wired right after fix).
+- Hover the rank "01" cell — confirm it's purple `#b08bff` post-P0-2 fix, not blue.
+- Screen-reader walk the table — confirm tag chip announces tag-count after P1-5.
+
+## Mechanical fixes (low-risk, ship-now)
+
+1. **P0-1** — Replace LiveDot with FreshnessBadge in clock slot (3-line diff).
+2. **P0-2** — Delete `DEVTO_BLUE`, swap to `var(--source-dev)` in 2 places (4-line diff).
+3. **P0-3** — Fix `DEVTO_BRAND_COLOR` export to `#b08bff` (1-line diff).
+4. **P1-1** — Add FreshnessBadge to cold-state clock slot (3-line diff).
+5. **P1-3** — Bump row padding to `py-3` at mobile (1-line diff on TerminalFeedTable, lands cross-source).
+6. **P1-5** — Add `aria-label` to tag chip (1-line diff).
+7. **P2-1** — Add tab-strip skeleton in `loading.tsx` (5-line diff).
+
+## Quick patches
+
+```tsx
+// P0-1 + P0-2 in one pass
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+// delete: const DEVTO_BLUE = "#6699ff";
+// in clock slot:
+clock={<FreshnessBadge source="devto" lastUpdatedAt={trendingFile.fetchedAt} />}
+// in rank cell:
+style={{ color: i < 10 ? "var(--source-dev)" : "var(--v4-ink-400)" }}
+// in TerminalFeedTable accent prop:
+accent="var(--source-dev)"
+```
+
+```tsx
+// P1-5 — tag chip a11y
+aria-label={`tag ${tag}${a.tags.length > 1 ? `, plus ${a.tags.length - 1} more` : ""}`}
+```
+
+Design-call items (P1-2, P1-4, P2-3) need product/design sign-off before patch.

--- a/docs/audits/impeccable/npm-audit.md
+++ b/docs/audits/impeccable/npm-audit.md
@@ -1,0 +1,113 @@
+# /npm — Impeccable design audit
+
+**Surface:** `/npm` (V4 SourceFeedTemplate · daily-ish cadence · npm registry adoption)
+**Branch:** `audit/imp-wave-11a-audits`
+**Date:** 2026-05-13
+**Counts:** P0 × 2 · P1 × 3 · P2 × 4 · P3 × 3
+
+**Headline:** Page renders rich, repo-linked package velocity in a clean V4 shell — but pairs a green pulsing `<LiveDot label="LIVE · 24H">` with a 50h-stale-threshold scraper, then doubles `linkedRepoCount` across TRACKED and LINKED REPOS KpiBand cells. Honest chrome and KpiBand semantics need the most surgery; tap targets and surface levels trail behind.
+
+---
+
+## P0 — Ship-blockers
+
+### P0-1 — Green pulsing "LIVE · 24H" beside `FreshnessBadge` (honest chrome)
+- [`src/app/npm/page.tsx:159`](../../../src/app/npm/page.tsx#L159)
+- npm scrape cadence is daily-ish; `NPM_STALE_THRESHOLD_MS` is 50h. The page emits `<LiveDot label={`LIVE · ${activeWindow.toUpperCase()}`} />` — that renders `v4-live-dot--money` with the green `var(--v4-shadow-pulse-money)` keyframe at `var(--v4-duration-pulse)`, beside the already-honest `<FreshnessBadge source="npm" .../>` on line 160. Two contradictory chrome signals next to each other; the louder one (green pulse) wins. Direct violation of the global "hardcoded LIVE/green-pulse outside `<FreshnessBadge>`" P0 rule.
+- **Fix:** Delete the `<LiveDot>` line. `FreshnessBadge` already prints FRESH/STALE/COLD + age. If a window indicator is still wanted, render `<span className="v2-mono muted">{activeWindow.toUpperCase()}</span>` after the clock — no pulse, no "LIVE" claim.
+- **Call:** Mechanical (one-line delete, no design tradeoff).
+
+### P0-2 — Clock copy `"UTC · SCRAPED"` paired with the LIVE dot reads as live-tick
+- [`src/app/npm/page.tsx:157-158`](../../../src/app/npm/page.tsx#L157-L158)
+- `<span className="big">{formatClock(file.fetchedAt)}</span>` + `<span className="muted">UTC · SCRAPED</span>` is fine alone, but next to the green `LIVE` dot it implies the clock is ticking. It is not — `fetchedAt` is the scrape timestamp, frozen until the next cron sweep.
+- **Fix:** After P0-1, swap the sub-label from `"UTC · SCRAPED"` to `"UTC · LAST SCRAPE"`. One word, removes the live-tick implication.
+- **Call:** Mechanical.
+
+---
+
+## P1 — Significant defects
+
+### P1-1 — npm brand red collides with negative-delta loss color
+- [`src/app/npm/page.tsx:36`](../../../src/app/npm/page.tsx#L36), [`:256`](../../../src/app/npm/page.tsx#L256), [`:435`](../../../src/app/npm/page.tsx#L435), [`:441`](../../../src/app/npm/page.tsx#L441)
+- `NPM_RED = "#cb3837"` paints rank-1 numbers, the active-tab underline, and the VersionPill border/text. Same row also paints negative deltas via `var(--v4-red)`. A user scanning column-3 sees two reds (rank brand vs loss signal) inside the same row at a glance — color is doing double duty.
+- **Fix:** Either (a) demote rank numerals to `var(--v4-ink-100)` and let only the active-tab underline carry `NPM_RED`, or (b) tokenize once as `--v4-src-npm` in `v4.css` and reserve `var(--v4-red)` exclusively for negative deltas. Option (a) is the surgical fix.
+- **Call:** Design.
+
+### P1-2 — TRACKED and LINKED REPOS show identical value
+- [`src/app/npm/page.tsx:167-187`](../../../src/app/npm/page.tsx#L167-L187)
+- `linkedRepoCount` is rendered into both `TRACKED` (line 168) and `LINKED REPOS` (line 184). Two of four KpiBand cells display the same number with different labels — wastes a quarter of the snapshot. "what npm package is moving?" answer in <3s is muddier when a cell repeats.
+- **Fix:** Replace `TRACKED` with `PACKAGES` and source it from `packages.length` (or `file.packages.length` if the file holds the full corpus). Keep `LINKED REPOS` as `linkedRepoCount`. Now TRACKED = corpus size, LINKED = the share with GitHub attached.
+- **Call:** Design.
+
+### P1-3 — VersionPill hardcodes `NPM_RED` alpha hex outside CSS tokens
+- [`src/app/npm/page.tsx:488-491`](../../../src/app/npm/page.tsx#L488-L491)
+- `border: 1px solid ${NPM_RED}4D` / `background: ${NPM_RED}0D` / `color: NPM_RED` — three hex string concatenations on inline style. Defeats theming and conflicts with the surface-level palette. Two of three are alpha-hex tricks (`4D` = 30%, `0D` = 5%) that don't compose with future CSS-var swaps.
+- **Fix:** Add `--v4-src-npm` + `--v4-src-npm-30` + `--v4-src-npm-05` to `v4.css`. Replace the three inline hex strings with `var(--v4-src-npm-*)`.
+- **Call:** Mechanical (light refactor).
+
+---
+
+## P2 — Polish
+
+### P2-1 — Tab buttons miss the 44×44 mobile minimum
+- [`src/app/npm/page.tsx:223`](../../../src/app/npm/page.tsx#L223)
+- `inline-flex min-h-[40px] items-center gap-2 px-3` — 40px tall · ~88px wide. Width passes, height is 4px shy of the 44×44 rule.
+- **Fix:** Bump to `min-h-[44px]`.
+- **Call:** Mechanical.
+
+### P2-2 — Fixed column widths crush Package cell at 375px
+- [`src/app/npm/page.tsx:274,283,297,312,326,341`](../../../src/app/npm/page.tsx#L274-L341)
+- Even after `hideBelow: "md"` / `"lg"` strips repo + 7d + 30d + version, at 375px the surviving columns are `rank 44 + active-mobile 100 = 144px` of fixed, leaving ~231px for Package (which renders 24px logo + 2.5 gap + name + truncated description). Tight but survivable; tested at 360px and description clips to ~14 chars.
+- **Fix:** Reduce `active-mobile` to `width: "84px"` and trim the rank column to `width: "32px"`. Gives Package ~30px more breathing room without losing legibility.
+- **Call:** Design.
+
+### P2-3 — Surface levels: only 2 of 6 used
+- [`src/app/npm/page.tsx:509`](../../../src/app/npm/page.tsx#L509), [`:160`](../../../src/app/npm/page.tsx#L160) (via FreshnessBadge), [`:213`](../../../src/app/npm/page.tsx#L213) (TabNav border only)
+- Page references `--v4-bg-025` (ColdState) and `--v4-bg-050` (via FreshnessBadge). The KpiBand cells, table rows, and SourceFeedTemplate shell all inherit further levels from the template — but `/npm`-owned chrome stays at 2. The 6-level rule asks each surface to deliberately step.
+- **Fix:** Adopt `--v4-bg-075` for the TabNav strip background (currently transparent), `--v4-bg-100` for the active-tab inset, leaving 025/050 for empty + freshness chrome. Adds two levels at zero functional cost.
+- **Call:** Design.
+
+### P2-4 — `loading.tsx` references stale `--v3-*` tokens
+- [`src/app/npm/loading.tsx:9-41`](../../../src/app/npm/loading.tsx#L9-L41)
+- Skeletons use `var(--v3-bg-050)` / `var(--v3-bg-100)`. Page lives in V4. If `--v3-*` ever gets removed, the skeleton renders transparent.
+- **Fix:** Swap to `var(--v4-bg-050)` / `var(--v4-bg-075)`.
+- **Call:** Mechanical.
+
+---
+
+## P3 — Nice-to-have
+
+### P3-1 — `LiveDot` announces "LIVE · 24H" via `aria-live="polite"`
+- [`src/components/ui/LiveDot.tsx:35`](../../../src/components/ui/LiveDot.tsx#L35), [`src/app/npm/page.tsx:159`](../../../src/app/npm/page.tsx#L159)
+- Even sighted users get a misleading chrome; screen readers get the literal announcement "LIVE · 24H" on every page load. Resolved automatically once P0-1 lands.
+- **Fix:** Falls out of P0-1.
+- **Call:** Mechanical.
+
+### P3-2 — `formatClock` returns the seconds-precision timestamp every render
+- [`src/app/npm/page.tsx:85-88`](../../../src/app/npm/page.tsx#L85-L88)
+- `.slice(11, 19)` renders `HH:MM:SS` — three digits past the cadence resolution (1 day). Implies precision the data doesn't support.
+- **Fix:** `.slice(11, 16)` → `HH:MM`. Visual quiet; matches cadence honesty.
+- **Call:** Design.
+
+### P3-3 — `<EntityLogo size={24}>` next to 13px font is logo-heavy
+- [`src/app/npm/page.tsx:365`](../../../src/app/npm/page.tsx#L365)
+- 24px logo paired with 13px package name + 11px description. Logo takes the visual lead over the name on a feed whose answer is "which package is moving?". Standard feed-row pattern across the repo is 20px.
+- **Fix:** `size={20}`. One token down, hierarchy reads cleaner.
+- **Call:** Design.
+
+---
+
+## Out of scope but noted
+
+- `error.tsx` mixes `var(--v2-sig-red)` / `var(--v2-ink-*)` with the surrounding V4 page. Tracked under the V4-token-sweep meta issue, not this audit.
+- `NpmBadge.tsx` uses `var(--red)` + `rgba(255, 77, 77, 0.4)` — only rendered on repo cards elsewhere; not on the `/npm` page itself. Out of scope.
+
+---
+
+## Verification checklist for the fix PR
+
+- [ ] `<LiveDot>` removed from `/npm`; only `<FreshnessBadge source="npm">` carries freshness state.
+- [ ] KpiBand TRACKED and LINKED REPOS show distinct numbers.
+- [ ] Tab nav: `min-h-[44px]` at 375px viewport.
+- [ ] No `--v3-*` token reference remains under `src/app/npm/`.
+- [ ] `rg "NPM_RED" src/app/npm/page.tsx` → only the active-tab underline reference (P1-1 option a).

--- a/docs/audits/impeccable/producthunt-audit.md
+++ b/docs/audits/impeccable/producthunt-audit.md
@@ -1,0 +1,164 @@
+# /producthunt audit — 2026-05-13
+
+> Impeccable design audit on `/producthunt` (host page + 3 components). Project rules applied: honest freshness chrome non-negotiable; ProductHunt brand `--source-producthunt: #da552f` token EXISTS (globals.css:182) but is bypassed by a hardcoded `PH_RED` const; PH cron cadence = 16h budget per `PRODUCTHUNT_STALE_THRESHOLD_MS` (source-health.ts:53). NewsSource union already lists `producthunt` so the freshness wiring is unblocked.
+
+## Files audited
+
+- [src/app/producthunt/page.tsx](../../../src/app/producthunt/page.tsx) — host page (574 LOC, table + cross-link panel + cold/empty/tabnav)
+- [src/app/producthunt/loading.tsx](../../../src/app/producthunt/loading.tsx) — skeleton
+- [src/app/producthunt/error.tsx](../../../src/app/producthunt/error.tsx) — error boundary
+- [src/components/producthunt/LaunchLinkIcons.tsx](../../../src/components/producthunt/LaunchLinkIcons.tsx) — Globe/X/GitHub mini-icons
+- [src/components/producthunt/PhBadge.tsx](../../../src/components/producthunt/PhBadge.tsx) — repo-card PH chip (off-route consumer)
+- [src/components/producthunt/RecentLaunches.tsx](../../../src/components/producthunt/RecentLaunches.tsx) — homepage 5-row section (currently orphaned, no importers)
+- Cross-refs: [FreshnessBadge.tsx](../../../src/components/shared/FreshnessBadge.tsx), [freshness.ts](../../../src/lib/news/freshness.ts), [LiveDot.tsx](../../../src/components/ui/LiveDot.tsx), [source-health.ts](../../../src/lib/source-health.ts#L53)
+
+## P0 findings
+
+### 1. Hardcoded `<LiveDot label="FRESH · 4H" />` — honest-chrome violation
+
+- **File**: [page.tsx:151](../../../src/app/producthunt/page.tsx#L151)
+- **Mechanical**: `<LiveDot label="FRESH · 4H" />` renders the default `tone="money"` (green, pulsing) with a static `FRESH · 4H` literal. The label has zero relation to `fetchedAt`, and the PH stale budget is **16h** (source-health.ts:53), not 4h — the copy is wrong on TWO axes (constant 4 vs. the 16h spec, and constant vs. the live age). Exact pattern called out in [feedback_freshness_chrome_must_be_honest](C:\Users\mirko\.claude\projects\c--dev-trendingrepo\memory\feedback_freshness_chrome_must_be_honest.md): "Never inline hardcoded 'FRESH · 1H' / green-pulse LiveDot. Wire `lastUpdatedAt` to `FreshnessBadge` via `classifyFreshness()`." `producthunt` is already a `NewsSource` (freshness.ts:24) so the badge compiles immediately.
+- **Fix**: Replace with `<FreshnessBadge source="producthunt" lastUpdatedAt={getProducthuntFetchedAt()} />`. Read the timestamp via the existing loader getter (producthunt.ts:84) — do NOT re-derive from `topLaunches[0]?.createdAt` (see #2). Optionally pass `oldestRecordAt={findOldestRecordAt(file)}` if PH records carry `lastRefreshedAt` stamps.
+- **Design call**: mechanical — single-line swap, no new tokens needed.
+
+### 2. Clock value reads launch `createdAt`, not scrape `fetchedAt` — second honest-chrome violation
+
+- **File**: [page.tsx:107](../../../src/app/producthunt/page.tsx#L107) (`fetchedAt = !cold ? topLaunches[0]?.createdAt : undefined`) + [page.tsx:149](../../../src/app/producthunt/page.tsx#L149) (`<span className="big">{formatClock(fetchedAt)}</span>`)
+- **Mechanical**: The comment two lines above admits the hack — "Pull lastFetchedAt off the loader's getter". The code does the opposite: it reads `topLaunches[0]?.createdAt`, i.e. the timestamp of the **top-voted launch's post date** on ProductHunt, not the time TrendingRepo last scraped. With the 7-day window + votes-desc sort, that timestamp is usually 1–6 days old — the muted `UTC · LATEST POST` sub-label half-acknowledges this but the visual reads as "this page is N days old". After #1, the FreshnessBadge would expose the true scrape age right next to a clock claiming an entirely different age. The two values must agree.
+- **Fix**: Replace `topLaunches[0]?.createdAt` with `getProducthuntFetchedAt()` (already imported via `producthuntCold` from `@/lib/producthunt`). Keep the `UTC · LATEST POST` sub-label OR rename to `UTC · LAST SCRAPE` to match. Recommend the latter — the page already shows per-launch `formatRelative(l.createdAt)` in the POSTED column for individual post age.
+- **Design call**: mechanical — one expression swap + sub-label copy fix.
+
+### 3. Brand color hardcoded as `PH_RED = "#DA552F"` — token EXISTS but is bypassed in 7 sites
+
+- **File**: [page.tsx:28](../../../src/app/producthunt/page.tsx#L28) (const declaration), then consumed at L161, L244, L259, L277, L287, L432, L465, L504, L561 — **9 use-sites** for one literal
+- **Mechanical**: `globals.css:182` already defines `--source-producthunt: #da552f` (oklch sibling at L183). The PhBadge component correctly threads `var(--source-producthunt)` via inline style (PhBadge.tsx:46,48,50,55) — so the token is the established convention. The page page bypasses it entirely. Worse, [RecentLaunches.tsx:20](../../../src/components/producthunt/RecentLaunches.tsx#L20) declares its OWN const `PH_ORANGE = "#DA552F"` — three different names (`PH_RED`, `PH_ORANGE`, `--source-producthunt`) all hold the same value, classic drift surface. The brand spec calls it ProductHunt orange `#da552f`; "PH_RED" const name actively misleads. The PageHead clock + tab underline + rank tint + hot-vote tint + cross-link tint + cold-state heading + empty-state heading all paint the same brand orange via the wrong path.
+- **Fix**: Delete the `PH_RED` const. Replace each call-site with `var(--source-producthunt)` (inline style for the dynamic ones, or a CSS class for the static ones). For the v4 KpiBand `pip` prop (page.tsx:161) pass `"var(--source-producthunt)"`. Also delete `PH_ORANGE` in RecentLaunches.tsx and route through the same token. Match the existing PhBadge.tsx pattern exactly. Optional: add a `--v4-src-ph` mirror in the v4 token block (globals.css:6226-6233) for consistency with `--v4-src-hn`/`--v4-src-x` etc.
+- **Design call**: mechanical — token exists, 10 literal sites collapse to one var reference.
+
+## P1 findings
+
+### 4. Loading skeleton on v3 tokens — drift vs. surrounding v4 page
+
+- **File**: [loading.tsx:10,14,18,23,30,38](../../../src/app/producthunt/loading.tsx#L10) — 6 references to `var(--v3-bg-050)` / `var(--v3-bg-100)`
+- **Mechanical**: globals.css alias chain keeps v3 visually identical to v4 today, but every other recent audit (huggingface, npm) flagged the same drift and the sweep is being done globally. PH is the only top-tier source-feed page still on v3 skeleton tokens.
+- **Fix**: `--v3-bg-050` → `--v4-bg-050`, `--v3-bg-100` → `--v4-bg-100`. One file, 6 lines.
+- **Design call**: mechanical.
+
+### 5. Error boundary on v2 tokens — same drift, older generation
+
+- **File**: [error.tsx:23,32,42,49,52](../../../src/app/producthunt/error.tsx#L23) — `--v2-sig-red`, `--v2-ink-000/300/400`
+- **Mechanical**: Two generations behind. Same global sweep applies as HF #9 audit finding.
+- **Fix**: `--v2-sig-red` → `--v4-red`, `--v2-ink-*` → `--v4-ink-*`. Five token swaps in one file.
+- **Design call**: mechanical.
+
+### 6. `RecentLaunches` component is orphan — zero importers, but ships in the bundle
+
+- **File**: [RecentLaunches.tsx](../../../src/components/producthunt/RecentLaunches.tsx) (153 LOC)
+- **Mechanical**: `grep -rn 'RecentLaunches\|from .*RecentLaunches' src/` returns only the file's own exports and the default re-export. No page imports it. The file references `getAiLaunches`, `getDerivedRepoByFullName`, `next/image`, `producthuntCold`, and the duplicate `PH_ORANGE` const — all dead weight if nothing renders it. The comment at L1-9 still describes it as a "homepage section". Either the homepage hook was removed during a sprint and the file orphaned, or the import is pending. Either way the file is currently dead code, and it owns one of two `PH_ORANGE` literals (see #3).
+- **Fix**: Decide intent. If `RecentLaunches` should ship on the homepage, restore the import on `/` (and clean up its `PH_ORANGE` per #3). If not, delete the file. K2-simplicity says delete unless there's a documented sprint to wire it back. Recommend delete + capture in `tasks/BACKLOG.md` if homepage revival is planned.
+- **Design call**: design — needs a product call (is the homepage strip on the roadmap?), then mechanical.
+
+### 7. `<div className="hidden mt-0.5 inline-flex …">` — `hidden` always wins, this block never renders
+
+- **File**: [page.tsx:364](../../../src/app/producthunt/page.tsx#L364)
+- **Mechanical**: The optional `<a>` rendering the github URL under the launch name carries Tailwind `hidden` AND `inline-flex` — `hidden` (display: none) wins. The branch is permanently invisible. This duplicates the GitHub icon already shown in the LINKS column via `<LaunchLinkIcons>`, so it was likely hidden on purpose during a redesign but left in the tree. Dead UI under a falsy gate.
+- **Fix**: Delete the entire conditional `launch.githubUrl ? (…) : null` block in `NameTagline` (page.tsx:359-379). The `LaunchLinkIcons` column owns the GH link affordance — including the stars badge tooltip. Removes ~20 LOC of dead JSX.
+- **Design call**: mechanical — straight deletion.
+
+### 8. TabNav `aria-current="page"` but no `role="tab"` / `role="tablist"` — pick a model
+
+- **File**: [page.tsx:544-571](../../../src/app/producthunt/page.tsx#L544)
+- **Mechanical**: `<nav aria-label="ProductHunt tabs">` with `<Link>` children using `aria-current="page"`. Visually it's the same orange-underline tab strip as reddit-trending's `AllTrendingTabs` which uses `role="tablist"`. Different ARIA contracts for visually-identical patterns — same finding as huggingface audit #10. Each PH tab is a `?tab=ai` / `?tab=all` query-string variation of the SAME route, NOT a different route. That's an intra-page tab control by Next.js routing semantics, not a route nav. So unlike HF (where each tab is a real sub-route), here `role="tablist"` is the more honest match.
+- **Fix**: Two options: (a) keep `<nav>` semantics (defensible — `aria-current="page"` works with `?tab=`); (b) switch to `role="tablist"` + `role="tab"` + `aria-selected`. Recommend (b): the URLs only differ in querystring, so screen readers should treat this as a tab control, not a navigation. Add `role="tablist"` to `<nav>` and `role="tab"` + `aria-selected={isActive}` on each `<Link>`. Drop `aria-current="page"` for `aria-selected`.
+- **Design call**: design — needs the same project-wide tab-vs-nav rule HF #10 surfaced.
+
+### 9. Cross-link panel anchor lacks `aria-label` — first link in a row is name-only
+
+- **File**: [page.tsx:414-421](../../../src/app/producthunt/page.tsx#L414)
+- **Mechanical**: `<a href={launch.url} target="_blank">{launch.name}</a>` opens an external PH page in a new tab. The repo `<Link>` next to it (L423) is internal and labeled by the fullName text. Screen readers announcing the launch-name link give no clue that it's external + opens PH; the row's `→` separator (L422) is presentational. The header row at L399 announces "CROSS-LINKED REPOS (n)" but the per-row destination is ambiguous.
+- **Fix**: Add `aria-label={`${launch.name} on ProductHunt`}` to the launch link (matching the pattern already used by `ThumbLink` at page.tsx:316). Optional: append `title={launch.tagline}` to surface the one-liner on hover.
+- **Design call**: mechanical — one prop.
+
+### 10. Mobile layout drops the thumbnail entirely — recognition cost spikes on 375px
+
+- **File**: [page.tsx:274-295](../../../src/app/producthunt/page.tsx#L274) (mobile grid `[32px_1fr_60px_70px]`)
+- **Mechanical**: Mobile hides the 40px logo column ("hides thumbnail + comments per spec" — comment at L273). The 7d list on /producthunt is a launch directory; without a logo on mobile, every row reads as text-only `#N · Name · tag tag · ▲500 · 3d`. PH launches are unusually logo-driven (products carry brand marks designed for the PH grid). Recognition density on mobile is significantly worse than desktop. Audit brief asks for "launch cards + maker bubbles" — neither is present in either layout. Tap target on the rank-number column is also 32px (below 44px spec).
+- **Fix**: Two-part. (a) Re-add the 32px logo as the second column on mobile: grid `[24px_32px_1fr_56px_60px]`. The thumbnail anchors recognition without bloating the row. (b) Wrap the row body in a `min-h-[44px]` link region so the touch target reaches the spec floor — currently rows are clickable via `<NameTagline>` only, with the rest of the row being whitespace.
+- **Design call**: design — small layout shift, lifts recognition + a11y together.
+
+### 11. Maker avatars never render — info-density gap vs. brief
+
+- **Files**: [page.tsx:128-134](../../../src/app/producthunt/page.tsx#L128) (makerSet counted), data shape at [producthunt.ts:35-40](../../../src/lib/producthunt.ts#L35)
+- **Mechanical**: Audit brief calls out "launch cards + maker bubbles + upvote counts". The MAKERS KPI counts unique shippers (good) but no row surfaces the maker face/handle. The `Launch.makers` payload carries `name`, `username`, `twitterUsername`, `websiteUrl` — enough to render 1-3 stacked initial chips per row. Currently a launch with one well-known maker (e.g. @rauchg) shipping reads identically to a stealth solo launch. Misses one of the strongest PH-native signals.
+- **Fix**: Add a 60-72px column between LINKS and VOTES on desktop: render up to 3 stacked monogram bubbles (size-5 each, -ml-1 stack) using `EntityLogo` with `shape="circle"`. Tooltip = comma-joined maker names. Hide on mobile by default; promote to a single bubble row if mobile spec adds space. Pattern reuses `EntityLogo` (already imported at L10).
+- **Design call**: design — net-new column, but matches the brief and is the highest-leverage information add. Lower priority than the P0s.
+
+## P2 findings
+
+### 12. KpiBand `pip: PH_RED` is a string literal but other cells use `var(--v4-*)` — type drift inside one band
+
+- **File**: [page.tsx:155-183](../../../src/app/producthunt/page.tsx#L155)
+- **Mechanical**: Cell 1 pip is `PH_RED` (hex literal), cells 2/3/4 pips are `var(--v4-acc) / var(--v4-money) / var(--v4-blue)`. KpiCell.pip accepts any CSS color, so neither is "wrong", but mixing string-literal hex with var-references in the same `cells` array makes the source style inconsistent. Folds into #3.
+- **Fix**: After #3 lands, cell 1's pip becomes `"var(--source-producthunt)"` and the band is uniform.
+- **Design call**: mechanical, gated on #3.
+
+### 13. `formatRelative` doesn't pluralize and ages `1m ago` vs `1 minute ago` are mismatched with the clock
+
+- **File**: [page.tsx:56-68](../../../src/app/producthunt/page.tsx#L56)
+- **Mechanical**: Helper renders `1m ago` / `1h ago` / `1d ago` — fine. The page-level clock at L149 shows full HH:MM:SS UTC. So the user sees `13:47:22 · UTC · LATEST POST` (the full clock) next to a row reading `3d ago`. The full clock is more precise than every per-row label — visually, the loudest temporal element on the page (the big clock) is also the least informative for the actual feed.
+- **Fix**: Drop the seconds from the clock — `HH:MM` is plenty since the underlying data is 7d-rolling. `formatClock` becomes `slice(11, 16)`. Bigger fix: once #2 lands, the clock can shrink one tier and the FreshnessBadge takes the visual anchor — clock becomes secondary metadata.
+- **Design call**: design — small hierarchy correction.
+
+### 14. Cold-state + Empty-state use inline `style={{ border: "1px dashed var(--v4-line-100)", borderRadius: 2 }}` — token-correct but inline vs the rest of the page using Tailwind utilities
+
+- **Files**: [page.tsx:452-485](../../../src/app/producthunt/page.tsx#L452) (ColdState), [487-518](../../../src/app/producthunt/page.tsx#L487) (EmptyState)
+- **Mechanical**: Both functions render a `<section>` with inline styles (radius 2, dashed border, bg, padding). The same shape elsewhere uses `border border-border-primary rounded-md bg-bg-secondary`. Inline styles are token-correct here but the mixed-paradigm makes maintenance worse — Tailwind sweep can't catch token changes inside inline `style` blobs.
+- **Fix**: Convert both `<section>` wrappers to Tailwind classes: `className="p-8 bg-bg-secondary border border-dashed border-border-primary rounded-sm"` (rounded-sm = 2px per project rule). Keep the inline color on the H2 heading (PH brand orange, via #3 token).
+- **Design call**: mechanical — class swap.
+
+### 15. Cold-state H2 is uppercase + 18px + letter-spacing 0.18em in brand orange — louder than the H1 it sits below
+
+- **Files**: [page.tsx:463-471](../../../src/app/producthunt/page.tsx#L463), [502-509](../../../src/app/producthunt/page.tsx#L502)
+- **Mechanical**: Same hierarchy inversion HF audit #18 called out. H1 is sans 30px weight 500 ink-000 (PageHead). Cold-state H2 is mono 18px weight 700 uppercase letter-spaced 0.18em in PH orange. On a cold day the empty state shouts louder than the page title.
+- **Fix**: Drop the brand-orange color on the cold-state heading; keep mono but in `var(--v4-ink-300)` at weight 600 / 14px. Same fix applies to EmptyState. Pairs with #14 class sweep.
+- **Design call**: design — small hierarchy correction.
+
+### 16. `tags` chip uses `bg-brand/15 text-brand` — uses the GLOBAL brand (Liquid Lava orange), not the PH source color
+
+- **File**: [page.tsx:347-353](../../../src/app/producthunt/page.tsx#L347)
+- **Mechanical**: Tag chips on rows render in `bg-brand/15 text-brand`. `--brand` is the global Liquid Lava orange (oklch ~0.7 0.18 28). PH's `--source-producthunt` is `#da552f` (oklch 0.619 0.175 36.4). They're close enough that the visual is "orange-on-orange-on-orange" but they're TWO different oranges per the design system. On the PH page the tag chip should sit in the SOURCE color so it pairs with the rank tint + hot-vote tint + tab underline, not the global brand.
+- **Fix**: After #3, swap chip classes to inline style: `style={{ background: "color-mix(in oklab, var(--source-producthunt) 15%, transparent)", color: "var(--source-producthunt)" }}`. Or add a utility class. Either way, decouple from `--brand`.
+- **Design call**: design — color-key honesty.
+
+### 17. Empty-state `tab === "ai"` copy promises tab switch but no inline CTA
+
+- **File**: [page.tsx:488-491](../../../src/app/producthunt/page.tsx#L488)
+- **Mechanical**: `"The ProductHunt scrape completed, but no launches matched the AI-adjacent 7-day filter. Try the All Launches tab for the full PH feed."` — copy invites the user to click "the All Launches tab" but no anchor is rendered. User has to scroll back up to find the strip. Friction.
+- **Fix**: Add a `<Link href="/producthunt?tab=all" className="v2-btn v2-btn-ghost mt-3 inline-flex">Show all launches →</Link>` below the body paragraph. Mirrors the error-boundary CTA pattern at error.tsx:64.
+- **Design call**: design — small affordance add.
+
+### 18. Hover transition omits `duration` — defaults to browser ~150ms, motion spec is 120-180ms
+
+- **Files**: [page.tsx:241, 274, 342, 364, 411, 418, 425, 556](../../../src/app/producthunt/page.tsx#L241) — all `transition-colors` without `duration-*`
+- **Mechanical**: Tailwind `transition-colors` defaults to 150ms via `transition-duration: 150ms`. Project tokens are `--motion-duration-fast: 120ms` and `--motion-duration-base: 180ms` (globals.css:346-347). Implicit 150ms is within range but not on the token grid.
+- **Fix**: Add `duration-150` (closest Tailwind preset) or extend the Tailwind config to expose `duration-fast` (120ms) / `duration-base` (180ms) custom keys. Recommend `duration-150` everywhere for K2-simplicity — single global pass.
+- **Design call**: mechanical.
+
+## What's working well (reference patterns to propagate)
+
+1. **`EntityLogo` fallback for blocked PH thumbnails** ([page.tsx:304-326](../../../src/app/producthunt/page.tsx#L304)) — switched from `next/image` after CORB/`ERR_BLOCKED_BY_ORB` errors. Inline comment documents the prior incident. Pattern other pages should adopt for third-party CDNs.
+2. **`cold` separation from "empty data"** ([producthunt.ts:81-83](../../../src/lib/producthunt.ts#L81)) — `producthuntCold` only fires when the scraper NEVER ran, NOT on empty days. Inline comment explicitly notes the prior conflation and the fix. Honest cold contract.
+3. **Per-tab counts in the strip** ([page.tsx:190](../../../src/app/producthunt/page.tsx#L190)) — `<TabNav active={activeTab} aiCount={ai7d.length} allCount={all7d.length} />` shows both counts even on the inactive tab. User sees "AI 12 · All 47" without switching. Great info-density move.
+4. **`ChevronUp` for upvotes** ([page.tsx:261, 289, 434](../../../src/app/producthunt/page.tsx#L261)) — single-glance signal that this is a vote count, not a generic number. Aligns with PH's native ▲ affordance without resorting to the literal `▲` Unicode glyph used in the orphaned `RecentLaunches`. Better typography hygiene.
+5. **CrossLinkedRepos drops the panel entirely when zero matches** ([page.tsx:389-395](../../../src/app/producthunt/page.tsx#L389)) — no orphan "empty box" on quiet days. Pattern matches HF cold-state graceful degrade.
+6. **ISR `revalidate = 600`** ([page.tsx:44](../../../src/app/producthunt/page.tsx#L44)) — 10-min cache aligns with the audit brief's data-store rules; tab-query variants get separate ISR keys per the comment at L42.
+7. **No `bg-black` violations** — the page uses `home-surface` + `bg-bg-secondary` everywhere; no opaque blacks.
+8. **No card shadows** — table + cross-link sections use `border + rounded-md` only. Compliant with the no-shadow rule.
+
+## Verify-in-context
+
+- **PH cron cadence**: `PRODUCTHUNT_STALE_THRESHOLD_MS = 16h`, `PRODUCTHUNT_DEGRADED_THRESHOLD_MS = 8h` (source-health.ts:53,59). Means the FreshnessBadge in #1 will read GREEN for the first 8h post-scrape, AMBER 8-16h, RED past 16h — matching the cadence the `FRESH · 4H` literal was trying (and failing) to approximate.
+- **`oldestRecordAt` stamping for PH**: `Launch` shape carries `createdAt` (post timestamp) but no `lastRefreshedAt` per-record. `findOldestRecordAt` in freshness.ts walks for `lastRefreshedAt` keys — passing PH's payload would return null. Skip the optional arg until the scraper adds the stamp (or thread `lastFetchedAt` as the single source of truth, which is acceptable for a slow-cron source).
+- **`force-static` vs `revalidate`**: Page exports `revalidate = 600` only; no `dynamic = "force-static"`. Next.js infers static + ISR. Acceptable for the current data shape. No drift.
+- **MarkVisited routeKey**: Not present on this page (unlike `/huggingface/*`). If sidebar fresh-count is supposed to flag PH new-data, the marker is missing. Out-of-scope for visual audit; worth a follow-up.
+- **rounded-md vs rounded-sm**: Page mixes `rounded-md` (table containers, ~6px) with the project rule "Card radii 2px". Quick scan: `rounded-md` appears at L213, L398. The project rule says **card** radii are 2px — the section wrappers may legitimately be cards. Recommend a separate ADR call on "what's a card vs. a panel"; for now flag as P3.


### PR DESCRIPTION
## Summary

5 LLM audits on the remaining high-traffic source-feed surfaces. Read-only markdown reports. Stacks on main.

## Findings — ~67 total

| Surface | P0 | P1 | P2 | P3 | Report |
|---|---|---|---|---|---|
| `/devto` | 3 | 5 | 4 | — | [devto-audit.md](docs/audits/impeccable/devto-audit.md) |
| `/producthunt` | 3 | 8 | 7 | — | [producthunt-audit.md](docs/audits/impeccable/producthunt-audit.md) |
| `/bluesky/trending` | 2 | 3 | 5 | 3 | [bluesky-trending-audit.md](docs/audits/impeccable/bluesky-trending-audit.md) |
| `/npm` | 2 | 3 | 4 | 3 | [npm-audit.md](docs/audits/impeccable/npm-audit.md) |
| `/arxiv` | 2 | 3 | 4 | 3 | [arxiv-audit.md](docs/audits/impeccable/arxiv-audit.md) |
| **Totals** | **12** | **22** | **24** | **9** | |

## Headlines per surface

- **`/devto`** — Three brand-color values for the SAME source on one page (`DEVTO_BLUE = "#6699ff"` blue + `DEVTO_BRAND_COLOR = "#0a0a0a"` black + `--source-dev: #b08bff` purple). One "source of truth" comment guarantees future drift to black.
- **`/producthunt`** — Big UTC clock reads `topLaunches[0].createdAt` (post age) not `lastFetchedAt`. Even with FreshnessBadge fixed, clock + badge would disagree. PH_RED hardcoded 9× despite token existing. `RecentLaunches.tsx` (153 LOC) has **zero importers**.
- **`/bluesky/trending`** — `force-static` page pulses green "LIVE · 24H" — structural lie. Half the page uses `--source-bluesky` correctly; the other half hardcodes `#0085FF` 6×. OPERATOR.md says bsky is GREEN — contradicts wave-6 audit's "degraded" framing.
- **`/npm`** — KpiBand cells 1 + 3 display **literally identical numbers** with different labels (TRACKED + LINKED REPOS both = `linkedRepoCount`). Copy/paste regression.
- **`/arxiv`** — Wire-up blocked: NewsSource has no `arxiv` member (same gap as wave-9a HuggingFace had pre-fix). Linked-repo pill is `<span>` not `<a>` — dead link.

## Cross-cutting meta-findings (wave-12+ candidates)

1. **WindowedFeedTable `.tab` buttons miss 44×44 across SIX feed surfaces** (HN/Reddit/Bsky/Devto/Lobsters/Arxiv). Wave-7a's `.tabs .tab` mobile fix MAY cover this (different selector — verify post-merge).
2. **`loading.tsx` skeletons still pin `--v3-*` tokens** on V4 pages (confirmed: /npm, /arxiv). Likely systemic across V4-migrated routes.
3. **NewsSource enum needs `arxiv` expansion** (same pattern as wave-9a HuggingFace).
4. **Orphan candidate: `RecentLaunches.tsx`** (/producthunt, 153 LOC, zero importers per audit) — but wave-9b lesson applies: re-verify imports before any deletion.

## What's NOT in this PR

Read-only audits. **Mechanical fixes land in wave-12+** when you greenlight. PR #1206 (wave-11b) ships the chart palette drift reconciliation in parallel.

## Test plan
- [x] 5 reports written and reviewable
- [ ] (wave-12) Apply mechanical fixes
- [ ] (wave-12 cross-cutting) Add `arxiv` to NewsSource enum (1 line + threshold)
- [ ] (wave-12 cross-cutting) Sweep `loading.tsx` skeletons for V3→V4 token migration
- [ ] (wave-12) Re-verify RecentLaunches.tsx orphan status before any deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)