### PR TITLE
feat(data-store): gzip payloads ≥50KB to cut Upstash egress (B.15 Arc 1)

### DIFF
--- a/apps/trendingrepo-worker/src/lib/redis.ts
+++ b/apps/trendingrepo-worker/src/lib/redis.ts
@@ -2,6 +2,7 @@
 // (relative to monorepo root). This file mirrors that contract in TypeScript so
 // the worker package is self-contained. Namespace must stay in lockstep.
 
+import { gunzipSync, gzipSync } from 'node:zlib';
 import type { Redis as IORedisType } from 'ioredis';
 import type { RedisHandle } from './types.js';
 import { loadEnv } from './env.js';
@@ -9,6 +10,26 @@ import { loadEnv } from './env.js';
 const NAMESPACE = 'ss:data:v1';
 const META_NAMESPACE = 'ss:meta:v1';
 const INVALID_KEY_LITERALS = new Set(['null', 'undefined']);
+
+// B.15 Arc 1 — gzip large payloads to cut Upstash egress on write + read.
+// `gz1:` magic prefix lets the reader detect compressed values and ungzip;
+// legacy uncompressed payloads pass through transparently. Threshold tuned
+// so small payloads (where gzip overhead > savings) stay plaintext.
+const GZIP_THRESHOLD_BYTES = 50_000;
+const GZIP_MAGIC_PREFIX = 'gz1:';
+
+function encodePayloadForStore(payload: string): string {
+  if (payload.length < GZIP_THRESHOLD_BYTES) return payload;
+  const compressed = gzipSync(Buffer.from(payload, 'utf8'));
+  return GZIP_MAGIC_PREFIX + compressed.toString('base64');
+}
+
+function decodePayloadFromStore(raw: string): string {
+  if (!raw.startsWith(GZIP_MAGIC_PREFIX)) return raw;
+  const b64 = raw.slice(GZIP_MAGIC_PREFIX.length);
+  const decompressed = gunzipSync(Buffer.from(b64, 'base64'));
+  return decompressed.toString('utf8');
+}
 
 let cachedHandle: RedisHandle | null = null;
 let warned = false;
@@ -148,7 +169,7 @@ export async function writeDataStore(
   if (!handle) {
     return { source: 'skipped', writtenAt };
   }
-  const payload = JSON.stringify(value);
+  const payload = encodePayloadForStore(JSON.stringify(value));
   const setOpts = opts.ttlSeconds && opts.ttlSeconds > 0 ? { ex: opts.ttlSeconds } : undefined;
 
   // Resolve writer: caller wins; otherwise pull from the run.ts-set
@@ -192,7 +213,7 @@ export async function readDataStore<T = unknown>(key: string): Promise<T | null>
   const raw = await handle.get(`${NAMESPACE}:${normalizedKey}`);
   if (raw === null) return null;
   try {
-    return JSON.parse(raw) as T;
+    return JSON.parse(decodePayloadFromStore(raw)) as T;
   } catch {
     return null;
   }

--- a/src/lib/__tests__/data-store.test.ts
+++ b/src/lib/__tests__/data-store.test.ts
@@ -231,3 +231,40 @@ test("ageMs is non-negative and reflects time since write", async () => {
   const result = await store.read("agecheck");
   assert.ok(result.ageMs >= 0, "ageMs should be non-negative");
 });
+
+// B.15 Arc 1 — gzipped payloads round-trip through parsePayload. The worker
+// writes large blobs with the `gz1:` magic prefix + base64-encoded gzip body;
+// the reader must transparently decompress before JSON.parse.
+test("read() transparently ungzips payloads with gz1: magic prefix", async () => {
+  const store = buildStore();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const zlib = require("zlib") as typeof import("zlib");
+  const payload = { items: Array.from({ length: 50 }, (_, i) => ({ i, val: `r${i}` })) };
+  const json = JSON.stringify(payload);
+  const compressed = zlib.gzipSync(Buffer.from(json, "utf8"));
+  const stored = "gz1:" + compressed.toString("base64");
+  fake.store.set("ss:data:v1:gz-payload", stored);
+  fake.store.set("ss:meta:v1:gz-payload", new Date().toISOString());
+
+  const result = await store.read<typeof payload>("gz-payload");
+  assert.equal(result.source, "redis");
+  assert.equal(result.data?.items.length, 50);
+  assert.equal(result.data?.items[0]?.val, "r0");
+});
+
+test("read() leaves legacy uncompressed payloads unchanged", async () => {
+  const store = buildStore();
+  fake.store.set("ss:data:v1:legacy", JSON.stringify({ shape: "plain" }));
+  fake.store.set("ss:meta:v1:legacy", new Date().toISOString());
+  const result = await store.read<{ shape: string }>("legacy");
+  assert.equal(result.source, "redis");
+  assert.equal(result.data?.shape, "plain");
+});
+
+test("read() returns null on corrupted gz1: payload (parse-safe)", async () => {
+  const store = buildStore();
+  fake.store.set("ss:data:v1:corrupt", "gz1:!!!not-valid-base64!!!");
+  fake.store.set("ss:meta:v1:corrupt", new Date().toISOString());
+  const result = await store.read<unknown>("corrupt");
+  assert.equal(result.source, "missing");
+});

--- a/src/lib/data-store.ts
+++ b/src/lib/data-store.ts
@@ -50,6 +50,31 @@ function fs(): FsModule {
   return _fs;
 }
 
+// Same lazy-load discipline as `fs` above — `zlib` is a Node builtin and the
+// webpack client bundle would otherwise pull in the polyfill. parsePayload is
+// only invoked from server reads, so the function-scoped require stays
+// invisible to the client module graph.
+type ZlibModule = typeof import("zlib");
+let _zlib: ZlibModule | null = null;
+function zlib(): ZlibModule {
+  if (_zlib) return _zlib;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  _zlib = require("zlib") as ZlibModule;
+  return _zlib;
+}
+
+// B.15 Arc 1 — symmetric ungzip for payloads written by the worker's
+// encodePayloadForStore() helper. Detected via the `gz1:` magic prefix;
+// legacy uncompressed payloads pass through unchanged.
+const GZIP_MAGIC_PREFIX = "gz1:";
+
+function decodePayloadFromStore(raw: string): string {
+  if (!raw.startsWith(GZIP_MAGIC_PREFIX)) return raw;
+  const b64 = raw.slice(GZIP_MAGIC_PREFIX.length);
+  const decompressed = zlib().gunzipSync(Buffer.from(b64, "base64"));
+  return decompressed.toString("utf8");
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -624,7 +649,7 @@ function parsePayload<T>(raw: unknown): T | null {
   if (raw === null || raw === undefined) return null;
   if (typeof raw === "string") {
     try {
-      return JSON.parse(raw) as T;
+      return JSON.parse(decodePayloadFromStore(raw)) as T;
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary

The worker re-writes large blobs (agent-commerce 7.57MB, reddit-all-posts 2.18MB, reddit-mentions 1.90MB, arxiv-recent 1.82MB) on every refresh. Each write counts against Upstash egress + command budget.

Wraps `writeDataStore`'s payload in gzip with a `gz1:` magic prefix when JSON exceeds **50KB**. The reader (`data-store.ts:parsePayload`) detects the prefix and ungzips transparently; legacy uncompressed payloads pass through unchanged for back-compat during rollout.

## Expected impact

- **agent-commerce**: ~7.5MB → ~750KB–2MB (70–90% reduction)
- **reddit/arxiv blobs**: collective ~5MB saved per write cycle
- **Read path**: +1ms gunzip overhead, well within budget
- **Smaller payloads (<50KB)**: stay plaintext — gzip overhead > savings

## Design notes

- Symmetric ungzip added to worker's `readDataStore()` since derived fetchers read what other fetchers wrote
- Lazy-loaded `zlib` in `data-store.ts` mirrors the existing `fs` discipline so the webpack client bundle stays unaffected
- `gz1:` magic prefix locked-in convention — see `feedback_redis_gzip_pattern.md`

## ⚠️ Rebase needed

This branch is **29 commits behind** `main` (audit-wave PRs landed since). Likely needs rebase before merge. No conflict expected in `data-store.ts` based on audit-wave PRs being UI-focused, but verify.

## Tests

3 new round-trip tests:
- read large `gz1:` payload
- read legacy uncompressed payload
- parse-safe on corrupted `gz1:` payload

All 15 data-store tests pass. Top-level `tsc --noEmit` and worker `tsc --noEmit` both green.

## Test plan

- [x] All data-store unit tests green
- [ ] Rebase onto main
- [ ] Post-merge + deploy `trendingrepo-app:vps-v6`: query Upstash `STRLEN ss:data:v1:agent-commerce` → expect <2MB (was 7.57MB)
- [ ] Confirm next `agent-commerce` cron writes a `gz1:`-prefixed payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)