### PR TITLE
chore(actions): migrate remaining automation to hosted runners

### DIFF
--- a/.github/workflows/aiso-self-scan.yml
+++ b/.github/workflows/aiso-self-scan.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   self-scan:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Trigger scan + capture event

--- a/.github/workflows/audit-freshness.yml
+++ b/.github/workflows/audit-freshness.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   audit:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   auto-merge:
     if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/backfill-meta.yml
+++ b/.github/workflows/backfill-meta.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   backfill:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/check-nitter.yml
+++ b/.github/workflows/check-nitter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/check-profile-completion.yml
+++ b/.github/workflows/check-profile-completion.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   audit:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   collect:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   collect:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/cron-agent-commerce.yml
+++ b/.github/workflows/cron-agent-commerce.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/cron-aiso-drain.yml
+++ b/.github/workflows/cron-aiso-drain.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: POST /api/cron/aiso-drain

--- a/.github/workflows/cron-digest-weekly.yml
+++ b/.github/workflows/cron-digest-weekly.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: POST /api/cron/digest/weekly

--- a/.github/workflows/cron-llm.yml
+++ b/.github/workflows/cron-llm.yml
@@ -41,7 +41,7 @@ jobs:
     if: |
       github.event_name == 'schedule' && github.event.schedule == '10 * * * *'
       || (github.event_name == 'workflow_dispatch' && inputs.job == 'aggregate')
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: GET /api/cron/llm/aggregate
@@ -71,7 +71,7 @@ jobs:
     if: |
       github.event_name == 'schedule' && github.event.schedule == '15 2 * * *'
       || (github.event_name == 'workflow_dispatch' && inputs.job == 'sync-models')
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: GET /api/cron/llm/sync-models

--- a/.github/workflows/cron-mcp-usage-rotate.yml
+++ b/.github/workflows/cron-mcp-usage-rotate.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: POST /api/cron/mcp/rotate-usage

--- a/.github/workflows/cron-pipeline-cleanup.yml
+++ b/.github/workflows/cron-pipeline-cleanup.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: POST /api/pipeline/cleanup

--- a/.github/workflows/cron-pipeline-ingest.yml
+++ b/.github/workflows/cron-pipeline-ingest.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: POST /api/pipeline/ingest

--- a/.github/workflows/cron-pipeline-persist.yml
+++ b/.github/workflows/cron-pipeline-persist.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: POST /api/pipeline/persist

--- a/.github/workflows/cron-pipeline-rebuild.yml
+++ b/.github/workflows/cron-pipeline-rebuild.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     # Rebuild can take substantially longer than an incremental ingest —
     # give it 30 min before the action runner hard-kills us. If a real
     # rebuild needs more, bump here rather than lowering the cadence.

--- a/.github/workflows/cron-reddit-daily.yml
+++ b/.github/workflows/cron-reddit-daily.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     # Bumped 15→30 min 2026-05-08 for Apify residential-proxy provider:
     # 45 subs × ~25-35s per sub (actor cold-start + scroll-paginate) ≈ 22 min
     # at steady state; 30 min gives headroom for Apify queue spikes.

--- a/.github/workflows/cron-twitter-outbound.yml
+++ b/.github/workflows/cron-twitter-outbound.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   fire:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Pick endpoint from schedule

--- a/.github/workflows/cron-webhooks-flush.yml
+++ b/.github/workflows/cron-webhooks-flush.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   run:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: POST /api/cron/webhooks/scan

--- a/.github/workflows/enrich-arxiv.yml
+++ b/.github/workflows/enrich-arxiv.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   enrich:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/health-watch.yml
+++ b/.github/workflows/health-watch.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ping-mcp-liveness.yml
+++ b/.github/workflows/ping-mcp-liveness.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   ping:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/probe-reddit.yml
+++ b/.github/workflows/probe-reddit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   probe:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/promote-unknown-mentions.yml
+++ b/.github/workflows/promote-unknown-mentions.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   promote:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/refresh-collection-rankings.yml
+++ b/.github/workflows/refresh-collection-rankings.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/refresh-hotness-snapshot.yml
+++ b/.github/workflows/refresh-hotness-snapshot.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-mcp-dependents.yml
+++ b/.github/workflows/refresh-mcp-dependents.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-mcp-smithery-rank.yml
+++ b/.github/workflows/refresh-mcp-smithery-rank.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-mcp-usage-snapshot.yml
+++ b/.github/workflows/refresh-mcp-usage-snapshot.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-npm-downloads.yml
+++ b/.github/workflows/refresh-npm-downloads.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-pypi-downloads.yml
+++ b/.github/workflows/refresh-pypi-downloads.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-reddit-baselines.yml
+++ b/.github/workflows/refresh-reddit-baselines.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/refresh-skill-claude.yml
+++ b/.github/workflows/refresh-skill-claude.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-derivatives.yml
+++ b/.github/workflows/refresh-skill-derivatives.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-forks-snapshot.yml
+++ b/.github/workflows/refresh-skill-forks-snapshot.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-skill-install-snapshot.yml
+++ b/.github/workflows/refresh-skill-install-snapshot.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/refresh-skill-lobehub.yml
+++ b/.github/workflows/refresh-skill-lobehub.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-skillsmp.yml
+++ b/.github/workflows/refresh-skill-skillsmp.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-skill-smithery.yml
+++ b/.github/workflows/refresh-skill-smithery.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker

--- a/.github/workflows/refresh-star-activity.yml
+++ b/.github/workflows/refresh-star-activity.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   append:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run-shadow-scoring.yml
+++ b/.github/workflows/run-shadow-scoring.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   shadow:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     env:
       REDIS_URL: ${{ secrets.REDIS_URL }}
       UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}

--- a/.github/workflows/scrape-arxiv.yml
+++ b/.github/workflows/scrape-arxiv.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-awesome-skills.yml
+++ b/.github/workflows/scrape-awesome-skills.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-claude-rss.yml
+++ b/.github/workflows/scrape-claude-rss.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-huggingface-datasets.yml
+++ b/.github/workflows/scrape-huggingface-datasets.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-huggingface-spaces.yml
+++ b/.github/workflows/scrape-huggingface-spaces.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-huggingface.yml
+++ b/.github/workflows/scrape-huggingface.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-npm-daily.yml
+++ b/.github/workflows/scrape-npm-daily.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scrape-openai-rss.yml
+++ b/.github/workflows/scrape-openai-rss.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   scrape:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sentry-fix-bot.yml
+++ b/.github/workflows/sentry-fix-bot.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   dispatch-agent:
     if: github.event.label.name == 'sentry-error'
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Plant @claude prompt with stack-trace context
         env:

--- a/.github/workflows/snapshot-consensus.yml
+++ b/.github/workflows/snapshot-consensus.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   snapshot:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     # Hard cap so a hung Redis read can't burn the GH Actions 6h budget.
     # Belt; suspenders is the ioredis commandTimeout in src/lib/data-store.ts.
     timeout-minutes: 15

--- a/.github/workflows/snapshot-top10-sparklines.yml
+++ b/.github/workflows/snapshot-top10-sparklines.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   snapshot:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     # Hard cap so a hung Redis read can't burn the GH Actions 6h budget.
     timeout-minutes: 15
     steps:

--- a/.github/workflows/snapshot-top10.yml
+++ b/.github/workflows/snapshot-top10.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   snapshot:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     # Hard cap so a hung Redis read can't burn the GH Actions 6h budget.
     timeout-minutes: 15
     steps:

--- a/.github/workflows/sweep-cross-source-mentions.yml
+++ b/.github/workflows/sweep-cross-source-mentions.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   sweep:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/sync-trustmrr.yml
+++ b/.github/workflows/sync-trustmrr.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/trendingrepo-worker.yml
+++ b/.github/workflows/trendingrepo-worker.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/trendingrepo-worker


### PR DESCRIPTION
## Summary
- Move remaining normal automation/data/probe workflows from the offline self-hosted runner label to ubuntu-latest.
- Leave cron-warmup and uptime-monitor on self-hosted for now because they run every 5 minutes and should be treated as a separate cost/perf decision.

## Validation
- node/js-yaml parsed every workflow file
- git diff --check
- npm run lint:guards