### PR TITLE
Keep protected routes on sign-in redirects

### DIFF
--- a/src/lib/__tests__/middleware-route-policy.test.ts
+++ b/src/lib/__tests__/middleware-route-policy.test.ts
@@ -44,4 +44,13 @@ test("middleware runs Clerk only for protected routes and session-aware APIs", (
     middlewareSource,
     /return middlewareForPublicRoutes\(req\);/,
   );
+  assert.doesNotMatch(
+    middlewareSource,
+    /await\s+auth\.protect\(/,
+    "protected routes should use the app redirect instead of Clerk's protect rewrite",
+  );
+  assert.match(
+    middlewareSource,
+    /const session = await auth\(\);[\s\S]*?if \(!session\.userId\) \{[\s\S]*?return redirect;/,
+  );
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -203,11 +203,16 @@ const middlewareWithClerk = clerkMiddleware(async (auth, req) => {
   const res = NextResponse.next();
   await setRefCookieIfNeeded(req, res);
 
-  // 3. Protected routes → Clerk's `auth.protect()` redirects to sign-in
-  //    if no valid session. Returns the same response we built above on
-  //    success, preserving the cookie.
+  // 3. Protected routes use our own redirect instead of `auth.protect()`.
+  //    With Clerk development keys, `auth.protect()` can rewrite signed-out
+  //    product routes to a 404 before users ever reach our sign-in page.
   if (isProtectedRoute(req)) {
-    await auth.protect();
+    const session = await auth();
+    if (!session.userId) {
+      const redirect = redirectToSignIn(req);
+      await setRefCookieIfNeeded(req, redirect);
+      return redirect;
+    }
   }
 
   return res;


### PR DESCRIPTION
## Summary
- replace `await auth.protect()` in middleware with an explicit Clerk session check
- keep signed-out protected routes redirecting to the app's `/sign-in?redirect_url=...` URL instead of Clerk development-key 404 rewrites
- extend middleware policy tests to prevent reintroducing `auth.protect()` for these product routes

## Validation
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/middleware-route-policy.test.ts src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- src/middleware.ts src/lib/__tests__/middleware-route-policy.test.ts`
- `git diff --check`
- `npm run build`
- `npm run lint:guards`