### PR TITLE
fix(docker): plumb SENTRY_AUTH_TOKEN as build ARG for VPS images (B.19)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,18 @@ ENV NODE_ENV=production
 # Give Next.js room — bookworm-slim allows up to host memory; cap heap to 4G
 # so we don't OOM other toolbox containers when building on the shared VPS.
 ENV NODE_OPTIONS=--max-old-space-size=4096
-# Sentry source-map upload is gated on SENTRY_AUTH_TOKEN — leave unset for
-# image builds, set at CI/build-arg time when we want symbolicated traces.
-ENV SENTRY_AUTH_TOKEN=""
+# Sentry source-map upload is gated on SENTRY_AUTH_TOKEN. Plumbed as a build
+# ARG so VPS deploys can pass the token from /opt/trendingrepo/.env.production
+# at `docker build` time. Defaults to empty so a forgotten arg silently skips
+# upload (matches the pre-2026-05-15 behavior) rather than failing the build.
+# Recipe: docker build --build-arg SENTRY_AUTH_TOKEN="$TOKEN" ...
+# Set SENTRY_ORG + SENTRY_PROJECT alongside (already in env.production).
+ARG SENTRY_AUTH_TOKEN=""
+ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+ARG SENTRY_ORG=""
+ENV SENTRY_ORG=$SENTRY_ORG
+ARG SENTRY_PROJECT=""
+ENV SENTRY_PROJECT=$SENTRY_PROJECT
 
 RUN npm run build
 


### PR DESCRIPTION
## Summary

Pre-this-fix, VPS-built trendingrepo images had `ENV SENTRY_AUTH_TOKEN=""` hard-coded in the builder stage. Result: `withSentryConfig`'s source-map upload step skipped during `next build`, and production stack traces in Sentry showed minified frames (`at e (n.js:1)`) instead of resolved ones (`at Component (file.tsx:123)`).

The runtime `SENTRY_AUTH_TOKEN` in `/opt/trendingrepo/.env.production` was present but never visible at `docker build` time.

## The fix

Convert the hard-coded `ENV` to `ARG` + `ENV` pair so deploys can pass the token via `--build-arg`:

```sh
docker build \
  --build-arg SENTRY_AUTH_TOKEN="$(grep '^SENTRY_AUTH_TOKEN=' /opt/trendingrepo/.env.production | cut -d= -f2-)" \
  --build-arg SENTRY_ORG="$(grep '^SENTRY_ORG=' /opt/trendingrepo/.env.production | cut -d= -f2-)" \
  --build-arg SENTRY_PROJECT="$(grep '^SENTRY_PROJECT=' /opt/trendingrepo/.env.production | cut -d= -f2-)" \
  -t trendingrepo-app:vps-vN .
```

Default remains empty — a forgotten `--build-arg` silently skips upload rather than failing the build (matches pre-fix behaviour for back-compat).

`SENTRY_ORG` + `SENTRY_PROJECT` plumbed the same way (`@sentry/nextjs` needs all three at build time).

## R.2 deploy recipe update needed post-merge

The handover's R.2 recipe in `~/.claude/plans/next-session-goal-2026-05-17.md` already documents this — just needs to be the active path once this PR lands.

## ⚠️ Rebase needed

This branch is **29 commits behind** `main`. Likely needs rebase before merge (low conflict risk — Dockerfile rarely touched by audit-wave UI PRs).

## Test plan

- [ ] Rebase onto main
- [ ] Post-merge + first deploy with `--build-arg`: trigger a known prod error
- [ ] Verify Sentry shows resolved stack frames (file paths + line numbers, not `at e (n.js:1)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)