### PR TITLE
fix: stabilize home freshness hydration

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -830,6 +830,7 @@ export default async function HomePage() {
   })();
   const refreshed = new Date(lastFetchedAt);
   const refreshedTime = refreshed.toISOString().slice(11, 19);
+  const freshnessNowMs = Date.now();
   const temporalCoverageStart = new Date(
     refreshed.getTime() - 365 * 24 * 3600 * 1000,
   )
@@ -988,6 +989,7 @@ export default async function HomePage() {
             categories={liveCategories}
             freshnessSource="repos"
             lastUpdatedAt={lastFetchedAt}
+            freshnessNowMs={freshnessNowMs}
           />
         </Card>
 

--- a/src/components/home/LiveTopTable.tsx
+++ b/src/components/home/LiveTopTable.tsx
@@ -145,6 +145,11 @@ interface LiveTopTableProps {
   /** ISO of the last successful collector write. Honest-chrome rule: don't
    * paint a green "live" pip when the underlying snapshot is hours/days old. */
   lastUpdatedAt?: string | null;
+  /**
+   * Server render timestamp used for relative freshness labels. Passing this
+   * through keeps the first client render identical to ISR HTML.
+   */
+  freshnessNowMs?: number;
 }
 
 const compactNumber = new Intl.NumberFormat("en-US", {
@@ -333,6 +338,7 @@ export function LiveTopTable({
   categories,
   freshnessSource = "repos",
   lastUpdatedAt = null,
+  freshnessNowMs,
 }: LiveTopTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>("rank");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -384,7 +390,11 @@ export function LiveTopTable({
         <span className="live-top-spacer" />
         <span className="live-top-meta">
           showing <b>{visible.length}</b> / {rows.length}
-          <FreshnessBadge source={freshnessSource} lastUpdatedAt={lastUpdatedAt} />
+          <FreshnessBadge
+            source={freshnessSource}
+            lastUpdatedAt={lastUpdatedAt}
+            nowMs={freshnessNowMs}
+          />
         </span>
       </div>
 
@@ -477,7 +487,11 @@ export function LiveTopTable({
                           {row.updatedAt ? (
                             <>
                               {" · "}
-                              <FreshnessChip updatedAt={row.updatedAt} size="xs" />
+                              <FreshnessChip
+                                updatedAt={row.updatedAt}
+                                size="xs"
+                                nowMs={freshnessNowMs}
+                              />
                             </>
                           ) : null}
                         </small>

--- a/src/components/home/__tests__/LiveTopTable.test.tsx
+++ b/src/components/home/__tests__/LiveTopTable.test.tsx
@@ -33,6 +33,7 @@ const row: LiveRow = {
   momentumScore: 88,
   mentionCount24h: 9,
   sources: { gh: 1, x: 2 },
+  updatedAt: "2026-05-04T11:00:00.000Z",
 };
 
 const categories: CategoryFacet[] = [
@@ -42,12 +43,18 @@ const categories: CategoryFacet[] = [
 describe("LiveTopTable", () => {
   it("renders the stars value as a strong starred number", () => {
     const { container } = render(
-      <LiveTopTable rows={[row]} categories={categories} />,
+      <LiveTopTable
+        rows={[row]}
+        categories={categories}
+        lastUpdatedAt="2026-05-04T11:00:00.000Z"
+        freshnessNowMs={new Date("2026-05-04T12:00:00.000Z").getTime()}
+      />,
     );
 
     const stars = container.querySelector("td.stars-num");
 
     expect(stars?.textContent).toContain("35.1k");
     expect(stars?.querySelector(".stars-main svg")).not.toBeNull();
+    expect(container.textContent).toContain("Updated 1h ago");
   });
 });

--- a/src/components/shared/FreshnessBadge.tsx
+++ b/src/components/shared/FreshnessBadge.tsx
@@ -17,6 +17,8 @@ interface FreshnessBadgeProps {
   /** Which source threshold to apply. Routes pick the NewsSource closest to
    * their cron cadence (e.g. `mcp`/`skills` for slow-cron Redis feeds). */
   source: NewsSource;
+  /** Stable render timestamp for Client Component hydration. */
+  nowMs?: number;
 }
 
 const TONE: Record<"live" | "warn" | "cold", { color: string; label: string }> = {
@@ -25,14 +27,18 @@ const TONE: Record<"live" | "warn" | "cold", { color: string; label: string }> =
   cold: { color: "var(--v4-red)", label: "COLD" },
 };
 
-export function FreshnessBadge({ lastUpdatedAt, source }: FreshnessBadgeProps) {
+export function FreshnessBadge({
+  lastUpdatedAt,
+  source,
+  nowMs,
+}: FreshnessBadgeProps) {
   const iso =
     lastUpdatedAt instanceof Date
       ? lastUpdatedAt.toISOString()
       : typeof lastUpdatedAt === "number"
         ? new Date(lastUpdatedAt).toISOString()
         : (lastUpdatedAt ?? null);
-  const verdict = classifyFreshness(source, iso);
+  const verdict = classifyFreshness(source, iso, nowMs);
   const tone = TONE[verdict.status];
   return (
     <span

--- a/src/components/shared/__tests__/FreshnessBadge.test.tsx
+++ b/src/components/shared/__tests__/FreshnessBadge.test.tsx
@@ -39,6 +39,18 @@ describe("FreshnessBadge", () => {
     expect(container.textContent).toContain("· 2m");
   });
 
+  it("can pin the reference clock for client hydration", () => {
+    const fetchedAt = new Date(NOW - 2 * 60 * 1000).toISOString();
+    const { container } = render(
+      <FreshnessBadge
+        lastUpdatedAt={fetchedAt}
+        source="reddit"
+        nowMs={NOW + 58 * 60 * 1000}
+      />,
+    );
+    expect(container.textContent).toContain("1h");
+  });
+
   it("renders '{h}h' for a sub-day age", () => {
     setNow(NOW);
     // 4h is past reddit's stale threshold (cold), but the ageLabel formatter


### PR DESCRIPTION
## Summary
- pass a server render timestamp into the home live table freshness UI
- let FreshnessBadge consume a pinned clock for client hydration
- add regression coverage for pinned freshness rendering

## Verification
- npx eslint src/app/page.tsx src/components/home/LiveTopTable.tsx src/components/shared/FreshnessBadge.tsx src/components/home/__tests__/LiveTopTable.test.tsx src/components/shared/__tests__/FreshnessBadge.test.tsx
- npx vitest run src/components/shared/__tests__/FreshnessBadge.test.tsx src/components/home/__tests__/LiveTopTable.test.tsx
- npm run typecheck
- npm run build
- local prod Playwright probe on / with public Clerk key: no bad responses, no page errors, no error boundary