### PR TITLE
audit(impeccable): wave-12-npm — close 2 P0 honest-chrome lies on /npm

### DIFF
--- a/src/app/npm/page.tsx
+++ b/src/app/npm/page.tsx
@@ -27,7 +27,6 @@ import { npmLogoUrl } from "@/lib/logos";
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { KpiBand } from "@/components/ui/KpiBand";
-import { LiveDot } from "@/components/ui/LiveDot";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 
 // npm brand red — no --v4-src-npm token exists in v4.css yet, so we hardcode
@@ -155,8 +154,8 @@ export default async function NpmPage({ searchParams }: NpmPageProps) {
         clock={
           <>
             <span className="big">{formatClock(file.fetchedAt)}</span>
-            <span className="muted">UTC · SCRAPED</span>
-            <LiveDot label={`LIVE · ${activeWindow.toUpperCase()}`} />
+            <span className="muted">UTC · LAST SCRAPE</span>
+            <span className="v2-mono muted">{activeWindow.toUpperCase()}</span>
             <FreshnessBadge source="npm" lastUpdatedAt={file.fetchedAt} />
           </>
         }


### PR DESCRIPTION
## Summary
Closes 2 P0 violations on `/npm` per [docs/audits/impeccable/npm-audit.md](docs/audits/impeccable/npm-audit.md).

- **P0-1**: Removed `<LiveDot label=\`LIVE · {activeWindow}\` />` (was rendered right next to the already-honest `<FreshnessBadge source="npm" .../>` — two contradictory chrome signals on one row, the louder green pulse won). npm cadence is daily-ish (50h stale threshold); calling it "LIVE" was a direct rule violation. Window indicator survives via `<span class="v2-mono muted">{window}</span>`.
- **P0-2**: `"UTC · SCRAPED"` → `"UTC · LAST SCRAPE"`. Removes the live-tick implication that paired with the deleted LiveDot.

## Cleanup
- Dropped orphan `LiveDot` import.

## Smoke target
- `curl -sI https://trendingrepo.com/npm` → 200
- Only one chrome signal renders alongside the clock: the FreshnessBadge.

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK

## Defers
- P1-1 / P1-2 / P1-3 (npm brand red collision, KpiBand TRACKED/LINKED dup, VersionPill alpha-hex), all P2/P3 — out of scope for this mechanical P0 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)