### PR TITLE
docs(audit): day-2 handoff — DRAIN-2026-05-14.md

### DIFF
--- a/docs/audits/impeccable/DRAIN-2026-05-14.md
+++ b/docs/audits/impeccable/DRAIN-2026-05-14.md
@@ -1,0 +1,173 @@
+# Impeccable audit drain — Day 2 (2026-05-14)
+
+**Session window**: 2026-05-14 ~10:30 AM – 11:30 AM GMT+8.
+**Operator status**: Greenlit "KEEP GOING!!!" + "your the BOSS" — full CTO authority for the day.
+**Mission**: continue the wave-12 fix wave, harden operations, drain the remaining day-1 PRs as CI clears.
+
+---
+
+## TL;DR
+
+- **8 new PRs shipped** today: 5 wave-12 fix PRs + 1 smoke auto-revalidate wiring + 1 CLAUDE.md playbook + 1 ops handoff (this PR).
+- **All 22 outstanding PRs** are now `MERGEABLE/BLOCKED` with auto-merge configured. They drain naturally as the saturated CI runner queue catches up.
+- **Production smoke** (24-route): 23/24 healthy. Only `/repo/sst/sst` still 500 — will resolve once #1213 (revalidate endpoint) merges and the new smoke workflow (#1221) auto-flushes it.
+- **Wave-12 closes 12 P0 honest-chrome violations** across 5 surfaces (arxiv, bluesky, devto, npm, producthunt). All follow the proven LIVE→FreshnessBadge mechanical pattern from waves 7c, 8, 9e, 10a, 10b.
+- **Operational hardening shipped**: post-deploy smoke now self-heals stuck ISR routes via /api/revalidate. Future incidents like the 2026-05-13 cookbook freeze auto-recover in the same workflow that detects them.
+
+---
+
+## What landed today (8 PRs)
+
+### Wave-12 fix PRs (5 PRs, 12 P0s closed)
+
+| PR | Surface | P0s | Pattern |
+|---|---|---|---|
+| **[#1215](https://github.com/0motionguy/starscreener/pull/1215)** | `/arxiv/trending` | 2 | LIVE→FreshnessBadge + cold-state chrome wired (added `arxiv` to NewsSource enum, ARXIV_STALE_THRESHOLD_MS = 12h) |
+| **[#1217](https://github.com/0motionguy/starscreener/pull/1217)** | `/bluesky/trending` | 2 | LIVE→FreshnessBadge + cold-state chrome wired |
+| **[#1218](https://github.com/0motionguy/starscreener/pull/1218)** | `/devto` | 3 + 1 P1 | LIVE→FreshnessBadge + DEVTO_BLUE drift fix (`var(--source-dev)`) + DevtoBadge.DEVTO_BRAND_COLOR fix + cold-state chrome |
+| **[#1219](https://github.com/0motionguy/starscreener/pull/1219)** | `/npm` | 2 | LiveDot delete (FreshnessBadge already on row) + "UTC · SCRAPED"→"UTC · LAST SCRAPE" |
+| **[#1220](https://github.com/0motionguy/starscreener/pull/1220)** | `/producthunt` | 3 | LIVE→FreshnessBadge + fetchedAt fix (was reading top-launch createdAt!) + PH_RED 9-site drift consolidated to `var(--source-producthunt)` |
+
+### Operational hardening (3 PRs)
+
+| PR | Purpose |
+|---|---|
+| **[#1221](https://github.com/0motionguy/starscreener/pull/1221)** | Wire `/api/revalidate` into post-deploy smoke. Pass-1 collects 5xx page-route failures → POST to /api/revalidate → settle 5s → re-probe ONCE. Routes that recover count as healed; routes that fail twice escalate to ops as before. Closes the loop on the 2026-05-13 stuck-ISR class of bugs. |
+| **[#1222](https://github.com/0motionguy/starscreener/pull/1222)** | `CLAUDE.md` "Anti-Patterns Already Burned": single-line entry documenting the stuck-ISR cache mode + 30-second runbook. Future operators don't have to re-discover it. |
+| (this PR) | Day-2 handoff doc. |
+
+---
+
+## State of the 22 open PRs (all `MERGEABLE/BLOCKED` with auto-merge armed)
+
+### Day-1 chain (5 PRs, rebased onto main yesterday)
+- #1209 wave-2 — 5 LLM audits + 6 mechanical fixes
+- #1150 wave-3a /signals
+- #1151 wave-3d /skills
+- #1152 wave-3c /funding
+- #1153 wave-3b /home
+
+### Day-1 flake-blocked (3 PRs, will rerun CI when #1211 lands)
+- #1193 wave-9d /tierlist a11y
+- #1194 wave-9a HuggingFace honest chrome
+- #1202 wave-10a /compare 4 P0s
+
+### Day-1 awaiting CI (2 PRs)
+- #1201 wave-10c /tierlist remaining P0s
+- #1206 wave-11b chart palette canonical
+
+### Day-1 follow-on PRs (4 PRs)
+- #1210 day-1 handoff doc
+- #1211 revenue-overlays cache flake fix (defeats mtime-resolution race)
+- #1212 wave-7b redo (8-file / 2951-LOC dead-code delete)
+- #1213 /api/revalidate endpoint
+
+### Day-2 PRs (8 PRs, all queued)
+- #1215, #1217, #1218, #1219, #1220 (wave-12 fixes)
+- #1221 (smoke auto-revalidate)
+- #1222 (CLAUDE.md playbook)
+- (this handoff PR)
+
+### Conflicting / superseded (1 PR)
+- #1176 — `CONFLICTING/DIRTY`. Superseded by #1212 (clean re-applied deletion). Operator can `gh pr close 1176 --comment "superseded by #1212"` once #1212 merges.
+
+---
+
+## Production smoke (24 routes)
+
+```
+/                                              200
+/signals                                       200
+/skills                                        200
+/mcp                                           200
+/funding                                       200
+/twitter                                       200
+/reddit/trending                               200
+/hackernews/trending                           200
+/compare                                       200
+/breakouts                                     200
+/huggingface                                   200
+/collections                                   200
+/tierlist                                      200
+/devto                                         200
+/producthunt                                   200
+/bluesky/trending                              200
+/npm                                           200
+/arxiv/trending                                200
+/repo/facebook/react                           200
+/repo/vercel/next.js                           200
+/repo/anthropics/anthropic-cookbook            200
+/repo/openai/openai-cookbook                   200
+/repo/cloudflare/workers-sdk                   200
+/repo/sst/sst                                  500   ← stuck-ISR; will heal post-#1213 + #1221
+```
+
+23 of 24 healthy. The last stuck route (`/repo/sst/sst`) auto-heals once both:
+1. `#1213` (`/api/revalidate` endpoint) merges, AND
+2. The next post-deploy smoke run fires (with `#1221` wiring active)
+
+OR an operator can manually flush right after #1213 lands:
+```bash
+curl -X POST https://trendingrepo.com/api/revalidate \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"paths": ["/repo/sst/sst"]}'
+```
+
+---
+
+## Wave-12 closed P0 detail
+
+### `/arxiv/trending` (#1215)
+- P0-1: `<LiveDot label="FRESH · 3H" />` → `<FreshnessBadge source="arxiv" lastUpdatedAt={file.fetchedAt} />`
+- P0-2: cold-state chrome wired (was empty)
+- Enabling: `arxiv` added to `NewsSource` enum; `ARXIV_STALE_THRESHOLD_MS = 12h`
+
+### `/bluesky/trending` (#1217)
+- P0-1: `<LiveDot label="LIVE · 24H" />` → `<FreshnessBadge source="bluesky" .../>`
+- P0-2: cold-state chrome wired
+
+### `/devto` (#1218)
+- P0-1: `<LiveDot label=\`LIVE · {windowDays}D\` />` → `<FreshnessBadge source="devto" .../>`
+- P0-2: `DEVTO_BLUE = "#6699ff"` (drift) → `DEVTO_ACCENT = "var(--v4-src-dev)"` (canonical)
+- P0-3: `DevtoBadge.DEVTO_BRAND_COLOR = "#0a0a0a"` → `"var(--source-dev)"` (was misleading channel-dot exporter)
+- P1-1 (folded): cold-state chrome wired
+
+### `/npm` (#1219)
+- P0-1: Removed redundant `<LiveDot>` (FreshnessBadge already rendered alongside; double signal)
+- P0-2: `"UTC · SCRAPED"` → `"UTC · LAST SCRAPE"` (removes live-tick implication)
+
+### `/producthunt` (#1220)
+- P0-1: `<LiveDot label="FRESH · 4H" />` → `<FreshnessBadge source="producthunt" .../>` (label was 4h vs. 16h spec — wrong on TWO axes)
+- P0-2: `fetchedAt = topLaunches[0]?.createdAt` (the post date of top-voted launch, often 1–6 days old) → `getProducthuntFetchedAt()` (the actual scrape time)
+- P0-3: `PH_RED = "#DA552F"` (9 use-sites) + `PH_ORANGE = "#DA552F"` in RecentLaunches (3 use-sites) → both consolidated to `var(--source-producthunt)`
+- Folded: cold-state chrome wired
+
+---
+
+## Wave-13 backlog (catalogued)
+
+Out of scope for today's mechanical P0 work, but worth ranking for a future wave:
+
+1. **P1 work across the 5 wave-12 surfaces** — brand color tokenization (arxiv `#B22234`, npm `#cb3837`), tap targets, KpiBand semantics (npm TRACKED/LINKED dup), VersionPill alpha-hex, ColdState dev-runbook leakage on multiple surfaces, tabpanel a11y, mobile reflow, EntityLogo size mismatches.
+2. **`RecentLaunches.tsx` orphan**: zero importers but ships in bundle. Audit recommended delete or restore. Now uses canonical `var(--source-producthunt)` (fixed in #1220) but still dead code.
+3. **Loading + error boundary V3/V2 token drift**: `loading.tsx` and `error.tsx` files across multiple surfaces still reference `--v3-bg-*` / `--v2-*`. Mechanical sweep.
+4. **Wave-12 audit follow-on for the 5 surfaces shipped today**: each surface still has 3-7 P1/P2 findings beyond the P0s closed in today's PRs.
+5. **CI runner pool sizing**: B.1.d batch 4 ubuntu→self-hosted migration left the pool undersized. Bulk-merge throughput is the bottleneck.
+
+---
+
+## Operator preferences honored
+
+- ✅ Operator's WIP on `audit/imp-wave-1` (54 modified files in `agent-commerce`, `agent-repos`, `brief`, `categories`, etc.) — never touched, never staged.
+- ✅ Used `git add <exact-path>` only; no `git add .` / `-A`.
+- ✅ All work in fresh `c:/dev/trendingrepo-wt/*` worktrees.
+- ✅ Each PR verified with local `npx tsc --noEmit` + `npm run lint:guards` before push.
+- ✅ Auto-merge configured per PR; nothing force-merged.
+- ✅ Honest-chrome rule (`feedback_freshness_chrome_must_be_honest`) applied uniformly across all 5 wave-12 surfaces.
+
+---
+
+## Files in this PR
+
+- `docs/audits/impeccable/DRAIN-2026-05-14.md` (new) — this document.


### PR DESCRIPTION
Day-2 (2026-05-14) audit drain handoff. 173-line markdown doc cataloguing today's 8 PRs (5 wave-12 fix + smoke auto-revalidate + CLAUDE.md playbook + this), the 22 outstanding PRs all auto-merge-armed, the 24-route smoke status (23/24 healthy), and the wave-13 backlog.

Companion to [DRAIN-2026-05-13.md](docs/audits/impeccable/DRAIN-2026-05-13.md) (day-1 handoff).

Pure docs PR — single new markdown file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)