### PR TITLE
audit(impeccable): wave-13d — tokenize arxiv brand color via --v4-src-arxiv

### DIFF
--- a/src/app/arxiv/trending/page.tsx
+++ b/src/app/arxiv/trending/page.tsx
@@ -30,10 +30,11 @@ import { KpiBand } from "@/components/ui/KpiBand";
 import { LiveDot } from "@/components/ui/LiveDot";
 import { MarkVisited } from "@/components/layout/MarkVisited";
 
-// arXiv brand: Cornell crimson. No `--v4-src-arxiv` token exists yet, so
-// hardcode the brand color rather than fall back to the generic `--v4-red`
-// (which is reserved for negative-delta semantics).
-const ARXIV_BRAND = "#B22234";
+// arXiv brand: Cornell crimson — read from the canonical CSS token in
+// globals.css. Reserved as `--v4-src-arxiv` (distinct from `--v4-red`,
+// which carries negative-delta semantics — keeping them separated avoids
+// rank-1 numerals and a future drop arrow reading as the same signal).
+const ARXIV_BRAND = "var(--v4-src-arxiv)";
 
 export const dynamic = "force-static";
 export const revalidate = 1800; // 30 min

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6232,6 +6232,10 @@ body::before {
   --v4-src-dev: #b08bff;
   --v4-src-claude: #ffb547;
   --v4-src-openai: #5cd6c0;
+  /* arXiv: Cornell crimson — kept distinct from --v4-red (negative-delta
+     semantics) so a row with rank-1 + a future drop arrow doesn't read as
+     two reds with the same meaning. */
+  --v4-src-arxiv: #B22234;
 
   /* Funding source palette (8 sources) */
   --v4-fund-cb: #3a4a8e;


### PR DESCRIPTION
## Summary
Closes the tokenization half of [arxiv-audit.md P1-1](docs/audits/impeccable/arxiv-audit.md). Adds `--v4-src-arxiv: #B22234` to `globals.css` alongside the other `--v4-src-*` tokens (`--v4-src-hn`, `--v4-src-x`, `--v4-src-bsky`, `--v4-src-dev`, etc), and rewires the `/arxiv/trending` page's `ARXIV_BRAND` constant to read it via `var(--v4-src-arxiv)` instead of the hardcoded hex.

## Why
Single source of truth. The audit explicitly noted: "No `--v4-src-arxiv` token exists yet, so hardcode the brand color rather than fall back to the generic `--v4-red`." Keeping it as an inline literal made future changes drift-prone.

## Why kept distinct from `--v4-red`
`--v4-red` carries negative-delta semantics. Keeping arxiv crimson on its own token avoids rank-1 numerals + a future drop arrow reading as the same signal in the same row.

## Net delta
**+9 / -4 LOC across 2 files.** All 6 call sites (pip, banner, rank tint, momentum bar, table accent, ColdState header) carry forward unchanged because `ARXIV_BRAND` now resolves to a CSS var string.

## Defers
The audit's P1-1 also called for "demote rank 2-10 to `var(--v4-ink-100)` so only rank-1 carries the brand mark" — that's a "design call" (density tradeoff) per the audit itself; out of scope for this mechanical token swap.

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK

## Smoke target
- `curl -sI https://trendingrepo.com/arxiv/trending` → 200 (visual identical — `var(--v4-src-arxiv)` resolves to `#B22234`, byte-for-byte the prior literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)