### PR TITLE
Fix live repo fallback telemetry latency

### DIFF
--- a/src/app/api/internal/github/live-repo/route.ts
+++ b/src/app/api/internal/github/live-repo/route.ts
@@ -8,7 +8,7 @@
 //   Cold misses on /repo/[owner]/[name] used to block page TTFB on a full
 //   GitHub API roundtrip. Extracting the live fetch into its own internal
 //   API gives the upstream call its own CDN cache (independent of the page's
-//   ISR cache) and lets us bound the GitHub roundtrip with a 1.5s timeout —
+//   ISR cache) and lets us bound the GitHub roundtrip with a 4s timeout —
 //   if GitHub is slow or rate-limited, the page falls through to notFound()
 //   instead of stalling for 10+ seconds.
 

--- a/src/app/repo/[owner]/[name]/page.tsx
+++ b/src/app/repo/[owner]/[name]/page.tsx
@@ -26,7 +26,7 @@
 //
 // Cold-miss path (repo not in our derived set): we call the shared bounded
 // live GitHub resolver used by /api/internal/github/live-repo. It keeps the
-// same Redis cache and 1.5s upstream timeout without self-fetching the app
+// same Redis cache and bounded upstream timeout without self-fetching the app
 // through a guessed host/port.
 
 import { notFound } from "next/navigation";
@@ -219,7 +219,7 @@ export default async function RepoDetailPage({ params }: PageProps) {
   // yet) and surface a "tracking started" banner so users understand why
   // every chip is empty.
   //
-  // The internal API has its own SWR cache (300s/3600s) and a 1.5s upstream
+  // The internal API has its own SWR cache (300s/3600s) and a bounded upstream
   // timeout — page TTFB is no longer hostage to GitHub's latency.
   let resolvedInput: Awaited<ReturnType<typeof resolveRepoProfileInput>> | null =
     null;

--- a/src/lib/__tests__/github-live.test.ts
+++ b/src/lib/__tests__/github-live.test.ts
@@ -88,4 +88,41 @@ test("live-repo fetch passes cache hints that keep the ISR page renderable", asy
     /next:\s*\{\s*revalidate:\s*\d+/,
     "next.revalidate must be set so the fetch participates in Next data cache",
   );
+  assert.match(
+    callSite,
+    /awaitTelemetry:\s*false/,
+    "live-repo fetch must not wait on Redis telemetry before returning GitHub data",
+  );
+});
+
+test("live-repo cache access is bounded best-effort", async () => {
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const src = await fs.readFile(
+    path.resolve(here, "..", "github-live.ts"),
+    "utf8",
+  );
+
+  assert.match(
+    src,
+    /LIVE_REPO_CACHE_READ_TIMEOUT_MS\s*=\s*250/,
+    "cache read must be bounded below the live upstream budget",
+  );
+  assert.match(
+    src,
+    /LIVE_REPO_CACHE_WRITE_TIMEOUT_MS\s*=\s*250/,
+    "cache write must be bounded below the live upstream budget",
+  );
+  assert.match(
+    src,
+    /withTimeout\(\s*store\.read<Repo>\(cacheKey\)/,
+    "live-repo Redis cache read must be guarded by withTimeout",
+  );
+  assert.match(
+    src,
+    /void withTimeout\(\s*store\.write\(cacheKey, repo/,
+    "live-repo Redis cache write must not block the response",
+  );
 });

--- a/src/lib/__tests__/github-telemetry.test.ts
+++ b/src/lib/__tests__/github-telemetry.test.ts
@@ -68,6 +68,12 @@ class FakeRedis {
   }
 }
 
+class HangingTelemetryRedis extends FakeRedis {
+  async hincrby(): Promise<number> {
+    return new Promise(() => undefined);
+  }
+}
+
 afterEach(() => {
   _setRedisForTests(null);
   _resetGithubFetchSentryForTests();
@@ -216,6 +222,37 @@ test("githubFetch records usage telemetry for a successful response", async () =
   assert.equal(hash.requests, "1");
   assert.equal(hash.success, "1");
   assert.equal(hash.lastOperation, "rate_limit");
+});
+
+test("githubFetch can return before Redis telemetry settles", async () => {
+  const pool = new FakePool();
+  _setRedisForTests(new HangingTelemetryRedis());
+  globalThis.fetch = (async () =>
+    new Response("{}", {
+      status: 200,
+      headers: {
+        "x-ratelimit-remaining": "4998",
+        "x-ratelimit-reset": "1800000000",
+      },
+    })) as typeof fetch;
+
+  const result = await Promise.race([
+    githubFetch("/rate_limit", {
+      pool,
+      operation: "rate_limit",
+      awaitTelemetry: false,
+    }),
+    new Promise<"timeout">((resolve) =>
+      setTimeout(() => resolve("timeout"), 100),
+    ),
+  ]);
+
+  assert.notEqual(result, "timeout");
+  const fetchResult = result as Awaited<ReturnType<typeof githubFetch>>;
+  assert.equal(fetchResult?.response.status, 200);
+  assert.deepEqual(pool.rateLimitRecords, [
+    { remaining: 4998, resetUnixSec: 1_800_000_000 },
+  ]);
 });
 
 test("githubFetch quarantines invalid tokens by fingerprint after 401", async () => {

--- a/src/lib/github-fetch.ts
+++ b/src/lib/github-fetch.ts
@@ -76,6 +76,12 @@ export interface GithubFetchOptions {
   signal?: AbortSignal;
   /** Logical operation name for Redis pool telemetry. */
   operation?: string;
+  /**
+   * Whether Redis-backed telemetry must complete before returning.
+   * Defaults to true for collectors/admin calls. Latency-sensitive page
+   * fallbacks can set this false so telemetry remains best-effort.
+   */
+  awaitTelemetry?: boolean;
 }
 
 export interface GithubFetchResult {
@@ -102,6 +108,7 @@ export async function githubFetch(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const method = options.method ?? "GET";
   const operation = options.operation ?? operationFromPath(pathOrUrl, method);
+  const awaitTelemetry = options.awaitTelemetry ?? true;
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     let token: string | null = null;
@@ -164,15 +171,18 @@ export async function githubFetch(
       });
     } catch (err) {
       clearTimeout(timer);
-      await recordGithubCall({
-        keyFingerprint: githubKeyFingerprint(token),
-        statusCode: 0,
-        rateLimitRemaining: null,
-        rateLimitReset: null,
-        responseTimeMs: Date.now() - startedAt,
-        operation,
-        success: false,
-      });
+      await recordGithubCallForFetch(
+        {
+          keyFingerprint: githubKeyFingerprint(token),
+          statusCode: 0,
+          rateLimitRemaining: null,
+          rateLimitReset: null,
+          responseTimeMs: Date.now() - startedAt,
+          operation,
+          success: false,
+        },
+        awaitTelemetry,
+      );
       if (attempt < MAX_ATTEMPTS - 1) {
         await sleep(RETRY_DELAYS_MS[attempt] ?? RETRY_DELAYS_MS.at(-1)!);
         continue;
@@ -202,15 +212,18 @@ export async function githubFetch(
     if (token && headerLimits) {
       pool.recordRateLimit(token, headerLimits.remaining, headerLimits.resetUnixSec);
     }
-    await recordGithubCall({
-      keyFingerprint: githubKeyFingerprint(token),
-      statusCode: res.status,
-      rateLimitRemaining: headerLimits?.remaining ?? null,
-      rateLimitReset: headerLimits?.resetUnixSec ?? null,
-      responseTimeMs: Date.now() - startedAt,
-      operation,
-      success: res.ok,
-    });
+    await recordGithubCallForFetch(
+      {
+        keyFingerprint: githubKeyFingerprint(token),
+        statusCode: res.status,
+        rateLimitRemaining: headerLimits?.remaining ?? null,
+        rateLimitReset: headerLimits?.resetUnixSec ?? null,
+        responseTimeMs: Date.now() - startedAt,
+        operation,
+        success: res.ok,
+      },
+      awaitTelemetry,
+    );
 
     // 401 → token is invalid; quarantine and retry with a different PAT.
     if (res.status === 401 && token) {
@@ -340,6 +353,18 @@ export async function githubFetch(
   }
 
   return null;
+}
+
+async function recordGithubCallForFetch(
+  params: Parameters<typeof recordGithubCall>[0],
+  awaitTelemetry: boolean,
+): Promise<void> {
+  const telemetry = recordGithubCall(params);
+  if (awaitTelemetry) {
+    await telemetry;
+  } else {
+    void telemetry;
+  }
 }
 
 function operationFromPath(pathOrUrl: string, method: string): string {

--- a/src/lib/github-live.ts
+++ b/src/lib/github-live.ts
@@ -20,7 +20,10 @@ import { githubFetch } from "./github-fetch";
 
 const LIVE_REPO_KEY_PREFIX = "ss:live-repo:v1:";
 const LIVE_REPO_TTL_SECONDS = 60 * 60; // 1h
-export const LIVE_REPO_UPSTREAM_TIMEOUT_MS = 1500;
+export const LIVE_REPO_UPSTREAM_TIMEOUT_MS = 4000;
+const LIVE_REPO_GITHUB_TIMEOUT_MS = 3500;
+const LIVE_REPO_CACHE_READ_TIMEOUT_MS = 250;
+const LIVE_REPO_CACHE_WRITE_TIMEOUT_MS = 250;
 
 interface GitHubRepoApiResponse {
   full_name: string;
@@ -69,6 +72,8 @@ async function fetchFromGitHub(
       operation: "live-repo-fetch",
       cache: "force-cache",
       next: { revalidate: 3600 },
+      timeoutMs: LIVE_REPO_GITHUB_TIMEOUT_MS,
+      awaitTelemetry: false,
     });
   } catch (err) {
     console.error("[github-live] fetch failed", owner, name, err);
@@ -164,19 +169,25 @@ export async function fetchGitHubRepoLive(
   const { getDataStore } = await import("./data-store");
   const store = getDataStore();
   try {
-    const cached = await store.read<Repo>(cacheKey);
+    const cached = await withTimeout(
+      store.read<Repo>(cacheKey),
+      LIVE_REPO_CACHE_READ_TIMEOUT_MS,
+      "github-live cache read",
+    );
     if (cached.data && cached.source !== "missing") return cached.data;
   } catch (err) {
-    console.warn("[github-live] cache read failed", err);
+    console.warn("[github-live] cache read skipped", err);
   }
   const gh = await fetchFromGitHub(owner, name);
   if (!gh) return null;
   const repo = synthesizeRepoFromGitHub(gh);
-  try {
-    await store.write(cacheKey, repo, { ttlSeconds: LIVE_REPO_TTL_SECONDS });
-  } catch (err) {
-    console.warn("[github-live] cache write failed", err);
-  }
+  void withTimeout(
+    store.write(cacheKey, repo, { ttlSeconds: LIVE_REPO_TTL_SECONDS }),
+    LIVE_REPO_CACHE_WRITE_TIMEOUT_MS,
+    "github-live cache write",
+  ).catch((err) => {
+    console.warn("[github-live] cache write skipped", err);
+  });
   return repo;
 }
 
@@ -197,6 +208,27 @@ export async function fetchGitHubRepoLiveWithinBudget(
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(
           () => reject(new Error("github-live timeout")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`${label} timeout`)),
           timeoutMs,
         );
       }),


### PR DESCRIPTION
## Summary
- keep the live GitHub repo fallback from waiting on Redis-backed telemetry before returning GitHub data
- bound live repo Redis cache read/write as best-effort so slow Redis cannot consume the page/API upstream budget
- update the internal route/page comments and add regression coverage for non-blocking telemetry + bounded cache access

## Validation
- `git diff --check`
- `npx tsx --test src/lib/__tests__/github-live.test.ts`
- `npx tsx --test src/lib/__tests__/github-telemetry.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/pipeline/__tests__/canonical-profile-endpoint.test.ts`
- `npm run lint:guards`
- `npm test` (1228 passed)
- `npm run build`
- clean-worktree gitleaks Docker scan: no leaks found