### PR TITLE
audit(impeccable): wave-12-devto — close 3 P0s + 1 P1 honest-chrome on /devto

### DIFF
--- a/src/app/devto/page.tsx
+++ b/src/app/devto/page.tsx
@@ -32,10 +32,14 @@ import { userLogoUrl } from "@/lib/logos";
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { EmptyState } from "@/components/ui/EmptyState";
 
-const DEVTO_BLUE = "#6699ff";
+// dev.to brand purple/violet — single source of truth via the canonical
+// CSS token. Replaces the prior local `DEVTO_ACCENT = "#6699ff"` which
+// drifted from the KpiBand pip + DevtoBadge fill (both purple) and made
+// the per-source color-key incoherent on the same surface.
+const DEVTO_ACCENT = "var(--v4-src-dev)";
 
 export const revalidate = 300;
 export const dynamic = "force-static";
@@ -73,11 +77,6 @@ function formatAgeFromIso(iso: string): string {
   return `${Math.round(hours / 24)}d`;
 }
 
-function formatClock(iso: string | undefined): string {
-  if (!iso) return "warming";
-  return new Date(iso).toISOString().slice(11, 19);
-}
-
 export default async function DevtoPage() {
   await Promise.all([
     refreshDevtoTrendingFromStore(),
@@ -102,6 +101,12 @@ export default async function DevtoPage() {
           }
           title="dev.to · top articles"
           lede="Long-form developer writing ranked by velocity score (reactions × time decay), with a sidebar leaderboard of cross-linked tracked repos."
+          clock={
+            <FreshnessBadge
+              source="devto"
+              lastUpdatedAt={trendingFile.fetchedAt}
+            />
+          }
         />
         <EmptyState
           variant="no-data"
@@ -135,11 +140,10 @@ export default async function DevtoPage() {
         title="dev.to · top articles"
         lede="Long-form developer writing ranked by velocity score (reactions × time decay)."
         clock={
-          <>
-            <span className="big">{formatClock(trendingFile.fetchedAt)}</span>
-            <span className="muted">UTC · SCRAPED</span>
-            <LiveDot label={`LIVE · ${trendingFile.windowDays}D`} />
-          </>
+          <FreshnessBadge
+            source="devto"
+            lastUpdatedAt={trendingFile.fetchedAt}
+          />
         }
         snapshot={
           <KpiBand
@@ -283,7 +287,7 @@ function ArticlesFeed({
       render: (_, i) => (
         <span
           className="font-mono text-[12px] tabular-nums font-semibold"
-          style={{ color: i < 10 ? DEVTO_BLUE : "var(--v4-ink-400)" }}
+          style={{ color: i < 10 ? DEVTO_ACCENT : "var(--v4-ink-400)" }}
         >
           {String(i + 1).padStart(2, "0")}
         </span>
@@ -407,7 +411,7 @@ function ArticlesFeed({
       rows={articles}
       columns={columns}
       rowKey={(a) => String(a.id)}
-      accent={DEVTO_BLUE}
+      accent={DEVTO_ACCENT}
       caption="Top dev.to articles ranked by velocity score"
       emptyTitle="// no articles in this window yet"
       emptySubtitle={emptySubtitle}

--- a/src/components/devto/DevtoBadge.tsx
+++ b/src/components/devto/DevtoBadge.tsx
@@ -31,9 +31,10 @@ interface DevtoBadgeProps {
   size?: "sm" | "md";
 }
 
-// dev.to brand black. Tailwind dark: variants flip to white background
-// + black text so the monogram stays legible on dark surfaces.
-const DEVTO_BLACK = "#0a0a0a";
+// dev.to brand purple — the canonical source-of-truth for any consumer
+// that needs to color a "dev.to" pip / channel-dot. The badge itself
+// renders directly against `var(--source-dev)`; this re-exported string
+// stays a CSS variable so dark/light theme flips resolve at render time.
 
 function buildTooltip(m: DevtoMentionForBadge): string {
   const tutorialNoun = m.mentions7d === 1 ? "tutorial" : "tutorials";
@@ -88,8 +89,8 @@ export function DevtoBadge({ mention, size = "sm" }: DevtoBadgeProps) {
   );
 }
 
-// Re-export the underlying color so the channel-dot indicator can use
-// the same source-of-truth without drifting on a brand refresh.
-export const DEVTO_BRAND_COLOR = DEVTO_BLACK;
+// Re-export the canonical brand color so any future channel-dot or pip
+// consumer stays aligned with the badge fill / border above.
+export const DEVTO_BRAND_COLOR = "var(--source-dev)";
 
 export default DevtoBadge;


### PR DESCRIPTION
## Summary
Closes 3 P0 + 1 P1 violations on `/devto` per [docs/audits/impeccable/devto-audit.md](docs/audits/impeccable/devto-audit.md).

- **P0-1**: Replaced `<LiveDot label=\`LIVE · {windowDays}D\` />` with `<FreshnessBadge source="devto" lastUpdatedAt={trendingFile.fetchedAt} />`. The 24h tab already shows 0 rows + a "Last scrape Xh ago" empty-state hint — exactly the dishonest-chrome scenario the rule names.
- **P0-2**: Removed `DEVTO_BLUE = "#6699ff"` (drift). Three colors claimed to be "dev.to" on a single route (KpiBand pip + DevtoBadge fill = purple, this constant = blue). Consolidated to `DEVTO_ACCENT = "var(--v4-src-dev)"`.
- **P0-3**: `DevtoBadge.DEVTO_BRAND_COLOR` re-exported `#0a0a0a` (black) as the "channel-dot" source of truth — but the badge fills with `var(--source-dev)` purple three lines below. Future consumers would get pitch-black. Fixed to re-export `"var(--source-dev)"`.
- **P1-1** (folded in): cold-state branch was stripping freshness chrome. Wired the same FreshnessBadge into the cold `<SourceFeedTemplate>`.

## Cleanup
- Dropped orphan `formatClock` helper.
- Dropped now-unused `DEVTO_BLACK` constant.

## Smoke target
- `curl -sI https://trendingrepo.com/devto` → 200
- FreshnessBadge renders with real timestamp (live/warn/cold per `classifyFreshness("devto", trendingFile.fetchedAt)`)
- Top-10 rank numerals + table accent + KpiBand pip + DevtoBadge fill all render in matching brand purple

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK

## Defers
- P1-2 / P1-3 / P1-4 / P1-5 (mobile reflow, tap targets, tag chip a11y, `EntityLogo` size) — out of scope for this mechanical P0 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)