### PR TITLE
chore(actions): bound hosted funding and Twitter collectors

### DIFF
--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   collect:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,6 +46,7 @@ jobs:
       # Continues on error so a flaky EDGAR doesn't blank the funding-news
       # commit step.
       - run: npm run scrape:sec-form-d ${{ github.event.inputs.dry_run == 'true' && '-- --output=.tmp/sec-form-d-preview.json' || '' }}
+        timeout-minutes: 8
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
           # Dual-write to TOOLBOX signal lake (funding.sec.formd).

--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -8,7 +8,7 @@ on:
       limit:
         description: "Number of repos to scan"
         required: false
-        default: "25"
+        default: "10"
       mode:
         description: "Collector mode (api or direct)"
         required: false
@@ -67,14 +67,14 @@ jobs:
           # but Vercel's filesystem is read-only / ephemeral so the writes
           # would not persist to the /twitter page.
           TWITTER_COLLECTOR_MODE: ${{ github.event.inputs.mode || 'direct' }}
-          TWITTER_COLLECTOR_LIMIT: ${{ github.event.inputs.limit || '25' }}
+          TWITTER_COLLECTOR_LIMIT: ${{ github.event.inputs.limit || '10' }}
           # 4 queries per repo = full tier-1 coverage. Tier 1 is the set of
           # "impossible to fake coincidentally" signals: repo_slug (owner/name),
           # repo_url (github.com/...), package_name (pip/npm install ...),
           # homepage_url, docs_url. Package + homepage matches are often the
           # highest-signal finds — tweets saying "npm i foo" don't hit a
-          # slug/url search. Cost at 4 queries × 25 repos × 8 firings/day ≈
-          # 800 actor runs/day ≈ ~$8/day at expected hit rate.
+          # slug/url search. Hosted runners default to 10 repos per run so
+          # the collector stays inside the 30-minute job timeout.
           TWITTER_COLLECTOR_QUERIES_PER_REPO: ${{ vars.TWITTER_COLLECTOR_QUERIES_PER_REPO || '4' }}
           TWITTER_COLLECTOR_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           TWITTER_COLLECTOR_REPOS: ${{ github.event.inputs.repos || '' }}
@@ -103,7 +103,7 @@ jobs:
           REDIS_URL: ${{ secrets.REDIS_URL }}
           TWITTER_COLLECTOR_PROVIDER: web
           TWITTER_COLLECTOR_MODE: ${{ github.event.inputs.mode || 'direct' }}
-          TWITTER_COLLECTOR_LIMIT: ${{ github.event.inputs.limit || '25' }}
+          TWITTER_COLLECTOR_LIMIT: ${{ github.event.inputs.limit || '10' }}
           TWITTER_COLLECTOR_QUERIES_PER_REPO: ${{ vars.TWITTER_COLLECTOR_QUERIES_PER_REPO || '4' }}
           TWITTER_COLLECTOR_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           TWITTER_COLLECTOR_REPOS: ${{ github.event.inputs.repos || '' }}


### PR DESCRIPTION
## Summary
- Add a 35-minute job bound to collect-funding and an 8-minute bound around the SEC Form D side-channel so the primary funding refresh can finish.
- Lower hosted Twitter default scan size from 25 repos to 10 repos per run after the 25-repo collector hit the 30-minute job timeout.

## Validation
- js-yaml parsed collect-funding.yml and collect-twitter.yml
- git diff --check