### PR TITLE
Improve mobile touch targets

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -126,7 +126,7 @@ export default async function PricingPage({ searchParams }: PricingPageProps) {
             <Link
               href="/pricing"
               aria-current={cadence === "monthly" ? "page" : undefined}
-              className={`px-3 py-1.5 ${
+              className={`inline-flex min-h-[36px] items-center px-3 py-1.5 ${
                 cadence === "monthly"
                   ? "bg-brand text-bg-primary"
                   : "text-text-tertiary hover:text-text-primary"
@@ -137,7 +137,7 @@ export default async function PricingPage({ searchParams }: PricingPageProps) {
             <Link
               href="/pricing?cadence=yearly"
               aria-current={cadence === "yearly" ? "page" : undefined}
-              className={`px-3 py-1.5 ${
+              className={`inline-flex min-h-[36px] items-center px-3 py-1.5 ${
                 cadence === "yearly"
                   ? "bg-brand text-bg-primary"
                   : "text-text-tertiary hover:text-text-primary"
@@ -152,7 +152,7 @@ export default async function PricingPage({ searchParams }: PricingPageProps) {
             {cadence}
             {" prices — "}
             <Link
-              className="underline decoration-dotted hover:text-brand"
+              className="inline-flex min-h-[32px] items-center align-middle underline decoration-dotted hover:text-brand"
               href={nextCadence === "yearly" ? "/pricing?cadence=yearly" : "/pricing"}
             >
               switch to {nextCadence}
@@ -200,7 +200,7 @@ export default async function PricingPage({ searchParams }: PricingPageProps) {
             and how private.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
-            <Link href="/" className="v2-btn v2-btn-primary inline-flex">
+            <Link href="/" className="v2-btn v2-btn-primary inline-flex min-h-[40px] items-center">
               START FREE
               <span aria-hidden style={{ marginLeft: 8 }}>→</span>
             </Link>

--- a/src/components/compare/CompareSelector.tsx
+++ b/src/components/compare/CompareSelector.tsx
@@ -275,7 +275,7 @@ export function CompareSelector() {
             type="button"
             onClick={openSearch}
             className={cn(
-              "rounded-badge px-3 py-1.5 border border-dashed border-border-primary",
+              "rounded-badge min-h-[40px] px-3 py-1.5 border border-dashed border-border-primary",
               "flex items-center gap-1.5 text-sm text-text-tertiary",
               "hover:border-text-secondary hover:text-text-secondary transition-colors cursor-pointer",
               isFull() && "opacity-50 pointer-events-none",

--- a/src/components/repo-detail/RepoIdHero.tsx
+++ b/src/components/repo-detail/RepoIdHero.tsx
@@ -345,10 +345,16 @@ export function RepoIdHero({
         }
         .rid-h1 .owner { color: var(--v3-ink-400, rgba(255,255,255,0.55)); font-weight: 400; }
         .rid-ext {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 32px;
+          height: 32px;
           margin-left: 8px;
           color: var(--v3-acc, #ffcb05);
           text-decoration: none;
           font-size: 18px;
+          vertical-align: middle;
         }
         .rid-desc {
           margin: 0;
@@ -504,6 +510,10 @@ function FullChartLinkPlacement({
           padding: 0 4px;
         }
         .rid-deeplink-btn {
+          display: inline-flex;
+          align-items: center;
+          min-height: 32px;
+          padding: 0 2px;
           font-family: var(--font-geist-mono, monospace);
           font-size: 10px;
           letter-spacing: 0.12em;

--- a/src/components/repo-detail/StarHistoryBlock.tsx
+++ b/src/components/repo-detail/StarHistoryBlock.tsx
@@ -298,6 +298,10 @@ export function StarHistoryBlock({ repo }: StarHistoryBlockProps): JSX.Element {
           text-transform: uppercase;
         }
         .shb-full-link {
+          display: inline-flex;
+          align-items: center;
+          min-height: 32px;
+          padding: 0 2px;
           font-family: var(--font-geist-mono, monospace);
           font-size: 10px;
           letter-spacing: 0.12em;
@@ -351,6 +355,10 @@ export function StarHistoryBlock({ repo }: StarHistoryBlockProps): JSX.Element {
           border-radius: 2px;
         }
         .shb-empty a {
+          display: inline-flex;
+          align-items: center;
+          min-height: 32px;
+          padding: 0 2px;
           color: var(--v3-acc, #ffcb05);
           text-transform: uppercase;
           font-size: 10px;


### PR DESCRIPTION
## Summary
- raise compare empty-slot buttons to a stable mobile tap height
- make pricing cadence/switch/CTA links meet mobile touch-target expectations
- expand repo-detail utility links for GitHub and star-history entry points without changing layout structure

## Validation
- `npm run lint -- src/components/compare/CompareSelector.tsx src/app/pricing/page.tsx src/components/repo-detail/RepoIdHero.tsx src/components/repo-detail/StarHistoryBlock.tsx`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run lint:guards`
- `npm run build`