### PR TITLE
audit(impeccable): wave-13b — delete dead 'hidden' GH link block in producthunt NameTagline

### DIFF
--- a/src/app/producthunt/page.tsx
+++ b/src/app/producthunt/page.tsx
@@ -328,7 +328,6 @@ function ThumbLink({ launch }: { launch: Launch }) {
 
 function NameTagline({ launch }: { launch: Launch }) {
   const tags = (launch.tags ?? []).slice(0, 4);
-  const stars = launch.githubRepo?.stars;
   return (
     <div className="min-w-0">
       <a
@@ -356,27 +355,6 @@ function NameTagline({ launch }: { launch: Launch }) {
           {launch.tagline}
         </p>
       </a>
-      {launch.githubUrl ? (
-        <a
-          href={launch.githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hidden mt-0.5 inline-flex items-center gap-1 text-[10px] font-mono text-text-tertiary hover:text-functional transition-colors"
-          title={
-            stars !== undefined
-              ? `${launch.githubUrl.replace(/^https?:\/\/github\.com\//, "")} · ${stars.toLocaleString("en-US")}★`
-              : launch.githubUrl
-          }
-        >
-          <span aria-hidden>↗</span>
-          <span className="truncate">
-            {launch.githubUrl.replace(/^https?:\/\/github\.com\//, "")}
-          </span>
-          {stars !== undefined ? (
-            <span className="text-text-muted">· {stars.toLocaleString("en-US")}★</span>
-          ) : null}
-        </a>
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Closes [producthunt-audit.md P1-7](docs/audits/impeccable/producthunt-audit.md). The optional `<a>` rendering each launch's GitHub URL under the name had Tailwind `hidden` AND `inline-flex` on its className — `hidden` (display: none) wins, so the entire branch was permanently invisible. Pure dead JSX gated behind a falsy display rule.

`LaunchLinkIcons` (rendered in the LINKS column) already owns the GitHub-link affordance including the stars badge tooltip, so removing this dead branch loses no UX.

## Changes
- Deleted the `launch.githubUrl ? (...) : null` block (~20 LOC of unreachable JSX)
- Removed the now-orphan `const stars = launch.githubRepo?.stars` (only used inside the deleted block)

## Net delta
**-22 LOC, +0 LOC** — one file.

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK

## Smoke target
- `curl -sI https://trendingrepo.com/producthunt` → 200 (visual identical — the deleted block was already invisible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)