### PR TITLE
Fix sidebar overlay Clerk context

### DIFF
--- a/src/lib/__tests__/middleware-route-policy.test.ts
+++ b/src/lib/__tests__/middleware-route-policy.test.ts
@@ -25,7 +25,7 @@ test("middleware keeps /you public while protecting account-backed subroutes", (
   assert.match(body, /["']\/api\/me\/\(\.\*\)["']/);
 });
 
-test("middleware only runs Clerk for protected routes", () => {
+test("middleware runs Clerk only for protected routes and session-aware APIs", () => {
   assert.doesNotMatch(
     middlewareSource,
     /export default getClerkPublishableKey\(\)\s*\?/,
@@ -33,7 +33,12 @@ test("middleware only runs Clerk for protected routes", () => {
   );
   assert.match(
     middlewareSource,
-    /if\s*\(isProtectedRoute\(req\)\)\s*\{[\s\S]*?return middlewareWithClerk\(req, event\);/,
+    /const isClerkSessionRoute = createRouteMatcher\(\[\s*["']\/api\/pipeline\/sidebar-overlay["'],?\s*\]\);/,
+    "sidebar overlay must run inside Clerk middleware so auth() can return a session or null",
+  );
+  assert.match(
+    middlewareSource,
+    /if\s*\(isProtectedRoute\(req\)\s*\|\|\s*isClerkSessionRoute\(req\)\)\s*\{[\s\S]*?return middlewareWithClerk\(req, event\);/,
   );
   assert.match(
     middlewareSource,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,6 +48,13 @@ const isProtectedRoute = createRouteMatcher([
   "/api/me/(.*)",
 ]);
 
+// Routes that are still public in the product sense, but need Clerk's
+// middleware context so route handlers can call `auth()` and decide their
+// own JSON response shape instead of throwing outside Clerk.
+const isClerkSessionRoute = createRouteMatcher([
+  "/api/pipeline/sidebar-overlay",
+]);
+
 // Routes that should NEVER pass through Clerk's session check — they own
 // their own auth schemes. Clerk's middleware respects publicRoutes by
 // default, but we go further by short-circuiting these before Clerk
@@ -211,7 +218,7 @@ export default function middleware(req: NextRequest, event: NextFetchEvent) {
     return middlewareWithoutClerk(req);
   }
 
-  if (isProtectedRoute(req)) {
+  if (isProtectedRoute(req) || isClerkSessionRoute(req)) {
     return middlewareWithClerk(req, event);
   }
 


### PR DESCRIPTION
## Summary
- route `/api/pipeline/sidebar-overlay` through Clerk middleware context without making all public pages globally Clerk-wrapped
- keep the route's own anonymous JSON `401` behavior instead of production `500` from calling `auth()` outside Clerk middleware
- lock the middleware policy with a static regression test

## Validation
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/middleware-route-policy.test.ts src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- src/middleware.ts src/lib/__tests__/middleware-route-policy.test.ts`
- `git diff --check`
- `npm run build`
- `npm run lint:guards`