### PR TITLE
Unblock critical GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   classify:
     name: Classify PR paths
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       data_only: ${{ steps.paths.outputs.data_only }}
@@ -82,7 +82,7 @@ jobs:
   gate:
     name: Typecheck, guards, tests, build, e2e
     needs: classify
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Data-only fast path
@@ -236,7 +236,7 @@ jobs:
     name: MCP server build
     needs: classify
     if: needs.classify.outputs.data_only != 'true'
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/cron-freshness-check.yml
+++ b/.github/workflows/cron-freshness-check.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/data-pr-validate.yml
+++ b/.github/workflows/data-pr-validate.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   validate:
     name: Validate data PR
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/enrich-repo-profiles.yml
+++ b/.github/workflows/enrich-repo-profiles.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   enrich:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   smoke:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       BASE_URL: https://trendingrepo.com

--- a/.github/workflows/scrape-producthunt.yml
+++ b/.github/workflows/scrape-producthunt.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   gitleaks:
     name: Gitleaks workspace scan
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/sweep-staleness.yml
+++ b/.github/workflows/sweep-staleness.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   sweep:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- move critical PR/deploy/data freshness workflows from the offline self-hosted runner to `ubuntu-latest`
- keep the change scoped to CI, data validation, secrets scan, post-deploy smoke, fast discovery, ProductHunt, repo profiles, freshness check, and staleness sweep

## Why
The only registered self-hosted runner (`gabagool-ams`) is offline, leaving PR checks and scheduled data refresh jobs queued indefinitely. This keeps build checks, smoke checks, and freshness recovery alive while the self-hosted runner is repaired separately.

## Verification
- parsed touched workflow YAML with `js-yaml`
- `git diff --check`