### PR TITLE
fix(data): keep arXiv refresh on reliable AI categories

### DIFF
--- a/scripts/scrape-arxiv.mjs
+++ b/scripts/scrape-arxiv.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Scrape arXiv for recent CS-AI/CL/LG papers.
+// Scrape arXiv for recent CS-AI/CL/LG/CV papers.
 //
 // arXiv's public API (Atom XML) lets us pull recent submissions in
 // specific categories without auth. Their TOS asks for a 3-second gap
@@ -49,9 +49,9 @@ const TRENDING_IN = resolve(DATA_DIR, "trending.json");
 const RECENT_IN = resolve(DATA_DIR, "recent-repos.json");
 const OUT_PATH = resolve(DATA_DIR, "arxiv-recent.json");
 
-const CATEGORIES = ["cs.AI", "cs.CL", "cs.LG", "cs.CV", "cs.MA", "stat.ML"];
+const CATEGORIES = ["cs.AI", "cs.CL", "cs.LG", "cs.CV"];
 const CATEGORY_MAX_RESULTS = 50;
-const MAX_PAPERS = 250;
+const MAX_PAPERS = 200;
 // GitHub-hosted egress can still trip arXiv's edge limiter at 3s gaps.
 const CATEGORY_REQUEST_GAP_MS = 20_000;
 


### PR DESCRIPTION
## Summary
- Keep the arXiv hosted-runner fanout to cs.AI, cs.CL, cs.LG, and cs.CV.
- Drop cs.MA/stat.ML from the batch because cs.MA hit arXiv 429/abort after the reliable AI categories had succeeded.

## Validation
- node --check scripts/scrape-arxiv.mjs
- git diff --check
- npm run lint:guards
- Rerun evidence from main after #1278: cs.AI/CL/LG/CV each returned 50 entries before cs.MA failed upstream.