### PR TITLE
audit(impeccable): wave-13e — tokenize npm brand color via --v4-src-npm + alpha variants

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6246,6 +6246,15 @@ body::before {
      semantics) so a row with rank-1 + a future drop arrow doesn't read as
      two reds with the same meaning. */
   --v4-src-arxiv: #B22234;
+  /* npm: brand red. Kept distinct from --v4-red (negative-delta semantics)
+     so a row with rank-1 numerals + a future drop arrow doesn't read as
+     two reds with the same meaning. Alpha variants exist for VersionPill
+     border (30%) + background (5%) — composing color-mix() at use-sites
+     would also work, but explicit tokens stay loud-fail-fast on theme
+     swaps. */
+  --v4-src-npm: #cb3837;
+  --v4-src-npm-30: rgba(203, 56, 55, 0.30);
+  --v4-src-npm-05: rgba(203, 56, 55, 0.05);
 
   /* Funding source palette (8 sources) */
   --v4-fund-cb: #3a4a8e;

--- a/src/app/npm/page.tsx
+++ b/src/app/npm/page.tsx
@@ -29,10 +29,11 @@ import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";
 import { KpiBand } from "@/components/ui/KpiBand";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 
-// npm brand red — no --v4-src-npm token exists in v4.css yet, so we hardcode
-// it once on the KpiBand pip and reuse the same hex for the active-tab
-// underline + accents below. Everything else stays tokenized via var(--v4-*).
-const NPM_RED = "#cb3837";
+// npm brand red — read from the canonical CSS token in globals.css. Reserved
+// as `--v4-src-npm` (distinct from --v4-red, which carries negative-delta
+// semantics). The matching --v4-src-npm-30 / --v4-src-npm-05 alpha variants
+// drive the VersionPill border + background below.
+const NPM_RED = "var(--v4-src-npm)";
 
 const WINDOWS: NpmWindow[] = ["24h", "7d", "30d"];
 const DEFAULT_WINDOW: NpmWindow = "24h";
@@ -484,8 +485,8 @@ function VersionPill({ pkg }: { pkg: NpmPackageRow }) {
     <span
       className="v2-mono inline-flex max-w-full items-center px-1.5 py-0.5 text-[10px] uppercase tracking-[0.14em]"
       style={{
-        border: `1px solid ${NPM_RED}4D`,
-        background: `${NPM_RED}0D`,
+        border: "1px solid var(--v4-src-npm-30)",
+        background: "var(--v4-src-npm-05)",
         color: NPM_RED,
         borderRadius: 2,
       }}


### PR DESCRIPTION
## Summary
Closes [npm-audit.md P1-3](docs/audits/impeccable/npm-audit.md) (and the tokenization half of P1-1). Adds `--v4-src-npm` + 30% / 5% alpha variants to `globals.css`. Rewires the `/npm` page's `NPM_RED` constant to read it via `var(--v4-src-npm)`, and fixes the `VersionPill` border + background to use the alpha tokens directly instead of the broken `\${NPM_RED}4D` / `\${NPM_RED}0D` hex-concat tricks.

## Why
1. `NPM_RED` was an inline literal because no `--v4-src-npm` token existed.
2. `VersionPill` did template-literal concatenation: `border: \`1px solid \${NPM_RED}4D\`` (30% alpha) and `background: \`\${NPM_RED}0D\`` (5% alpha). This is a brittle pattern — once `NPM_RED` becomes a CSS var, the concat produces `var(--v4-src-npm)4D` which is invalid CSS. So the alpha tokens are necessary to enable the tokenization.

## Changes
**globals.css** — 3 tokens added alongside the existing `--v4-src-*` family:
```css
--v4-src-npm: #cb3837;
--v4-src-npm-30: rgba(203, 56, 55, 0.30);  /* VersionPill border */
--v4-src-npm-05: rgba(203, 56, 55, 0.05);  /* VersionPill background */
```

**npm/page.tsx** — `NPM_RED = "var(--v4-src-npm)"`. VersionPill style switches the two alpha-hex concat sites to direct `var(--v4-src-npm-30)` / `var(--v4-src-npm-05)`. All 7 other call sites carry forward unchanged.

## Defers
The audit's P1-1 also called for "demote rank 2-10 to `var(--v4-ink-100)` so only rank-1 carries the brand mark" — that's a "design call" (density tradeoff) per the audit itself; out of scope for this mechanical token swap.

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK
- [x] grep confirms no remaining `\${NPM_RED}<hex>` template-literal patterns

## Smoke target
- `curl -sI https://trendingrepo.com/npm` → 200
- VersionPill renders with the same border + background tint visually (alpha values match the prior hex magic numbers exactly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)