### PR TITLE
audit(impeccable): wave-12-bluesky — close 2 P0 honest-chrome lies on /bluesky/trending

### DIFF
--- a/src/app/bluesky/trending/page.tsx
+++ b/src/app/bluesky/trending/page.tsx
@@ -25,7 +25,7 @@ import { repoLogoUrl, userLogoUrl } from "@/lib/logos";
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 
 export const dynamic = "force-static";
 
@@ -56,11 +56,6 @@ function formatAgeHours(ageHours: number | undefined): string {
   return `${Math.round(ageHours / 24)}d`;
 }
 
-function formatClock(iso: string | undefined): string {
-  if (!iso) return "warming";
-  return new Date(iso).toISOString().slice(11, 19);
-}
-
 export default async function BlueskyTrendingPage() {
   await Promise.all([
     refreshBlueskyTrendingFromStore(),
@@ -87,6 +82,12 @@ export default async function BlueskyTrendingPage() {
           }
           title="Bluesky · top posts"
           lede="Posts merged across curated AI query families (agents, LLMs, coding agents, MCP, workflow), scored by engagement and cross-linked to GitHub repos."
+          clock={
+            <FreshnessBadge
+              source="bluesky"
+              lastUpdatedAt={trendingFile.fetchedAt}
+            />
+          }
         />
         <ColdState />
       </main>
@@ -112,11 +113,10 @@ export default async function BlueskyTrendingPage() {
         title="Bluesky · top posts"
         lede="Posts merged across curated AI query families (agents, LLMs, coding agents, MCP, workflow), scored by engagement and cross-linked to GitHub repos."
         clock={
-          <>
-            <span className="big">{formatClock(trendingFile.fetchedAt)}</span>
-            <span className="muted">UTC · SCRAPED</span>
-            <LiveDot label="LIVE · 24H" />
-          </>
+          <FreshnessBadge
+            source="bluesky"
+            lastUpdatedAt={trendingFile.fetchedAt}
+          />
         }
         snapshot={
           <KpiBand


### PR DESCRIPTION
## Summary
Closes 2 P0 honest-chrome violations on `/bluesky/trending` per [docs/audits/impeccable/bluesky-trending-audit.md](docs/audits/impeccable/bluesky-trending-audit.md).

- **P0-1**: Replaced `<LiveDot label="LIVE · 24H" />` (hardcoded green pulse, zero coupling to `trendingFile.fetchedAt`) with `<FreshnessBadge source="bluesky" lastUpdatedAt={trendingFile.fetchedAt} />`.
- **P0-2**: Cold-state branch was stripping freshness chrome entirely. Wired the same `<FreshnessBadge>` into the cold `<SourceFeedTemplate>`. The operator note flags bluesky scraper as degradation-prone — this is exactly when honest chrome matters most.

## Cleanup
- Dropped orphan `formatClock` helper (only call site was the `LiveDot` chrome we deleted).
- `bluesky` was already a `NewsSource` enum member, so no `freshness.ts` change needed.

## Smoke target
- `curl -sI https://trendingrepo.com/bluesky/trending` → 200
- FreshnessBadge renders with real timestamp

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK

## Defers
- P1 / P2 / P3 findings (`#0085FF` brand drift on 6 sites, mobile tap targets, ColdState runbook leakage, tabpanel a11y) — out of scope for this mechanical P0 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)