### PR TITLE
Skip sidebar overlay fetch when signed out

### DIFF
--- a/src/components/layout/SidebarUserOverlayBridge.tsx
+++ b/src/components/layout/SidebarUserOverlayBridge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useAuth } from "@clerk/nextjs";
 import { create } from "zustand";
 
 interface SidebarOverlayState {
@@ -33,13 +34,26 @@ export function SidebarUserOverlayBridge() {
 }
 
 function SidebarUserOverlayBridgeInner() {
+  const { isLoaded, userId } = useAuth();
   const setOverlay = useSidebarOverlayStore((s) => s.setOverlay);
   const reset = useSidebarOverlayStore((s) => s.reset);
 
   useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!userId) {
+      reset();
+      return;
+    }
+
     let cancelled = false;
 
-    fetch("/api/pipeline/sidebar-overlay", { credentials: "include" })
+    const params = new URLSearchParams({ userId });
+    fetch(`/api/pipeline/sidebar-overlay?${params.toString()}`, {
+      credentials: "include",
+    })
       .then((response) =>
         response.ok ? (response.json() as Promise<OverlayResponse>) : null,
       )
@@ -58,7 +72,7 @@ function SidebarUserOverlayBridgeInner() {
     return () => {
       cancelled = true;
     };
-  }, [setOverlay, reset]);
+  }, [isLoaded, reset, setOverlay, userId]);
 
   return null;
 }

--- a/src/lib/__tests__/auth-provider-policy.test.ts
+++ b/src/lib/__tests__/auth-provider-policy.test.ts
@@ -26,3 +26,13 @@ test("root layout owns the only ClerkProvider", () => {
     );
   }
 });
+
+test("sidebar user overlay fetch waits for a signed-in Clerk user", () => {
+  const body = source("src/components/layout/SidebarUserOverlayBridge.tsx");
+  assert.match(body, /import \{ useAuth \} from "@clerk\/nextjs";/);
+  assert.match(body, /const \{ isLoaded, userId \} = useAuth\(\);/);
+  assert.match(body, /if \(!isLoaded\) \{\s*return;\s*\}/);
+  assert.match(body, /if \(!userId\) \{[\s\S]*?reset\(\);[\s\S]*?return;\s*\}/);
+  assert.match(body, /new URLSearchParams\(\{ userId \}\)/);
+  assert.match(body, /\/api\/pipeline\/sidebar-overlay\?\$\{params\.toString\(\)\}/);
+});


### PR DESCRIPTION
## Summary
- gate the sidebar user overlay fetch on Clerk `useAuth()` being loaded with a signed-in `userId`
- reset the transient overlay store locally for signed-out viewers instead of making a guaranteed `401` request on every public page
- include `userId` in the overlay request for the route's existing defense-in-depth check
- add a static regression test for the signed-in fetch policy

## Validation
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/middleware-route-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- src/components/layout/SidebarUserOverlayBridge.tsx src/lib/__tests__/auth-provider-policy.test.ts`
- `git diff --check`
- `npm run build`
- `npm run lint:guards`