### PR TITLE
Defer hosted Clerk auth widget until client ready

### DIFF
--- a/src/components/auth/ClerkAuthForm.tsx
+++ b/src/components/auth/ClerkAuthForm.tsx
@@ -16,10 +16,15 @@ interface ClerkAuthFormProps {
   signUpUrl?: string;
 }
 
-function useReferralUnsafeMetadata(): ClerkReferralUnsafeMetadata | undefined {
-  const [metadata, setMetadata] = useState<
-    ClerkReferralUnsafeMetadata | undefined
-  >(undefined);
+interface ReferralMetadataState {
+  metadata?: ClerkReferralUnsafeMetadata;
+  ready: boolean;
+}
+
+function useReferralUnsafeMetadata(): ReferralMetadataState {
+  const [state, setState] = useState<ReferralMetadataState>({
+    ready: false,
+  });
 
   useEffect(() => {
     const raw = window.localStorage.getItem(AUTH_REFERRAL_STORAGE_KEY);
@@ -27,10 +32,29 @@ function useReferralUnsafeMetadata(): ClerkReferralUnsafeMetadata | undefined {
     if (raw && !parsed) {
       window.localStorage.removeItem(AUTH_REFERRAL_STORAGE_KEY);
     }
-    setMetadata(parsed);
+    setState({ metadata: parsed, ready: true });
   }, []);
 
-  return metadata;
+  return state;
+}
+
+function ClerkAuthSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading account form"
+      className="w-full max-w-md rounded border border-[#222a32] bg-[#0b0d0f] p-8"
+    >
+      <span className="sr-only">Loading account form</span>
+      <div className="mx-auto mb-6 h-6 w-40 rounded bg-[#151a20]" />
+      <div className="space-y-3">
+        <div className="h-11 rounded border border-[#222a32] bg-[#101418]" />
+        <div className="h-11 rounded border border-[#222a32] bg-[#101418]" />
+        <div className="h-11 rounded bg-[#ff6b35]/35" />
+      </div>
+    </div>
+  );
 }
 
 export function ClerkAuthForm({
@@ -39,14 +63,18 @@ export function ClerkAuthForm({
   signInUrl,
   signUpUrl,
 }: ClerkAuthFormProps) {
-  const unsafeMetadata = useReferralUnsafeMetadata();
+  const { metadata, ready } = useReferralUnsafeMetadata();
+
+  if (!ready) {
+    return <ClerkAuthSkeleton />;
+  }
 
   if (mode === "sign-up") {
     return (
       <SignUp
         signInUrl={signInUrl}
         fallbackRedirectUrl={fallbackRedirectUrl}
-        unsafeMetadata={unsafeMetadata}
+        unsafeMetadata={metadata}
       />
     );
   }
@@ -55,7 +83,7 @@ export function ClerkAuthForm({
     <SignIn
       signUpUrl={signUpUrl}
       fallbackRedirectUrl={fallbackRedirectUrl}
-      unsafeMetadata={unsafeMetadata}
+      unsafeMetadata={metadata}
       withSignUp
     />
   );

--- a/src/lib/__tests__/auth-provider-policy.test.ts
+++ b/src/lib/__tests__/auth-provider-policy.test.ts
@@ -36,3 +36,10 @@ test("sidebar user overlay fetch waits for a signed-in Clerk user", () => {
   assert.match(body, /new URLSearchParams\(\{ userId \}\)/);
   assert.match(body, /\/api\/pipeline\/sidebar-overlay\?\$\{params\.toString\(\)\}/);
 });
+
+test("hosted Clerk form waits for client-only referral state", () => {
+  const body = source("src/components/auth/ClerkAuthForm.tsx");
+  assert.match(body, /ready: false/);
+  assert.match(body, /if \(!ready\) \{\s*return <ClerkAuthSkeleton \/>;\s*\}/);
+  assert.match(body, /unsafeMetadata=\{metadata\}/);
+});


### PR DESCRIPTION
## Summary
- Gate the hosted Clerk sign-in/sign-up widget until the client referral handoff read has completed.
- Keep server and first-client markup stable with a branded auth skeleton.
- Add a policy test so hosted auth keeps the client-only boundary.

## Validation
- `npm run lint -- src/components/auth/ClerkAuthForm.tsx src/lib/__tests__/auth-provider-policy.test.ts`
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run lint:guards`
- `npm run build`