### PR TITLE
audit(impeccable): wave-13a — V3/V2 token drift sweep across 132 loading/error files

### DIFF
--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -20,7 +20,7 @@ export default function AdminError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/admin/ideas-queue/error.tsx
+++ b/src/app/admin/ideas-queue/error.tsx
@@ -20,7 +20,7 @@ export default function AdminIdeasQueueError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN/IDEAS-QUEUE"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminIdeasQueueError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminIdeasQueueError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/admin/login/error.tsx
+++ b/src/app/admin/login/error.tsx
@@ -20,7 +20,7 @@ export default function AdminLoginError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN/LOGIN"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminLoginError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminLoginError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/admin/pool/error.tsx
+++ b/src/app/admin/pool/error.tsx
@@ -20,7 +20,7 @@ export default function AdminPoolError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN/POOL"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminPoolError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminPoolError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/admin/revenue-queue/error.tsx
+++ b/src/app/admin/revenue-queue/error.tsx
@@ -20,7 +20,7 @@ export default function AdminRevenueQueueError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN/REVENUE-QUEUE"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminRevenueQueueError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminRevenueQueueError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/admin/scoring-shadow/error.tsx
+++ b/src/app/admin/scoring-shadow/error.tsx
@@ -20,7 +20,7 @@ export default function AdminScoringShadowError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN/SCORING-SHADOW"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminScoringShadowError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminScoringShadowError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/admin/staleness/error.tsx
+++ b/src/app/admin/staleness/error.tsx
@@ -20,7 +20,7 @@ export default function AdminStalenessError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN/STALENESS"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminStalenessError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminStalenessError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/admin/unknown-mentions/error.tsx
+++ b/src/app/admin/unknown-mentions/error.tsx
@@ -20,7 +20,7 @@ export default function AdminUnknownMentionsError({ error, reset }: ErrorProps) 
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ADMIN/UNKNOWN-MENTIONS"}
       </p>
@@ -30,7 +30,7 @@ export default function AdminUnknownMentionsError({ error, reset }: ErrorProps) 
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AdminUnknownMentionsError({ error, reset }: ErrorProps) 
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/agent-commerce/[slug]/error.tsx
+++ b/src/app/agent-commerce/[slug]/error.tsx
@@ -20,7 +20,7 @@ export default function AgentCommerceSlugError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · AGENT-COMMERCE/[SLUG]"}
       </p>
@@ -30,7 +30,7 @@ export default function AgentCommerceSlugError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AgentCommerceSlugError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/agent-commerce/[slug]/loading.tsx
+++ b/src/app/agent-commerce/[slug]/loading.tsx
@@ -7,20 +7,20 @@ export default function AgentCommerceDetailLoading() {
         <div className="flex items-start gap-3">
           <div
             className="h-12 w-12 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5 flex-1">
             <div
               className="h-3 w-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-7 w-72 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-96 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -29,7 +29,7 @@ export default function AgentCommerceDetailLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function AgentCommerceDetailLoading() {
             <div
               key={i}
               className="h-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/agent-commerce/error.tsx
+++ b/src/app/agent-commerce/error.tsx
@@ -20,7 +20,7 @@ export default function AgentCommerceError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · AGENT-COMMERCE"}
       </p>
@@ -30,7 +30,7 @@ export default function AgentCommerceError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AgentCommerceError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/agent-commerce/facilitator/[name]/error.tsx
+++ b/src/app/agent-commerce/facilitator/[name]/error.tsx
@@ -20,7 +20,7 @@ export default function FacilitatorError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · AGENT-COMMERCE/FACILITATOR"}
       </p>
@@ -30,7 +30,7 @@ export default function FacilitatorError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function FacilitatorError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/agent-commerce/facilitator/[name]/loading.tsx
+++ b/src/app/agent-commerce/facilitator/[name]/loading.tsx
@@ -7,20 +7,20 @@ export default function FacilitatorDetailLoading() {
         <div className="flex items-start gap-3">
           <div
             className="h-12 w-12 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5 flex-1">
             <div
               className="h-3 w-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-7 w-72 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-96 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -29,7 +29,7 @@ export default function FacilitatorDetailLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function FacilitatorDetailLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/agent-commerce/loading.tsx
+++ b/src/app/agent-commerce/loading.tsx
@@ -7,27 +7,27 @@ export default function AgentCommerceLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function AgentCommerceLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/agent-repos/[slug]/error.tsx
+++ b/src/app/agent-repos/[slug]/error.tsx
@@ -20,7 +20,7 @@ export default function AgentReposSlugError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · AGENT-REPOS/[SLUG]"}
       </p>
@@ -30,7 +30,7 @@ export default function AgentReposSlugError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AgentReposSlugError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/agent-repos/[slug]/loading.tsx
+++ b/src/app/agent-repos/[slug]/loading.tsx
@@ -7,20 +7,20 @@ export default function AgentRepoDetailLoading() {
         <div className="flex items-start gap-3">
           <div
             className="h-12 w-12 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5 flex-1">
             <div
               className="h-3 w-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-7 w-72 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-96 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -29,7 +29,7 @@ export default function AgentRepoDetailLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function AgentRepoDetailLoading() {
             <div
               key={i}
               className="h-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/agent-repos/error.tsx
+++ b/src/app/agent-repos/error.tsx
@@ -20,7 +20,7 @@ export default function AgentReposError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · AGENT-REPOS"}
       </p>
@@ -30,7 +30,7 @@ export default function AgentReposError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AgentReposError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/agent-repos/loading.tsx
+++ b/src/app/agent-repos/loading.tsx
@@ -7,27 +7,27 @@ export default function AgentReposLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function AgentReposLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/alerts/error.tsx
+++ b/src/app/alerts/error.tsx
@@ -20,7 +20,7 @@ export default function AlertsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ALERTS"}
       </p>
@@ -30,7 +30,7 @@ export default function AlertsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AlertsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/alerts/loading.tsx
+++ b/src/app/alerts/loading.tsx
@@ -7,15 +7,15 @@ export default function AlertsLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div className="space-y-1.5">
@@ -23,7 +23,7 @@ export default function AlertsLoading() {
             <div
               key={i}
               className="h-20 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/alerts/new/error.tsx
+++ b/src/app/alerts/new/error.tsx
@@ -20,7 +20,7 @@ export default function AlertsNewError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ALERTS/NEW"}
       </p>
@@ -30,7 +30,7 @@ export default function AlertsNewError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function AlertsNewError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/arxiv/trending/error.tsx
+++ b/src/app/arxiv/trending/error.tsx
@@ -20,7 +20,7 @@ export default function ArxivTrendingError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · ARXIV/TRENDING"}
       </p>
@@ -30,7 +30,7 @@ export default function ArxivTrendingError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ArxivTrendingError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/arxiv/trending/loading.tsx
+++ b/src/app/arxiv/trending/loading.tsx
@@ -7,27 +7,27 @@ export default function ArxivTrendingLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function ArxivTrendingLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/bluesky/trending/error.tsx
+++ b/src/app/bluesky/trending/error.tsx
@@ -20,7 +20,7 @@ export default function BlueskyTrendingError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · BLUESKY/TRENDING"}
       </p>
@@ -30,7 +30,7 @@ export default function BlueskyTrendingError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function BlueskyTrendingError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/bluesky/trending/loading.tsx
+++ b/src/app/bluesky/trending/loading.tsx
@@ -7,27 +7,27 @@ export default function BlueskyTrendingLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function BlueskyTrendingLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/breakouts/error.tsx
+++ b/src/app/breakouts/error.tsx
@@ -20,7 +20,7 @@ export default function BreakoutsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · BREAKOUTS"}
       </p>
@@ -30,7 +30,7 @@ export default function BreakoutsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function BreakoutsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/breakouts/loading.tsx
+++ b/src/app/breakouts/loading.tsx
@@ -7,27 +7,27 @@ export default function BreakoutsLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function BreakoutsLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/categories/[slug]/error.tsx
+++ b/src/app/categories/[slug]/error.tsx
@@ -20,7 +20,7 @@ export default function CategoriesSlugError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · CATEGORIES/[SLUG]"}
       </p>
@@ -30,7 +30,7 @@ export default function CategoriesSlugError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function CategoriesSlugError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/categories/[slug]/loading.tsx
+++ b/src/app/categories/[slug]/loading.tsx
@@ -7,15 +7,15 @@ export default function CategoryDetailLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-40 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-8 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-96 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
@@ -23,7 +23,7 @@ export default function CategoryDetailLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -32,7 +32,7 @@ export default function CategoryDetailLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/categories/error.tsx
+++ b/src/app/categories/error.tsx
@@ -20,7 +20,7 @@ export default function CategoriesError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · CATEGORIES"}
       </p>
@@ -30,7 +30,7 @@ export default function CategoriesError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function CategoriesError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/categories/loading.tsx
+++ b/src/app/categories/loading.tsx
@@ -8,27 +8,27 @@ export default function CategoriesLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function CategoriesLoading() {
             <div
               key={i}
               className="h-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/cli/error.tsx
+++ b/src/app/cli/error.tsx
@@ -20,7 +20,7 @@ export default function CliError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · CLI"}
       </p>
@@ -30,7 +30,7 @@ export default function CliError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function CliError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/collections/[slug]/error.tsx
+++ b/src/app/collections/[slug]/error.tsx
@@ -20,7 +20,7 @@ export default function CollectionsSlugError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · COLLECTIONS/[SLUG]"}
       </p>
@@ -30,7 +30,7 @@ export default function CollectionsSlugError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function CollectionsSlugError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/collections/[slug]/loading.tsx
+++ b/src/app/collections/[slug]/loading.tsx
@@ -8,20 +8,20 @@ export default function CollectionDetailLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-40 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-8 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-96 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         {/* members */}
         <div className="space-y-1.5">
@@ -29,7 +29,7 @@ export default function CollectionDetailLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/collections/error.tsx
+++ b/src/app/collections/error.tsx
@@ -20,7 +20,7 @@ export default function CollectionsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · COLLECTIONS"}
       </p>
@@ -30,7 +30,7 @@ export default function CollectionsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function CollectionsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/collections/loading.tsx
+++ b/src/app/collections/loading.tsx
@@ -7,15 +7,15 @@ export default function CollectionsLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
@@ -23,7 +23,7 @@ export default function CollectionsLoading() {
             <div
               key={i}
               className="h-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/compare/error.tsx
+++ b/src/app/compare/error.tsx
@@ -20,7 +20,7 @@ export default function CompareError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · COMPARE"}
       </p>
@@ -30,7 +30,7 @@ export default function CompareError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function CompareError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/compare/loading.tsx
+++ b/src/app/compare/loading.tsx
@@ -8,15 +8,15 @@ export default function CompareLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* repo selector chips */}
@@ -25,14 +25,14 @@ export default function CompareLoading() {
             <div
               key={i}
               className="h-9 w-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
         {/* chart */}
         <div
           className="h-72 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         {/* comparison rows */}
         <div className="space-y-1.5">
@@ -40,7 +40,7 @@ export default function CompareLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/consensus/[owner]/[name]/error.tsx
+++ b/src/app/consensus/[owner]/[name]/error.tsx
@@ -20,7 +20,7 @@ export default function ConsensusRepoError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · CONSENSUS/[OWNER]/[NAME]"}
       </p>
@@ -30,7 +30,7 @@ export default function ConsensusRepoError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ConsensusRepoError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/consensus/[owner]/[name]/loading.tsx
+++ b/src/app/consensus/[owner]/[name]/loading.tsx
@@ -7,20 +7,20 @@ export default function ConsensusDetailLoading() {
         <div className="flex items-start gap-3">
           <div
             className="h-12 w-12 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5 flex-1">
             <div
               className="h-3 w-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-7 w-72 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-96 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -29,7 +29,7 @@ export default function ConsensusDetailLoading() {
             <div
               key={i}
               className="h-14 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function ConsensusDetailLoading() {
             <div
               key={i}
               className="h-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/consensus/error.tsx
+++ b/src/app/consensus/error.tsx
@@ -20,7 +20,7 @@ export default function ConsensusError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · CONSENSUS"}
       </p>
@@ -30,7 +30,7 @@ export default function ConsensusError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ConsensusError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/consensus/loading.tsx
+++ b/src/app/consensus/loading.tsx
@@ -7,27 +7,27 @@ export default function ConsensusLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function ConsensusLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/design-lab/primitives/error.tsx
+++ b/src/app/design-lab/primitives/error.tsx
@@ -20,7 +20,7 @@ export default function DesignLabPrimitivesError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · DESIGN-LAB/PRIMITIVES"}
       </p>
@@ -30,7 +30,7 @@ export default function DesignLabPrimitivesError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function DesignLabPrimitivesError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/devto/error.tsx
+++ b/src/app/devto/error.tsx
@@ -20,7 +20,7 @@ export default function DevtoError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · DEVTO"}
       </p>
@@ -30,7 +30,7 @@ export default function DevtoError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function DevtoError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/devto/loading.tsx
+++ b/src/app/devto/loading.tsx
@@ -7,27 +7,27 @@ export default function DevToLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function DevToLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/digest/[date]/error.tsx
+++ b/src/app/digest/[date]/error.tsx
@@ -20,7 +20,7 @@ export default function DigestDateError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · DIGEST/[DATE]"}
       </p>
@@ -30,7 +30,7 @@ export default function DigestDateError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function DigestDateError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/digest/[date]/loading.tsx
+++ b/src/app/digest/[date]/loading.tsx
@@ -7,15 +7,15 @@ export default function DigestDateLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-96 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div className="space-y-3">
@@ -23,7 +23,7 @@ export default function DigestDateLoading() {
             <div
               key={i}
               className="h-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/digest/error.tsx
+++ b/src/app/digest/error.tsx
@@ -20,7 +20,7 @@ export default function DigestError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · DIGEST"}
       </p>
@@ -30,7 +30,7 @@ export default function DigestError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function DigestError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/digest/loading.tsx
+++ b/src/app/digest/loading.tsx
@@ -7,15 +7,15 @@ export default function DigestLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div className="space-y-2">
@@ -23,7 +23,7 @@ export default function DigestLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/embed/top10/error.tsx
+++ b/src/app/embed/top10/error.tsx
@@ -21,15 +21,15 @@ export default function EmbedTop10Error({ error, reset }: ErrorProps) {
         padding: 16,
         fontFamily: "ui-monospace, monospace",
         fontSize: 12,
-        color: "var(--v2-ink-300)",
+        color: "var(--v4-ink-300)",
       }}
     >
-      <p style={{ color: "var(--v2-sig-red)", marginBottom: 8 }}>
+      <p style={{ color: "var(--v4-red)", marginBottom: 8 }}>
         {"// EMBED · ERROR"}
       </p>
       <p style={{ marginBottom: 8 }}>Failed to render embed.</p>
       {error.digest && (
-        <p style={{ fontSize: 10, color: "var(--v2-ink-400)" }}>
+        <p style={{ fontSize: 10, color: "var(--v4-ink-400)" }}>
           {"// DIGEST: "}
           {error.digest}
         </p>
@@ -40,9 +40,9 @@ export default function EmbedTop10Error({ error, reset }: ErrorProps) {
         style={{
           marginTop: 8,
           padding: "4px 8px",
-          border: "1px solid var(--v2-line-200)",
+          border: "1px solid var(--v4-line-200)",
           background: "transparent",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           fontFamily: "inherit",
           fontSize: 11,
           textTransform: "uppercase",

--- a/src/app/funding/error.tsx
+++ b/src/app/funding/error.tsx
@@ -20,7 +20,7 @@ export default function FundingError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · FUNDING"}
       </p>
@@ -30,7 +30,7 @@ export default function FundingError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function FundingError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/funding/loading.tsx
+++ b/src/app/funding/loading.tsx
@@ -7,27 +7,27 @@ export default function FundingLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function FundingLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/funding/sec/error.tsx
+++ b/src/app/funding/sec/error.tsx
@@ -20,7 +20,7 @@ export default function FundingSecError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · FUNDING · SEC"}
       </p>
@@ -30,7 +30,7 @@ export default function FundingSecError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,7 +39,7 @@ export default function FundingSecError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head back to the funding
         radar.
@@ -47,10 +47,10 @@ export default function FundingSecError({ error, reset }: ErrorProps) {
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/funding/sec/loading.tsx
+++ b/src/app/funding/sec/loading.tsx
@@ -7,27 +7,27 @@ export default function FundingSecLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-96 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function FundingSecLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/githubrepo/loading.tsx
+++ b/src/app/githubrepo/loading.tsx
@@ -14,15 +14,15 @@ export default function GithubRepoLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-96 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
 
@@ -32,7 +32,7 @@ export default function GithubRepoLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -40,7 +40,7 @@ export default function GithubRepoLoading() {
         {/* RankTabs row */}
         <div
           className="h-10 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
 
         {/* Trending top-50 rows */}
@@ -49,7 +49,7 @@ export default function GithubRepoLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -60,7 +60,7 @@ export default function GithubRepoLoading() {
             <div
               key={i}
               className="h-24 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/hackernews/trending/error.tsx
+++ b/src/app/hackernews/trending/error.tsx
@@ -20,7 +20,7 @@ export default function HackerNewsTrendingError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · HACKERNEWS/TRENDING"}
       </p>
@@ -30,7 +30,7 @@ export default function HackerNewsTrendingError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function HackerNewsTrendingError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/hackernews/trending/loading.tsx
+++ b/src/app/hackernews/trending/loading.tsx
@@ -7,27 +7,27 @@ export default function HackerNewsTrendingLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function HackerNewsTrendingLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/huggingface/datasets/error.tsx
+++ b/src/app/huggingface/datasets/error.tsx
@@ -20,7 +20,7 @@ export default function HuggingfaceDatasetsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · HUGGINGFACE/DATASETS"}
       </p>
@@ -30,7 +30,7 @@ export default function HuggingfaceDatasetsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function HuggingfaceDatasetsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/huggingface/datasets/loading.tsx
+++ b/src/app/huggingface/datasets/loading.tsx
@@ -7,27 +7,27 @@ export default function HuggingfaceDatasetsLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function HuggingfaceDatasetsLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/huggingface/error.tsx
+++ b/src/app/huggingface/error.tsx
@@ -20,7 +20,7 @@ export default function HuggingfaceError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · HUGGINGFACE"}
       </p>
@@ -30,7 +30,7 @@ export default function HuggingfaceError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function HuggingfaceError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/huggingface/loading.tsx
+++ b/src/app/huggingface/loading.tsx
@@ -7,27 +7,27 @@ export default function HuggingfaceLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function HuggingfaceLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/huggingface/spaces/error.tsx
+++ b/src/app/huggingface/spaces/error.tsx
@@ -20,7 +20,7 @@ export default function HuggingfaceSpacesError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · HUGGINGFACE/SPACES"}
       </p>
@@ -30,7 +30,7 @@ export default function HuggingfaceSpacesError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function HuggingfaceSpacesError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/huggingface/spaces/loading.tsx
+++ b/src/app/huggingface/spaces/loading.tsx
@@ -7,27 +7,27 @@ export default function HuggingfaceSpacesLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function HuggingfaceSpacesLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/huggingface/trending/error.tsx
+++ b/src/app/huggingface/trending/error.tsx
@@ -20,7 +20,7 @@ export default function HuggingfaceTrendingError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · HUGGINGFACE/TRENDING"}
       </p>
@@ -30,7 +30,7 @@ export default function HuggingfaceTrendingError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function HuggingfaceTrendingError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/huggingface/trending/loading.tsx
+++ b/src/app/huggingface/trending/loading.tsx
@@ -7,27 +7,27 @@ export default function HuggingfaceTrendingLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function HuggingfaceTrendingLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/ideas/[id]/error.tsx
+++ b/src/app/ideas/[id]/error.tsx
@@ -20,7 +20,7 @@ export default function IdeaDetailError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · IDEAS/[ID]"}
       </p>
@@ -30,7 +30,7 @@ export default function IdeaDetailError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function IdeaDetailError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/ideas/[id]/loading.tsx
+++ b/src/app/ideas/[id]/loading.tsx
@@ -7,21 +7,21 @@ export default function IdeaDetailLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-8 w-96 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* idea body */}
         <div
           className="h-64 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         {/* reactions strip */}
         <div className="flex gap-2">
@@ -29,7 +29,7 @@ export default function IdeaDetailLoading() {
             <div
               key={i}
               className="h-9 w-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/ideas/error.tsx
+++ b/src/app/ideas/error.tsx
@@ -20,7 +20,7 @@ export default function IdeasError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · IDEAS"}
       </p>
@@ -30,7 +30,7 @@ export default function IdeasError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function IdeasError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/ideas/loading.tsx
+++ b/src/app/ideas/loading.tsx
@@ -7,15 +7,15 @@ export default function IdeasLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* tab strip (hot / new / shipped) */}
@@ -24,7 +24,7 @@ export default function IdeasLoading() {
             <div
               key={i}
               className="h-8 w-20 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -34,7 +34,7 @@ export default function IdeasLoading() {
             <div
               key={i}
               className="h-24 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/lobsters/error.tsx
+++ b/src/app/lobsters/error.tsx
@@ -20,7 +20,7 @@ export default function LobstersError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · LOBSTERS"}
       </p>
@@ -30,7 +30,7 @@ export default function LobstersError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function LobstersError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/lobsters/loading.tsx
+++ b/src/app/lobsters/loading.tsx
@@ -7,27 +7,27 @@ export default function LobstersLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function LobstersLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/mcp/[slug]/error.tsx
+++ b/src/app/mcp/[slug]/error.tsx
@@ -20,7 +20,7 @@ export default function McpSlugError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · MCP/[SLUG]"}
       </p>
@@ -30,7 +30,7 @@ export default function McpSlugError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function McpSlugError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/mcp/[slug]/loading.tsx
+++ b/src/app/mcp/[slug]/loading.tsx
@@ -7,20 +7,20 @@ export default function McpDetailLoading() {
         <div className="flex items-start gap-3">
           <div
             className="h-12 w-12 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5 flex-1">
             <div
               className="h-3 w-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-7 w-72 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-96 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -29,7 +29,7 @@ export default function McpDetailLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function McpDetailLoading() {
             <div
               key={i}
               className="h-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/mcp/error.tsx
+++ b/src/app/mcp/error.tsx
@@ -20,7 +20,7 @@ export default function McpError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · MCP"}
       </p>
@@ -30,7 +30,7 @@ export default function McpError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function McpError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/mcp/loading.tsx
+++ b/src/app/mcp/loading.tsx
@@ -8,27 +8,27 @@ export default function McpLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -37,7 +37,7 @@ export default function McpLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/methodology/loading.tsx
+++ b/src/app/methodology/loading.tsx
@@ -21,24 +21,24 @@ export default function MethodologyLoading() {
         <div className="space-y-3">
           <div
             className="h-3 w-40 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-9 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="space-y-2 pt-2">
             <div
               className="h-3 w-full rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-3 w-[92%] rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-3 w-[85%] rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -48,14 +48,14 @@ export default function MethodologyLoading() {
           <div key={section} className="space-y-2">
             <div
               className="h-5 w-48 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             {Array.from({ length: 4 }).map((_, line) => (
               <div
                 key={line}
                 className="h-3 rounded-[2px]"
                 style={{
-                  background: "var(--v3-bg-050)",
+                  background: "var(--v4-bg-050)",
                   width: `${88 - line * 6}%`,
                 }}
               />

--- a/src/app/npm/error.tsx
+++ b/src/app/npm/error.tsx
@@ -20,7 +20,7 @@ export default function NpmError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · NPM"}
       </p>
@@ -30,7 +30,7 @@ export default function NpmError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function NpmError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/npm/loading.tsx
+++ b/src/app/npm/loading.tsx
@@ -7,27 +7,27 @@ export default function NpmLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function NpmLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/papers/error.tsx
+++ b/src/app/papers/error.tsx
@@ -20,7 +20,7 @@ export default function PapersError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · PAPERS"}
       </p>
@@ -30,7 +30,7 @@ export default function PapersError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function PapersError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/papers/loading.tsx
+++ b/src/app/papers/loading.tsx
@@ -7,27 +7,27 @@ export default function PapersLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function PapersLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/portal/docs/error.tsx
+++ b/src/app/portal/docs/error.tsx
@@ -20,7 +20,7 @@ export default function PortalDocsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · PORTAL/DOCS"}
       </p>
@@ -30,7 +30,7 @@ export default function PortalDocsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function PortalDocsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/pricing/error.tsx
+++ b/src/app/pricing/error.tsx
@@ -20,7 +20,7 @@ export default function PricingError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · PRICING"}
       </p>
@@ -30,7 +30,7 @@ export default function PricingError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function PricingError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/producthunt/error.tsx
+++ b/src/app/producthunt/error.tsx
@@ -20,7 +20,7 @@ export default function ProducthuntError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · PRODUCTHUNT"}
       </p>
@@ -30,7 +30,7 @@ export default function ProducthuntError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ProducthuntError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/producthunt/loading.tsx
+++ b/src/app/producthunt/loading.tsx
@@ -7,27 +7,27 @@ export default function ProductHuntLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function ProductHuntLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/reddit/error.tsx
+++ b/src/app/reddit/error.tsx
@@ -20,7 +20,7 @@ export default function RedditError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · REDDIT"}
       </p>
@@ -30,7 +30,7 @@ export default function RedditError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function RedditError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/reddit/loading.tsx
+++ b/src/app/reddit/loading.tsx
@@ -7,27 +7,27 @@ export default function RedditLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function RedditLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/reddit/trending/error.tsx
+++ b/src/app/reddit/trending/error.tsx
@@ -20,7 +20,7 @@ export default function RedditTrendingError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · REDDIT/TRENDING"}
       </p>
@@ -30,7 +30,7 @@ export default function RedditTrendingError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function RedditTrendingError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/reddit/trending/loading.tsx
+++ b/src/app/reddit/trending/loading.tsx
@@ -7,27 +7,27 @@ export default function RedditTrendingLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function RedditTrendingLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/repo/[owner]/[name]/error.tsx
+++ b/src/app/repo/[owner]/[name]/error.tsx
@@ -20,7 +20,7 @@ export default function RepoProfileError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · REPO/[OWNER]/[NAME]"}
       </p>
@@ -30,7 +30,7 @@ export default function RepoProfileError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function RepoProfileError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/repo/[owner]/[name]/loading.tsx
+++ b/src/app/repo/[owner]/[name]/loading.tsx
@@ -12,16 +12,16 @@ export default function RepoLoading() {
         <div className="flex items-center gap-3">
           <div
             className="h-10 w-10 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5">
             <div
               className="h-5 w-64 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -32,7 +32,7 @@ export default function RepoLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -40,7 +40,7 @@ export default function RepoLoading() {
         {/* Chart placeholder */}
         <div
           className="h-64 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
 
         {/* Two-column panel grid */}
@@ -49,7 +49,7 @@ export default function RepoLoading() {
             <div
               key={i}
               className="h-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/repo/[owner]/[name]/star-activity/error.tsx
+++ b/src/app/repo/[owner]/[name]/star-activity/error.tsx
@@ -20,7 +20,7 @@ export default function StarActivityError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · REPO/STAR-ACTIVITY"}
       </p>
@@ -30,7 +30,7 @@ export default function StarActivityError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function StarActivityError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/repo/[owner]/[name]/star-activity/loading.tsx
+++ b/src/app/repo/[owner]/[name]/star-activity/loading.tsx
@@ -7,28 +7,28 @@ export default function StarActivityLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-40 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* large chart */}
         <div
           className="h-96 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/research/error.tsx
+++ b/src/app/research/error.tsx
@@ -20,7 +20,7 @@ export default function ResearchError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · RESEARCH"}
       </p>
@@ -30,7 +30,7 @@ export default function ResearchError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ResearchError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/research/loading.tsx
+++ b/src/app/research/loading.tsx
@@ -7,27 +7,27 @@ export default function ResearchLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function ResearchLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/revenue/error.tsx
+++ b/src/app/revenue/error.tsx
@@ -20,7 +20,7 @@ export default function RevenueError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · REVENUE"}
       </p>
@@ -30,7 +30,7 @@ export default function RevenueError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function RevenueError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/revenue/loading.tsx
+++ b/src/app/revenue/loading.tsx
@@ -7,27 +7,27 @@ export default function RevenueLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function RevenueLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/s/[shortId]/error.tsx
+++ b/src/app/s/[shortId]/error.tsx
@@ -20,7 +20,7 @@ export default function ShortLinkError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · S/[SHORTID]"}
       </p>
@@ -30,7 +30,7 @@ export default function ShortLinkError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ShortLinkError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/search/error.tsx
+++ b/src/app/search/error.tsx
@@ -20,7 +20,7 @@ export default function SearchError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · SEARCH"}
       </p>
@@ -30,7 +30,7 @@ export default function SearchError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function SearchError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/search/loading.tsx
+++ b/src/app/search/loading.tsx
@@ -7,21 +7,21 @@ export default function SearchLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* search bar */}
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         {/* results */}
         <div className="space-y-1.5">
@@ -29,7 +29,7 @@ export default function SearchLoading() {
             <div
               key={i}
               className="h-14 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/signals/error.tsx
+++ b/src/app/signals/error.tsx
@@ -20,7 +20,7 @@ export default function SignalsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · SIGNALS"}
       </p>
@@ -30,7 +30,7 @@ export default function SignalsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function SignalsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/signals/loading.tsx
+++ b/src/app/signals/loading.tsx
@@ -7,27 +7,27 @@ export default function SignalsLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function SignalsLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/skills/[slug]/error.tsx
+++ b/src/app/skills/[slug]/error.tsx
@@ -20,7 +20,7 @@ export default function SkillsSlugError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · SKILLS/[SLUG]"}
       </p>
@@ -30,7 +30,7 @@ export default function SkillsSlugError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function SkillsSlugError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/skills/[slug]/loading.tsx
+++ b/src/app/skills/[slug]/loading.tsx
@@ -8,20 +8,20 @@ export default function SkillDetailLoading() {
         <div className="flex items-start gap-3">
           <div
             className="h-12 w-12 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5 flex-1">
             <div
               className="h-3 w-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-7 w-72 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-96 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -31,7 +31,7 @@ export default function SkillDetailLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -41,7 +41,7 @@ export default function SkillDetailLoading() {
             <div
               key={i}
               className="h-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/skills/error.tsx
+++ b/src/app/skills/error.tsx
@@ -20,7 +20,7 @@ export default function SkillsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · SKILLS"}
       </p>
@@ -30,7 +30,7 @@ export default function SkillsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function SkillsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/skills/loading.tsx
+++ b/src/app/skills/loading.tsx
@@ -10,22 +10,22 @@ export default function SkillsLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
 
         {/* VerdictRibbon */}
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
 
         {/* KpiBand */}
@@ -34,7 +34,7 @@ export default function SkillsLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -45,7 +45,7 @@ export default function SkillsLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/submit/error.tsx
+++ b/src/app/submit/error.tsx
@@ -20,7 +20,7 @@ export default function SubmitError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · SUBMIT"}
       </p>
@@ -30,7 +30,7 @@ export default function SubmitError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function SubmitError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/submit/revenue/error.tsx
+++ b/src/app/submit/revenue/error.tsx
@@ -20,7 +20,7 @@ export default function SubmitRevenueError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · SUBMIT/REVENUE"}
       </p>
@@ -30,7 +30,7 @@ export default function SubmitRevenueError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function SubmitRevenueError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/tierlist/[shortId]/error.tsx
+++ b/src/app/tierlist/[shortId]/error.tsx
@@ -20,7 +20,7 @@ export default function TierlistShortError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TIERLIST/[SHORTID]"}
       </p>
@@ -30,7 +30,7 @@ export default function TierlistShortError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function TierlistShortError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/tierlist/[shortId]/loading.tsx
+++ b/src/app/tierlist/[shortId]/loading.tsx
@@ -7,15 +7,15 @@ export default function TierlistShareLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div className="space-y-2">
@@ -23,7 +23,7 @@ export default function TierlistShareLoading() {
             <div
               key={i}
               className="h-20 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/tierlist/error.tsx
+++ b/src/app/tierlist/error.tsx
@@ -20,7 +20,7 @@ export default function TierlistError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TIERLIST"}
       </p>
@@ -30,7 +30,7 @@ export default function TierlistError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function TierlistError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/tierlist/loading.tsx
+++ b/src/app/tierlist/loading.tsx
@@ -7,15 +7,15 @@ export default function TierlistLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* tier rows */}
@@ -24,7 +24,7 @@ export default function TierlistLoading() {
             <div
               key={i}
               className="h-20 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/tools/error.tsx
+++ b/src/app/tools/error.tsx
@@ -20,7 +20,7 @@ export default function ToolsError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TOOLS"}
       </p>
@@ -30,7 +30,7 @@ export default function ToolsError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ToolsError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/tools/revenue-estimate/error.tsx
+++ b/src/app/tools/revenue-estimate/error.tsx
@@ -20,7 +20,7 @@ export default function ToolsRevenueEstimateError({ error, reset }: ErrorProps) 
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TOOLS/REVENUE-ESTIMATE"}
       </p>
@@ -30,7 +30,7 @@ export default function ToolsRevenueEstimateError({ error, reset }: ErrorProps) 
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ToolsRevenueEstimateError({ error, reset }: ErrorProps) 
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/tools/revenue-estimate/loading.tsx
+++ b/src/app/tools/revenue-estimate/loading.tsx
@@ -7,15 +7,15 @@ export default function RevenueEstimateLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-72 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-96 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* form strip */}
@@ -24,14 +24,14 @@ export default function RevenueEstimateLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
         {/* result band */}
         <div
           className="h-32 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
       </div>
     </div>

--- a/src/app/tools/star-history/error.tsx
+++ b/src/app/tools/star-history/error.tsx
@@ -20,7 +20,7 @@ export default function ToolsStarHistoryError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TOOLS/STAR-HISTORY"}
       </p>
@@ -30,7 +30,7 @@ export default function ToolsStarHistoryError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ToolsStarHistoryError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/tools/star-history/loading.tsx
+++ b/src/app/tools/star-history/loading.tsx
@@ -7,26 +7,26 @@ export default function StarHistoryLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* repo input strip */}
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         {/* chart */}
         <div
           className="h-[480px] rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
       </div>
     </div>

--- a/src/app/tools/treemap/error.tsx
+++ b/src/app/tools/treemap/error.tsx
@@ -20,7 +20,7 @@ export default function ToolsTreemapError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TOOLS/TREEMAP"}
       </p>
@@ -30,7 +30,7 @@ export default function ToolsTreemapError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function ToolsTreemapError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/tools/treemap/loading.tsx
+++ b/src/app/tools/treemap/loading.tsx
@@ -7,15 +7,15 @@ export default function TreemapLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         {/* control strip */}
@@ -24,14 +24,14 @@ export default function TreemapLoading() {
             <div
               key={i}
               className="h-8 w-28 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
         {/* treemap canvas */}
         <div
           className="h-[560px] rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
       </div>
     </div>

--- a/src/app/top/error.tsx
+++ b/src/app/top/error.tsx
@@ -20,7 +20,7 @@ export default function TopError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TOP"}
       </p>
@@ -30,7 +30,7 @@ export default function TopError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function TopError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/top/loading.tsx
+++ b/src/app/top/loading.tsx
@@ -7,27 +7,27 @@ export default function TopLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -36,7 +36,7 @@ export default function TopLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/top10/[date]/error.tsx
+++ b/src/app/top10/[date]/error.tsx
@@ -20,7 +20,7 @@ export default function Top10DateError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TOP10/[DATE]"}
       </p>
@@ -30,7 +30,7 @@ export default function Top10DateError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function Top10DateError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/top10/[date]/loading.tsx
+++ b/src/app/top10/[date]/loading.tsx
@@ -7,27 +7,27 @@ export default function Top10DateLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-32 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-64 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="space-y-1.5">
           {Array.from({ length: 10 }).map((_, i) => (
             <div
               key={i}
               className="h-14 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/top10/error.tsx
+++ b/src/app/top10/error.tsx
@@ -20,7 +20,7 @@ export default function Top10Error({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TOP10"}
       </p>
@@ -30,7 +30,7 @@ export default function Top10Error({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function Top10Error({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/top10/loading.tsx
+++ b/src/app/top10/loading.tsx
@@ -7,27 +7,27 @@ export default function Top10Loading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="space-y-1.5">
           {Array.from({ length: 10 }).map((_, i) => (
             <div
               key={i}
               className="h-14 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/twitter/error.tsx
+++ b/src/app/twitter/error.tsx
@@ -20,7 +20,7 @@ export default function TwitterError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · TWITTER"}
       </p>
@@ -30,7 +30,7 @@ export default function TwitterError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function TwitterError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/twitter/loading.tsx
+++ b/src/app/twitter/loading.tsx
@@ -8,27 +8,27 @@ export default function TwitterLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function TwitterLoading() {
             <div
               key={i}
               className="h-8 w-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -47,7 +47,7 @@ export default function TwitterLoading() {
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/u/[handle]/error.tsx
+++ b/src/app/u/[handle]/error.tsx
@@ -20,7 +20,7 @@ export default function UserHandleError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · U/[HANDLE]"}
       </p>
@@ -30,7 +30,7 @@ export default function UserHandleError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function UserHandleError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/u/[handle]/loading.tsx
+++ b/src/app/u/[handle]/loading.tsx
@@ -7,20 +7,20 @@ export default function UserProfileLoading() {
         <div className="flex items-start gap-3">
           <div
             className="h-14 w-14 rounded-full"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div className="flex flex-col gap-1.5 flex-1">
             <div
               className="h-3 w-32 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
             <div
               className="h-7 w-72 rounded-[2px]"
-              style={{ background: "var(--v3-bg-100)" }}
+              style={{ background: "var(--v4-bg-100)" }}
             />
             <div
               className="h-3 w-96 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           </div>
         </div>
@@ -29,7 +29,7 @@ export default function UserProfileLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -38,7 +38,7 @@ export default function UserProfileLoading() {
             <div
               key={i}
               className="h-16 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/watchlist/error.tsx
+++ b/src/app/watchlist/error.tsx
@@ -20,7 +20,7 @@ export default function WatchlistError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · WATCHLIST"}
       </p>
@@ -30,7 +30,7 @@ export default function WatchlistError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function WatchlistError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/watchlist/loading.tsx
+++ b/src/app/watchlist/loading.tsx
@@ -7,27 +7,27 @@ export default function WatchlistLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div
           className="h-12 rounded-[2px]"
-          style={{ background: "var(--v3-bg-050)" }}
+          style={{ background: "var(--v4-bg-050)" }}
         />
         <div className="space-y-1.5">
           {Array.from({ length: 10 }).map((_, i) => (
             <div
               key={i}
               className="h-12 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>

--- a/src/app/you/error.tsx
+++ b/src/app/you/error.tsx
@@ -20,7 +20,7 @@ export default function YouError({ error, reset }: ErrorProps) {
     <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
       <p
         className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v2-sig-red)" }}
+        style={{ fontSize: 11, color: "var(--v4-red)" }}
       >
         {"// ERROR · YOU"}
       </p>
@@ -30,7 +30,7 @@ export default function YouError({ error, reset }: ErrorProps) {
           fontSize: "clamp(24px, 3.5vw, 32px)",
           fontWeight: 510,
           letterSpacing: "-0.022em",
-          color: "var(--v2-ink-000)",
+          color: "var(--v4-ink-000)",
           lineHeight: 1.1,
           marginBottom: 12,
         }}
@@ -39,17 +39,17 @@ export default function YouError({ error, reset }: ErrorProps) {
       </h1>
       <p
         className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v2-ink-300)" }}
+        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
       >
         This surface failed to render. Try again, or head home if it keeps erroring.
       </p>
       {error.digest && (
         <p
           className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
+          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
         >
           {"// DIGEST: "}
-          <span style={{ color: "var(--v2-ink-300)" }}>{error.digest}</span>
+          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
         </p>
       )}
       <div className="flex flex-wrap items-center justify-center gap-2">

--- a/src/app/you/loading.tsx
+++ b/src/app/you/loading.tsx
@@ -7,15 +7,15 @@ export default function YouLoading() {
         <div className="space-y-2">
           <div
             className="h-3 w-24 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
           <div
             className="h-7 w-56 rounded-[2px]"
-            style={{ background: "var(--v3-bg-100)" }}
+            style={{ background: "var(--v4-bg-100)" }}
           />
           <div
             className="h-3 w-80 rounded-[2px]"
-            style={{ background: "var(--v3-bg-050)" }}
+            style={{ background: "var(--v4-bg-050)" }}
           />
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
@@ -23,7 +23,7 @@ export default function YouLoading() {
             <div
               key={i}
               className="h-20 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>
@@ -32,7 +32,7 @@ export default function YouLoading() {
             <div
               key={i}
               className="h-40 rounded-[2px]"
-              style={{ background: "var(--v3-bg-050)" }}
+              style={{ background: "var(--v4-bg-050)" }}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
Mechanical sweep that closes a P1/P2 finding called out across multiple wave-11a + wave-12 audit reports (arxiv P2-4, npm P2-4, producthunt P1-4 + P1-5, huggingface audit, etc).

**132 files swept, 696 token replacements.**

| Token mapping | Where | Count |
|---|---|---|
| `var(--v3-bg-050)` → `var(--v4-bg-050)` | loading.tsx files | majority |
| `var(--v3-bg-100)` → `var(--v4-bg-100)` | loading.tsx files | rest |
| `var(--v2-ink-*)` → `var(--v4-ink-*)` | error.tsx files | majority |
| `var(--v2-line-200)` → `var(--v4-line-200)` | error.tsx files | many |
| `var(--v2-sig-red)` → `var(--v4-red)` | error.tsx files | rest |

## Why this is byte-identical at runtime
CSS cascade chain confirmed by reading `globals.css`:
```
--v2-bg-050  = var(--v3-bg-050)  = var(--color-bg-raised) = --v4-bg-050
--v2-sig-red = var(--v3-sig-red) = var(--color-negative)  = --v4-red
... etc — all 7 token pairs trace to the same --color-* root
```

## Files touched
- 58 `loading.tsx` files (V3 → V4)
- 74 `error.tsx` files (V2 → V4)

Net delta: **+696 / -696** (1:1 token rename, zero content change).

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK
- [x] `[check-v3-token-budget]` reports "counts dropped for 2 pattern(s)" (the exact telemetry that confirms drift was closed)

## Smoke target
Production renders should be byte-identical pre/post-merge — this is a token-name refactor only, the resolved CSS values don't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)