### PR TITLE
fix(data): keep stale reddit snapshot on zero-post refresh

### DIFF
--- a/data/_meta/reddit.json
+++ b/data/_meta/reddit.json
@@ -1,8 +1,8 @@
 {
   "source": "reddit",
   "reason": "ok",
-  "ts": "2026-05-15T09:06:23.507Z",
+  "ts": "2026-05-15T06:26:29.898Z",
   "count": 1,
-  "durationMs": 278710,
+  "durationMs": 277466,
   "extra": {}
 }

--- a/data/reddit-all-posts.json
+++ b/data/reddit-all-posts.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-15T09:01:44.874Z",
+  "lastFetchedAt": "2026-05-15T06:21:52.520Z",
   "scannedSubreddits": [
     "ClaudeAI",
     "ChatGPT",

--- a/data/reddit-mentions.json
+++ b/data/reddit-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-15T09:01:44.874Z",
+  "fetchedAt": "2026-05-15T06:21:52.520Z",
   "cold": true,
   "authMode": "public-json",
   "effectiveFetchMode": "rss-atom",


### PR DESCRIPTION
## Summary
- undo the timestamp-only Reddit changes from #1297 after the fast-discovery run failed its zero-post health check
- keep the useful non-Reddit HN/trending/metadata refresh that already landed on main

## Validation
- parsed `data/_meta/reddit.json`, `data/reddit-all-posts.json`, and `data/reddit-mentions.json`
- confirmed `reddit-all-posts.posts.length === 0` and `reddit-mentions.mentions` remains empty, so the newer timestamp was misleading
- `git diff --check`