### PR TITLE
audit(impeccable): wave-12-arxiv — close 2 P0 honest-chrome lies on /arxiv/trending

### DIFF
--- a/src/app/arxiv/trending/page.tsx
+++ b/src/app/arxiv/trending/page.tsx
@@ -27,7 +27,7 @@ import { repoLogoUrl } from "@/lib/logos";
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { MarkVisited } from "@/components/layout/MarkVisited";
 
 // arXiv brand: Cornell crimson. No `--v4-src-arxiv` token exists yet, so
@@ -69,11 +69,6 @@ function formatAuthors(authors: string[]): string {
   return `${authors.slice(0, 3).join(", ")} et al.`;
 }
 
-function formatClock(iso: string | undefined): string {
-  if (!iso) return "warming";
-  return new Date(iso).toISOString().slice(11, 19);
-}
-
 export default async function ArxivTrendingPage() {
   await refreshArxivFromStore();
   const file = getArxivRecentFile();
@@ -93,6 +88,9 @@ export default async function ArxivTrendingPage() {
           }
           title="arXiv · trending"
           lede="Domain-scored arXiv paper feed across cs.AI / cs.CL / cs.LG. Recency + linked-repo momentum drive the cold-start ranking; citation + social-mention enrichment lands next."
+          clock={
+            <FreshnessBadge source="arxiv" lastUpdatedAt={file.fetchedAt} />
+          }
         />
         <ColdState />
       </main>
@@ -119,11 +117,7 @@ export default async function ArxivTrendingPage() {
         title="arXiv · trending"
         lede="Domain-scored arXiv paper feed across cs.AI / cs.CL / cs.LG. Recency + linked-repo momentum drive the cold-start ranking; citation + social-mention enrichment lands next."
         clock={
-          <>
-            <span className="big">{formatClock(file.fetchedAt)}</span>
-            <span className="muted">UTC · SCRAPED</span>
-            <LiveDot label="FRESH · 3H" />
-          </>
+          <FreshnessBadge source="arxiv" lastUpdatedAt={file.fetchedAt} />
         }
         snapshot={
           <KpiBand

--- a/src/lib/news/freshness.ts
+++ b/src/lib/news/freshness.ts
@@ -25,11 +25,15 @@ export type NewsSource =
   | "twitter"
   | "npm"
   | "mcp"
-  | "skills";
+  | "skills"
+  | "arxiv";
 
 export type FreshnessStatus = "live" | "warn" | "cold";
 
 const TWITTER_STALE_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+// arXiv scraper runs every 3h; data cadence is daily-ish.
+// 12h budget = 3h cron + 9h grace before the badge goes cold.
+const ARXIV_STALE_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 
 /**
  * Mapping from NewsSource → stale threshold in ms. We treat the *stale*
@@ -56,6 +60,8 @@ export const SOURCE_STALE_MS: Record<NewsSource, number> = {
   // existing match for slow-cron Redis-published feeds.
   mcp: NPM_STALE_THRESHOLD_MS,
   skills: NPM_STALE_THRESHOLD_MS,
+  // arXiv: 3h scraper cron, daily-ish data cadence.
+  arxiv: ARXIV_STALE_THRESHOLD_MS,
 };
 
 /** Soft warn threshold = 50% of the stale threshold. Past it the badge


### PR DESCRIPTION
## Summary
Closes 2 P0 honest-chrome violations on `/arxiv/trending` per [docs/audits/impeccable/arxiv-audit.md](docs/audits/impeccable/arxiv-audit.md).

- **P0-1**: Replaced `<LiveDot label="FRESH · 3H" />` (hardcoded green pulse, zero coupling to `file.fetchedAt`) with `<FreshnessBadge source="arxiv" lastUpdatedAt={file.fetchedAt} />`.
- **P0-2**: Cold-state branch was stripping freshness chrome entirely. Wired the same `<FreshnessBadge>` into the cold `<SourceFeedTemplate>` so users distinguish "just-warming" from "operator-down".

## Enabling change
- `NewsSource` enum + `SOURCE_STALE_MS` map gained `"arxiv"` member.
- `ARXIV_STALE_THRESHOLD_MS = 12h` (3h scraper cron + 9h grace).

## Cleanup
- Dropped orphan `formatClock` helper (only call site was the `LiveDot` chrome we deleted).

## Smoke target
- `curl -sI https://trendingrepo.com/arxiv/trending` → 200
- FreshnessBadge renders with real timestamp (live/warn/cold per `classifyFreshness("arxiv", file.fetchedAt)`)

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK
- [ ] Post-deploy smoke + visual confirm FreshnessBadge renders correctly

## Defers
- P1 / P2 / P3 findings (brand-color drift, `defaultWindow` semantics, ColdState runbook leakage, tap targets, V3 token drift) — out of scope for this mechanical P0 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)