### PR TITLE
Fix local /you dashboard auth policy

### DIFF
--- a/src/lib/__tests__/middleware-route-policy.test.ts
+++ b/src/lib/__tests__/middleware-route-policy.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { join } from "node:path";
+
+const middlewareSource = readFileSync(
+  join(process.cwd(), "src", "middleware.ts"),
+  "utf8",
+);
+
+test("middleware keeps /you public while protecting account-backed subroutes", () => {
+  const matcher = middlewareSource.match(
+    /const isProtectedRoute = createRouteMatcher\(\[([\s\S]*?)\]\);/,
+  );
+  assert.ok(matcher, "expected protected route matcher in middleware");
+
+  const body = matcher[1] ?? "";
+  assert.doesNotMatch(
+    body,
+    /["']\/you\(\.\*\)["']/,
+    "/you must remain public because it renders localStorage-backed state",
+  );
+  assert.match(body, /["']\/you\/alerts\(\.\*\)["']/);
+  assert.match(body, /["']\/you\/refer\(\.\*\)["']/);
+  assert.match(body, /["']\/api\/me\/\(\.\*\)["']/);
+});

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -52,7 +52,7 @@ export async function getUser(): Promise<LoadedUser | null> {
 
 /**
  * Throws (via redirect) when not signed-in. Use in routes that should
- * never render anonymously: `/you/*`, `/api/me/*`.
+ * never render anonymously: `/you/alerts`, `/you/refer`, `/api/me/*`.
  */
 export async function requireUser(): Promise<LoadedUser> {
   const loaded = await getUser();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,10 +39,12 @@ const AGENT_COMMERCE_COST_GUARD_IPS = new Set([
 ]);
 const AGENT_COMMERCE_COST_GUARD_IPV6_PREFIXES = ["2a03:2880:f806:"];
 
-// Routes that require an authenticated Clerk session. Hitting these
-// signed-out triggers Clerk's redirect to /sign-in.
+// Routes that require an authenticated Clerk session. Keep `/you` itself
+// public: it is the local-storage dashboard for signed-out users. Only the
+// account-backed subroutes and `/api/me/*` require Clerk.
 const isProtectedRoute = createRouteMatcher([
-  "/you(.*)",
+  "/you/alerts(.*)",
+  "/you/refer(.*)",
   "/api/me/(.*)",
 ]);
 


### PR DESCRIPTION
## Summary
- keep `/you` public so signed-out users can use the localStorage dashboard
- keep `/you/alerts`, `/you/refer`, and `/api/me/*` protected behind Clerk
- add regression coverage for the middleware route policy

## Validation
- `git diff --check`
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/middleware-route-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint:guards`
- `npm run build`
- local production probe on `127.0.0.1:13024`: `/you` 200; `/you/alerts`, `/you/refer`, `/api/me/profile` redirect to sign-in
- `npm test` (1229 passed)
- clean-worktree gitleaks Docker scan: no leaks found