### PR TITLE
Tighten repo and compare mobile touch targets

### DIFF
--- a/src/components/compare/CompareClient.tsx
+++ b/src/components/compare/CompareClient.tsx
@@ -500,7 +500,10 @@ function PageHeader() {
         aria-label="Breadcrumb"
         className="flex items-center gap-1.5 text-xs text-text-tertiary"
       >
-        <Link href="/" className="hover:text-text-primary transition-colors">
+        <Link
+          href="/"
+          className="inline-flex min-h-[32px] items-center hover:text-text-primary transition-colors"
+        >
           Home
         </Link>
         <span aria-hidden="true">/</span>

--- a/src/components/compare/CompareProfileGrid.tsx
+++ b/src/components/compare/CompareProfileGrid.tsx
@@ -318,7 +318,10 @@ function PageHeader() {
       aria-label="Breadcrumb"
       className="flex items-center gap-1.5 text-xs text-text-tertiary"
     >
-      <Link href="/" className="hover:text-text-primary transition-colors">
+      <Link
+        href="/"
+        className="inline-flex min-h-[32px] items-center hover:text-text-primary transition-colors"
+      >
         Home
       </Link>
       <span aria-hidden="true">/</span>

--- a/src/components/repo-detail/RepoDetailChart.tsx
+++ b/src/components/repo-detail/RepoDetailChart.tsx
@@ -593,7 +593,7 @@ export function RepoDetailChart({
               type="button"
               onClick={() => setTimeRange(tab.value)}
               className={cn(
-                "px-2.5 py-1 text-[11px] font-mono font-medium uppercase tracking-[0.16em] rounded-[1px] transition-colors",
+                "inline-flex min-h-[40px] min-w-[40px] items-center justify-center px-2.5 py-1 text-[11px] font-mono font-medium uppercase tracking-[0.16em] rounded-[1px] transition-colors",
               )}
               style={
                 timeRange === tab.value


### PR DESCRIPTION
## Summary
- Increase repo-detail star chart time tabs to stable mobile tap targets.
- Increase compare breadcrumb Home links so the remaining first-party tiny target is gone.

## Validation
- `npm run lint -- src/components/repo-detail/RepoDetailChart.tsx src/components/compare/CompareClient.tsx src/components/compare/CompareProfileGrid.tsx`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run lint:guards`
- `npm run build`