### PR TITLE
Harden repo relative time hydration

### DIFF
--- a/src/components/compare/StatIcon.tsx
+++ b/src/components/compare/StatIcon.tsx
@@ -6,7 +6,7 @@ export interface StatIconProps {
   icon?: LucideIcon;
   iconNode?: ReactNode;
   label: string;
-  value: string | number;
+  value: ReactNode;
   hint?: string;
   tone?: "default" | "brand" | "up" | "down" | "warn";
 }
@@ -33,7 +33,12 @@ export function StatIcon({
   return (
     <div
       className="flex items-center gap-2 min-w-0"
-      title={hint ?? `${label}: ${value}`}
+      title={
+        hint ??
+        (typeof value === "string" || typeof value === "number"
+          ? `${label}: ${value}`
+          : label)
+      }
     >
       {iconNode ?? (
         Icon ? (

--- a/src/components/repo-detail/FundingPanel.tsx
+++ b/src/components/repo-detail/FundingPanel.tsx
@@ -11,10 +11,10 @@
 import type { JSX } from "react";
 import { ArrowUpRight, Landmark } from "lucide-react";
 
-import { getRelativeTime } from "@/lib/utils";
 import type { RepoFundingEvent } from "@/lib/funding/repo-events";
 import type { FundingRoundType } from "@/lib/funding/types";
 import { EntityLogo } from "@/components/ui/EntityLogo";
+import { RelativeTime } from "@/components/ui/RelativeTime";
 import { resolveLogoUrl } from "@/lib/logos";
 
 interface FundingPanelProps {
@@ -168,7 +168,7 @@ function FundingRow({
         className="v2-mono-tight tabular-nums"
         style={{ fontSize: 11, color: "var(--v2-ink-400)" }}
       >
-        {getRelativeTime(announcedAt)}
+        <RelativeTime iso={announcedAt} />
       </span>
 
       {visibleInvestors.length > 0 ? (

--- a/src/components/repo-detail/NpmAdoptionPanel.tsx
+++ b/src/components/repo-detail/NpmAdoptionPanel.tsx
@@ -3,7 +3,8 @@ import { Download, ExternalLink, Package, TrendingUp } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { NpmPackageRow } from "@/lib/npm";
 import type { DailyDownload } from "@/lib/npm-daily";
-import { cn, formatNumber, getRelativeTime } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/RelativeTime";
+import { cn, formatNumber } from "@/lib/utils";
 
 interface NpmAdoptionPanelProps {
   packages: NpmPackageRow[];
@@ -353,7 +354,7 @@ function PackageRow({
           {pkg.latestVersion ?? "unknown"}
         </span>
         {pkg.publishedAt && (
-          <span className="block">{getRelativeTime(pkg.publishedAt)}</span>
+          <RelativeTime iso={pkg.publishedAt} className="block" />
         )}
       </td>
     </tr>

--- a/src/components/repo-detail/ProjectSurfaceMap.tsx
+++ b/src/components/repo-detail/ProjectSurfaceMap.tsx
@@ -16,9 +16,10 @@ import type { AisoToolsDimension, AisoToolsScan } from "@/lib/aiso-tools";
 import { getRepoMetadata } from "@/lib/repo-metadata";
 import { getRepoProfile, type RepoProfileStatus } from "@/lib/repo-profiles";
 import { fetchGithubRepoHomepageUrl } from "@/lib/github-repo-homepage";
-import { formatNumber, getRelativeTime } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils";
 import { AisoRetryButton } from "./AisoRetryButton";
 import { EntityLogo } from "@/components/ui/EntityLogo";
+import { RelativeTime } from "@/components/ui/RelativeTime";
 import { repoDisplayLogoUrl, resolveLogoUrl } from "@/lib/logos";
 
 type AisoUiStatus =
@@ -846,7 +847,11 @@ export async function ProjectSurfaceMap({
             style={{ color: "var(--v3-ink-400)" }}
           >
             {aisoScan.completedAt
-              ? `scanned ${getRelativeTime(aisoScan.completedAt)}`
+              ? (
+                  <>
+                    scanned <RelativeTime iso={aisoScan.completedAt} />
+                  </>
+                )
               : `scan status: ${aisoScan.status}`}
           </p>
         </div>

--- a/src/components/repo-detail/RecentMentionsFeed.tsx
+++ b/src/components/repo-detail/RecentMentionsFeed.tsx
@@ -14,7 +14,7 @@
 
 import { useMemo, useState } from "react";
 import { ExternalLink } from "lucide-react";
-import { getRelativeTime } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/RelativeTime";
 import type { FreshnessSnapshot } from "@/lib/source-health";
 import { FreshnessChips } from "./FreshnessChips";
 import { MentionsLoadMore } from "./MentionsLoadMore";
@@ -278,7 +278,7 @@ export function MentionRow({ item: m }: { item: MentionItem }) {
             >
               ▶ {sourceLabel}
             </span>
-            <span className="mention-age">{getRelativeTime(m.createdAt)}</span>
+            <RelativeTime iso={m.createdAt} className="mention-age" />
           </header>
           <footer className="mention-meta">
             <span className="mention-stat">

--- a/src/components/repo-detail/RelatedIdeasPanel.tsx
+++ b/src/components/repo-detail/RelatedIdeasPanel.tsx
@@ -17,8 +17,8 @@ import type { JSX } from "react";
 import Link from "next/link";
 import { Lightbulb } from "lucide-react";
 
+import { RelativeTime } from "@/components/ui/RelativeTime";
 import type { IdeaItem, IdeaItemReactions } from "@/lib/repo-ideas";
-import { getRelativeTime } from "@/lib/utils";
 
 interface RelatedIdeasPanelProps {
   items: IdeaItem[];
@@ -32,14 +32,6 @@ function formatReactions(reactions: IdeaItemReactions | undefined): string | nul
   if ((reactions.buy ?? 0) > 0) parts.push(`buy ${reactions.buy}`);
   if ((reactions.invest ?? 0) > 0) parts.push(`invest ${reactions.invest}`);
   return parts.length > 0 ? parts.join(" · ") : null;
-}
-
-function safeRelativeTime(iso: string): string {
-  try {
-    return getRelativeTime(iso);
-  } catch {
-    return "unknown";
-  }
 }
 
 export function RelatedIdeasPanel({
@@ -66,7 +58,6 @@ export function RelatedIdeasPanel({
         {items.map((item) => {
           const reactionsLabel = formatReactions(item.reactions);
           const handle = item.author ? item.author.replace(/^@+/, "") : null;
-          const posted = safeRelativeTime(item.createdAt);
 
           return (
             <li key={item.id} className="py-3 first:pt-0 last:pb-0">
@@ -86,7 +77,7 @@ export function RelatedIdeasPanel({
                     <div className="mt-1.5 flex items-center gap-2 font-mono text-[10px] uppercase tracking-wider text-text-tertiary">
                       {handle ? <span>by @{handle}</span> : null}
                       {handle ? <span aria-hidden>·</span> : null}
-                      <span>{posted}</span>
+                      <RelativeTime iso={item.createdAt} />
                     </div>
                   </div>
 

--- a/src/components/repo-detail/RepoDetailStats.tsx
+++ b/src/components/repo-detail/RepoDetailStats.tsx
@@ -19,7 +19,8 @@ import {
 import type { Repo } from "@/lib/types";
 import { BrandStar } from "@/components/shared/BrandStar";
 import { StatIcon } from "@/components/compare/StatIcon";
-import { formatNumber, getRelativeTime } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/RelativeTime";
+import { formatNumber } from "@/lib/utils";
 
 interface RepoDetailStatsProps {
   repo: Repo;
@@ -38,17 +39,17 @@ function deltaTone(n: number): "up" | "down" | "default" {
 
 export function RepoDetailStats({ repo }: RepoDetailStatsProps): JSX.Element {
   const lastReleaseValue = repo.lastReleaseAt
-    ? getRelativeTime(repo.lastReleaseAt)
+    ? <RelativeTime iso={repo.lastReleaseAt} />
     : "—";
   const lastReleaseHint = repo.lastReleaseAt
-    ? `${repo.lastReleaseTag ?? "release"} · ${getRelativeTime(repo.lastReleaseAt)}`
+    ? `${repo.lastReleaseTag ?? "release"} · ${repo.lastReleaseAt}`
     : "No release tracked";
 
   const lastCommitValue = repo.lastCommitAt
-    ? getRelativeTime(repo.lastCommitAt)
+    ? <RelativeTime iso={repo.lastCommitAt} />
     : "—";
   const lastCommitHint = repo.lastCommitAt
-    ? `Last commit ${getRelativeTime(repo.lastCommitAt)}`
+    ? `Last commit ${repo.lastCommitAt}`
     : "Commit activity unknown";
 
   return (
@@ -145,4 +146,3 @@ function DeltaChip({ label, value }: { label: string; value: number }) {
 }
 
 export default RepoDetailStats;
-

--- a/src/components/repo-detail/RepoIdHero.tsx
+++ b/src/components/repo-detail/RepoIdHero.tsx
@@ -24,7 +24,8 @@ import { ChannelChipRow } from "./ChannelChipRow";
 import { RepoMetricStrip } from "./RepoMetricStrip";
 import { RepoActionRow } from "./RepoActionRow";
 import { TrackedExternalLink } from "@/components/analytics/TrackedExternalLink";
-import { formatNumber, getRelativeTime } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/RelativeTime";
+import { formatNumber } from "@/lib/utils";
 import type { Repo } from "@/lib/types";
 
 interface RepoIdHeroProps {
@@ -137,9 +138,6 @@ export function RepoIdHero({
   const crossSignal = repo.crossSignalScore ?? 0;
   const sd24 = repo.starsDelta24h ?? 0;
   const sd30 = repo.starsDelta30d ?? 0;
-  const ageLabel = repo.lastCommitAt
-    ? getRelativeTime(repo.lastCommitAt)
-    : null;
   const narrative = buildNarrative(repo);
 
   // 30D percentage relative to (current - delta) so it's a true growth %
@@ -214,8 +212,10 @@ export function RepoIdHero({
                   {repo.contributors} contribs
                 </span>
               ) : null}
-              {ageLabel ? (
-                <span className="rid-stat rid-stat-age">{ageLabel}</span>
+              {repo.lastCommitAt ? (
+                <span className="rid-stat rid-stat-age">
+                  <RelativeTime iso={repo.lastCommitAt} />
+                </span>
               ) : null}
               {fetchedAt ? (
                 <FreshnessBadge source="mcp" lastUpdatedAt={fetchedAt} />

--- a/src/components/repo-detail/RepoMetricStrip.tsx
+++ b/src/components/repo-detail/RepoMetricStrip.tsx
@@ -11,9 +11,10 @@
 // supplied by the page (the surface map is async, so the page resolves it
 // once and passes the count down to keep this component sync).
 
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import { Sparkline } from "@/components/shared/Sparkline";
-import { formatNumber, getRelativeTime } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/RelativeTime";
+import { formatNumber } from "@/lib/utils";
 import type { Repo } from "@/lib/types";
 
 interface RepoMetricStripProps {
@@ -26,7 +27,7 @@ interface MetricDef {
   label: string;
   value: string;
   delta?: { text: string; positive: boolean };
-  sub?: string;
+  sub?: ReactNode;
   spark?: number[];
   positive?: boolean;
 }
@@ -61,7 +62,11 @@ function buildMetrics(
         ? "MIXED"
         : "THIN";
   const lastCommit = repo.lastCommitAt
-    ? `last commit ${getRelativeTime(repo.lastCommitAt)}`
+    ? (
+        <>
+          last commit <RelativeTime iso={repo.lastCommitAt} />
+        </>
+      )
     : "last commit unknown";
 
   return [

--- a/src/components/repo-detail/RepoRevenuePanel.tsx
+++ b/src/components/repo-detail/RepoRevenuePanel.tsx
@@ -10,7 +10,8 @@ import {
 
 import type { RevenueOverlay } from "@/lib/types";
 import { classifyFreshness } from "@/lib/revenue-overlays";
-import { formatNumber, getRelativeTime } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/RelativeTime";
+import { formatNumber } from "@/lib/utils";
 
 interface RepoRevenuePanelProps {
   verified: RevenueOverlay | null;
@@ -132,7 +133,7 @@ function VerifiedRevenueCard({
               color: "var(--v3-sig-amber)",
             }}
           >
-            updated {getRelativeTime(overlay.asOf)}
+            updated <RelativeTime iso={overlay.asOf} />
           </span>
         ) : null}
       </header>
@@ -258,7 +259,7 @@ function SelfReportedRevenueCard({
               color: "var(--v3-sig-amber)",
             }}
           >
-            {getRelativeTime(overlay.asOf)}
+            <RelativeTime iso={overlay.asOf} />
           </span>
         ) : null}
       </header>

--- a/src/components/repo-detail/RepoSignalSnapshot.tsx
+++ b/src/components/repo-detail/RepoSignalSnapshot.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import {
   Activity,
   GitCommit,
@@ -10,7 +10,8 @@ import type { LucideIcon } from "lucide-react";
 import type { Repo } from "@/lib/types";
 import type { NpmPackageRow } from "@/lib/npm";
 import type { Launch } from "@/lib/producthunt";
-import { formatNumber, getRelativeTime } from "@/lib/utils";
+import { RelativeTime } from "@/components/ui/RelativeTime";
+import { formatNumber } from "@/lib/utils";
 import type { MentionItem } from "./MentionMeta";
 
 interface RepoSignalSnapshotProps {
@@ -23,7 +24,7 @@ interface RepoSignalSnapshotProps {
 interface SnapshotCard {
   label: string;
   value: string;
-  detail: string;
+  detail: ReactNode;
   icon: LucideIcon;
   tone?: "up" | "warning" | "default";
   /** Long-form explanation surfaced via `title` on the card. */
@@ -110,7 +111,11 @@ export function RepoSignalSnapshot({
       detail: productHuntLaunch
         ? "ProductHunt launch attached"
         : repo.lastCommitAt
-          ? `last commit ${getRelativeTime(repo.lastCommitAt)}`
+          ? (
+              <>
+                last commit <RelativeTime iso={repo.lastCommitAt} />
+              </>
+            )
           : "website/package scan pending",
       icon: hasProjectSurface ? Globe2 : GitCommit,
       tone: hasProjectSurface ? "up" : "warning",

--- a/src/components/repo-detail/StarHistoryBlock.tsx
+++ b/src/components/repo-detail/StarHistoryBlock.tsx
@@ -11,12 +11,13 @@
 import Link from "next/link";
 import type { JSX } from "react";
 import { ChartStat, ChartStats } from "@/components/ui/ChartShell";
+import { RelativeTime } from "@/components/ui/RelativeTime";
 import { CHART_TOKENS } from "@/lib/charts/theme/tokens";
 import {
   getStarActivity,
   type StarActivityPoint,
 } from "@/lib/star-activity";
-import { formatNumber, getRelativeTime } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils";
 import type { Repo } from "@/lib/types";
 
 export interface StarHistoryBlockProps {
@@ -269,7 +270,11 @@ export function StarHistoryBlock({ repo }: StarHistoryBlockProps): JSX.Element {
           }
           sub={
             stats.spike
-              ? `${getRelativeTime(stats.spike.date)} · peak day`
+              ? (
+                  <>
+                    <RelativeTime iso={stats.spike.date} /> · peak day
+                  </>
+                )
               : "no breakout in window"
           }
         />

--- a/src/components/ui/RelativeTime.tsx
+++ b/src/components/ui/RelativeTime.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getRelativeTime } from "@/lib/utils";
+
+interface RelativeTimeProps {
+  iso: string;
+  className?: string;
+  prefix?: string;
+  suffix?: string;
+  title?: string;
+}
+
+function safeRelativeTime(iso: string): string {
+  try {
+    const label = getRelativeTime(iso);
+    return label.includes("NaN") ? "unknown" : label;
+  } catch {
+    return "unknown";
+  }
+}
+
+export function RelativeTime({
+  iso,
+  className,
+  prefix = "",
+  suffix = "",
+  title,
+}: RelativeTimeProps) {
+  const [label, setLabel] = useState(() => safeRelativeTime(iso));
+
+  useEffect(() => {
+    const update = () => setLabel(safeRelativeTime(iso));
+    update();
+    const intervalId = window.setInterval(update, 60_000);
+    return () => window.clearInterval(intervalId);
+  }, [iso]);
+
+  return (
+    <time
+      dateTime={iso}
+      title={title ?? iso}
+      className={className}
+      suppressHydrationWarning
+    >
+      {prefix}
+      {label}
+      {suffix}
+    </time>
+  );
+}

--- a/src/components/ui/__tests__/RelativeTime.test.tsx
+++ b/src/components/ui/__tests__/RelativeTime.test.tsx
@@ -1,0 +1,27 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RelativeTime } from "@/components/ui/RelativeTime";
+
+describe("RelativeTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders a time element and refreshes after mount", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T00:00:00.000Z"));
+
+    const { getByText } = render(
+      <RelativeTime iso="2026-05-14T23:55:00.000Z" />,
+    );
+
+    expect(getByText("5m ago").tagName).toBe("TIME");
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(getByText("6m ago")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reusable client-side `RelativeTime` component that suppresses hydration drift and refreshes labels after mount.
- Route repo-detail relative-age labels through the component so SSR/client clocks do not produce text mismatches.
- Allow `StatIcon` values to render React nodes for hydrated relative time labels.

## Validation
- `npm run lint -- src/components/ui/RelativeTime.tsx src/components/ui/__tests__/RelativeTime.test.tsx src/components/compare/StatIcon.tsx src/components/repo-detail/FundingPanel.tsx src/components/repo-detail/NpmAdoptionPanel.tsx src/components/repo-detail/ProjectSurfaceMap.tsx src/components/repo-detail/RecentMentionsFeed.tsx src/components/repo-detail/RelatedIdeasPanel.tsx src/components/repo-detail/RepoDetailStats.tsx src/components/repo-detail/RepoIdHero.tsx src/components/repo-detail/RepoMetricStrip.tsx src/components/repo-detail/RepoRevenuePanel.tsx src/components/repo-detail/RepoSignalSnapshot.tsx src/components/repo-detail/StarHistoryBlock.tsx`
- `npx vitest run src/components/ui/__tests__/RelativeTime.test.tsx --config vitest.config.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run lint:guards`
- `npm run build`

## Follow-up
- `npm audit --audit-level=high` reports pre-existing dependency advisories in `next`, `drizzle-orm`, `postcss`, `vite/esbuild`, and a Storybook transitive chain. This PR does not alter dependencies; those should be handled in a separate dependency-upgrade PR.