### PR TITLE
Tighten remaining mobile touch targets

### DIFF
--- a/src/app/you/YouClient.tsx
+++ b/src/app/you/YouClient.tsx
@@ -709,6 +709,10 @@ function PanelEmpty({
         <Link
           href={cta}
           style={{
+            display: "inline-flex",
+            alignItems: "center",
+            minHeight: 32,
+            padding: "0 2px",
             color: "var(--v4-acc)",
             textDecoration: "none",
             letterSpacing: "0.08em",
@@ -821,6 +825,9 @@ const textBtnStyle: React.CSSProperties = {
 };
 
 const resetBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  minHeight: 40,
   fontFamily: "var(--font-geist-mono), monospace",
   fontSize: 11,
   padding: "6px 12px",

--- a/src/components/compare/CompareSharePanel.tsx
+++ b/src/components/compare/CompareSharePanel.tsx
@@ -91,11 +91,11 @@ function buildPagePath(state: CompareSharePanelState): string {
 }
 
 const TAB_BUTTON_BASE =
-  "px-3 py-1.5 text-[10px] font-mono uppercase tracking-[0.14em] transition-colors";
+  "inline-flex min-h-[36px] items-center px-3 py-1.5 text-[10px] font-mono uppercase tracking-[0.14em] transition-colors";
 const ROW_BASE =
-  "flex items-center justify-between gap-3 px-3 py-2.5 rounded-[3px] border border-border-primary bg-bg-secondary hover:bg-bg-tertiary transition-colors";
+  "flex min-h-[40px] items-center justify-between gap-3 px-3 py-2.5 rounded-[3px] border border-border-primary bg-bg-secondary hover:bg-bg-tertiary transition-colors";
 const ICON_BUTTON_BASE =
-  "shrink-0 inline-flex items-center justify-center rounded-[3px] border border-border-primary bg-bg-tertiary p-1.5 text-text-tertiary hover:text-text-primary hover:bg-bg-card";
+  "shrink-0 inline-flex min-h-[32px] min-w-[32px] items-center justify-center rounded-[3px] border border-border-primary bg-bg-tertiary p-1.5 text-text-tertiary hover:text-text-primary hover:bg-bg-card";
 
 export function CompareSharePanel({
   state,
@@ -304,7 +304,7 @@ export function CompareSharePanel({
             href={watermarkedSquareUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[10px] font-mono uppercase tracking-[0.14em] text-text-tertiary hover:text-text-primary px-3 py-1 self-end"
+            className="inline-flex min-h-[32px] items-center text-[10px] font-mono uppercase tracking-[0.14em] text-text-tertiary hover:text-text-primary px-3 py-1 self-end"
           >
             Preview ↗
           </a>

--- a/src/components/compare/StarterPackRow.tsx
+++ b/src/components/compare/StarterPackRow.tsx
@@ -46,7 +46,7 @@ function repoIdToFullName(id: string): string {
 
 const CHIP_BASE = cn(
   "inline-flex items-center gap-1.5",
-  "px-3 py-1.5",
+  "min-h-[40px] px-3 py-1.5",
   "border border-border-primary",
   "bg-bg-secondary",
   "rounded-md",

--- a/src/components/layout/header.css
+++ b/src/components/layout/header.css
@@ -16,7 +16,7 @@
 .topbar::after{ content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px;
   background:linear-gradient(90deg, transparent, var(--acc-glow), transparent 60%, var(--line-300) 100%); opacity:0.55; }
 
-.brand{ display:flex; align-items:center; gap:11px; min-width:260px; cursor:pointer; text-decoration:none; }
+.brand{ display:flex; align-items:center; gap:11px; min-width:260px; min-height:44px; cursor:pointer; text-decoration:none; }
 .brand-mark{ width:34px; height:34px; flex:none; position:relative; display:flex; align-items:center; justify-content:center;
   background:#0d0f12; border:1px solid var(--line-300);
   box-shadow: inset 0 0 0 1px rgba(255,107,53,0.10), 0 0 18px rgba(255,107,53,0.18); }


### PR DESCRIPTION
## Summary
- Expand compare starter-pack chips and share-panel controls for stronger mobile tap targets.
- Increase `/you` empty-state CTA and reset filter control hit areas.
- Give the header brand link a stable 44px hit area on mobile.

## Validation
- `npm run lint -- src/components/compare/StarterPackRow.tsx src/components/compare/CompareSharePanel.tsx src/app/you/YouClient.tsx`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run lint:guards`
- `npm run build`