### PR TITLE
fix(revenue-overlays): defeat mtime-resolution race in self-reported cache

### DIFF
--- a/src/lib/revenue-overlays.ts
+++ b/src/lib/revenue-overlays.ts
@@ -229,15 +229,23 @@ export function _resetRevenueOverlaysCacheForTests(): void {
 // ---------------------------------------------------------------------------
 
 // Cache invalidates on either a TTL tick (10s) or a change in the
-// submissions file's mtime. The mtime check means an approve/reject lands
-// in the overlay map immediately instead of waiting for the TTL — important
-// for both the admin UX and for deterministic test runs.
+// submissions file's signature (mtime + size). The signature check means an
+// approve/reject lands in the overlay map immediately instead of waiting for
+// the TTL — important for both the admin UX and for deterministic test runs.
+//
+// Why mtime AND size: some filesystems (and CI runners under load) round
+// mtime to whole seconds. A rapid submit-then-approve in the same second
+// produces identical mtimes, which would let the cache return a stale view
+// that excludes the just-approved row. Including the size in the signature
+// catches the case where a row's status field grew (pending → approved adds
+// the moderatedAt ISO string and switches "pending_moderation" to "approved")
+// even when mtime resolution swallowed the timestamp delta.
 const SELF_REPORTED_CACHE_TTL_MS = 10_000;
 
 let selfReportedCache:
   | {
       fetchedAtMs: number;
-      mtimeMs: number;
+      signature: string;
       byFullName: Map<string, RevenueOverlay>;
     }
   | null = null;
@@ -317,22 +325,23 @@ function trustmrrLinkToOverlay(
   };
 }
 
-function currentSubmissionsMtimeMs(): number {
+function currentSubmissionsSignature(): string {
   const path = submissionsFilePath();
-  if (!existsSync(path)) return -1;
+  if (!existsSync(path)) return "missing";
   try {
-    return statSync(path).mtimeMs;
+    const stat = statSync(path);
+    return `${stat.mtimeMs}:${stat.size}`;
   } catch {
-    return -1;
+    return "missing";
   }
 }
 
 function ensureSelfReportedCache() {
   const now = Date.now();
-  const mtimeMs = currentSubmissionsMtimeMs();
+  const signature = currentSubmissionsSignature();
   if (
     selfReportedCache &&
-    selfReportedCache.mtimeMs === mtimeMs &&
+    selfReportedCache.signature === signature &&
     now - selfReportedCache.fetchedAtMs < SELF_REPORTED_CACHE_TTL_MS
   ) {
     return selfReportedCache;
@@ -350,7 +359,7 @@ function ensureSelfReportedCache() {
       );
     }
   }
-  selfReportedCache = { fetchedAtMs: now, mtimeMs, byFullName };
+  selfReportedCache = { fetchedAtMs: now, signature, byFullName };
   return selfReportedCache;
 }
 


### PR DESCRIPTION
## Summary
- Includes file size (alongside mtime) in the self-reported overlay cache signature, defeating the 1-second-mtime-resolution race that caused intermittent test failures in CI.
- 1 file changed, +20/-11 LOC. No behaviour change for the happy path.
- Unblocks **#1193, #1194, #1202** which have been stuck on the same flaky test.

## Root cause
`ensureSelfReportedCache` in [src/lib/revenue-overlays.ts](src/lib/revenue-overlays.ts) keyed cache invalidation on `mtime` only. Some filesystems (and self-hosted CI runners under load) round `mtime` to whole seconds. A rapid submit-then-approve flow lands within the same second → mtime unchanged → cache returns a stale view that excludes the just-approved row → `assert.ok(overlay)` returns null → test fails.

The status field going from `"pending_moderation"` to `"approved"` plus adding a moderatedAt ISO string changes the file size by ~16 chars. Combining size with mtime in the cache signature catches this case.

## Failing test
[src/lib/__tests__/revenue-overlays.test.ts#L73](src/lib/__tests__/revenue-overlays.test.ts#L73) → `getSelfReportedOverlay reads only approved self_report rows`.

## Why this matters now
Catalogued in [docs/audits/impeccable/DRAIN-2026-05-13.md](docs/audits/impeccable/DRAIN-2026-05-13.md) Category C as the wave-12 backlog item blocking 3 audit PRs. Landing this unblocks the impeccable drain queue.

## Test plan
- [ ] CI green on this PR's own test suite (the very test that was failing)
- [ ] After merge: re-run CI on #1193, #1194, #1202 → expect green

🤖 Generated with [Claude Code](https://claude.com/claude-code)