### PR TITLE
perf(scripts): batched skip-existing in backfill-star-activity (Arc 2 extension)

### DIFF
--- a/scripts/__tests__/data-store-write.test.mjs
+++ b/scripts/__tests__/data-store-write.test.mjs
@@ -11,6 +11,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   writeDataStore,
+  readDataStoreMany,
+  writeDataStoreMany,
   _resetForTests,
   closeDataStore,
 } from "../_data-store-write.mjs";
@@ -160,6 +162,105 @@ test("writeDataStore: rejects invalid keys (blank/null/undefined literals)", asy
       () => writeDataStore("undefined", { x: 1 }),
       /invalid key/i,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B.15 Arc 2 — batched helper tests
+// ---------------------------------------------------------------------------
+//
+// `readDataStoreMany` + `writeDataStoreMany` are the Upstash-quota fix shipped
+// 2026-05-15 (incident-driven). These tests cover the no-Redis-env path
+// (returns aligned nulls / skipped result) — the same graceful-skip
+// discipline the single-write tests above exercise. End-to-end pipeline
+// behavior is verified via the integration smoke against live Redis.
+
+test("readDataStoreMany: returns aligned nulls when Redis disabled", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    process.env.DATA_STORE_DISABLE = "1";
+    try {
+      const result = await readDataStoreMany(["a", "b", "c"]);
+      assert.deepEqual(result, [null, null, null]);
+    } finally {
+      delete process.env.DATA_STORE_DISABLE;
+    }
+  });
+});
+
+test("readDataStoreMany: empty input returns empty array", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    const result = await readDataStoreMany([]);
+    assert.deepEqual(result, []);
+  });
+});
+
+test("readDataStoreMany: handles non-array input gracefully", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    // @ts-expect-error — intentionally passing invalid type
+    const result = await readDataStoreMany(null);
+    assert.deepEqual(result, []);
+  });
+});
+
+test("readDataStoreMany: maps invalid slugs to null without crashing", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    process.env.DATA_STORE_DISABLE = "1";
+    try {
+      const result = await readDataStoreMany(["valid", "", "null", "undefined", "also-valid"]);
+      // No Redis configured, so all entries collapse to null. The point of
+      // this test is that the invalid keys don't throw — they just yield
+      // null in their aligned slot.
+      assert.equal(result.length, 5);
+      for (const cell of result) assert.equal(cell, null);
+    } finally {
+      delete process.env.DATA_STORE_DISABLE;
+    }
+  });
+});
+
+test("writeDataStoreMany: empty input returns skipped result", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    const result = await writeDataStoreMany([]);
+    assert.equal(result.source, "skipped");
+    assert.deepEqual(result.results, []);
+    assert.match(result.writtenAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+test("writeDataStoreMany: returns skipped when Redis disabled, with per-entry markers", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    process.env.DATA_STORE_DISABLE = "1";
+    try {
+      const result = await writeDataStoreMany([
+        { key: "alpha", value: { n: 1 } },
+        { key: "beta", value: { n: 2 } },
+        { key: "gamma", value: { n: 3 } },
+      ]);
+      assert.equal(result.source, "skipped");
+      assert.equal(result.results.length, 3);
+      for (const r of result.results) {
+        assert.equal(r.ok, false);
+        assert.match(r.error, /disabled/i);
+      }
+    } finally {
+      delete process.env.DATA_STORE_DISABLE;
+    }
+  });
+});
+
+test("writeDataStoreMany: non-array input collapses to skipped/empty", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    // @ts-expect-error — intentionally passing invalid type
+    const result = await writeDataStoreMany(undefined);
+    assert.equal(result.source, "skipped");
+    assert.deepEqual(result.results, []);
   });
 });
 

--- a/scripts/_data-store-write.mjs
+++ b/scripts/_data-store-write.mjs
@@ -111,6 +111,41 @@ function makeIoRedisAdapter(client) {
     async get(key) {
       return client.get(key);
     },
+    // B.15 Arc 2 — batched GET. ioredis MGET returns Array<string|null>.
+    async mget(...keys) {
+      if (keys.length === 0) return [];
+      return client.mget(...keys);
+    },
+    // B.15 Arc 2 — pipeline wrapper. Builds N commands into a single round
+    // trip (and a single Upstash request when REST is the backend). Each
+    // pipeline.exec() counts as 1 Upstash request regardless of N
+    // sub-commands — that's the request-count savings for star-activity.
+    pipeline() {
+      const p = client.pipeline();
+      return {
+        _native: p,
+        set(key, value, opts) {
+          if (opts && typeof opts.ex === "number" && opts.ex > 0) {
+            p.set(key, value, "EX", opts.ex);
+          } else {
+            p.set(key, value);
+          }
+          return this;
+        },
+        get(key) {
+          p.get(key);
+          return this;
+        },
+        async exec() {
+          // ioredis pipeline.exec() returns Array<[Error|null, Result]>.
+          // Normalize to Array<{ ok: boolean, value?, error? }> so callers
+          // don't have to know which backend is in use.
+          const raw = await p.exec();
+          if (!raw) return [];
+          return raw.map(([err, value]) => (err ? { ok: false, error: err } : { ok: true, value }));
+        },
+      };
+    },
     async quit() {
       try {
         await client.quit();
@@ -253,6 +288,183 @@ export async function writeDataStore(key, value, opts = {}) {
   ]);
 
   return { source: "redis", writtenAt };
+}
+
+/**
+ * B.15 Arc 2 — Batched read for many slugs in ONE Redis round-trip (and ONE
+ * Upstash REST request when wired through pipeline.exec internally). Returns
+ * an array aligned with the input slugs, each entry null if the slug is
+ * missing / unparseable / Redis disabled.
+ *
+ * Use this instead of `readDataStore` in a loop when reading >10 slugs at
+ * once. For star-activity (2980 slugs), splitting into chunks of N=100 turns
+ * 2980 GETs into 30 MGETs — 99% request reduction against the Upstash quota.
+ *
+ * @param {string[]} keys Array of slugs.
+ * @returns {Promise<Array<unknown | null>>}
+ */
+export async function readDataStoreMany(keys) {
+  if (!Array.isArray(keys) || keys.length === 0) return [];
+  const client = await getClient();
+  if (!client) return keys.map(() => null);
+  // Normalize + map invalid keys to null pre-emptively to keep the response
+  // array shape stable.
+  const validIndices = [];
+  const validKeys = [];
+  for (let i = 0; i < keys.length; i += 1) {
+    const k = typeof keys[i] === "string" ? keys[i].trim() : "";
+    if (!k || INVALID_KEY_LITERALS.has(k)) continue;
+    validIndices.push(i);
+    validKeys.push(`${NAMESPACE}:${k}`);
+  }
+  const result = new Array(keys.length).fill(null);
+  if (validKeys.length === 0) return result;
+  // `mget` may or may not exist on the adapter (ioredis adapter added 2026-05-15,
+  // @upstash/redis exposes it natively). Fall back to parallel single GETs.
+  const raw =
+    typeof client.mget === "function"
+      ? await client.mget(...validKeys)
+      : await Promise.all(validKeys.map((k) => client.get(k)));
+  for (let i = 0; i < validIndices.length; i += 1) {
+    const cell = raw[i];
+    if (cell === null || cell === undefined) continue;
+    if (typeof cell === "string") {
+      try {
+        result[validIndices[i]] = JSON.parse(cell);
+      } catch {
+        // leave null
+      }
+    } else if (typeof cell === "object") {
+      // Upstash REST may auto-decode JSON.
+      result[validIndices[i]] = cell;
+    }
+  }
+  return result;
+}
+
+/**
+ * B.15 Arc 2 — Batched write for many slug/value pairs. Builds a single
+ * pipeline of 2N SETs (payload + meta per entry) and executes in ONE round
+ * trip. Per-entry result reflects which payload AND meta SETs succeeded.
+ *
+ * Critical for staying under Upstash request quotas: pipeline.exec() counts
+ * as 1 Upstash request regardless of N sub-commands.
+ *
+ * @param {Array<{ key: string, value: unknown, opts?: { ttlSeconds?: number } }>} entries
+ * @param {{ stampPerRecord?: boolean; writer?: string; runId?: string; commit?: string }} [globalOpts]
+ *   Applied to all entries (overridable per-entry not supported — keep it
+ *   simple). stampPerRecord and writer/runId/commit follow the same rules
+ *   as single-entry writeDataStore.
+ * @returns {Promise<{ source: "redis" | "skipped"; writtenAt: string; results: Array<{ key: string, ok: boolean, error?: string }> }>}
+ */
+export async function writeDataStoreMany(entries, globalOpts = {}) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return { source: "skipped", writtenAt: new Date().toISOString(), results: [] };
+  }
+  const writtenAt = new Date().toISOString();
+
+  // Per-record stamping mirrors single-write writeDataStore — applied before
+  // serialization so the stored payload includes the lastRefreshedAt field.
+  if (globalOpts.stampPerRecord !== false) {
+    for (const entry of entries) {
+      if (entry?.value && typeof entry.value === "object") {
+        stampTrackedRepos(entry.value, writtenAt);
+      }
+    }
+  }
+
+  const client = await getClient();
+  if (!client) {
+    return {
+      source: "skipped",
+      writtenAt,
+      results: entries.map((e) => ({ key: e.key, ok: false, error: "redis disabled" })),
+    };
+  }
+
+  // Compose meta with provenance (same logic as single-write writeDataStore).
+  const writer =
+    globalOpts.writer ??
+    (process.env.GITHUB_WORKFLOW
+      ? `github-actions:${process.env.GITHUB_WORKFLOW}`
+      : undefined);
+  const runId = globalOpts.runId ?? process.env.GITHUB_RUN_ID;
+  const commitFull = globalOpts.commit ?? process.env.GITHUB_SHA;
+  const commit = commitFull ? commitFull.slice(0, 7) : undefined;
+  const hasProvenance =
+    writer !== undefined || runId !== undefined || commit !== undefined;
+  const metaValue = hasProvenance
+    ? JSON.stringify({
+        writtenAt,
+        ...(writer !== undefined ? { writer } : {}),
+        ...(runId !== undefined ? { runId } : {}),
+        ...(commit !== undefined ? { commit } : {}),
+      })
+    : writtenAt;
+
+  // Build a single pipeline for all 2N SETs. If the adapter doesn't support
+  // pipeline (older ioredis adapter shape, or a fake), fall back to parallel
+  // single-key SETs — slower but correct.
+  if (typeof client.pipeline !== "function") {
+    const results = await Promise.all(
+      entries.map(async (entry) => {
+        try {
+          const payload = JSON.stringify(entry.value);
+          const setOpts =
+            entry.opts?.ttlSeconds && entry.opts.ttlSeconds > 0
+              ? { ex: entry.opts.ttlSeconds }
+              : undefined;
+          await client.set(`${NAMESPACE}:${entry.key.trim()}`, payload, setOpts);
+          await client.set(`${META_NAMESPACE}:${entry.key.trim()}`, metaValue, setOpts);
+          return { key: entry.key, ok: true };
+        } catch (err) {
+          return { key: entry.key, ok: false, error: String(err?.message ?? err) };
+        }
+      }),
+    );
+    return { source: "redis", writtenAt, results };
+  }
+
+  const pipeline = client.pipeline();
+  const order = []; // remember entry order for result mapping
+  for (const entry of entries) {
+    const normalizedKey = entry.key.trim();
+    if (!normalizedKey || INVALID_KEY_LITERALS.has(normalizedKey)) {
+      // Push synthetic failure tracker — don't add to pipeline; we'll
+      // emit ok:false directly in the result.
+      order.push({ key: entry.key, valid: false });
+      continue;
+    }
+    const payload = JSON.stringify(entry.value);
+    const setOpts =
+      entry.opts?.ttlSeconds && entry.opts.ttlSeconds > 0
+        ? { ex: entry.opts.ttlSeconds }
+        : undefined;
+    pipeline.set(`${NAMESPACE}:${normalizedKey}`, payload, setOpts);
+    pipeline.set(`${META_NAMESPACE}:${normalizedKey}`, metaValue, setOpts);
+    order.push({ key: entry.key, valid: true });
+  }
+  const execResults = await pipeline.exec();
+  // execResults is interleaved [payloadResult0, metaResult0, payloadResult1, ...]
+  // for each valid entry. Map back per entry.
+  const results = [];
+  let cursor = 0;
+  for (const o of order) {
+    if (!o.valid) {
+      results.push({ key: o.key, ok: false, error: "invalid key" });
+      continue;
+    }
+    const payloadR = execResults[cursor];
+    const metaR = execResults[cursor + 1];
+    cursor += 2;
+    if (payloadR && metaR && payloadR.ok && metaR.ok) {
+      results.push({ key: o.key, ok: true });
+    } else {
+      const error = payloadR?.error ?? metaR?.error ?? "pipeline result missing";
+      results.push({ key: o.key, ok: false, error: String(error?.message ?? error) });
+    }
+  }
+  return { source: "redis", writtenAt, results };
 }
 
 /**

--- a/scripts/append-star-activity.mjs
+++ b/scripts/append-star-activity.mjs
@@ -22,6 +22,8 @@ import "./_load-env.mjs";
 import {
   writeDataStore,
   readDataStore,
+  readDataStoreMany,
+  writeDataStoreMany,
   closeDataStore,
 } from "./_data-store-write.mjs";
 import { loadTrackedReposFromFiles } from "./_tracked-repos.mjs";
@@ -181,6 +183,137 @@ async function appendOne(fullName, token) {
   return next;
 }
 
+// B.15 Arc 2 — batched append for a chunk of repos.
+//
+// Per-chunk Redis-request budget (against Upstash limits):
+//   1 × MGET                (existing payload reads, N keys)
+//   1 × pipeline.exec()     (2N SETs: payload + meta per entry)
+//   1 × MGET (verify)       (read-back, N keys)
+//   = 3 Upstash requests for N repos (vs. 4N in the sequential loop).
+//
+// At N=100, 2980 repos → 30 chunks × 3 requests = 90 requests for the
+// full run vs. ~11,920 for the per-repo loop.
+//
+// Errors are isolated per repo:
+//   - GitHub fetch fail → repo recorded as failure, others continue
+//   - MGET partial (some null) → bootstrap from null is normal, treated ok
+//   - Pipeline per-entry SET fail → recorded, other entries proceed
+//   - Verify mismatch → recorded as failure
+//
+// Returns: { ok: string[], failed: Array<{ repo: string, reason: string }> }
+async function appendChunk(repos, token) {
+  if (!Array.isArray(repos) || repos.length === 0) {
+    return { ok: [], failed: [] };
+  }
+  const ok = [];
+  const failed = [];
+  const slugs = repos.map(payloadSlug);
+
+  // Phase 1 — batched read of existing payloads (1 Upstash request).
+  let existings;
+  try {
+    existings = await readDataStoreMany(slugs);
+  } catch (err) {
+    // Treat as full-chunk MGET failure — fall back to bootstrap-from-null
+    // for every repo. The write/verify path is still tried so the next
+    // run has fresh state.
+    console.warn(`[chunk] MGET failed (${err?.message ?? err}); bootstrapping null`);
+    existings = repos.map(() => null);
+  }
+
+  // Phase 2 — parallel GitHub fetches. Each call is independent + token-pooled
+  // upstream. Promise.allSettled so one 5xx doesn't kill the chunk.
+  const fetchSettled = await Promise.allSettled(
+    repos.map((fullName) => fetchCurrentStars(fullName, token)),
+  );
+
+  // Phase 3 — build new payloads from (existing, currentStars).
+  const newPayloads = new Array(repos.length).fill(null);
+  for (let i = 0; i < repos.length; i += 1) {
+    const fullName = repos[i];
+    const settle = fetchSettled[i];
+    if (settle.status !== "fulfilled") {
+      failed.push({ repo: fullName, reason: `fetchCurrentStars: ${settle.reason?.message ?? settle.reason}` });
+      continue;
+    }
+    const currentStars = settle.value;
+    const existing = existings[i];
+    const next = appendToday(
+      existing && typeof existing === "object"
+        ? { ...existing, repoId: fullName }
+        : null,
+      currentStars,
+    );
+    next.repoId = fullName;
+    newPayloads[i] = next;
+  }
+
+  // Phase 4 — batched write via pipeline.exec (1 Upstash request).
+  const entriesToWrite = [];
+  const entryIndexByKey = new Map();
+  for (let i = 0; i < repos.length; i += 1) {
+    if (newPayloads[i] === null) continue;
+    const slug = slugs[i];
+    entriesToWrite.push({ key: slug, value: newPayloads[i] });
+    entryIndexByKey.set(slug, i);
+  }
+  if (entriesToWrite.length === 0) {
+    return { ok, failed };
+  }
+
+  let writeResult;
+  try {
+    writeResult = await writeDataStoreMany(entriesToWrite, { stampPerRecord: false });
+  } catch (err) {
+    // Full pipeline failure — record everyone in the chunk as failed.
+    for (const e of entriesToWrite) {
+      failed.push({ repo: repos[entryIndexByKey.get(e.key)], reason: `pipeline: ${err?.message ?? err}` });
+    }
+    return { ok, failed };
+  }
+  if (writeResult.source !== "redis") {
+    for (const e of entriesToWrite) {
+      failed.push({ repo: repos[entryIndexByKey.get(e.key)], reason: "data-store write skipped" });
+    }
+    return { ok, failed };
+  }
+
+  // Phase 5 — batched read-back verify (1 Upstash request).
+  const verifySlugs = entriesToWrite.map((e) => e.key);
+  let readBacks;
+  try {
+    readBacks = await readDataStoreMany(verifySlugs);
+  } catch (err) {
+    // Verify failure ≠ write failure — log soft + still count writes as ok.
+    console.warn(`[chunk] readback MGET failed (${err?.message ?? err}); skipping per-entry verify`);
+    readBacks = entriesToWrite.map(() => undefined);
+  }
+
+  for (let i = 0; i < entriesToWrite.length; i += 1) {
+    const entry = entriesToWrite[i];
+    const expected = entry.value;
+    const fullName = repos[entryIndexByKey.get(entry.key)];
+    const writeStatus = writeResult.results[i];
+    if (!writeStatus?.ok) {
+      failed.push({ repo: fullName, reason: `write: ${writeStatus?.error ?? "unknown"}` });
+      continue;
+    }
+    // If we couldn't verify (MGET failed), trust the pipeline SET success.
+    if (readBacks[i] === undefined) {
+      ok.push(fullName);
+      continue;
+    }
+    try {
+      assertReadBackMatches(entry.key, expected, readBacks[i]);
+      ok.push(fullName);
+    } catch (err) {
+      failed.push({ repo: fullName, reason: `verify: ${err?.message ?? err}` });
+    }
+  }
+
+  return { ok, failed };
+}
+
 async function main() {
   const args = parseArgs();
   assertWritableDataStoreEnv();
@@ -206,18 +339,29 @@ async function main() {
 
   console.log(`[append-star-activity] appending today's point for ${repos.length} repos`);
 
+  // B.15 Arc 2 — chunked batched append. Default N=100 keeps each pipeline
+  // payload + MGET response well under Upstash's 10MB-per-response limit
+  // (~30KB per star-activity payload × 100 = ~3MB worst case).
+  const CHUNK_SIZE = Number(process.env.APPEND_STAR_ACTIVITY_CHUNK_SIZE) || 100;
   let ok = 0;
   let failed = 0;
-  for (const fullName of repos) {
-    try {
-      const next = await appendOne(fullName, token);
-      console.log(
-        `[ok] ${fullName} points=${next.points.length} latest=${next.points[next.points.length - 1].s}`,
-      );
+  for (let start = 0; start < repos.length; start += CHUNK_SIZE) {
+    const chunk = repos.slice(start, start + CHUNK_SIZE);
+    const chunkIdx = Math.floor(start / CHUNK_SIZE) + 1;
+    const chunkTotal = Math.ceil(repos.length / CHUNK_SIZE);
+    console.log(
+      `[chunk ${chunkIdx}/${chunkTotal}] processing ${chunk.length} repos (start=${start})`,
+    );
+    const result = await appendChunk(chunk, token);
+    for (const repo of result.ok) {
       ok += 1;
-    } catch (err) {
+      // One-line per-success log preserved for parity with the legacy loop —
+      // operators piping output to grep still get a `[ok] <name>` row.
+      console.log(`[ok] ${repo}`);
+    }
+    for (const fail of result.failed) {
       failed += 1;
-      console.error(`[fail] ${fullName}: ${err?.message ?? err}`);
+      console.error(`[fail] ${fail.repo}: ${fail.reason}`);
     }
   }
 

--- a/scripts/backfill-star-activity.mjs
+++ b/scripts/backfill-star-activity.mjs
@@ -25,6 +25,7 @@ import "./_load-env.mjs";
 import {
   writeDataStore,
   readDataStore,
+  readDataStoreMany,
   closeDataStore,
 } from "./_data-store-write.mjs";
 import { loadTrackedReposFromFiles } from "./_tracked-repos.mjs";
@@ -330,6 +331,37 @@ async function main() {
     `[backfill-star-activity] starting (${repos.length} repos, dry-run=${args.dryRun}, skip-existing=${args.skipExisting})`,
   );
 
+  // B.15 Arc 2 extension — when --skip-existing is on, pre-load every repo's
+  // existing payload via batched MGET at startup instead of doing N
+  // per-repo readDataStore calls inside the main loop. For 2,980 repos this
+  // turns ~2,980 GETs into ~30 MGET pipeline calls (one per chunk of 100)
+  // = 99% Upstash request reduction on the skip-check path. The per-repo
+  // write at end-of-walk stays sequential (each follows a 30s-5min GitHub
+  // walk; batching saves negligibly there).
+  const existingBySlug = new Map();
+  if (args.skipExisting) {
+    const CHUNK = 100;
+    const slugs = repos.map((fullName) => payloadSlug(fullName));
+    console.log(
+      `[backfill-star-activity] pre-loading ${slugs.length} existing payloads via MGET (chunks of ${CHUNK})`,
+    );
+    for (let start = 0; start < slugs.length; start += CHUNK) {
+      const slugChunk = slugs.slice(start, start + CHUNK);
+      try {
+        const values = await readDataStoreMany(slugChunk);
+        for (let i = 0; i < slugChunk.length; i += 1) {
+          existingBySlug.set(slugChunk[i], values[i]);
+        }
+      } catch (err) {
+        // Don't abort backfill on MGET failure — fall back to the original
+        // per-repo readDataStore for any unresolved slug below.
+        console.warn(
+          `[backfill-star-activity] MGET chunk start=${start} failed (${err?.message ?? err}); will fall back per-repo`,
+        );
+      }
+    }
+  }
+
   const startedAt = Date.now();
   let ok = 0;
   let skipped = 0;
@@ -340,9 +372,15 @@ async function main() {
     try {
       // Resume support — if the repo already has a real backfilled payload
       // (>0 points OR explicitly snapshot-only), skip the API walk. The
-      // operator can force a re-walk by omitting --skip-existing.
+      // operator can force a re-walk by omitting --skip-existing. Lookup
+      // hits the pre-loaded MGET map first; falls back to per-repo readDataStore
+      // when the slug wasn't in any successful chunk.
       if (args.skipExisting) {
-        const existing = await readDataStore(payloadSlug(fullName));
+        const slug = payloadSlug(fullName);
+        let existing = existingBySlug.get(slug);
+        if (existing === undefined) {
+          existing = await readDataStore(slug);
+        }
         if (
           existing &&
           typeof existing === "object" &&


### PR DESCRIPTION
## Summary

Stacks on the B.15 Arc 2 PR. When `--skip-existing` is on, pre-load all repos' existing payloads via batched `MGET` at startup instead of doing N per-repo `readDataStore` calls inside the main loop.

## Impact

For 2,980 tracked repos this turns **~2,980 individual GETs into ~30 MGET pipeline calls** (chunks of 100) = **99% Upstash request reduction** on the skip-check path.

Each `pipeline.exec()` / `MGET` counts as ONE Upstash request regardless of N sub-commands.

## Why this matters

Backfill is rarely run (manual operation; spike-load behavior) so this isn't a daily-savings issue — but when backfill DOES run, it currently bursts thousands of Redis reads upfront in series. Post-this-PR, that burst becomes 30 batched calls.

## Implementation notes

- Per-chunk `MGET` failure falls back to per-repo `readDataStore` (so a transient network blip on chunk 5 doesn't kill the whole 30-chunk preload)
- Per-repo write path (`writeAndVerifyStarActivity`, called after the 30s–5min GitHub walk) stays **sequential** — batching the writes there saves negligibly since the GitHub walk dominates wall time anyway, and per-repo error isolation is critical for backfill
- Depends on the `readDataStoreMany` helper introduced in the Arc 2 PR (`feat/b15-arc2-star-activity-mset`)

## ⚠️ Merge order (R.21 recipe)

**Merge order matters**:
1. Merge **Arc 2 PR FIRST** (this PR's dependency for `readDataStoreMany`)
2. Then rebase this PR onto `main`
3. Then merge this PR

## ⚠️ Rebase needed

This branch is **5 commits behind** `main`.

## Test plan

- [x] `node --check` passes on the modified script
- [ ] Merge Arc 2 first
- [ ] Rebase this PR onto main
- [ ] Manual test: `node scripts/backfill-star-activity.mjs --skip-existing --dry-run --repos vercel/next.js` — confirm MGET batching active

🤖 Generated with [Claude Code](https://claude.com/claude-code)