### PR TITLE
fix(ci): detach Next smoke server in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         # binds 127.0.0.1:3023 → toolbox-trendingrepo-1 container (production
         # trendingrepo). Use 13023 to avoid the conflict during CI test runs.
         run: |
-          STARSCREENER_BASE_URL=http://localhost:13023 npx next start -p 13023 &
+          STARSCREENER_BASE_URL=http://localhost:13023 nohup npx next start -p 13023 > .next-server.log 2>&1 &
           echo $! > .next-pid
           for i in $(seq 1 60); do
             if curl -sSf http://localhost:13023/ >/dev/null 2>&1; then
@@ -206,6 +206,7 @@ jobs:
             sleep 1
           done
           echo "server failed to start within 60s" >&2
+          cat .next-server.log >&2 || true
           exit 1
 
       # STARSCREENER_BASE_URL is honored by playwright.config.ts: when set,


### PR DESCRIPTION
## Summary
- Run `next start` under `nohup` with stdout/stderr redirected to `.next-server.log`.
- Print `.next-server.log` if startup never becomes reachable.
- This addresses a main-push CI wrapper that showed all steps passed but kept `Start production server` marked in-progress, jamming newer Actions runs.

## Validation
- js-yaml parsed `.github/workflows/ci.yml`
- `git diff --check`