### PR TITLE
fix: restore skills and profile routes

### DIFF
--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -611,11 +611,17 @@ function ListTaxonomyTabs({
       count: formatNumber(listCounts[slug]),
     })),
   ];
+  const hrefs = Object.fromEntries(
+    items.map((item) => [
+      item.id,
+      item.id === "all" ? "/skills" : `/skills?list=${item.id}`,
+    ]),
+  );
   return (
     <TabBar
       items={items}
       active={activeSlug ?? "all"}
-      hrefFor={(id) => (id === "all" ? "/skills" : `/skills?list=${id}`)}
+      hrefs={hrefs}
       className="v4-tab-bar--skills"
     />
   );

--- a/src/app/you/page.tsx
+++ b/src/app/you/page.tsx
@@ -11,7 +11,7 @@
 
 import type { Metadata } from "next";
 
-import { getUser } from "@/lib/auth/server";
+import { getOptionalUser } from "@/lib/auth/server";
 
 import YouClient from "./YouClient";
 
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
 export const dynamic = "force-dynamic";
 
 export default async function YouPage() {
-  const user = await getUser();
+  const user = await getOptionalUser();
   const account = user
     ? {
         handle: user.profile.handle,

--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -52,6 +52,12 @@ export interface TabBarProps {
   /** When provided, tabs render as <a href={hrefFor(id)}> instead of <button>. */
   hrefFor?: (id: string) => string;
   /**
+   * Server-component-safe link mode. Use this instead of `hrefFor` when the
+   * caller is a server component, because functions cannot cross the RSC
+   * boundary into this client component.
+   */
+  hrefs?: Record<string, string>;
+  /**
    * Optional right-aligned slot rendered after the tabs (e.g. "Sort · momentum",
    * "live"). Mockup pattern from home.html § 05 Live · top 50.
    */
@@ -64,6 +70,7 @@ export function TabBar({
   active,
   onChange,
   hrefFor,
+  hrefs,
   rightSlot,
   className,
 }: TabBarProps) {
@@ -85,11 +92,12 @@ export function TabBar({
             ) : null}
           </>
         );
-        if (hrefFor) {
+        const href = hrefFor ? hrefFor(item.id) : hrefs?.[item.id];
+        if (href) {
           return (
             <a
               key={item.id}
-              href={hrefFor(item.id)}
+              href={href}
               className={cls}
               role="tab"
               aria-selected={isActive}

--- a/src/components/ui/__tests__/v4-filters.test.tsx
+++ b/src/components/ui/__tests__/v4-filters.test.tsx
@@ -167,6 +167,19 @@ describe("TabBar", () => {
     expect(links[0].getAttribute("href")).toBe("/?cat=all");
   });
 
+  it("renders link mode from serializable hrefs", () => {
+    const { container } = render(
+      <TabBar
+        items={items}
+        active="hn"
+        hrefs={{ all: "/", hn: "/?cat=hn", rdt: "/?cat=rdt" }}
+      />,
+    );
+    const links = container.querySelectorAll("a.v4-tab");
+    expect(links).toHaveLength(3);
+    expect(links[1].getAttribute("href")).toBe("/?cat=hn");
+  });
+
   it("renders count slot", () => {
     const { container } = render(<TabBar items={items} active="all" />);
     const counts = container.querySelectorAll(".v4-tab__count");

--- a/src/lib/__tests__/middleware-route-policy.test.ts
+++ b/src/lib/__tests__/middleware-route-policy.test.ts
@@ -31,9 +31,19 @@ test("middleware runs Clerk only for protected routes and session-aware APIs", (
     /export default getClerkPublishableKey\(\)\s*\?/,
     "public pages must not be globally wrapped by Clerk middleware",
   );
+  const sessionRouteMatcher = middlewareSource.match(
+    /const isClerkSessionRoute = createRouteMatcher\(\[([\s\S]*?)\]\);/,
+  );
+  assert.ok(sessionRouteMatcher, "expected Clerk session route matcher");
+  const sessionRouteBody = sessionRouteMatcher[1] ?? "";
   assert.match(
-    middlewareSource,
-    /const isClerkSessionRoute = createRouteMatcher\(\[\s*["']\/api\/pipeline\/sidebar-overlay["'],?\s*\]\);/,
+    sessionRouteBody,
+    /["']\/you["']/,
+    "/you must run inside Clerk middleware so optional auth can return a session or null",
+  );
+  assert.match(
+    sessionRouteBody,
+    /["']\/api\/pipeline\/sidebar-overlay["']/,
     "sidebar overlay must run inside Clerk middleware so auth() can return a session or null",
   );
   assert.match(

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -42,12 +42,30 @@ export interface LoadedUser {
 export async function getUser(): Promise<LoadedUser | null> {
   // Reading cookies() forces Next 15 to treat the route as dynamic, which
   // is required for `auth()` to read the Clerk session token.
-  cookies();
+  await cookies();
   const { userId } = await auth();
   if (!userId) return null;
   const profile = await loadProfileOrLazyCreate(userId);
   if (!profile) return null;
   return { clerkUserId: userId, profile };
+}
+
+/**
+ * Optional auth for public pages. These surfaces must stay usable as anonymous
+ * local-only tools even when Clerk middleware is unavailable in CI/local envs.
+ */
+export async function getOptionalUser(): Promise<LoadedUser | null> {
+  try {
+    return await getUser();
+  } catch (error) {
+    if (isMissingClerkMiddlewareError(error)) {
+      console.warn(
+        "[auth] optional Clerk context unavailable; rendering signed-out state",
+      );
+      return null;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -133,6 +151,14 @@ async function loadProfileOrLazyCreate(
  * 5 minutes per user via cookie to avoid hammering the DB on every page
  * view of a busy user.
  */
+function isMissingClerkMiddlewareError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes("Clerk can't detect usage of clerkMiddleware") ||
+    error.message.includes("auth() was called but Clerk can't detect")
+  );
+}
+
 export async function touchLastSeen(profileId: string): Promise<void> {
   await db
     .update(profiles)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,9 +49,11 @@ const isProtectedRoute = createRouteMatcher([
 ]);
 
 // Routes that are still public in the product sense, but need Clerk's
-// middleware context so route handlers can call `auth()` and decide their
-// own JSON response shape instead of throwing outside Clerk.
+// middleware context so route handlers/server components can call `auth()`
+// and decide their own anonymous-vs-signed-in shape instead of throwing
+// outside Clerk.
 const isClerkSessionRoute = createRouteMatcher([
+  "/you",
   "/api/pipeline/sidebar-overlay",
 ]);
 


### PR DESCRIPTION
## Summary
- fixes `/skills` by replacing a server-to-client function prop with serializable tab hrefs
- fixes `/you` profile route by using optional auth and running the public route through Clerk session middleware when configured
- adds regression coverage for server-safe TabBar hrefs and middleware route policy

## Verification
- `npx eslint src/components/ui/TabBar.tsx src/app/skills/page.tsx src/lib/auth/server.ts src/app/you/page.tsx src/middleware.ts src/lib/__tests__/middleware-route-policy.test.ts src/components/ui/__tests__/v4-filters.test.tsx`
- `npx vitest run --config vitest.config.ts src/components/ui/__tests__/v4-filters.test.tsx`
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/middleware-route-policy.test.ts`
- `npm run typecheck`
- `npm run build`
- Playwright local prod probe: `/skills` and `/you` render content without the route error boundary