### PR TITLE
fix: stop agent-commerce sidebar prefetch

### DIFF
--- a/src/components/layout/SidebarContent.tsx
+++ b/src/components/layout/SidebarContent.tsx
@@ -234,6 +234,7 @@ type BadgeTone = "default" | "accent" | "danger" | "delta";
 
 interface V2NavRowProps {
   href?: string;
+  prefetch?: boolean;
   onClick?: () => void;
   icon: SidebarIconComponent;
   label: string;
@@ -284,6 +285,7 @@ function renderLabel(label: string): ReactNode {
 
 function V2NavRow({
   href,
+  prefetch,
   onClick,
   icon: Icon,
   label,
@@ -327,7 +329,7 @@ function V2NavRow({
 
   if (href) {
     return (
-      <Link href={href} className={className}>
+      <Link href={href} prefetch={prefetch} className={className}>
         {content}
       </Link>
     );
@@ -656,6 +658,7 @@ export function SidebarContent({
           />
           <V2NavRow
             href="/agent-commerce"
+            prefetch={false}
             icon={Coins}
             label="Agent Commerce"
             badge="x402"

--- a/src/lib/__tests__/sidebar-prefetch-policy.test.ts
+++ b/src/lib/__tests__/sidebar-prefetch-policy.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const sidebarSource = readFileSync(
+  join(process.cwd(), "src", "components", "layout", "SidebarContent.tsx"),
+  "utf8",
+);
+
+test("agent-commerce sidebar link does not auto-prefetch", () => {
+  assert.match(
+    sidebarSource,
+    /<Link href=\{href\} prefetch=\{prefetch\} className=\{className\}>/,
+    "V2NavRow must forward prefetch to Next Link",
+  );
+  assert.match(
+    sidebarSource,
+    /<V2NavRow\s+href="\/agent-commerce"\s+prefetch=\{false\}/,
+    "agent-commerce is crawler-guarded and should not prefetch from every page",
+  );
+});


### PR DESCRIPTION
## Summary
- keeps the sidebar Agent Commerce link clickable but disables automatic Next prefetch for that crawler-guarded route
- prevents headless/crawler-like browsers from getting a background `/agent-commerce?_rsc=...` 429 on every page
- adds a source-level regression test for the prefetch policy

## Verification
- `npx eslint src/components/layout/SidebarContent.tsx src/lib/__tests__/sidebar-prefetch-policy.test.ts`
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/sidebar-prefetch-policy.test.ts`
- `npm run typecheck`
- `npm run build`
- Local browser dev probe: `/`, `/sign-in`, and `/you` had zero bad responses, zero `/agent-commerce` 429s, and zero console errors