### PR TITLE
feat(api): /api/revalidate endpoint for flushing stuck ISR cache

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,124 @@
+// POST /api/revalidate
+//
+// Operational tool to flush stuck ISR cache entries for specific paths.
+// Gated by CRON_SECRET via the same verifyCronAuth helper every cron route
+// uses; no public access.
+//
+// Why this exists: Vercel ISR (revalidate=300) caches both 2xx AND 5xx
+// responses with stale-while-revalidate=31535700 (≈1 year). When a build-time
+// or first-render failure caches a 500 page, the SWR background refresh
+// sometimes also fails (rate-limit, transient upstream) — leaving the route
+// stuck at 500 even after the underlying code bug is fixed and redeployed.
+//
+// Discovered 2026-05-13: 5 of 7 sampled /repo/[owner]/[name] routes stuck
+// at 500 on production despite the latest deployment's deploy URL serving
+// the same routes 200. `curl -H "Cache-Control: no-cache"` flushed 2 of 5;
+// the other 3 stayed stuck. This endpoint gives ops a programmatic flush.
+//
+// Body shape:
+//   { paths: ["/repo/sst/sst", "/repo/sindresorhus/ky"] }
+//
+// Response:
+//   { ok: true, revalidated: ["/repo/sst/sst", "/repo/sindresorhus/ky"] }
+//
+// Caller is responsible for verifying the route returns 200 after the flush
+// (the underlying code bug may also need fixing). This endpoint only flushes
+// the cache.
+
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+
+import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+
+export const runtime = "nodejs";
+
+const MAX_PATHS_PER_REQUEST = 50;
+const PATH_PATTERN = /^\/[A-Za-z0-9_\-./[\]]+$/;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const verdict = verifyCronAuth(request);
+  if (verdict.kind !== "ok") {
+    return authFailureResponse(verdict);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "request body must be valid JSON" },
+      { status: 400 },
+    );
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json(
+      { ok: false, error: "body must be a JSON object" },
+      { status: 400 },
+    );
+  }
+
+  const raw = (body as { paths?: unknown }).paths;
+  if (!Array.isArray(raw)) {
+    return NextResponse.json(
+      { ok: false, error: "paths must be a non-empty array" },
+      { status: 400 },
+    );
+  }
+  if (raw.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: "paths must contain at least one entry" },
+      { status: 400 },
+    );
+  }
+  if (raw.length > MAX_PATHS_PER_REQUEST) {
+    return NextResponse.json(
+      { ok: false, error: `paths cap is ${MAX_PATHS_PER_REQUEST} per request` },
+      { status: 400 },
+    );
+  }
+
+  const paths: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") {
+      return NextResponse.json(
+        { ok: false, error: "every path entry must be a string" },
+        { status: 400 },
+      );
+    }
+    if (!PATH_PATTERN.test(entry)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `invalid path: ${entry} — must start with / and use only [A-Za-z0-9_\\-./[\\]]`,
+        },
+        { status: 400 },
+      );
+    }
+    paths.push(entry);
+  }
+
+  const revalidated: string[] = [];
+  const errors: Array<{ path: string; error: string }> = [];
+  for (const path of paths) {
+    try {
+      revalidatePath(path);
+      revalidated.push(path);
+    } catch (err) {
+      errors.push({
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return NextResponse.json(
+    {
+      ok: errors.length === 0,
+      revalidated,
+      errors,
+      requestedAt: new Date().toISOString(),
+    },
+    { status: errors.length === 0 ? 200 : 207 },
+  );
+}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -27,76 +27,40 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { parseBody } from "@/lib/api/parse-body";
 
 export const runtime = "nodejs";
 
 const MAX_PATHS_PER_REQUEST = 50;
 const PATH_PATTERN = /^\/[A-Za-z0-9_\-./[\]]+$/;
 
+const RevalidateBodySchema = z.object({
+  paths: z
+    .array(
+      z
+        .string()
+        .regex(
+          PATH_PATTERN,
+          "path must start with / and use only [A-Za-z0-9_\\-./[\\]]",
+        ),
+    )
+    .min(1, "paths must contain at least one entry")
+    .max(
+      MAX_PATHS_PER_REQUEST,
+      `paths cap is ${MAX_PATHS_PER_REQUEST} per request`,
+    ),
+});
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const verdict = verifyCronAuth(request);
-  if (verdict.kind !== "ok") {
-    return authFailureResponse(verdict);
-  }
+  const deny = authFailureResponse(verifyCronAuth(request));
+  if (deny) return deny;
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { ok: false, error: "request body must be valid JSON" },
-      { status: 400 },
-    );
-  }
-
-  if (!body || typeof body !== "object") {
-    return NextResponse.json(
-      { ok: false, error: "body must be a JSON object" },
-      { status: 400 },
-    );
-  }
-
-  const raw = (body as { paths?: unknown }).paths;
-  if (!Array.isArray(raw)) {
-    return NextResponse.json(
-      { ok: false, error: "paths must be a non-empty array" },
-      { status: 400 },
-    );
-  }
-  if (raw.length === 0) {
-    return NextResponse.json(
-      { ok: false, error: "paths must contain at least one entry" },
-      { status: 400 },
-    );
-  }
-  if (raw.length > MAX_PATHS_PER_REQUEST) {
-    return NextResponse.json(
-      { ok: false, error: `paths cap is ${MAX_PATHS_PER_REQUEST} per request` },
-      { status: 400 },
-    );
-  }
-
-  const paths: string[] = [];
-  for (const entry of raw) {
-    if (typeof entry !== "string") {
-      return NextResponse.json(
-        { ok: false, error: "every path entry must be a string" },
-        { status: 400 },
-      );
-    }
-    if (!PATH_PATTERN.test(entry)) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: `invalid path: ${entry} — must start with / and use only [A-Za-z0-9_\\-./[\\]]`,
-        },
-        { status: 400 },
-      );
-    }
-    paths.push(entry);
-  }
+  const parsed = await parseBody(request, RevalidateBodySchema);
+  if (!parsed.ok) return parsed.response;
+  const { paths } = parsed.data;
 
   const revalidated: string[] = [];
   const errors: Array<{ path: string; error: string }> = [];


### PR DESCRIPTION
## Summary
- New `POST /api/revalidate` endpoint, gated by `CRON_SECRET` via the existing `verifyCronAuth` helper.
- Body: `{ paths: ["/repo/sst/sst", ...] }`, cap 50, path-shape validation.
- Calls `revalidatePath()` per path; returns structured response with errors per-path (HTTP 207 if any fail, 200 if all succeed).

## Why
During the 2026-05-13 audit drain I discovered 5 of 7 sampled `/repo/[owner]/[name]` routes were stuck at 500 on production despite the latest deployment's deploy URL serving the same routes **200**. Vercel ISR (`revalidate=300, stale-while-revalidate=31535700`) had cached a stale 500 page from before #1159 deployed, and the background SWR refresh was either dormant or hitting a flaky upstream.

`curl -H "Cache-Control: no-cache"` bypassed CF and flushed 2 of 5 routes by triggering a fresh Vercel render. The other 3 (`sst/sst`, `sindresorhus/ky`, `cloudflare/workers-sdk`) stayed stuck. This endpoint gives operators a direct programmatic flush.

Root cause + workaround analysis lives in [docs/audits/impeccable/DRAIN-2026-05-13.md](docs/audits/impeccable/DRAIN-2026-05-13.md) (wave-12 backlog #1).

## Usage
```bash
curl -X POST https://trendingrepo.com/api/revalidate \
  -H "Authorization: Bearer $CRON_SECRET" \
  -H "Content-Type: application/json" \
  -d '{"paths": ["/repo/sst/sst", "/repo/sindresorhus/ky", "/repo/cloudflare/workers-sdk"]}'
```

## Next-step follow-on (separate PR)
Wire this into the post-deploy smoke workflow: when a probe returns 5xx on a route previously 2xx, auto-POST to `/api/revalidate` once before escalating. Closes the loop on stuck-ISR auto-healing.

## Test plan
- [ ] CI green (typecheck + lint:guards + build + e2e)
- [ ] Manual test post-merge: use the curl command above with real `CRON_SECRET` to flush the 3 stuck routes
- [ ] Verify the 3 routes return 200 after the flush
- [ ] Optionally extend smoke workflow per the follow-on idea above

🤖 Generated with [Claude Code](https://claude.com/claude-code)