### PR TITLE
feat(account): connect account hub and auth funnel success

### DIFF
--- a/docs/AUTH-SETUP.md
+++ b/docs/AUTH-SETUP.md
@@ -13,7 +13,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxx
 CLERK_SECRET_KEY=sk_test_xxxxxxxxxxxx
 
 # After wiring https://<domain>/api/webhooks/clerk in Clerk → Webhooks →
-# Endpoints (subscribe to user.created, user.updated, user.deleted):
+# Endpoints (subscribe to user.created, user.updated, user.deleted, session.created):
 CLERK_WEBHOOK_SIGNING_SECRET=whsec_xxxxxxxxxxxx
 
 # -- Supabase Postgres -------------------------------------------------------
@@ -51,7 +51,7 @@ FOUNDER_DISCORD_INVITE=
    - In Clerk → API Keys, copy publishable + secret keys.
    - In Clerk → Webhooks → Endpoints → Add Endpoint:
      - URL: `https://<your-domain>/api/webhooks/clerk` (use `ngrok` URL during dev).
-     - Subscribe to `user.created`, `user.updated`, `user.deleted`.
+     - Subscribe to `user.created`, `user.updated`, `user.deleted`, `session.created`.
      - Copy the signing secret into `CLERK_WEBHOOK_SIGNING_SECRET`.
 3. **Generate the webhook KEK**: `node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"` → set as `WEBHOOK_SECRET_KEK`.
 4. **Run migrations** (locally first):

--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -105,7 +105,7 @@ Lives on `/submit/revenue` (`src/components/submissions/DropRevenuePage.tsx`).
 | 1 | `revenue_claim_open` | `DropRevenuePage` mount, including repo-detail handoffs | `repo`, `source` (`repo_detail` \| `submit_revenue_page`), `repo_present` |
 | 2 | `revenue_claim_submit_success` | Revenue API responded `ok: true` | `repo`, `source`, `mode` (`trustmrr_link` \| `self_report`), `kind` (`created` \| `duplicate`) |
 
-### `account-auth` - single account CTA to hosted auth
+### `account-auth` - single account CTA to hosted auth and success
 
 The header exposes one anonymous-user account entry, not separate sign-in and
 sign-up buttons. Clerk's hosted forms still cross-link between sign-in and
@@ -116,6 +116,12 @@ sign-up after the user lands on the auth surface.
 | 1 | `account_cta_click` | Header `Account` click | `source` (`header`), `auth_path` (`/sign-in` \| `/sign-up`) |
 | 2 | `sign_in_view` | `/sign-in` hosted auth page mount | `redirect_present` |
 | 2′ | `sign_up_view` | `/sign-up` hosted auth page mount | `redirect_present` |
+| 3 | `sign_in_success` | Clerk `session.created` webhook | `source` (`clerk_webhook`), `session_id` |
+| 3′ | `sign_up_success` | Clerk `user.created` webhook | `source` (`clerk_webhook`), `profile_handle`, `referral_present` |
+
+`sign_in_success` requires `session.created` to be enabled on the Clerk webhook
+subscription. `sign_up_success` is already covered by the required
+`user.created` subscription.
 
 ---
 

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -4,6 +4,7 @@
 //   user.created  →  insert profile row + reserve handle
 //   user.updated  →  refresh email, displayName, avatarUrl
 //   user.deleted  →  soft-delete (set deleted_at)
+//   session.created  →  record successful sign-in for account funnel analytics
 //
 // Svix HMAC verification is mandatory — without it any caller can spoof
 // `user.created` events and create fake profiles. See
@@ -21,6 +22,7 @@ import { db } from "@/lib/db/client";
 import { profiles } from "@/lib/db/schema/profiles";
 import { referralCodes, referrals } from "@/lib/db/schema/referrals";
 import { reserveHandleFromClerk } from "@/lib/auth/handle";
+import { posthogCapture } from "@/lib/analytics/posthog";
 import { deriveCode } from "@/lib/referrals/code";
 import { verifyRefCookie } from "@/lib/referrals/cookie";
 import {
@@ -62,7 +64,12 @@ interface ClerkUserPayload {
 
 interface ClerkWebhookEvent {
   type: string;
-  data: ClerkUserPayload;
+  data: ClerkUserPayload | ClerkSessionPayload;
+}
+
+interface ClerkSessionPayload {
+  id: string;
+  user_id: string | null;
 }
 
 function pickPrimaryEmail(payload: ClerkUserPayload): string | null {
@@ -117,13 +124,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
     switch (event.type) {
       case "user.created":
-        await handleUserCreated(event.data, req);
+        await handleUserCreated(event.data as ClerkUserPayload, req);
         break;
       case "user.updated":
-        await handleUserUpdated(event.data);
+        await handleUserUpdated(event.data as ClerkUserPayload);
         break;
       case "user.deleted":
-        await handleUserDeleted(event.data);
+        await handleUserDeleted(event.data as ClerkUserPayload);
+        break;
+      case "session.created":
+        handleSessionCreated(event.data as ClerkSessionPayload);
         break;
       default:
         // Ignore other event types — we'd rather Clerk continue
@@ -204,6 +214,34 @@ async function handleUserCreated(
   } catch (err) {
     console.warn("[clerk-webhook] referral attribution failed", data.id, err);
   }
+
+  posthogCapture("funnel_step", {
+    step: "sign_up_success",
+    flow: "account-auth",
+    distinct_id: data.id,
+    source: "clerk_webhook",
+    $insert_id: `clerk:user.created:${data.id}`,
+    profile_handle: insertedProfile.handle,
+    referral_present: Boolean(
+      data.unsafe_metadata?.trRef?.code || req.cookies.get("tr_ref")?.value,
+    ),
+  });
+}
+
+function handleSessionCreated(data: ClerkSessionPayload): void {
+  if (!data.user_id) {
+    console.warn("[clerk-webhook] session.created missing user_id", data.id);
+    return;
+  }
+
+  posthogCapture("funnel_step", {
+    step: "sign_in_success",
+    flow: "account-auth",
+    distinct_id: data.user_id,
+    source: "clerk_webhook",
+    $insert_id: `clerk:session.created:${data.id}`,
+    session_id: data.id,
+  });
 }
 
 interface AttributeReferralInput {

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -60,7 +60,7 @@ const CHART_TOOLS: ToolEntry[] = [
     title: "Treemap",
     desc: "Sector treemap of trending repos — area scales with momentum, color encodes category.",
     href: "/tools/treemap",
-    status: "soon",
+    status: "live",
   },
 ];
 

--- a/src/app/you/YouClient.tsx
+++ b/src/app/you/YouClient.tsx
@@ -33,8 +33,19 @@ import { ProfileTemplate } from "@/components/templates/ProfileTemplate";
 import { SectionHead } from "@/components/ui/SectionHead";
 import { KpiBand, type KpiCell } from "@/components/ui/KpiBand";
 import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
+import { buildAuthHref } from "@/lib/auth/redirect-url";
 
-export default function YouClient() {
+export interface YouAccountSummary {
+  handle: string;
+  email: string;
+  displayName: string | null;
+}
+
+export default function YouClient({
+  account,
+}: {
+  account: YouAccountSummary | null;
+}) {
   // Hydration gate — zustand/persist loads from localStorage post-mount,
   // so render a stable placeholder until client state is truly live.
   const [hydrated, setHydrated] = useState(false);
@@ -104,7 +115,13 @@ export default function YouClient() {
             <b>YOU</b> · TERMINAL · /YOU
           </>
         }
-        identity={<YouIdentity watchCount={watchCount} hydrated={hydrated} />}
+        identity={
+          <YouIdentity
+            account={account}
+            watchCount={watchCount}
+            hydrated={hydrated}
+          />
+        }
         verdict={
           hydrated && watchCount > 0 ? (
             <VerdictRibbon
@@ -160,8 +177,16 @@ export default function YouClient() {
               onClearCompare={clearCompare}
             />
 
-            <SectionHead num="// 02" title="Account" meta="LOCAL ONLY" />
-            <AccountPanel hydrated={hydrated} watchCount={watchCount} />
+            <SectionHead
+              num="// 02"
+              title="Account"
+              meta={account ? `@${account.handle}` : "LOCAL ONLY"}
+            />
+            <AccountPanel
+              account={account}
+              hydrated={hydrated}
+              watchCount={watchCount}
+            />
 
             <SectionHead num="// 03" title="Preferences" />
             <PreferencesPanel
@@ -179,7 +204,11 @@ export default function YouClient() {
         rightRail={
           <>
             <SectionHead num="// 04" title="Quick links" />
-            <QuickLinks watchCount={watchCount} compareCount={compareCount} />
+            <QuickLinks
+              account={account}
+              watchCount={watchCount}
+              compareCount={compareCount}
+            />
           </>
         }
       />
@@ -190,12 +219,20 @@ export default function YouClient() {
 // --- Composition helpers --------------------------------------------------
 
 function YouIdentity({
+  account,
   watchCount,
   hydrated,
 }: {
+  account: YouAccountSummary | null;
   watchCount: number;
   hydrated: boolean;
 }) {
+  const marker = account ? `@${account.handle}` : "@local";
+  const headline = account?.displayName?.trim() || "Your signal";
+  const lede = account
+    ? "Account tools are live here: alert rules, referral desk, and your local watchlist context in one place."
+    : "No account required. Your watchlist, compare shortlist, and filter preferences stay in this browser.";
+
   return (
     <div
       style={{
@@ -222,24 +259,23 @@ function YouIdentity({
           flexShrink: 0,
         }}
       >
-        u
+        {account ? account.handle.slice(0, 1).toLowerCase() : "u"}
       </div>
       <div style={{ flex: 1, minWidth: 0 }}>
         <h1
           className="v4-page-head__h1"
           style={{ marginTop: 0, marginBottom: 4 }}
         >
-          Your signal{" "}
+          {headline}{" "}
           <span style={{ color: "var(--v4-ink-300)", fontSize: "0.6em" }}>
-            @local
+            {marker}
           </span>
         </h1>
         <p
           className="v4-page-head__lede"
           style={{ marginTop: 0, marginBottom: 10 }}
         >
-          No account, no tracking. StarScreener keeps your watchlist,
-          compare shortlist, and filter preferences in your browser.
+          {lede}
         </p>
         <div
           style={{
@@ -253,7 +289,7 @@ function YouIdentity({
             letterSpacing: "0.06em",
           }}
         >
-          <span>local-only</span>
+          <span>{account ? "account active" : "local-only"}</span>
           <span>
             ●{" "}
             <b style={{ color: "var(--v4-money)" }}>
@@ -444,12 +480,78 @@ function ActivityPanel({
 }
 
 function AccountPanel({
+  account,
   hydrated,
   watchCount,
 }: {
+  account: YouAccountSummary | null;
   hydrated: boolean;
   watchCount: number;
 }) {
+  if (account) {
+    return (
+      <div
+        style={{
+          border: "1px solid var(--v4-line-200)",
+          borderRadius: 4,
+          padding: 16,
+          background: "var(--v4-bg-050)",
+          display: "grid",
+          gridTemplateColumns: "1fr",
+          gap: 12,
+        }}
+      >
+        <div style={kvRowStyle}>
+          <span style={kvLabelStyle}>Profile</span>
+          <span style={kvValueStyle}>@{account.handle}</span>
+        </div>
+        <div style={kvRowStyle}>
+          <span style={kvLabelStyle}>Email</span>
+          <span style={kvValueStyle}>{account.email}</span>
+        </div>
+        <div style={kvRowStyle}>
+          <span style={kvLabelStyle}>Local state</span>
+          <span style={kvValueStyle}>
+            {hydrated
+              ? `${watchCount} watched repo${watchCount === 1 ? "" : "s"}`
+              : "syncing..."}
+          </span>
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            gap: 8,
+            paddingTop: 4,
+          }}
+        >
+          <Link href="/you/alerts" style={accountToolLinkStyle}>
+            <span>Watchlist alerts</span>
+            <span>rules -&gt;</span>
+          </Link>
+          <Link href="/you/refer" style={accountToolLinkStyle}>
+            <span>Referral desk</span>
+            <span>code -&gt;</span>
+          </Link>
+        </div>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-geist-mono), monospace",
+            fontSize: 10,
+            color: "var(--v4-ink-400)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            lineHeight: 1.6,
+          }}
+        >
+          Server-backed tools use your account. Watchlist and compare state
+          still stay local until sync is explicitly shipped.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div
       style={{
@@ -464,7 +566,7 @@ function AccountPanel({
     >
       <div style={kvRowStyle}>
         <span style={kvLabelStyle}>Plan</span>
-        <span style={kvValueStyle}>Local · free forever</span>
+        <span style={kvValueStyle}>Local preview</span>
       </div>
       <div style={kvRowStyle}>
         <span style={kvLabelStyle}>Storage</span>
@@ -475,11 +577,17 @@ function AccountPanel({
         <span style={kvValueStyle}>off · per-device</span>
       </div>
       <div style={kvRowStyle}>
+        <span style={kvLabelStyle}>Account</span>
+        <Link href={buildAuthHref("/sign-in", "/you")} style={kvLinkStyle}>
+          Sign in or create account
+        </Link>
+      </div>
+      <div style={kvRowStyle}>
         <span style={kvLabelStyle}>State</span>
         <span style={kvValueStyle}>
           {hydrated
             ? `${watchCount} watched repo${watchCount === 1 ? "" : "s"}`
-            : "syncing…"}
+            : "syncing..."}
         </span>
       </div>
       <p
@@ -493,8 +601,8 @@ function AccountPanel({
           lineHeight: 1.6,
         }}
       >
-        StarScreener does not store accounts. Your data lives in this browser
-        until you clear site data.
+        Sign in once to unlock alerts and referrals. Your current local
+        watchlist remains in this browser.
       </p>
     </div>
   );
@@ -569,9 +677,11 @@ function PreferencesPanel({
 }
 
 function QuickLinks({
+  account,
   watchCount,
   compareCount,
 }: {
+  account: YouAccountSummary | null;
   watchCount: number;
   compareCount: number;
 }) {
@@ -591,6 +701,18 @@ function QuickLinks({
       meta: compareCount > 0 ? `${compareCount} staged` : "empty",
     },
     { href: "/signals", label: "Signals", meta: "newsroom" },
+    ...(account
+      ? [
+          { href: "/you/alerts", label: "Alerts", meta: "account" },
+          { href: "/you/refer", label: "Referrals", meta: "account" },
+        ]
+      : [
+          {
+            href: buildAuthHref("/sign-in", "/you"),
+            label: "Account",
+            meta: "sign in",
+          },
+        ]),
   ];
   return (
     <ul
@@ -845,6 +967,7 @@ const kvRowStyle: React.CSSProperties = {
   justifyContent: "space-between",
   alignItems: "baseline",
   gap: 12,
+  minWidth: 0,
 };
 
 const kvLabelStyle: React.CSSProperties = {
@@ -859,4 +982,33 @@ const kvValueStyle: React.CSSProperties = {
   fontFamily: "var(--font-geist-mono), monospace",
   fontSize: 12,
   color: "var(--v4-ink-100)",
+  minWidth: 0,
+  overflow: "hidden",
+  textAlign: "right",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const kvLinkStyle: React.CSSProperties = {
+  ...kvValueStyle,
+  color: "var(--v4-acc)",
+  textDecoration: "none",
+};
+
+const accountToolLinkStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: 10,
+  minHeight: 44,
+  padding: "10px 12px",
+  border: "1px solid var(--v4-line-200)",
+  borderRadius: 3,
+  color: "var(--v4-ink-100)",
+  background: "var(--v4-bg-075)",
+  textDecoration: "none",
+  fontFamily: "var(--font-geist-mono), monospace",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
 };

--- a/src/app/you/page.tsx
+++ b/src/app/you/page.tsx
@@ -1,23 +1,37 @@
-// TrendingRepo — /you profile landing.
+// TrendingRepo - /you profile landing.
 //
-// Zero-auth personal signal panel. Pulls local-only state (watchlist +
-// compare + filters) out of zustand and renders a compact "what you've
-// been tracking" summary. All state is client-persisted via localStorage
-// — there is no server-side account yet.
+// Personal signal panel. Pulls local-only state (watchlist + compare +
+// filters) out of zustand and renders a compact "what you've been tracking"
+// summary. When a Clerk session is present, the same hub also exposes
+// server-backed account tools such as alerts and referrals.
 //
 // Server wrapper owns the metadata export; the interactive shell lives
 // in ./YouClient because Next.js 15 forbids `export const metadata` from
 // a "use client" module.
 
 import type { Metadata } from "next";
+
+import { getUser } from "@/lib/auth/server";
+
 import YouClient from "./YouClient";
 
 export const metadata: Metadata = {
-  title: "Your signal — TrendingRepo",
+  title: "Your signal - TrendingRepo",
   description:
-    "Personal watchlist, compare shortlist, and saved filter summary. No account required — TrendingRepo keeps your signal local.",
+    "Personal watchlist, compare shortlist, account tools, and saved filter summary.",
 };
 
-export default function YouPage() {
-  return <YouClient />;
+export const dynamic = "force-dynamic";
+
+export default async function YouPage() {
+  const user = await getUser();
+  const account = user
+    ? {
+        handle: user.profile.handle,
+        email: user.profile.email,
+        displayName: user.profile.displayName,
+      }
+    : null;
+
+  return <YouClient account={account} />;
 }

--- a/src/lib/__vitest__/analytics-funnel.test.ts
+++ b/src/lib/__vitest__/analytics-funnel.test.ts
@@ -22,6 +22,11 @@ describe("PostHog funnel helper", () => {
       flow: "account-auth",
       source: "header",
     });
+    captureFunnelStep({
+      step: "sign_up_success",
+      flow: "account-auth",
+      source: "clerk_webhook",
+    });
     setWindowPostHog({
       __loaded: true,
       capture: (event: string, props: unknown) => captures.push({ event, props }),
@@ -39,6 +44,14 @@ describe("PostHog funnel helper", () => {
           step: "account_cta_click",
           flow: "account-auth",
           source: "header",
+        },
+      },
+      {
+        event: "funnel_step",
+        props: {
+          step: "sign_up_success",
+          flow: "account-auth",
+          source: "clerk_webhook",
         },
       },
     ]);

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -57,7 +57,7 @@ function enqueueFunnelStep(props: FunnelStepProps): void {
  * 4. `compare-add`       repo-detail -> compare add -> /compare
  * 5. `submit-repo`       /submit open -> form fill -> submit success
  * 6. `revenue-claim`     repo-detail/direct -> claim revenue form -> submit success
- * 7. `account-auth`      header account CTA -> hosted sign-in/sign-up page
+ * 7. `account-auth`      header account CTA -> hosted auth -> webhook success
  */
 export type FunnelFlow =
   | "discover-repo"
@@ -96,7 +96,9 @@ export type FunnelStep =
   // account auth
   | "account_cta_click"
   | "sign_in_view"
-  | "sign_up_view";
+  | "sign_up_view"
+  | "sign_in_success"
+  | "sign_up_success";
 
 interface FunnelStepProps {
   step: FunnelStep;


### PR DESCRIPTION
## Summary
- make `/you` account-aware while preserving local watchlist and compare state
- expose signed-in account tools directly from `/you`: Watchlist alerts and Referral desk
- emit PostHog `account-auth` success steps from Clerk webhooks (`user.created`, `session.created`)
- mark the shipped `/tools/treemap` route live in the tools hub

## Validation
- `npx eslint src/app/you/page.tsx src/app/you/YouClient.tsx src/app/api/webhooks/clerk/route.ts src/app/tools/page.tsx src/lib/analytics/funnel.ts src/lib/__vitest__/analytics-funnel.test.ts`
- `npm run test:hooks -- src/lib/__vitest__/analytics-funnel.test.ts`
- `npm run typecheck`
- `npm run lint:guards`
- `npm run build`
- `git diff --check`