### PR TITLE
feat(analytics): track account auth funnel

### DIFF
--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -105,6 +105,18 @@ Lives on `/submit/revenue` (`src/components/submissions/DropRevenuePage.tsx`).
 | 1 | `revenue_claim_open` | `DropRevenuePage` mount, including repo-detail handoffs | `repo`, `source` (`repo_detail` \| `submit_revenue_page`), `repo_present` |
 | 2 | `revenue_claim_submit_success` | Revenue API responded `ok: true` | `repo`, `source`, `mode` (`trustmrr_link` \| `self_report`), `kind` (`created` \| `duplicate`) |
 
+### `account-auth` - single account CTA to hosted auth
+
+The header exposes one anonymous-user account entry, not separate sign-in and
+sign-up buttons. Clerk's hosted forms still cross-link between sign-in and
+sign-up after the user lands on the auth surface.
+
+| # | Step | Trigger | Notable extra properties |
+| - | ---- | ------- | ------------------------ |
+| 1 | `account_cta_click` | Header `Account` click | `source` (`header`), `auth_path` (`/sign-in` \| `/sign-up`) |
+| 2 | `sign_in_view` | `/sign-in` hosted auth page mount | `redirect_present` |
+| 2′ | `sign_up_view` | `/sign-up` hosted auth page mount | `redirect_present` |
+
 ---
 
 ## Adding a new flow

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -12,6 +12,7 @@
 // just gives operators a route-based fallback.
 
 import { AuthUnavailable } from "@/components/auth/AuthUnavailable";
+import { FunnelMount } from "@/components/analytics/FunnelMount";
 import { ClerkAuthForm } from "@/components/auth/ClerkAuthForm";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import {
@@ -37,6 +38,11 @@ export default async function Page({ searchParams }: SignInPageProps) {
 
   return (
     <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
+      <FunnelMount
+        step="sign_in_view"
+        flow="account-auth"
+        properties={{ redirect_present: redirectUrl !== "/" }}
+      />
       {clerkPublishableKey ? (
         <ClerkAuthForm
           mode="sign-in"

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -16,6 +16,7 @@
 //   `unsafe_metadata.trRef`.
 
 import { AuthUnavailable } from "@/components/auth/AuthUnavailable";
+import { FunnelMount } from "@/components/analytics/FunnelMount";
 import { ClerkAuthForm } from "@/components/auth/ClerkAuthForm";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import {
@@ -41,6 +42,11 @@ export default async function Page({ searchParams }: SignUpPageProps) {
 
   return (
     <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-12">
+      <FunnelMount
+        step="sign_up_view"
+        flow="account-auth"
+        properties={{ redirect_present: redirectUrl !== "/" }}
+      />
       {clerkPublishableKey ? (
         <ClerkAuthForm
           mode="sign-up"

--- a/src/components/layout/HeaderAccount.tsx
+++ b/src/components/layout/HeaderAccount.tsx
@@ -5,6 +5,7 @@ import { useUser } from "@clerk/nextjs";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { buildAuthHref } from "@/lib/auth/redirect-url";
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 
 interface HeaderAccountProps {
   publishableKey?: string;
@@ -45,10 +46,21 @@ function useAuthHref(): { href: string; refreshHref: () => string } {
 function SignedOutAccountLink() {
   const router = useRouter();
   const { href, refreshHref } = useAuthHref();
+
+  const trackAccountClick = useCallback((nextHref: string) => {
+    captureFunnelStep({
+      step: "account_cta_click",
+      flow: "account-auth",
+      source: "header",
+      auth_path: nextHref.startsWith("/sign-up") ? "/sign-up" : "/sign-in",
+    });
+  }, []);
+
   return (
     <Link
       href={href}
       onClick={(event) => {
+        const nextHref = refreshHref();
         if (
           event.defaultPrevented ||
           event.button !== 0 ||
@@ -57,11 +69,14 @@ function SignedOutAccountLink() {
           event.altKey ||
           event.shiftKey
         ) {
-          refreshHref();
+          if (!event.defaultPrevented) {
+            trackAccountClick(nextHref);
+          }
           return;
         }
         event.preventDefault();
-        router.push(refreshHref());
+        trackAccountClick(nextHref);
+        router.push(nextHref);
       }}
       onFocus={refreshHref}
       onPointerEnter={refreshHref}

--- a/src/lib/__vitest__/analytics-funnel.test.ts
+++ b/src/lib/__vitest__/analytics-funnel.test.ts
@@ -17,6 +17,11 @@ describe("PostHog funnel helper", () => {
     const captures: Array<{ event: string; props: unknown }> = [];
 
     captureFunnelStep({ step: "home_view", flow: "discover-repo" });
+    captureFunnelStep({
+      step: "account_cta_click",
+      flow: "account-auth",
+      source: "header",
+    });
     setWindowPostHog({
       __loaded: true,
       capture: (event: string, props: unknown) => captures.push({ event, props }),
@@ -27,6 +32,14 @@ describe("PostHog funnel helper", () => {
       {
         event: "funnel_step",
         props: { step: "home_view", flow: "discover-repo" },
+      },
+      {
+        event: "funnel_step",
+        props: {
+          step: "account_cta_click",
+          flow: "account-auth",
+          source: "header",
+        },
       },
     ]);
   });

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -57,6 +57,7 @@ function enqueueFunnelStep(props: FunnelStepProps): void {
  * 4. `compare-add`       repo-detail -> compare add -> /compare
  * 5. `submit-repo`       /submit open -> form fill -> submit success
  * 6. `revenue-claim`     repo-detail/direct -> claim revenue form -> submit success
+ * 7. `account-auth`      header account CTA -> hosted sign-in/sign-up page
  */
 export type FunnelFlow =
   | "discover-repo"
@@ -64,7 +65,8 @@ export type FunnelFlow =
   | "watchlist-add"
   | "compare-add"
   | "submit-repo"
-  | "revenue-claim";
+  | "revenue-claim"
+  | "account-auth";
 
 /**
  * Canonical step identifiers. Listed centrally so any regression in
@@ -90,7 +92,11 @@ export type FunnelStep =
   | "submit_success"
   // revenue claim
   | "revenue_claim_open"
-  | "revenue_claim_submit_success";
+  | "revenue_claim_submit_success"
+  // account auth
+  | "account_cta_click"
+  | "sign_in_view"
+  | "sign_up_view";
 
 interface FunnelStepProps {
   step: FunnelStep;


### PR DESCRIPTION
## Summary
- Keep the anonymous header as a single `Account` CTA and track clicks as `account_cta_click`.
- Track hosted `/sign-in` and `/sign-up` page views in a new `account-auth` funnel.
- Document the funnel contract and cover the queued PostHog helper path in Vitest.

## Validation
- `npx eslint src/lib/analytics/funnel.ts src/components/layout/HeaderAccount.tsx src/app/sign-in/[[...sign-in]]/page.tsx src/app/sign-up/[[...sign-up]]/page.tsx src/lib/__vitest__/analytics-funnel.test.ts`
- `npm run test:hooks -- src/lib/__vitest__/analytics-funnel.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run lint:guards`