### PR TITLE
Fix PostHog analytics setup

### DIFF
--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -333,7 +333,7 @@ Boot guard in `env.ts:142-164`: production throws unless
 | Var | Used by | Notes |
 |---|---|---|
 | `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` | scripts/_logger.mjs + Next runtime + worker | org `agnt-pf` (EU `de.sentry.io`), project id 4511285393686608 |
-| `POSTHOG_KEY`, `POSTHOG_API_KEY`, `POSTHOG_HOST`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST` | `src/lib/analytics/posthog.ts` + uptime workflow | shared with AISO + AGNT |
+| `POSTHOG_KEY`, `POSTHOG_API_KEY`, `POSTHOG_HOST`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_TOKEN`, `NEXT_PUBLIC_POSTHOG_HOST` | `src/lib/analytics/posthog.ts`, `src/components/providers/PostHogProvider.tsx` + uptime workflow | shared US PostHog project with AISO + AGNT |
 | `RESEND_API_KEY`, `EMAIL_FROM`, `DIGEST_ENABLED`, `DIGEST_USER_EMAILS_JSON` | `/api/cron/digest/weekly` | gated; opt-in master flag |
 | `OPS_ALERT_WEBHOOK` | platform-fatal alerts | HTTPS only |
 

--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -24,6 +24,11 @@ If both `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_TOKEN` are unset
 (preview / local dev without analytics provisioned), the helper is a silent
 no-op.
 
+The client is configured for explicit analytics only: autocapture, feature
+flags, surveys, product tours, conversations, session recording, web-vitals
+capture, and external PostHog extension loading are disabled. Re-enable those
+only with a matching product/dashboard owner and a fresh performance check.
+
 All funnel events share the same PostHog event name (`funnel_step`) and
 are differentiated by the `step` and `flow` properties — this lets the
 PostHog UI build funnels from a single event series filtered by `flow`,

--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -28,6 +28,9 @@ The client is configured for explicit analytics only: autocapture, feature
 flags, surveys, product tours, conversations, session recording, web-vitals
 capture, and external PostHog extension loading are disabled. Re-enable those
 only with a matching product/dashboard owner and a fresh performance check.
+The SDK is loaded from PostHog's slim client bundle; `$pageview` is captured
+by `src/components/analytics/PostHogPageviewBridge.tsx` instead of the SDK's
+history-autocapture extension.
 
 All funnel events share the same PostHog event name (`funnel_step`) and
 are differentiated by the `step` and `flow` properties — this lets the

--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -20,8 +20,9 @@ ergonomic wrappers ride on top of the helper:
   replacement for `<a target="_blank">` when the parent is a server
   component but the click should still emit a funnel step.
 
-If `NEXT_PUBLIC_POSTHOG_KEY` is unset (preview / local dev without
-analytics provisioned), the helper is a silent no-op.
+If both `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_TOKEN` are unset
+(preview / local dev without analytics provisioned), the helper is a silent
+no-op.
 
 All funnel events share the same PostHog event name (`funnel_step`) and
 are differentiated by the `step` and `flow` properties — this lets the
@@ -96,12 +97,22 @@ the dashboard can spot as `submit_fill` without a downstream
 
 ## Verifying locally
 
-- Set `NEXT_PUBLIC_POSTHOG_KEY` in `.env.local`. With
-  `NODE_ENV=development` the client SDK runs in debug mode and logs
-  every capture to the console.
+- Set `NEXT_PUBLIC_POSTHOG_KEY` (or PostHog's documented
+  `NEXT_PUBLIC_POSTHOG_TOKEN`) in `.env.local`. With `NODE_ENV=development`
+  the client SDK runs in debug mode and logs every capture to the console.
+- Set `NEXT_PUBLIC_POSTHOG_HOST` to the same region as the public token
+  (`https://us.i.posthog.com` for the current shared project). Host values
+  are trimmed at runtime so accidental trailing newlines do not break the SDK.
+  The client accepts the repo's existing `NEXT_PUBLIC_POSTHOG_KEY` env name
+  and PostHog's documented `NEXT_PUBLIC_POSTHOG_TOKEN` name.
 - PostHog "Live events" tab shows the events as they land. Filter on
   `event = funnel_step` to see only the funnel surface; group by
   `properties.flow` to slice per-funnel.
+- Headless Playwright/Chromium is bot-filtered by the SDK by default, so
+  `capture()` returns no event in those probes. If you need a synthetic
+  browser smoke test, override `posthog.config.opt_out_useragent_filter`
+  only inside the probe and confirm an event request lands on `/e/` or
+  `/i/v0/e/`.
 - Funnel charts: PostHog → Insights → New funnel → pick `funnel_step`
   multiple times, fix `flow` to the chosen flow id and `step` to the
   step you want for that position.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import "@/lib/bootstrap";
 import { ToasterLazy } from "@/components/feedback/ToasterLazy";
 import { StoreProvider } from "@/components/providers/StoreProvider";
 import { PostHogProvider } from "@/components/providers/PostHogProvider";
+import { PostHogIdentifyBridge } from "@/components/analytics/PostHogIdentifyBridge";
 import { AppShell } from "@/components/layout/AppShell";
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/layout/Sidebar";
@@ -223,6 +224,7 @@ export default async function RootLayout({
           Skip to main content
         </a>
         <PostHogProvider>
+          <PostHogIdentifyBridge />
           <StoreProvider>
             <DesignSystemProvider>
               <IdleMount>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Suspense } from "react";
 // Trimmed to 3 actively-rendered fonts (Geist sans, Geist Mono, Space
 // Grotesk display). Inter and JetBrains Mono lived only as CSS-fallback
 // strings in globals.css after `var(--font-geist*)` and never painted
@@ -14,6 +15,7 @@ import { ToasterLazy } from "@/components/feedback/ToasterLazy";
 import { StoreProvider } from "@/components/providers/StoreProvider";
 import { PostHogProvider } from "@/components/providers/PostHogProvider";
 import { PostHogIdentifyBridge } from "@/components/analytics/PostHogIdentifyBridge";
+import { PostHogPageviewBridge } from "@/components/analytics/PostHogPageviewBridge";
 import { AppShell } from "@/components/layout/AppShell";
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/layout/Sidebar";
@@ -224,6 +226,9 @@ export default async function RootLayout({
           Skip to main content
         </a>
         <PostHogProvider>
+          <Suspense fallback={null}>
+            <PostHogPageviewBridge />
+          </Suspense>
           <PostHogIdentifyBridge />
           <StoreProvider>
             <DesignSystemProvider>

--- a/src/components/analytics/PostHogIdentifyBridge.tsx
+++ b/src/components/analytics/PostHogIdentifyBridge.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect } from "react";
+import type { PostHog } from "posthog-js";
+
+import { useClientSession } from "@/components/layout/useClientSession";
+
+function getLoadedPostHog(): PostHog | null {
+  if (typeof window === "undefined") return null;
+  const posthog = (window as unknown as { posthog?: PostHog }).posthog;
+  return posthog?.__loaded ? posthog : null;
+}
+
+export function PostHogIdentifyBridge() {
+  const { loaded, userId } = useClientSession();
+
+  useEffect(() => {
+    if (!loaded || !userId) return;
+
+    const identify = () => {
+      getLoadedPostHog()?.identify(userId, {
+        project: "trendingrepo",
+        surface: "web",
+      });
+    };
+
+    if (getLoadedPostHog()) {
+      identify();
+      return;
+    }
+
+    window.addEventListener("trendingrepo:posthog-ready", identify, {
+      once: true,
+    });
+    return () => {
+      window.removeEventListener("trendingrepo:posthog-ready", identify);
+    };
+  }, [loaded, userId]);
+
+  return null;
+}

--- a/src/components/analytics/PostHogIdentifyBridge.tsx
+++ b/src/components/analytics/PostHogIdentifyBridge.tsx
@@ -1,15 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
-import type { PostHog } from "posthog-js";
 
 import { useClientSession } from "@/components/layout/useClientSession";
-
-function getLoadedPostHog(): PostHog | null {
-  if (typeof window === "undefined") return null;
-  const posthog = (window as unknown as { posthog?: PostHog }).posthog;
-  return posthog?.__loaded ? posthog : null;
-}
+import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
 
 export function PostHogIdentifyBridge() {
   const { loaded, userId } = useClientSession();
@@ -18,13 +12,13 @@ export function PostHogIdentifyBridge() {
     if (!loaded || !userId) return;
 
     const identify = () => {
-      getLoadedPostHog()?.identify(userId, {
+      getLoadedBrowserPostHog()?.identify(userId, {
         project: "trendingrepo",
         surface: "web",
       });
     };
 
-    if (getLoadedPostHog()) {
+    if (getLoadedBrowserPostHog()) {
       identify();
       return;
     }

--- a/src/components/analytics/PostHogPageviewBridge.tsx
+++ b/src/components/analytics/PostHogPageviewBridge.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
+
+export function PostHogPageviewBridge() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const lastCapturedUrlRef = useRef<string | null>(null);
+
+  const pageKey = useMemo(() => {
+    if (!pathname) return null;
+    const query = searchParams.toString();
+    return query ? `${pathname}?${query}` : pathname;
+  }, [pathname, searchParams]);
+
+  useEffect(() => {
+    if (!pageKey) return;
+
+    const capturePageview = () => {
+      const posthog = getLoadedBrowserPostHog();
+      if (!posthog) return;
+
+      const url = new URL(pageKey, window.location.origin).toString();
+      if (lastCapturedUrlRef.current === url) return;
+
+      lastCapturedUrlRef.current = url;
+      posthog.capture("$pageview", {
+        $current_url: url,
+        project: "trendingrepo",
+        surface: "web",
+      });
+    };
+
+    if (getLoadedBrowserPostHog()) {
+      capturePageview();
+      return;
+    }
+
+    window.addEventListener("trendingrepo:posthog-ready", capturePageview, {
+      once: true,
+    });
+    return () => {
+      window.removeEventListener("trendingrepo:posthog-ready", capturePageview);
+    };
+  }, [pageKey]);
+
+  return null;
+}

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -1,19 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, type ReactNode } from "react";
 import type { PostHog } from "posthog-js";
+import { flushPendingFunnelSteps } from "@/lib/analytics/funnel";
+import { resolvePublicPostHogConfig } from "@/lib/analytics/posthog-config";
 // NOTE: type-only import is erased by SWC; no runtime cost.
 
-interface PHContext {
-  client: PostHog;
-  Provider: React.ComponentType<{ client: PostHog; children: React.ReactNode }>;
-}
-
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
-  const [ctx, setCtx] = useState<PHContext | null>(null);
-
+export function PostHogProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
-    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    const { key, host } = resolvePublicPostHogConfig({
+      NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+      NEXT_PUBLIC_POSTHOG_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_TOKEN,
+      NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    });
     if (!key) return;
 
     let cancelled = false;
@@ -22,14 +21,12 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     const load = async () => {
       if (cancelled || triggered) return;
       triggered = true;
-      const [{ default: posthog }, { PostHogProvider: PHProvider }] = await Promise.all([
-        import("posthog-js"),
-        import("posthog-js/react"),
-      ]);
+      const { default: posthog } = await import("posthog-js");
       if (cancelled) return;
       if (!posthog.__loaded) {
         posthog.init(key, {
-          api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+          api_host: host,
+          defaults: "2026-01-30",
           capture_pageview: "history_change",
           capture_pageleave: true,
           person_profiles: "identified_only",
@@ -48,7 +45,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       // Expose via window so legacy callers (funnel.ts) can capture without
       // importing posthog-js eagerly themselves.
       (window as unknown as { posthog?: PostHog }).posthog = posthog;
-      setCtx({ client: posthog, Provider: PHProvider });
+      flushPendingFunnelSteps();
+      window.dispatchEvent(new Event("trendingrepo:posthog-ready"));
     };
 
     // Idle trigger
@@ -77,10 +75,5 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // Render children unwrapped while client is null. The PHProvider wrapper
-  // is only required when callers use posthog-js/react's hooks; our
-  // imperative captures (funnel.ts via window.posthog) work without it.
-  if (!ctx) return <>{children}</>;
-  const Provider = ctx.Provider;
-  return <Provider client={ctx.client}>{children}</Provider>;
+  return <>{children}</>;
 }

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, type ReactNode } from "react";
-import type { PostHog } from "posthog-js";
 import { flushPendingFunnelSteps } from "@/lib/analytics/funnel";
+import type { BrowserPostHogClient } from "@/lib/analytics/posthog-client";
 import { resolvePublicPostHogConfig } from "@/lib/analytics/posthog-config";
 // NOTE: type-only import is erased by SWC; no runtime cost.
 
@@ -21,21 +21,22 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
     const load = async () => {
       if (cancelled || triggered) return;
       triggered = true;
-      const { default: posthog } = await import("posthog-js");
+      const { default: posthog } = await import("posthog-js/dist/module.slim");
       if (cancelled) return;
       if (!posthog.__loaded) {
         posthog.init(key, {
           api_host: host,
           defaults: "2026-01-30",
-          capture_pageview: "history_change",
+          capture_pageview: false,
           capture_pageleave: true,
           autocapture: false,
           capture_performance: false,
           person_profiles: "identified_only",
-          // Keep PostHog to explicit analytics only. Funnels are wired by
+          // Keep PostHog to explicit analytics only. Pageviews are captured by
+          // PostHogPageviewBridge, and funnels are wired by
           // captureFunnelStep/FunnelMount/TrackedExternalLink, so the app does
-          // not need the remote survey, flag, product-tour, web-vitals,
-          // dead-click, exception, or recording extension bundles.
+          // not need the survey, flag, product-tour, web-vitals, dead-click,
+          // exception, history-autocapture, or recording extension bundles.
           disable_session_recording: true,
           disable_surveys: true,
           disable_surveys_automatic_display: true,
@@ -53,7 +54,7 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
       }
       // Expose via window so legacy callers (funnel.ts) can capture without
       // importing posthog-js eagerly themselves.
-      (window as unknown as { posthog?: PostHog }).posthog = posthog;
+      (window as unknown as { posthog?: BrowserPostHogClient }).posthog = posthog;
       flushPendingFunnelSteps();
       window.dispatchEvent(new Event("trendingrepo:posthog-ready"));
     };

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -29,13 +29,22 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
           defaults: "2026-01-30",
           capture_pageview: "history_change",
           capture_pageleave: true,
+          autocapture: false,
+          capture_performance: false,
           person_profiles: "identified_only",
-          // Skip the session-recording chunk on every page. Replay-on-error
-          // is already gated by the Sentry replay flag (Phase 1 perf work);
-          // PostHog recording isn't wired into any internal review surface
-          // today. Flip back to false if a future analyst wants session
-          // replay.
+          // Keep PostHog to explicit analytics only. Funnels are wired by
+          // captureFunnelStep/FunnelMount/TrackedExternalLink, so the app does
+          // not need the remote survey, flag, product-tour, web-vitals,
+          // dead-click, exception, or recording extension bundles.
           disable_session_recording: true,
+          disable_surveys: true,
+          disable_surveys_automatic_display: true,
+          disable_web_experiments: true,
+          disable_product_tours: true,
+          disable_conversations: true,
+          disable_external_dependency_loading: true,
+          advanced_disable_feature_flags: true,
+          advanced_disable_toolbar_metrics: true,
           loaded: (i) => {
             i.register({ project: "trendingrepo", surface: "web" });
             if (process.env.NODE_ENV === "development") i.debug();

--- a/src/lib/__vitest__/analytics-funnel.test.ts
+++ b/src/lib/__vitest__/analytics-funnel.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function setWindowPostHog(posthog: unknown) {
+  (window as unknown as { posthog?: unknown }).posthog = posthog;
+}
+
+describe("PostHog funnel helper", () => {
+  afterEach(() => {
+    setWindowPostHog(undefined);
+    vi.resetModules();
+  });
+
+  it("queues funnel steps until the SDK is ready", async () => {
+    const { captureFunnelStep, flushPendingFunnelSteps } = await import(
+      "@/lib/analytics/funnel"
+    );
+    const captures: Array<{ event: string; props: unknown }> = [];
+
+    captureFunnelStep({ step: "home_view", flow: "discover-repo" });
+    setWindowPostHog({
+      __loaded: true,
+      capture: (event: string, props: unknown) => captures.push({ event, props }),
+    });
+    flushPendingFunnelSteps();
+
+    expect(captures).toEqual([
+      {
+        event: "funnel_step",
+        props: { step: "home_view", flow: "discover-repo" },
+      },
+    ]);
+  });
+});

--- a/src/lib/__vitest__/posthog-config.test.ts
+++ b/src/lib/__vitest__/posthog-config.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_POSTHOG_HOST,
+  normalizePostHogHost,
+  resolvePublicPostHogConfig,
+  resolveServerPostHogConfig,
+} from "@/lib/analytics/posthog-config";
+
+describe("PostHog config", () => {
+  it("trims env host values and removes trailing slashes", () => {
+    expect(normalizePostHogHost("https://us.i.posthog.com\r\n/")).toBe(
+      "https://us.i.posthog.com",
+    );
+  });
+
+  it("falls back to the US ingestion host", () => {
+    expect(normalizePostHogHost(" \n\t ")).toBe(DEFAULT_POSTHOG_HOST);
+  });
+
+  it("accepts either server PostHog key env name", () => {
+    expect(
+      resolveServerPostHogConfig({
+        POSTHOG_API_KEY: " api-key ",
+        POSTHOG_HOST: " https://us.i.posthog.com\n",
+      }).key,
+    ).toBe("api-key");
+  });
+
+  it("accepts both repo and docs public token env names", () => {
+    expect(
+      resolvePublicPostHogConfig({
+        NEXT_PUBLIC_POSTHOG_TOKEN: " docs-token ",
+        NEXT_PUBLIC_POSTHOG_HOST: " https://us.i.posthog.com\n",
+      }),
+    ).toEqual({
+      key: "docs-token",
+      host: "https://us.i.posthog.com",
+    });
+
+    expect(
+      resolvePublicPostHogConfig({
+        NEXT_PUBLIC_POSTHOG_KEY: " repo-key ",
+        NEXT_PUBLIC_POSTHOG_TOKEN: " docs-token ",
+      }).key,
+    ).toBe("repo-key");
+  });
+});

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -20,7 +20,7 @@
 
 "use client";
 
-import type { PostHog } from "posthog-js";
+import { getLoadedBrowserPostHog, type BrowserPostHogClient } from "@/lib/analytics/posthog-client";
 
 const MAX_PENDING_FUNNEL_STEPS = 50;
 const pendingFunnelSteps: FunnelStepProps[] = [];
@@ -35,10 +35,8 @@ const pendingFunnelSteps: FunnelStepProps[] = [];
  * Returns `null` while the SDK is dormant (server-render, before idle,
  * or when no public PostHog token is set and the provider bailed).
  */
-function getPosthog(): PostHog | null {
-  if (typeof window === "undefined") return null;
-  const ph = (window as unknown as { posthog?: PostHog }).posthog;
-  return ph?.__loaded ? ph : null;
+function getPosthog(): BrowserPostHogClient | null {
+  return getLoadedBrowserPostHog();
 }
 
 function enqueueFunnelStep(props: FunnelStepProps): void {

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -3,7 +3,7 @@
 // Wraps `posthog-js` so call sites emit a single event shape
 // (`funnel_step`) without reaching for the SDK directly. PostHog is
 // initialised by `<PostHogProvider>` (src/components/providers); when
-// `NEXT_PUBLIC_POSTHOG_KEY` is unset the SDK never loads and every
+// no public PostHog token is set the SDK never loads and every
 // capture here becomes a no-op.
 //
 // All funnels documented in `docs/POSTHOG-FUNNELS.md`. Add a new flow
@@ -22,6 +22,9 @@
 
 import type { PostHog } from "posthog-js";
 
+const MAX_PENDING_FUNNEL_STEPS = 50;
+const pendingFunnelSteps: FunnelStepProps[] = [];
+
 /**
  * Runtime accessor for the PostHog SDK. The SDK is dynamically loaded by
  * `<PostHogProvider>` (idle / first-interaction) and exposed on
@@ -30,12 +33,19 @@ import type { PostHog } from "posthog-js";
  * client bundle that calls `captureFunnelStep`.
  *
  * Returns `null` while the SDK is dormant (server-render, before idle,
- * or when `NEXT_PUBLIC_POSTHOG_KEY` is unset and the provider bailed).
+ * or when no public PostHog token is set and the provider bailed).
  */
 function getPosthog(): PostHog | null {
   if (typeof window === "undefined") return null;
   const ph = (window as unknown as { posthog?: PostHog }).posthog;
   return ph?.__loaded ? ph : null;
+}
+
+function enqueueFunnelStep(props: FunnelStepProps): void {
+  if (pendingFunnelSteps.length >= MAX_PENDING_FUNNEL_STEPS) {
+    pendingFunnelSteps.shift();
+  }
+  pendingFunnelSteps.push(props);
 }
 
 /**
@@ -85,17 +95,31 @@ interface FunnelStepProps {
  * Emit a single funnel step. Safe to call from any client component.
  * No-ops when:
  *   - running on the server (typeof window === "undefined")
- *   - PostHog SDK was never initialised (NEXT_PUBLIC_POSTHOG_KEY unset)
+ *   - PostHog SDK was never initialised (no public PostHog token)
  */
 export function captureFunnelStep(props: FunnelStepProps): void {
   try {
-    // getPosthog() short-circuits to null on the server, before the
-    // lazy-loaded SDK has finished initialising, or when the provider
-    // bailed out (NEXT_PUBLIC_POSTHOG_KEY unset). Skipping when the
-    // SDK is dormant avoids accidental queueing in preview / local-dev
-    // builds without analytics provisioned.
-    getPosthog()?.capture("funnel_step", props);
+    const posthog = getPosthog();
+    if (posthog) {
+      posthog.capture("funnel_step", props);
+      return;
+    }
+    enqueueFunnelStep(props);
   } catch {
     // Analytics must never throw upstream.
+  }
+}
+
+export function flushPendingFunnelSteps(): void {
+  const posthog = getPosthog();
+  if (!posthog || pendingFunnelSteps.length === 0) return;
+
+  const steps = pendingFunnelSteps.splice(0, pendingFunnelSteps.length);
+  for (const props of steps) {
+    try {
+      posthog.capture("funnel_step", props);
+    } catch {
+      // Analytics must never throw upstream.
+    }
   }
 }

--- a/src/lib/analytics/posthog-client.ts
+++ b/src/lib/analytics/posthog-client.ts
@@ -1,0 +1,13 @@
+export interface BrowserPostHogClient {
+  __loaded?: boolean;
+  capture(eventName: string, properties?: Record<string, unknown>): unknown;
+  debug(): void;
+  identify(distinctId: string, properties?: Record<string, unknown>): unknown;
+  register(properties: Record<string, unknown>): unknown;
+}
+
+export function getLoadedBrowserPostHog(): BrowserPostHogClient | null {
+  if (typeof window === "undefined") return null;
+  const posthog = (window as unknown as { posthog?: BrowserPostHogClient }).posthog;
+  return posthog?.__loaded ? posthog : null;
+}

--- a/src/lib/analytics/posthog-config.ts
+++ b/src/lib/analytics/posthog-config.ts
@@ -1,0 +1,30 @@
+export const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+
+type PostHogEnv = Record<string, string | undefined>;
+
+function cleanEnvValue(value: string | undefined | null): string | undefined {
+  const cleaned = value?.trim().replace(/\s+/g, "");
+  return cleaned ? cleaned : undefined;
+}
+
+export function normalizePostHogHost(host: string | undefined | null): string {
+  return (cleanEnvValue(host) ?? DEFAULT_POSTHOG_HOST).replace(/\/+$/, "");
+}
+
+export function resolvePublicPostHogConfig(env: PostHogEnv = process.env) {
+  return {
+    key:
+      cleanEnvValue(env.NEXT_PUBLIC_POSTHOG_KEY) ??
+      cleanEnvValue(env.NEXT_PUBLIC_POSTHOG_TOKEN),
+    host: normalizePostHogHost(env.NEXT_PUBLIC_POSTHOG_HOST),
+  };
+}
+
+export function resolveServerPostHogConfig(env: PostHogEnv = process.env) {
+  return {
+    key: cleanEnvValue(env.POSTHOG_KEY) ?? cleanEnvValue(env.POSTHOG_API_KEY),
+    host: normalizePostHogHost(
+      cleanEnvValue(env.POSTHOG_HOST) ?? cleanEnvValue(env.NEXT_PUBLIC_POSTHOG_HOST),
+    ),
+  };
+}

--- a/src/lib/analytics/posthog.ts
+++ b/src/lib/analytics/posthog.ts
@@ -1,39 +1,38 @@
-// PostHog capture helper backed by the official `posthog-node` SDK so events
-// are batched + flushed periodically instead of one POST per call.
+// PostHog capture helper backed by the official `posthog-node` SDK.
 //
 // Used by the pool-aware GitHub fetch paths (src/lib/github-fetch.ts and
 // src/lib/pipeline/adapters/github-adapter.ts) so we get per-call
 // observability on token burn-rate, status codes, and rate-limit posture.
 //
 // Contract:
-//   - Fire-and-forget: callers `void posthogCapture(...)`. The SDK queues the
-//     event in memory and flushes asynchronously (every 20 events or 10s).
-//   - Silent no-op when `POSTHOG_KEY` is unset (dev / preview without
+//   - Fire-and-forget: callers `void posthogCapture(...)`. The SDK flushes
+//     each event immediately so short-lived serverless invocations do not hold
+//     analytics in memory.
+//   - Silent no-op when no server PostHog key is set (dev / preview without
 //     analytics provisioned). Warns once.
 //   - Distinct ID convention: pass `distinct_id` in `properties`. Falls back
 //     to "system" so the capture call is always well-formed for PostHog.
 //
-// Endpoint: https://eu.i.posthog.com (project lives in EU region).
-
 import { PostHog } from "posthog-node";
+import { resolveServerPostHogConfig } from "./posthog-config";
 
 let client: PostHog | null = null;
 let warned = false;
 
 function getClient(): PostHog | null {
-  const key = process.env.POSTHOG_KEY;
+  const { key, host } = resolveServerPostHogConfig();
   if (!key) {
     if (!warned) {
       warned = true;
-      console.warn("[posthog] POSTHOG_KEY not set; events suppressed");
+      console.warn("[posthog] POSTHOG_KEY/POSTHOG_API_KEY not set; events suppressed");
     }
     return null;
   }
   if (!client) {
     client = new PostHog(key, {
-      host: "https://eu.i.posthog.com",
-      flushAt: 20,
-      flushInterval: 10_000,
+      host,
+      flushAt: 1,
+      flushInterval: 0,
     });
   }
   return client;
@@ -41,7 +40,7 @@ function getClient(): PostHog | null {
 
 /**
  * Fire-and-forget PostHog capture. Queues to the SDK's internal batch; never
- * throws. No-ops when `POSTHOG_KEY` is missing.
+ * throws. No-ops when no server PostHog key is set.
  */
 export function posthogCapture(
   event: string,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -50,11 +50,16 @@ const EnvSchema = z.object({
   CRON_SECRET: z.string().min(16).optional(),
 
   // ── Observability ──────────────────────────────────────────────────────
-  // PostHog project API key (EU region). Consumed by
-  // src/lib/analytics/posthog.ts for fire-and-forget per-call captures
-  // (e.g. github_api_call from the pool-aware fetch paths). When unset,
+  // PostHog analytics. Client capture uses the NEXT_PUBLIC_* project token;
+  // server capture uses POSTHOG_KEY or POSTHOG_API_KEY. Host values must
+  // match the token region; the current shared project is US. When unset,
   // the helper is a silent no-op — analytics is best-effort.
+  NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+  NEXT_PUBLIC_POSTHOG_TOKEN: z.string().optional(),
+  NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
   POSTHOG_KEY: z.string().optional(),
+  POSTHOG_API_KEY: z.string().optional(),
+  POSTHOG_HOST: z.string().optional(),
 
   // ── Persistence ────────────────────────────────────────────────────────
   // Both legacy STARSCREENER_* and new TRENDINGREPO_* are accepted during


### PR DESCRIPTION
## Summary
- normalize PostHog client/server env handling and support `NEXT_PUBLIC_POSTHOG_TOKEN`
- keep PostHog lazy-loaded without remounting the app tree via `posthog-js/react`
- queue funnel steps until the SDK is ready and identify signed-in users when PostHog loads
- disable unused PostHog client surfaces: autocapture, flags, surveys, tours, conversations, web-vitals/perf capture, session recording, toolbar metrics, and external extension loading
- switch the lazy client import to PostHog's slim bundle and replace SDK history autocapture with a tiny Next route pageview bridge
- document the current US PostHog setup and explicit-funnel-only runtime contract

## Verification
- `npx vitest run --config vitest.config.ts src/lib/__vitest__/posthog-config.test.ts src/lib/__vitest__/analytics-funnel.test.ts`
- `npx eslint src/components/providers/PostHogProvider.tsx src/components/analytics/PostHogIdentifyBridge.tsx src/components/analytics/PostHogPageviewBridge.tsx src/lib/analytics/funnel.ts src/lib/analytics/posthog-client.ts src/app/layout.tsx`
- `npm run typecheck`
- `npm run lint:guards`
- `npm run build`
- `node scripts/perf-bundle.mjs --top=20` (0 violations)
- PostHog lazy chunk measured at ~93.3 KB uncompressed after slim import, down from ~182.7 KB on the default entrypoint

## Live checks
- Production deployment: `dpl_4G9XrisVXZzVECJzrwZqD5kMbDU8`
- `https://trendingrepo.com` resolved directly to Vercel returns `layout-d8c75c506354f014.js`
- Cloudflare DNS-over-HTTPS returns apex `A 76.76.21.21`; `www` is `cname.vercel-dns.com`
- browser PostHog config reports `apiHost=https://us.i.posthog.com`, `defaults=2026-01-30`, `capture_pageview=false`, `autocapture=false`, `capture_performance=false`, `disable_external_dependency_loading=true`, `advanced_disable_feature_flags=true`
- live browser request inventory is PostHog config only; no `surveys.js`, `dead-clicks-autocapture.js`, `web-vitals.js`, `exception-autocapture.js`, `/flags`, or session-recording extension requests

## Note
Closed #1230 because it used an older audit branch and pulled unrelated commits into the comparison. This PR is the clean three-commit version.