### PR TITLE
Unblock secondary scraper workflows

### DIFF
--- a/.github/workflows/scrape-bluesky.yml
+++ b/.github/workflows/scrape-bluesky.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-devto.yml
+++ b/.github/workflows/scrape-devto.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-lobsters.yml
+++ b/.github/workflows/scrape-lobsters.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-npm.yml
+++ b/.github/workflows/scrape-npm.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- move Bluesky, dev.to, Lobsters, and npm refresh workflows to `ubuntu-latest`
- these four sources are currently keeping `/api/health` in `status: stale` after the primary refreshes recovered

## Verification
- parsed touched workflow YAML with `js-yaml`
- `git diff --check`