### PR TITLE
Reduce build warning noise

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_NAME, SITE_URL, SITE_DESCRIPTION, safeJsonLd } from "@/lib/seo";
+import { SITE_NAME, SITE_URL, safeJsonLd } from "@/lib/seo";
 
 const HREF = "/about";
 const TITLE = `About ${SITE_NAME}`;

--- a/src/app/admin/sweep-cost/page.tsx
+++ b/src/app/admin/sweep-cost/page.tsx
@@ -48,7 +48,6 @@ const CHANNEL_ORDER = [
   "lobsters",
   "producthunt",
 ] as const;
-type Channel = (typeof CHANNEL_ORDER)[number];
 
 interface ChannelStats {
   channel: string;

--- a/src/app/api/cron/aiso-drain/route.ts
+++ b/src/app/api/cron/aiso-drain/route.ts
@@ -131,8 +131,6 @@ const DrainRequestSchema = z
   })
   .passthrough();
 
-type DrainRequestBody = z.infer<typeof DrainRequestSchema>;
-
 function parseLimit(raw: unknown): number {
   if (typeof raw !== "number" || !Number.isFinite(raw) || raw <= 0) {
     return DEFAULT_LIMIT;

--- a/src/app/api/cron/digest/weekly/route.ts
+++ b/src/app/api/cron/digest/weekly/route.ts
@@ -39,7 +39,6 @@ import {
   loadUserEmailMapFromEnv,
   collectAlertsByUser,
   pickTopBreakouts,
-  type DigestUserEmailMap,
 } from "@/lib/pipeline/alerts/weekly-digest";
 import { pipeline } from "@/lib/pipeline/pipeline";
 import {

--- a/src/app/api/og/star-activity/route.tsx
+++ b/src/app/api/og/star-activity/route.tsx
@@ -474,17 +474,14 @@ function StarActivityCard({
   watermark: boolean;
 }) {
   const isVertical = aspect === "v";
-  const { width, height } = ASPECT_DIMENSIONS[aspect];
+  const { width } = ASPECT_DIMENSIONS[aspect];
   const themeConfig = CHART_THEMES[theme];
   const isLight = themeConfig.light;
   const textPrimary = isLight ? "#1f1f1f" : OG_COLORS.textPrimary;
-  const textSecondary = isLight ? "#3a3a3a" : OG_COLORS.textSecondary;
   const textTertiary = isLight ? "#5a5a5a" : OG_COLORS.textTertiary;
   const cardBg = themeConfig.cardBg.startsWith("var(")
     ? OG_COLORS.bg
     : themeConfig.cardBg;
-  const accentColor = isLight ? "#1f1f1f" : OG_COLORS.brand;
-
   const padding = isVertical
     ? "56px 64px 64px 64px"
     : aspect === "yt"

--- a/src/app/api/pipeline/__tests__/deltas-route.test.ts
+++ b/src/app/api/pipeline/__tests__/deltas-route.test.ts
@@ -75,7 +75,10 @@ function makeStubStore(): DataStore {
       }
       return { data: null, source: "missing", ageMs: 0, fresh: false };
     },
-    async write<T>(_key: string, _value: T, _opts?: DataWriteOptions) {
+    async write<T>(key: string, value: T, opts?: DataWriteOptions) {
+      void key;
+      void value;
+      void opts;
       // swallow — the route writes a deltas:<repo>:<window> entry that we
       // don't assert against here.
     },
@@ -100,7 +103,6 @@ function makeStubStore(): DataStore {
 // imports it. tsx compiles ESM imports to CJS so the binding lives in
 // require.cache and is reassignable via property descriptor swap.
 function patchGetDataStore(stub: DataStore): void {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const path = require.resolve("../../../../lib/data-store");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mod = require(path) as Record<string, unknown>;

--- a/src/app/api/watchlist/private/route.ts
+++ b/src/app/api/watchlist/private/route.ts
@@ -159,7 +159,7 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
   }
 
   const { fullNames: rawList } = parsed.data;
-  const { valid: _valid, invalid } = normalizeFullNames(rawList);
+  const { invalid } = normalizeFullNames(rawList);
   // Normalization / validation happens inside setPrivateWatchlist too; we
   // call it here only to expose the `dropped` list in the response so
   // the client can surface it in a toast.

--- a/src/app/bluesky/trending/page.tsx
+++ b/src/app/bluesky/trending/page.tsx
@@ -7,7 +7,6 @@
 import type { Metadata } from "next";
 import {
   BLUESKY_TRENDING_KEYWORDS,
-  getBlueskyTopPosts,
   getBlueskyTrendingFile,
   refreshBlueskyTrendingFromStore,
 } from "@/lib/bluesky-trending";
@@ -62,7 +61,6 @@ export default async function BlueskyTrendingPage() {
     refreshBlueskyMentionsFromStore(),
   ]);
   const trendingFile = getBlueskyTrendingFile();
-  const posts = getBlueskyTopPosts(50);
   const allPosts = trendingFile.posts;
   // Reserved — mention counts surface on /research and via SignalTable.
   void BLUESKY_TRENDING_KEYWORDS;

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -27,7 +27,6 @@ export default function Error({
       ).Sentry;
       if (sentry?.captureException) sentry.captureException(error);
     }
-    // eslint-disable-next-line no-console
     console.error("[app/error] unhandled render error", error);
   }, [error]);
 

--- a/src/app/hackernews/trending/page.tsx
+++ b/src/app/hackernews/trending/page.tsx
@@ -7,7 +7,6 @@
 
 import type { Metadata } from "next";
 import {
-  getHnTopStories,
   getHnTrendingFile,
   refreshHackernewsTrendingFromStore,
 } from "@/lib/hackernews-trending";
@@ -72,7 +71,6 @@ export default async function HackerNewsTrendingPage() {
     refreshHackernewsMentionsFromStore(),
   ]);
   const trendingFile = getHnTrendingFile();
-  const stories = getHnTopStories(50);
   const allStories = trendingFile.stories;
   const cold = allStories.length === 0;
 

--- a/src/app/huggingface/datasets/page.tsx
+++ b/src/app/huggingface/datasets/page.tsx
@@ -21,7 +21,7 @@ import {
   type FeedColumn,
 } from "@/components/feed/TerminalFeedTable";
 import { EntityLogo } from "@/components/ui/EntityLogo";
-import { huggingFaceLogoUrl, huggingFaceAuthorLogoUrl } from "@/lib/logos";
+import { huggingFaceAuthorLogoUrl } from "@/lib/logos";
 
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";

--- a/src/app/huggingface/spaces/page.tsx
+++ b/src/app/huggingface/spaces/page.tsx
@@ -20,7 +20,7 @@ import {
   type FeedColumn,
 } from "@/components/feed/TerminalFeedTable";
 import { EntityLogo } from "@/components/ui/EntityLogo";
-import { huggingFaceLogoUrl, huggingFaceAuthorLogoUrl } from "@/lib/logos";
+import { huggingFaceAuthorLogoUrl } from "@/lib/logos";
 
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";

--- a/src/app/huggingface/trending/page.tsx
+++ b/src/app/huggingface/trending/page.tsx
@@ -19,7 +19,7 @@ import {
   type FeedColumn,
 } from "@/components/feed/TerminalFeedTable";
 import { EntityLogo } from "@/components/ui/EntityLogo";
-import { huggingFaceLogoUrl, huggingFaceAuthorLogoUrl } from "@/lib/logos";
+import { huggingFaceAuthorLogoUrl } from "@/lib/logos";
 
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";

--- a/src/app/papers/page.tsx
+++ b/src/app/papers/page.tsx
@@ -15,7 +15,6 @@ import {
   type ArxivPaperTrending,
 } from "@/lib/arxiv";
 import { TerminalFeedTable, type FeedColumn } from "@/components/feed/TerminalFeedTable";
-import { repoLogoUrl } from "@/lib/logos";
 
 // V4 (CORPUS) primitives.
 import { SourceFeedTemplate } from "@/components/templates/SourceFeedTemplate";

--- a/src/app/x402/route.ts
+++ b/src/app/x402/route.ts
@@ -1,5 +1,3 @@
-import type { NextRequest } from "next/server";
-
 // x402 — HTTP 402 Payment Required entrypoint for agent-side micropayments.
 //
 // The actual priced endpoints live on TOOLBOX (`api.aiso.tools/v1/x402/*`).
@@ -47,7 +45,8 @@ async function getToolboxManifest(): Promise<unknown> {
   }
 }
 
-export async function GET(_req: NextRequest): Promise<Response> {
+export async function GET(request: Request): Promise<Response> {
+  void request;
   const manifest = await getToolboxManifest();
   if (manifest === null) return stubResponse(503);
   return new Response(JSON.stringify(manifest), {
@@ -61,7 +60,8 @@ export async function GET(_req: NextRequest): Promise<Response> {
   });
 }
 
-export function HEAD(_req: NextRequest): Response {
+export function HEAD(request: Request): Response {
+  void request;
   return new Response(null, {
     status: 200,
     headers: {
@@ -74,7 +74,8 @@ export function HEAD(_req: NextRequest): Response {
 
 // Legacy POST/OPTIONS — agents that probed the old stub still get a
 // well-formed 402; bots discover the manifest via GET above.
-export function POST(_req: NextRequest): Response {
+export function POST(request: Request): Response {
+  void request;
   return stubResponse(402);
 }
 

--- a/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
+++ b/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
@@ -37,7 +37,6 @@ import type { AlertRuleType, AlertCadence } from "@/lib/db/schema/alerts";
 
 interface AddAlertRuleDialogProps {
   existingRuleCount: number;
-  defaultTimezone: string;
 }
 
 const RULE_TYPE_OPTIONS: Array<{
@@ -93,7 +92,6 @@ type DialogPhase = "form" | "secret-reveal";
 
 export function AddAlertRuleDialog({
   existingRuleCount,
-  defaultTimezone: _defaultTimezone,
 }: AddAlertRuleDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [open, setOpen] = useState(false);

--- a/src/app/you/alerts/page.tsx
+++ b/src/app/you/alerts/page.tsx
@@ -140,7 +140,6 @@ export default async function YouAlertsPage() {
           </div>
           <AddAlertRuleDialog
             existingRuleCount={serializedRules.length}
-            defaultTimezone={prefs.timezone}
           />
         </section>
 

--- a/src/components/__tests__/TagsBar.test.tsx
+++ b/src/components/__tests__/TagsBar.test.tsx
@@ -6,7 +6,6 @@ import { useFilterStore } from "@/lib/store";
 import { TAG_RULES } from "@/lib/pipeline/classification/tag-rules";
 
 const FIRST_TAG = TAG_RULES[0];
-const SECOND_TAG = TAG_RULES[1] ?? TAG_RULES[0];
 
 beforeEach(() => {
   act(() => {

--- a/src/components/admin/IdeasQueueAdmin.tsx
+++ b/src/components/admin/IdeasQueueAdmin.tsx
@@ -70,33 +70,36 @@ export function IdeasQueueAdmin() {
     }
   }, [router]);
 
-  async function moderate(id: string, action: "approve" | "reject") {
-    setBusyId(id);
-    setError(null);
-    try {
-      const res = await fetch("/api/admin/ideas-queue", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ id, action }),
-      });
-      if (res.status === 401) {
-        router.push("/admin/login?next=/admin/ideas-queue");
-        return;
+  const moderate = useCallback(
+    async (id: string, action: "approve" | "reject") => {
+      setBusyId(id);
+      setError(null);
+      try {
+        const res = await fetch("/api/admin/ideas-queue", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ id, action }),
+        });
+        if (res.status === 401) {
+          router.push("/admin/login?next=/admin/ideas-queue");
+          return;
+        }
+        const payload = (await res.json()) as
+          | { ok: true; idea: IdeaRecord }
+          | { ok: false; error: string };
+        if (!payload.ok) throw new Error(payload.error ?? "request failed");
+        setIdeas((prev) =>
+          prev.map((row) => (row.id === id ? payload.idea : row)),
+        );
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusyId(null);
       }
-      const payload = (await res.json()) as
-        | { ok: true; idea: IdeaRecord }
-        | { ok: false; error: string };
-      if (!payload.ok) throw new Error(payload.error ?? "request failed");
-      setIdeas((prev) =>
-        prev.map((row) => (row.id === id ? payload.idea : row)),
-      );
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusyId(null);
-    }
-  }
+    },
+    [router],
+  );
 
   useEffect(() => {
     void loadQueue();
@@ -113,9 +116,7 @@ export function IdeasQueueAdmin() {
       }
       void moderate(row.id, action);
     },
-    // moderate is stable within this component instance; eslint-disable-next-line
-    // react-hooks/exhaustive-deps would only narrow noise here.
-    [],
+    [moderate],
   );
 
   const confirmReject = useCallback(() => {
@@ -123,7 +124,7 @@ export function IdeasQueueAdmin() {
     const target = pendingReject;
     setPendingReject(null);
     void moderate(target.id, "reject");
-  }, [pendingReject]);
+  }, [moderate, pendingReject]);
 
   return (
     <main className="min-h-screen bg-bg-primary text-text-primary font-mono">

--- a/src/components/admin/ReferralsQueueAdmin.tsx
+++ b/src/components/admin/ReferralsQueueAdmin.tsx
@@ -63,33 +63,36 @@ export function ReferralsQueueAdmin() {
     }
   }, [router]);
 
-  async function moderate(id: string, action: "approve" | "reject") {
-    setBusyId(id);
-    setError(null);
-    try {
-      const res = await fetch("/api/admin/referrals", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ id, action }),
-      });
-      if (res.status === 401) {
-        router.push("/admin/login?next=/admin/referrals");
-        return;
+  const moderate = useCallback(
+    async (id: string, action: "approve" | "reject") => {
+      setBusyId(id);
+      setError(null);
+      try {
+        const res = await fetch("/api/admin/referrals", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ id, action }),
+        });
+        if (res.status === 401) {
+          router.push("/admin/login?next=/admin/referrals");
+          return;
+        }
+        const payload = (await res.json()) as
+          | { ok: true; referral: AdminReferralRow }
+          | { ok: false; error: string };
+        if (!payload.ok) throw new Error(payload.error ?? "request failed");
+        // Optimistic UI: post-action both states (cleared flags / admin_rejected)
+        // remove the row from the queue selector, so drop it locally.
+        setRows((prev) => prev.filter((row) => row.id !== id));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusyId(null);
       }
-      const payload = (await res.json()) as
-        | { ok: true; referral: AdminReferralRow }
-        | { ok: false; error: string };
-      if (!payload.ok) throw new Error(payload.error ?? "request failed");
-      // Optimistic UI: post-action both states (cleared flags / admin_rejected)
-      // remove the row from the queue selector, so drop it locally.
-      setRows((prev) => prev.filter((row) => row.id !== id));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusyId(null);
-    }
-  }
+    },
+    [router],
+  );
 
   useEffect(() => {
     void loadQueue();
@@ -103,7 +106,7 @@ export function ReferralsQueueAdmin() {
       }
       void moderate(row.id, action);
     },
-    [],
+    [moderate],
   );
 
   const confirmReject = useCallback(() => {
@@ -111,7 +114,7 @@ export function ReferralsQueueAdmin() {
     const target = pendingReject;
     setPendingReject(null);
     void moderate(target.id, "reject");
-  }, [pendingReject]);
+  }, [moderate, pendingReject]);
 
   return (
     <main className="min-h-screen bg-bg-primary text-text-primary font-mono">

--- a/src/components/admin/RevenueQueueAdmin.tsx
+++ b/src/components/admin/RevenueQueueAdmin.tsx
@@ -103,33 +103,36 @@ export function RevenueQueueAdmin() {
     }
   }, [router]);
 
-  async function moderate(id: string, action: "approve" | "reject") {
-    setBusyId(id);
-    setError(null);
-    try {
-      const res = await fetch("/api/admin/revenue-queue", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ id, action }),
-      });
-      if (res.status === 401) {
-        router.push("/admin/login?next=/admin/revenue-queue");
-        return;
+  const moderate = useCallback(
+    async (id: string, action: "approve" | "reject") => {
+      setBusyId(id);
+      setError(null);
+      try {
+        const res = await fetch("/api/admin/revenue-queue", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ id, action }),
+        });
+        if (res.status === 401) {
+          router.push("/admin/login?next=/admin/revenue-queue");
+          return;
+        }
+        const payload = (await res.json()) as
+          | { ok: true; submission: AdminSubmission }
+          | { ok: false; error: string };
+        if (!payload.ok) throw new Error(payload.error ?? "request failed");
+        setSubmissions((prev) =>
+          prev.map((row) => (row.id === id ? payload.submission : row)),
+        );
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusyId(null);
       }
-      const payload = (await res.json()) as
-        | { ok: true; submission: AdminSubmission }
-        | { ok: false; error: string };
-      if (!payload.ok) throw new Error(payload.error ?? "request failed");
-      setSubmissions((prev) =>
-        prev.map((row) => (row.id === id ? payload.submission : row)),
-      );
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusyId(null);
-    }
-  }
+    },
+    [router],
+  );
 
   useEffect(() => {
     void loadQueue();
@@ -146,7 +149,7 @@ export function RevenueQueueAdmin() {
       }
       void moderate(row.id, action);
     },
-    [],
+    [moderate],
   );
 
   const confirmReject = useCallback(() => {
@@ -154,7 +157,7 @@ export function RevenueQueueAdmin() {
     const target = pendingReject;
     setPendingReject(null);
     void moderate(target.id, "reject");
-  }, [pendingReject]);
+  }, [moderate, pendingReject]);
 
   return (
     <main className="min-h-screen bg-bg-primary text-text-primary font-mono">

--- a/src/components/signals-terminal/SourceFeedPanel.tsx
+++ b/src/components/signals-terminal/SourceFeedPanel.tsx
@@ -16,8 +16,6 @@ import { Card, CardHeader } from "@/components/ui/Card";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import { SourceMark, SOURCE_BRAND_COLOR } from "./SourceMark";
 
-type Variant = "list" | "tweet" | "rss";
-
 export interface ListItem {
   id: string;
   title: string;

--- a/src/components/terminal/BubbleMapCanvas.tsx
+++ b/src/components/terminal/BubbleMapCanvas.tsx
@@ -241,7 +241,7 @@ export function BubbleMapCanvas({ windows, width, height }: BubbleMapCanvasProps
         </g>
       );
     });
-  }, [seeds, draggingId, handlePointerDown]);
+  }, [seeds, draggingId, groupRefs, handlePointerDown]);
 
   // Top spider-strip stats — Node/01-flavored mono labels with arrows.
   // The dominant category (first legendEntry) drives the `category=` field;

--- a/src/components/top10/Top10Page.tsx
+++ b/src/components/top10/Top10Page.tsx
@@ -170,8 +170,6 @@ export function Top10Page({
     return payload[category];
   }, [category, window, metric, repoSlice, payload]);
 
-  const meta = categoryMeta[category];
-
   function pickCategory(next: Top10Category) {
     setCategory(next);
     const m = categoryMeta[next];
@@ -188,7 +186,6 @@ export function Top10Page({
         aspect={aspect}
         theme={theme}
         bundle={liveBundle}
-        meta={meta}
         payload={payload}
         categoryMeta={categoryMeta}
         onCategory={pickCategory}
@@ -208,7 +205,6 @@ interface MainProps {
   aspect: ShareAspect;
   theme: Top10Theme;
   bundle: Top10Bundle;
-  meta: CategoryMeta;
   payload: Top10Payload;
   categoryMeta: Record<Top10Category, CategoryMeta>;
   onCategory: (c: Top10Category) => void;
@@ -225,7 +221,6 @@ function Main({
   aspect,
   theme,
   bundle,
-  meta,
   payload,
   categoryMeta,
   onCategory,
@@ -1632,7 +1627,6 @@ function MoreGrid({
       {cats.map((c) => (
         <Mini
           key={c}
-          category={c}
           meta={meta[c]}
           bundle={payload[c]}
           onOpen={() => onPick(c)}
@@ -1643,12 +1637,10 @@ function MoreGrid({
 }
 
 function Mini({
-  category,
   meta,
   bundle,
   onOpen,
 }: {
-  category: Top10Category;
   meta: CategoryMeta;
   bundle: Top10Bundle;
   onOpen: () => void;

--- a/src/lib/data-store.ts
+++ b/src/lib/data-store.ts
@@ -890,7 +890,6 @@ function defaultRedisFactory(url: string, token?: string): RedisClientLike {
     // shape stays compatible with Upstash REST (which auto-decodes JSON
     // values). The data-store's parsePayload() tolerates both shapes.
     mget: (...keys) => client.mget(...keys) as Promise<unknown[]>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     set: (key, value, opts) => {
       const hasEx = opts && typeof opts.ex === "number" && opts.ex > 0;
       const hasNx = opts?.nx === true;

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -27,9 +27,7 @@ type DbInstance = ReturnType<typeof drizzle<typeof schema>>;
 // Globals reused across hot reloads in dev + warm Lambdas in prod. Without
 // these, Next's dev server would open a new pool on every fast-refresh.
 declare global {
-  // eslint-disable-next-line no-var
   var __trendingrepo_db: DbInstance | undefined;
-  // eslint-disable-next-line no-var
   var __trendingrepo_db_direct: DbInstance | undefined;
 }
 

--- a/src/lib/derived-repos/decorators/__tests__/twitter.test.ts
+++ b/src/lib/derived-repos/decorators/__tests__/twitter.test.ts
@@ -117,7 +117,9 @@ test("decorateWithTwitter maps signal metrics/score/badge fields onto the repo",
   assert.equal(out.twitter.lastScannedAt, signal.updatedAt);
 
   // Mapping must not leak any other top-level field changes.
-  const { twitter: _t, ...rest } = out;
-  const { twitter: _orig, ...repoRest } = repo;
+  const { twitter: outTwitter, ...rest } = out;
+  const { twitter: repoTwitter, ...repoRest } = repo;
+  void outTwitter;
+  void repoTwitter;
   assert.deepEqual(rest, repoRest);
 });

--- a/src/lib/pipeline/__tests__/ai-unicorn-seed.test.ts
+++ b/src/lib/pipeline/__tests__/ai-unicorn-seed.test.ts
@@ -25,7 +25,6 @@ import { test } from "node:test";
 import {
   appendFileSync,
   existsSync,
-  mkdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -36,7 +35,6 @@ import { join } from "node:path";
 
 // Seeder module — ESM .mjs; node:test + tsx handles interop. We cast the
 // import to `any` because the .mjs file has no TS declarations.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as seeder from "../../../../scripts/seed-ai-unicorn-repos.mjs";
 
 // ---------------------------------------------------------------------------

--- a/src/lib/pipeline/ingestion/stargazer-backfill.ts
+++ b/src/lib/pipeline/ingestion/stargazer-backfill.ts
@@ -149,7 +149,7 @@ export async function backfillStargazerHistory(
     // request — it's page 1 of real data for small repos where we'll walk
     // the whole list anyway.
     if (probe.ok) {
-      const count = await safeReadPage(probe, perDay);
+      await safeReadPage(probe, perDay);
       totalFetched += 1;
       startPage = Math.max(2, lastPage - maxPages + 1);
     } else {

--- a/src/lib/pipeline/scoring/engine.ts
+++ b/src/lib/pipeline/scoring/engine.ts
@@ -217,10 +217,10 @@ export function classifyMovement(
 export function computeScore(
   input: ScoringInput,
   modifierInput: ModifierInput,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   allInputs?: ScoringInput[],
   previousStatus?: MovementStatus,
 ): RepoScore {
+  void allInputs;
   const weights = resolveWeights(input.categoryId);
   const components = computeAllComponents(input);
   const modifiers = computeAllModifiers(modifierInput);

--- a/src/lib/pipeline/storage/debounced-persist.ts
+++ b/src/lib/pipeline/storage/debounced-persist.ts
@@ -52,7 +52,6 @@ export function createDebouncedPersist(
       timer = setTimeout(() => {
         timer = null;
         opts.flush().catch((err) => {
-          // eslint-disable-next-line no-console
           console.error(`[${opts.label}] debounced persist failed`, err);
         });
       }, Math.max(0, delayMs));

--- a/src/lib/pipeline/storage/file-persistence.ts
+++ b/src/lib/pipeline/storage/file-persistence.ts
@@ -138,7 +138,6 @@ export async function readJsonlFile<T>(filename: string): Promise<T[]> {
       out.push(JSON.parse(line) as T);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      // eslint-disable-next-line no-console
       console.warn(
         `[file-persistence] skipping malformed JSONL line ${i + 1} in ${filename}: ${message}`,
       );

--- a/src/lib/pricing/user-tiers.ts
+++ b/src/lib/pricing/user-tiers.ts
@@ -100,21 +100,6 @@ async function loadIndex(): Promise<Map<string, UserTierRecord>> {
 }
 
 /**
- * Read-through helper. Returns a Map that MUST NOT be mutated by callers
- * (it's shared with the cache). Tests can call `__resetUserTierCacheForTests`
- * to force a reload after touching the file directly.
- */
-async function getIndex(): Promise<Map<string, UserTierRecord>> {
-  const { mtimeMs, size } = statSignature();
-  if (_cache && _cache.mtimeMs === mtimeMs && _cache.size === size) {
-    return _cache.byUserId;
-  }
-  const byUserId = await loadIndex();
-  _cache = { mtimeMs, size, byUserId };
-  return byUserId;
-}
-
-/**
  * Telemetry hook for tests — lets the entitlements test prove the cache
  * actually skips disk on repeat reads.
  */


### PR DESCRIPTION
## Summary
- remove unused imports, stale types, and unused eslint suppressions that were polluting `next build`
- make admin moderation callbacks satisfy hook dependency checks
- keep `x402` route handlers compatible with existing tests while marking unused requests explicitly

## Verification
- `npx eslint <touched files>`
- `npm run typecheck`
- `npm run lint:guards`
- `npm run build`
- `npm run test`
- targeted Vitest/node-test checks for `x402`, `TagsBar`, deltas route, Twitter decorator, and AI unicorn seed tests