### PR TITLE
Fix duplicate Clerk provider on auth pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { ClerkProvider } from "@clerk/nextjs";
 import { Suspense } from "react";
 // Trimmed to 3 actively-rendered fonts (Geist sans, Geist Mono, Space
 // Grotesk display). Inter and JetBrains Mono lived only as CSS-fallback
@@ -20,7 +21,9 @@ import { AppShell } from "@/components/layout/AppShell";
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/layout/Sidebar";
 import ClerkRefHandoff from "@/components/auth/ClerkRefHandoff";
+import { clerkAppearance } from "@/lib/auth/clerk-appearance";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
+import { buildAuthHref } from "@/lib/auth/redirect-url";
 import {
   getPublicSidebarShell,
   type SidebarShellResponse,
@@ -176,6 +179,28 @@ export default async function RootLayout({
     initialSidebarShell = null;
   }
   const clerkPublishableKey = getClerkPublishableKey();
+  const appChrome = (
+    <>
+      <IdleMount>
+        <ClerkRefHandoff />
+      </IdleMount>
+      <Header clerkPublishableKey={clerkPublishableKey} />
+      <MobileDrawerLazy />
+      <AppShell>
+        <Sidebar initialShell={initialSidebarShell} />
+        <main id="main-content" className="app-main">{children}</main>
+      </AppShell>
+      <SidebarUserOverlayBridge />
+      <MobileNavLazy />
+      <IdleMount>
+        <BrowserAlertBridgeLazy />
+      </IdleMount>
+      <IdleMount>
+        <GlobalShortcutsLazy />
+      </IdleMount>
+      <ToasterLazy />
+    </>
+  );
 
   return (
     <html
@@ -234,29 +259,19 @@ export default async function RootLayout({
           <PostHogIdentifyBridge />
           <StoreProvider>
             <DesignSystemProvider>
-              <IdleMount>
-                <ClerkRefHandoff />
-              </IdleMount>
-              <Header clerkPublishableKey={clerkPublishableKey} />
-              <MobileDrawerLazy />
-              <AppShell>
-                <Sidebar initialShell={initialSidebarShell} />
-                <main id="main-content" className="app-main">{children}</main>
-              </AppShell>
-              {/*
-                Mounted unconditionally — the bridge is smart enough to
-                render nothing for anonymous viewers and only fires the
-                overlay fetch once a Clerk session resolves.
-              */}
-              <SidebarUserOverlayBridge />
-              <MobileNavLazy />
-              <IdleMount>
-                <BrowserAlertBridgeLazy />
-              </IdleMount>
-              <IdleMount>
-                <GlobalShortcutsLazy />
-              </IdleMount>
-              <ToasterLazy />
+              {clerkPublishableKey ? (
+                <ClerkProvider
+                  publishableKey={clerkPublishableKey}
+                  appearance={clerkAppearance}
+                  signInUrl={buildAuthHref("/sign-in", "/you")}
+                  signUpUrl={buildAuthHref("/sign-up", "/you")}
+                  afterSignOutUrl="/"
+                >
+                  {appChrome}
+                </ClerkProvider>
+              ) : (
+                appChrome
+              )}
             </DesignSystemProvider>
           </StoreProvider>
         </PostHogProvider>

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,19 +1,18 @@
-// Clerk hosted sign-in page — full-page, branded.
+// Clerk hosted sign-in page: full-page, branded.
 //
 // Catch-all route: covers /sign-in, /sign-in/factor-one, /sign-in/sso-callback, etc.
 // Required by Clerk's <SignIn /> component when used as a hosted page (vs modal).
 //
 // Why a hosted page in addition to the modal:
-//   • Better SEO landing experience (Google can index /sign-in)
-//   • Cleaner deep-link target for the header CTA — /sign-in?redirect_url=/u/foo
-//   • Required for /sign-up to function as a route (paired)
+//   - Better SEO landing experience (Google can index /sign-in)
+//   - Cleaner deep-link target for the header CTA: /sign-in?redirect_url=/u/foo
+//   - Required for /sign-up to function as a route (paired)
 //
 // The modal-based <SignInButton mode="modal" /> still works elsewhere; this
 // just gives operators a route-based fallback.
 
-import { ClerkProvider } from "@clerk/nextjs";
+import { AuthUnavailable } from "@/components/auth/AuthUnavailable";
 import { ClerkAuthForm } from "@/components/auth/ClerkAuthForm";
-import { clerkAppearance } from "@/lib/auth/clerk-appearance";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import {
   buildAuthHref,
@@ -39,30 +38,14 @@ export default async function Page({ searchParams }: SignInPageProps) {
   return (
     <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
       {clerkPublishableKey ? (
-        <ClerkProvider
-          publishableKey={clerkPublishableKey}
-          appearance={clerkAppearance}
-        >
-          <ClerkAuthForm
-            mode="sign-in"
-            signUpUrl={signUpUrl}
-            fallbackRedirectUrl={redirectUrl}
-          />
-        </ClerkProvider>
+        <ClerkAuthForm
+          mode="sign-in"
+          signUpUrl={signUpUrl}
+          fallbackRedirectUrl={redirectUrl}
+        />
       ) : (
         <AuthUnavailable action="sign in" />
       )}
-    </div>
-  );
-}
-
-function AuthUnavailable({ action }: { action: string }) {
-  return (
-    <div className="max-w-md rounded border border-white/10 bg-black/30 p-6 text-center">
-      <h1 className="text-lg font-semibold">Auth unavailable</h1>
-      <p className="mt-2 text-sm text-white/70">
-        Clerk is not configured for this environment, so {action} is disabled.
-      </p>
     </div>
   );
 }

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,4 +1,4 @@
-// Clerk hosted sign-up page — full-page, branded.
+// Clerk hosted sign-up page: full-page, branded.
 //
 // Catch-all route: covers /sign-up, /sign-up/verify-email-address, etc.
 // Required by Clerk's <SignUp /> component when used as a hosted page.
@@ -15,9 +15,8 @@
 //   `unsafeMetadata` prop. The webhook then credits the signup from
 //   `unsafe_metadata.trRef`.
 
-import { ClerkProvider } from "@clerk/nextjs";
+import { AuthUnavailable } from "@/components/auth/AuthUnavailable";
 import { ClerkAuthForm } from "@/components/auth/ClerkAuthForm";
-import { clerkAppearance } from "@/lib/auth/clerk-appearance";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import {
   buildAuthHref,
@@ -27,7 +26,7 @@ import {
 
 export const metadata = {
   title: "Sign up",
-  description: "Sign up to TrendingRepo — track agents, MCPs, repos",
+  description: "Sign up to TrendingRepo: track agents, MCPs, repos",
 };
 
 interface SignUpPageProps {
@@ -43,30 +42,14 @@ export default async function Page({ searchParams }: SignUpPageProps) {
   return (
     <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
       {clerkPublishableKey ? (
-        <ClerkProvider
-          publishableKey={clerkPublishableKey}
-          appearance={clerkAppearance}
-        >
-          <ClerkAuthForm
-            mode="sign-up"
-            signInUrl={signInUrl}
-            fallbackRedirectUrl={redirectUrl}
-          />
-        </ClerkProvider>
+        <ClerkAuthForm
+          mode="sign-up"
+          signInUrl={signInUrl}
+          fallbackRedirectUrl={redirectUrl}
+        />
       ) : (
         <AuthUnavailable action="sign up" />
       )}
-    </div>
-  );
-}
-
-function AuthUnavailable({ action }: { action: string }) {
-  return (
-    <div className="max-w-md rounded border border-white/10 bg-black/30 p-6 text-center">
-      <h1 className="text-lg font-semibold">Auth unavailable</h1>
-      <p className="mt-2 text-sm text-white/70">
-        Clerk is not configured for this environment, so {action} is disabled.
-      </p>
     </div>
   );
 }

--- a/src/components/auth/AuthUnavailable.tsx
+++ b/src/components/auth/AuthUnavailable.tsx
@@ -1,0 +1,24 @@
+interface AuthUnavailableProps {
+  action: string;
+}
+
+export function AuthUnavailable({ action }: AuthUnavailableProps) {
+  return (
+    <div
+      className="max-w-md rounded p-6 text-center"
+      style={{
+        background: "var(--v4-bg-050)",
+        border: "1px solid var(--v4-line-200)",
+        color: "var(--v4-ink-100)",
+      }}
+    >
+      <h1 className="text-lg font-semibold">Auth unavailable</h1>
+      <p
+        className="mt-2 text-sm"
+        style={{ color: "var(--v4-ink-300)" }}
+      >
+        Clerk is not configured for this environment, so {action} is disabled.
+      </p>
+    </div>
+  );
+}

--- a/src/components/layout/HeaderAccount.tsx
+++ b/src/components/layout/HeaderAccount.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { ClerkProvider, useUser } from "@clerk/nextjs";
+import { useUser } from "@clerk/nextjs";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
-import { clerkAppearance } from "@/lib/auth/clerk-appearance";
 import { buildAuthHref } from "@/lib/auth/redirect-url";
 
 interface HeaderAccountProps {
@@ -118,15 +117,5 @@ export function HeaderAccount({ publishableKey }: HeaderAccountProps) {
     return <SignedOutAccountLink />;
   }
 
-  return (
-    <ClerkProvider
-      publishableKey={publishableKey}
-      appearance={clerkAppearance}
-      signInUrl={buildAuthHref("/sign-in", "/you")}
-      signUpUrl={buildAuthHref("/sign-up", "/you")}
-      afterSignOutUrl="/"
-    >
-      <HeaderAccountLoaded />
-    </ClerkProvider>
-  );
+  return <HeaderAccountLoaded />;
 }

--- a/src/components/layout/header.css
+++ b/src/components/layout/header.css
@@ -91,17 +91,7 @@
 .btn-drop::after{ content:''; position:absolute; inset:-3px; border:1px dashed rgba(255,107,53,0.35); pointer-events:none; opacity:0; transition:opacity .2s; }
 .btn-drop:hover::after{ opacity:1; }
 
-/* Anonymous-user secondary CTA — quieter than DROP REPO */
-.btn-signin{
-  height:38px; padding:0 14px; display:inline-flex; align-items:center; gap:6px;
-  border:1px solid var(--line-300); background:var(--bg-050); color:var(--ink-200);
-  font-family:var(--mono); font-size:11px; font-weight:600; letter-spacing:0.14em; text-transform:uppercase;
-  text-decoration:none; cursor:pointer;
-  transition: border-color .15s, background .15s, color .15s;
-}
-.btn-signin:hover{ border-color:var(--ink-400); background:var(--bg-100); color:var(--ink-000); }
-
-/* Anonymous-user primary CTA — same chrome as btn-drop */
+/* Anonymous-user account CTA: single entry for sign-in and sign-up. */
 .btn-signup{
   height:38px; padding:0 16px 0 14px; display:flex; align-items:center; gap:8px;
   background:var(--acc); color:#190902; border:1px solid var(--acc-hover);
@@ -175,7 +165,6 @@
     height:15px;
   }
 
-  .btn-signin{ display:none; }
   .btn-signup{
     height:34px;
     padding:0 10px;

--- a/src/lib/__tests__/auth-provider-policy.test.ts
+++ b/src/lib/__tests__/auth-provider-policy.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+function source(path: string): string {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+test("root layout owns the only ClerkProvider", () => {
+  assert.match(
+    source("src/app/layout.tsx"),
+    /import \{ ClerkProvider \} from "@clerk\/nextjs";/,
+  );
+
+  for (const path of [
+    "src/components/layout/HeaderAccount.tsx",
+    "src/app/sign-in/[[...sign-in]]/page.tsx",
+    "src/app/sign-up/[[...sign-up]]/page.tsx",
+  ]) {
+    const body = source(path);
+    assert.doesNotMatch(
+      body,
+      /ClerkProvider/,
+      `${path} must use the root ClerkProvider, not mount its own`,
+    );
+  }
+});

--- a/src/lib/auth/clerk-appearance.ts
+++ b/src/lib/auth/clerk-appearance.ts
@@ -1,6 +1,6 @@
-// Clerk <SignIn /> / <SignUp /> appearance — matches trendingrepo's
-// dark canvas + Liquid Lava accent. Wired through page-local ClerkProvider
-// wrappers so the root layout does not load Clerk on every public page.
+// Clerk <SignIn /> / <SignUp /> appearance: matches trendingrepo's
+// dark canvas + Liquid Lava accent. The root layout owns the single
+// ClerkProvider used by the header account CTA and hosted auth pages.
 //
 // Variables map to Clerk's high-level theme tokens; elements override
 // individual sub-component class names where a token can't reach


### PR DESCRIPTION
## Summary
- move ClerkProvider ownership to the root layout so header account state and hosted auth pages share one provider
- remove page-local and header-local ClerkProvider mounts that caused `/sign-in` and `/sign-up` runtime errors
- share the auth-unavailable fallback card and align it with V4 surface tokens
- remove the unused `.btn-signin` header CSS after consolidating the signed-out header CTA to one Account button
- add a source-policy regression test for single-provider ownership

## Validation
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/middleware-route-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- src/app/layout.tsx src/components/auth/AuthUnavailable.tsx src/components/layout/HeaderAccount.tsx src/app/sign-in/[[...sign-in]]/page.tsx src/app/sign-up/[[...sign-up]]/page.tsx src/lib/auth/clerk-appearance.ts`
- `git diff --check`
- `npm run build`
- local production probe on `127.0.0.1:13026`: `/sign-in`, `/sign-up`, `/`, `/you` returned 200; `/you/alerts` redirected to sign-in when Clerk env is absent
- `npm run lint:guards`
- `npm test` (1231 passed)
- clean-worktree gitleaks Docker scan: no leaks found

## Notes
A Playwright visual pass against production caught the bug before this patch: `/sign-in` and `/sign-up` logged `@clerk/nextjs: You've added multiple <ClerkProvider> components`.