### PR TITLE
feat(ci): wire /api/revalidate into post-deploy smoke for stuck-ISR self-healing

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -57,8 +57,11 @@ jobs:
             "/api/health?soft=1"
           )
 
+          # Pass 1: probe every route, collect page-route failures into
+          # `stuck_paths` for the self-heal pass below.
           failures=0
-          report="post-deploy-smoke results\n"
+          stuck_paths=()
+          report="post-deploy-smoke results (pass 1)\n"
           for route in "${routes[@]}"; do
             url="${BASE_URL}${route}"
             line="$(curl -sS -o /dev/null -w "%{http_code} %{time_total} %{size_download}" "$url")"
@@ -66,6 +69,11 @@ jobs:
             report+="${route} => ${line}\n"
             if [ "$code" != "200" ]; then
               failures=$((failures + 1))
+              # Only page routes (not /api/*) are eligible for ISR flush —
+              # /api/health and friends don't go through revalidatePath().
+              if [[ "$route" != /api/* ]]; then
+                stuck_paths+=("$route")
+              fi
             fi
           done
 
@@ -79,6 +87,52 @@ jobs:
           report+="/api/cron/freshness/state => ${cron_line}\n"
           if [ "$cron_code" != "200" ]; then
             failures=$((failures + 1))
+          fi
+
+          # Self-heal pass: if pass-1 caught page-route failures, POST those
+          # paths to /api/revalidate (CRON_SECRET-gated) and re-probe ONCE.
+          # Vercel ISR caches both 2xx AND 5xx with stale-while-revalidate
+          # ~= 1 year, so a transient 500 (or one cached pre-fix) would
+          # otherwise persist for weeks. Discovered 2026-05-13: 5 cookbook
+          # /repo/* routes were stuck at 500 on the prod alias even though
+          # the same routes returned 200 on the deploy URL — Vercel ISR
+          # was serving a cached pre-#1159 500 page. revalidatePath() flushes
+          # the entry so the next request renders fresh. Anything that fails
+          # twice is a real regression and escalates to ops via the alert step.
+          if [ "${#stuck_paths[@]}" -gt 0 ] && [ -n "${CRON_SECRET:-}" ]; then
+            paths_json="$(printf '"%s",' "${stuck_paths[@]}")"
+            paths_json="[${paths_json%,}]"
+            revalidate_body="{\"paths\":${paths_json}}"
+            report+="\n[self-heal] POST /api/revalidate body=${revalidate_body}\n"
+            revalidate_code="$(curl -sS -X POST \
+              -H "Authorization: Bearer ${CRON_SECRET}" \
+              -H "Content-Type: application/json" \
+              -d "$revalidate_body" \
+              -o /dev/null \
+              -w "%{http_code}" \
+              "${BASE_URL}/api/revalidate" || echo "000")"
+            report+="[self-heal] /api/revalidate => ${revalidate_code}\n"
+            # Brief settle window for the revalidatePath() call to drop
+            # the cache entry before we re-probe the same URLs.
+            sleep 5
+
+            # Pass 2: re-probe the previously-failed page routes only.
+            retry_failures=0
+            report+="\npost-deploy-smoke results (pass 2 — post-revalidate)\n"
+            for route in "${stuck_paths[@]}"; do
+              url="${BASE_URL}${route}"
+              line="$(curl -sS -o /dev/null -w "%{http_code} %{time_total} %{size_download}" "$url")"
+              code="$(echo "$line" | awk '{print $1}')"
+              report+="${route} => ${line}\n"
+              if [ "$code" != "200" ]; then
+                retry_failures=$((retry_failures + 1))
+              fi
+            done
+
+            # Replace the page-route failure count with the retry result —
+            # routes that recovered count as healed; routes that didn't
+            # stay in the failure tally so the workflow still alerts ops.
+            failures=$((failures - ${#stuck_paths[@]} + retry_failures))
           fi
 
           echo -e "$report"


### PR DESCRIPTION
## Summary
Pass 1 collects 5xx page-route failures into `stuck_paths`. If any caught, POST those paths to `/api/revalidate` (CRON_SECRET-gated, the endpoint from #1213), settle 5s, then re-probe ONCE. Routes that recover count as healed; routes that fail twice stay in the failure tally so the workflow still alerts ops.

## Why
Vercel ISR caches both 2xx AND 5xx responses with `stale-while-revalidate ~= 1 year` on the `/repo/[owner]/[name]` route. A transient 500 — or one cached pre-fix — would otherwise persist for weeks even after the underlying bug ships.

Discovered 2026-05-13: 5 cookbook `/repo/*` routes were stuck at 500 on the prod alias even though the same routes returned 200 on the deploy URL. Vercel ISR was serving a cached pre-#1159 500 page. 3 of 5 self-healed during the day-1 drain; 2 needed manual `curl -H "Cache-Control: no-cache"` nudges. PR #1213 added the `/api/revalidate` endpoint; this PR closes the loop so future stuck-ISR incidents auto-heal in the same workflow that detects them.

## Constraints honored
- **Single retry only** — don't loop. Real regressions still alert.
- **Page routes only** — `/api/*` is excluded since `revalidatePath()` doesn't govern API routes.
- **No-op when `CRON_SECRET` is not set** (e.g. forks running the workflow).
- **Backward compatible** — pass-1-clean smokes are unchanged in behaviour.

## Depends on
- #1213 (`/api/revalidate` endpoint) must merge first. This PR will fail self-heal step gracefully (revalidate POST returns 4xx → routes fail twice → workflow alerts as before) until #1213 is on main.

## Verification
- [x] `python -c 'import yaml; yaml.safe_load(open(workflow))'` → YAML valid
- [ ] Post-merge: trigger a synthetic 5xx (e.g. revert #1159 in a branch + force smoke) to confirm self-heal pass fires and recovers
- [ ] Confirm CI alert step still fires when both passes fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)