### PR TITLE
Fix Clerk middleware on public pages

### DIFF
--- a/src/lib/__tests__/middleware-route-policy.test.ts
+++ b/src/lib/__tests__/middleware-route-policy.test.ts
@@ -24,3 +24,19 @@ test("middleware keeps /you public while protecting account-backed subroutes", (
   assert.match(body, /["']\/you\/refer\(\.\*\)["']/);
   assert.match(body, /["']\/api\/me\/\(\.\*\)["']/);
 });
+
+test("middleware only runs Clerk for protected routes", () => {
+  assert.doesNotMatch(
+    middlewareSource,
+    /export default getClerkPublishableKey\(\)\s*\?/,
+    "public pages must not be globally wrapped by Clerk middleware",
+  );
+  assert.match(
+    middlewareSource,
+    /if\s*\(isProtectedRoute\(req\)\)\s*\{[\s\S]*?return middlewareWithClerk\(req, event\);/,
+  );
+  assert.match(
+    middlewareSource,
+    /return middlewareForPublicRoutes\(req\);/,
+  );
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,7 +19,7 @@
 // only set when not already present — first-touch wins, last-touch loses.
 
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
 
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import { signRefCookie } from "@/lib/referrals/cookie";
@@ -167,6 +167,20 @@ async function middlewareWithoutClerk(
   return res;
 }
 
+async function middlewareForPublicRoutes(
+  req: NextRequest,
+): Promise<NextResponse | undefined> {
+  const url = req.nextUrl;
+  if (isBypassed(url.pathname)) return;
+  if (isAgentCommerceCostGuardPath(url.pathname) && isCostGuardCrawler(req)) {
+    return crawlerCostGuardResponse();
+  }
+
+  const res = NextResponse.next();
+  await setRefCookieIfNeeded(req, res);
+  return res;
+}
+
 const middlewareWithClerk = clerkMiddleware(async (auth, req) => {
   const url = req.nextUrl;
 
@@ -192,9 +206,17 @@ const middlewareWithClerk = clerkMiddleware(async (auth, req) => {
   return res;
 });
 
-export default getClerkPublishableKey()
-  ? middlewareWithClerk
-  : middlewareWithoutClerk;
+export default function middleware(req: NextRequest, event: NextFetchEvent) {
+  if (!getClerkPublishableKey()) {
+    return middlewareWithoutClerk(req);
+  }
+
+  if (isProtectedRoute(req)) {
+    return middlewareWithClerk(req, event);
+  }
+
+  return middlewareForPublicRoutes(req);
+}
 
 export const config = {
   // Default Clerk matcher — exclude Next internals + static files. Same


### PR DESCRIPTION
## Summary
- avoid wrapping public pages in Clerk middleware so anonymous HTML requests do not bounce through Clerk handshake
- keep Clerk middleware for `/you/alerts`, `/you/refer`, and `/api/me/*`
- preserve referral-cookie attribution and crawler cost guard on public traffic
- add regression coverage so the middleware cannot go back to a global Clerk export

## Validation
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/middleware-route-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- src/middleware.ts src/lib/__tests__/middleware-route-policy.test.ts`
- `npm run lint:guards`
- `npm run build`
- local production probe on `127.0.0.1:13025`: public pages `/`, `/you`, `/compare`, `/signals`, `/search`, `/pricing`, `/sign-in`, `/sign-up` returned 200; protected `/you/alerts` and `/api/me/profile` redirected to sign-in when Clerk env is absent
- `npm test` (1230 passed)
- clean-worktree gitleaks Docker scan: no leaks found