### PR TITLE
fix(build): extract stale thresholds to client-safe file (unblock Vercel)

### DIFF
--- a/src/lib/news/freshness.ts
+++ b/src/lib/news/freshness.ts
@@ -13,7 +13,7 @@ import {
   FAST_DATA_STALE_THRESHOLD_MS,
   NPM_STALE_THRESHOLD_MS,
   PRODUCTHUNT_STALE_THRESHOLD_MS,
-} from "@/lib/source-health";
+} from "@/lib/source-health-thresholds";
 
 export type NewsSource =
   | "reddit"

--- a/src/lib/source-health-thresholds.ts
+++ b/src/lib/source-health-thresholds.ts
@@ -1,0 +1,18 @@
+// Stale-threshold constants extracted from source-health.ts so client
+// components (e.g. FreshnessBadge via news/freshness.ts) can import them
+// without dragging the server-only data loaders along.
+//
+// Edit values here; source-health.ts re-exports them so server callers
+// see the same numbers without further changes.
+
+/** Fast-cron data sources (Reddit/HN/Bluesky/Lobsters): 4h budget. */
+export const FAST_DATA_STALE_THRESHOLD_MS = 4 * 60 * 60 * 1000;
+
+/** ProductHunt: 16h budget (slower cadence). */
+export const PRODUCTHUNT_STALE_THRESHOLD_MS = 16 * 60 * 60 * 1000;
+
+/** Dev.to: 26h budget. */
+export const DEVTO_STALE_THRESHOLD_MS = 26 * 60 * 60 * 1000;
+
+/** npm: 50h budget. */
+export const NPM_STALE_THRESHOLD_MS = 50 * 60 * 60 * 1000;

--- a/src/lib/source-health.ts
+++ b/src/lib/source-health.ts
@@ -49,10 +49,23 @@ import {
 // healthy. 4h = 2× the cron cadence + 2× headroom — matches the
 // audit-freshness 6h budget for these same sources without firing
 // false alarms.
-export const FAST_DATA_STALE_THRESHOLD_MS = 4 * 60 * 60 * 1000;
-export const PRODUCTHUNT_STALE_THRESHOLD_MS = 16 * 60 * 60 * 1000;
-export const DEVTO_STALE_THRESHOLD_MS = 26 * 60 * 60 * 1000;
-export const NPM_STALE_THRESHOLD_MS = 50 * 60 * 60 * 1000;
+// Threshold constants moved to src/lib/source-health-thresholds.ts so client
+// components (FreshnessBadge → news/freshness.ts) can import them without
+// dragging the server-only loaders along. Re-exported here for compatibility
+// with existing server-side callers; do not edit values here.
+export {
+  FAST_DATA_STALE_THRESHOLD_MS,
+  PRODUCTHUNT_STALE_THRESHOLD_MS,
+  DEVTO_STALE_THRESHOLD_MS,
+  NPM_STALE_THRESHOLD_MS,
+} from "./source-health-thresholds";
+
+import {
+  FAST_DATA_STALE_THRESHOLD_MS,
+  PRODUCTHUNT_STALE_THRESHOLD_MS,
+  DEVTO_STALE_THRESHOLD_MS,
+  NPM_STALE_THRESHOLD_MS,
+} from "./source-health-thresholds";
 
 const FAST_20M_DEGRADED_THRESHOLD_MS = 45 * 60 * 1000;
 const FAST_HOURLY_DEGRADED_THRESHOLD_MS = 90 * 60 * 1000;


### PR DESCRIPTION
Hotfix to unblock production deploys. CompareWaveTop (client) imports FreshnessBadge → freshness.ts → source-health.ts → server-only modules. Extracts the 4 stale-threshold constants into a client-safe file. Build tested locally with successful next build.