### PR TITLE
audit(impeccable): wave-13f — WindowedFeedTable tabpanel a11y (closes shared-component gap)

### DIFF
--- a/src/components/feed/WindowedFeedTable.tsx
+++ b/src/components/feed/WindowedFeedTable.tsx
@@ -73,8 +73,10 @@ export function WindowedFeedTable({
           {(["24h", "7d", "30d"] as const).map((w) => (
             <a
               key={w}
+              id={`window-tab-${w}`}
               role="tab"
               aria-selected={activeWindow === w}
+              aria-controls={`window-panel-${w}`}
               className={`tab${activeWindow === w ? " on" : ""}`}
               href={`?${windowParam}=${w}`}
             >
@@ -87,7 +89,16 @@ export function WindowedFeedTable({
             </span>
           </span>
         </div>
-        {tableActive}
+        {/* Single tabpanel — only the active window's table is rendered, so
+            we point aria-labelledby at the active tab id. Closes the
+            tablist-without-tabpanel a11y gap (bluesky-trending audit P2-1). */}
+        <div
+          role="tabpanel"
+          id={`window-panel-${activeWindow}`}
+          aria-labelledby={`window-tab-${activeWindow}`}
+        >
+          {tableActive}
+        </div>
       </>
     );
   }
@@ -149,8 +160,10 @@ function LegacyToggle({
           <button
             key={w}
             type="button"
+            id={`window-tab-${w}`}
             role="tab"
             aria-selected={win === w}
+            aria-controls={`window-panel-${w}`}
             className={`tab${win === w ? " on" : ""}`}
             onClick={() => setWin(w)}
           >
@@ -161,7 +174,16 @@ function LegacyToggle({
           <span className="muted">{count} rows · {win}</span>
         </span>
       </div>
-      {table}
+      {/* Single tabpanel — only the active window's table is rendered, so
+          we point aria-labelledby at the active tab id. Closes the
+          tablist-without-tabpanel a11y gap (bluesky-trending audit P2-1). */}
+      <div
+        role="tabpanel"
+        id={`window-panel-${win}`}
+        aria-labelledby={`window-tab-${win}`}
+      >
+        {table}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
Closes [bluesky-trending-audit.md P2-1](docs/audits/impeccable/bluesky-trending-audit.md) (also referenced in arxiv, devto, npm, producthunt audits — same shared `WindowedFeedTable` component).

`WindowedFeedTable` rendered `<div role="tablist">` + `<a/button role="tab" aria-selected>` correctly, but the table content was raw — no `role="tabpanel"` wrapper, no `aria-labelledby` linkage. Screen readers announced the tabs but had no context for what they controlled.

## Fix
Applied to **both render paths** (opt-in URL-driven mode + LegacyToggle client mode): wrap `{table}` / `{tableActive}` in a `<div>` with:
- `role="tabpanel"`
- `id="window-panel-{activeWindow}"`
- `aria-labelledby="window-tab-{activeWindow}"`

Each tab gets `id="window-tab-{w}"` + `aria-controls="window-panel-{w}"`.

## Why one tabpanel (not three)
Only the active window's table is rendered (the others aren't mounted). So we point `aria-labelledby` at the active tab id rather than running 3 hidden panels with `display: none` toggles.

## Surfaces affected
Every page consuming `WindowedFeedTable`:
- `/arxiv/trending`
- `/bluesky/trending`
- `/devto`
- `/npm`
- `/producthunt`
- (and any future surface)

## Verification
- [x] `npx tsc --noEmit` → green
- [x] `npm run lint:guards` → all 11 sub-checks OK
- [x] `npx vitest run src/components/feed/__tests__/` → no tests match (component has no existing test file; behavior unchanged from a runtime POV)

## Smoke target
- All 5 surface routes return 200 — visual identical, only the ARIA tree changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)