### PR TITLE
feat(sidebar): profile card + remove Collections nav row

### DIFF
--- a/src/components/layout/SidebarContent.tsx
+++ b/src/components/layout/SidebarContent.tsx
@@ -42,7 +42,6 @@ import {
   FileText,
   GitCompareArrows,
   GraduationCap,
-  Library,
   Lightbulb,
   Package,
   Plug,
@@ -74,6 +73,7 @@ import {
 } from "./SidebarWatchlistPreview";
 import { SidebarRecentViewedRepos } from "./SidebarRecentViewedRepos";
 import { SidebarFooter } from "./SidebarFooter";
+import { SidebarProfileCard } from "./SidebarProfileCard";
 import { cn } from "@/lib/utils";
 import { CursorRail } from "@/components/v3/CursorRail";
 
@@ -741,15 +741,6 @@ export function SidebarContent({
           {/* "Predict" sidebar entry removed 2026-05-09. The DB descriptor
               remains for a future prediction writer, but no public route is
               shipped until predictions land in Redis like the other surfaces. */}
-          <V2NavRow
-            href="/collections"
-            icon={Library}
-            label="Collections"
-            active={
-              pathname === "/collections" ||
-              pathname.startsWith("/collections/")
-            }
-          />
         </V2Section>
 
         {/* TOOLS */}
@@ -807,6 +798,7 @@ export function SidebarContent({
         </V2Section>
       </CursorRail>
 
+      <SidebarProfileCard />
       <SidebarFooter compact={compact} onToggleCompact={onToggleCompact} />
     </div>
   );

--- a/src/components/layout/SidebarProfileCard.tsx
+++ b/src/components/layout/SidebarProfileCard.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * SidebarProfileCard — post-signup identity strip + 6-tile launcher.
+ * Anonymous users get nothing (no Clerk → tree returns null). Signed-in
+ * users get a beta-brand eyebrow, monogram avatar, handle, tier badge,
+ * and a 3×2 grid linking to WATCH / ALERTS / DROPS / AGENT / CLI / MCP.
+ *
+ * Wiring:
+ *   - Handle + avatar come from Clerk `useUser()`.
+ *   - WATCH count → `useWatchlistStore` (already populated client-side).
+ *   - ALERTS count → `useSidebarOverlayStore.unreadAlerts` (fetched by the
+ *     existing SidebarUserOverlayBridge on layout mount — we piggyback
+ *     instead of issuing a duplicate request).
+ *   - DROPS count → 0 stub. `/api/me/submissions/count` does not exist
+ *     yet; surfaces as a follow-up.
+ *   - AGENT / CLI / MCP tiles are link-only (no counts).
+ *
+ * Mounted between the sidebar's `<CursorRail>` content and `<SidebarFooter>`,
+ * so it sits just above the footer chrome on every page that shows the
+ * sidebar.
+ */
+import { useUser } from "@clerk/nextjs";
+
+import { useWatchlistStore } from "@/lib/store";
+import { useSidebarOverlayStore } from "./SidebarUserOverlayBridge";
+import { SidebarProfileTile } from "./SidebarProfileTile";
+
+const CLERK_PUBLIC_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+function avatarInitials(input: string): string {
+  const cleaned = input.replace(/^user_/, "").trim();
+  if (!cleaned) return "AC";
+  const parts = cleaned.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`.toUpperCase();
+  }
+  return cleaned.slice(0, 2).toUpperCase();
+}
+
+export function SidebarProfileCard() {
+  if (!CLERK_PUBLIC_KEY) return null;
+  return <SidebarProfileCardInner />;
+}
+
+function SidebarProfileCardInner() {
+  const { isLoaded, isSignedIn, user } = useUser();
+  const watchCount = useWatchlistStore((s) => s.repos.length);
+  const unreadAlerts = useSidebarOverlayStore((s) => s.unreadAlerts);
+
+  // First paint: render a skeleton so we don't flash the unauthenticated
+  // empty state in front of an actually-signed-in user. Reads from Clerk
+  // settle within a couple of frames in practice.
+  if (!isLoaded) {
+    return <SidebarProfileCardSkeleton />;
+  }
+
+  if (!isSignedIn || !user) {
+    return null;
+  }
+
+  const handle =
+    user.username ||
+    user.firstName ||
+    user.primaryEmailAddress?.emailAddress?.split("@")[0] ||
+    "you";
+  const initials = avatarInitials(user.fullName || handle);
+
+  return (
+    <div
+      className="shrink-0 space-y-2 border-t px-3 py-3"
+      style={{ borderColor: "var(--v4-line-100)" }}
+    >
+      <div
+        className="font-mono text-[9px] uppercase tracking-[0.18em]"
+        style={{ color: "var(--ink-400)" }}
+      >
+        TRENDINGREPO BETA{" "}
+        <span style={{ color: "var(--v3-acc)" }}>/ // OPEN SOURCE · LIVE</span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div
+          aria-hidden
+          className="flex h-8 w-8 items-center justify-center rounded-sm text-[11px] font-semibold"
+          style={{
+            background: "var(--v4-acc-soft)",
+            color: "var(--v3-acc)",
+            border: "1px solid var(--v4-line-100)",
+          }}
+        >
+          {initials}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div
+            className="truncate text-[12px] font-medium"
+            style={{ color: "var(--ink-100)" }}
+            title={handle}
+          >
+            {handle}
+          </div>
+          <div
+            className="font-mono text-[9px] uppercase tracking-[0.18em]"
+            style={{ color: "var(--ink-400)" }}
+          >
+            PRO · LVL 12
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-1.5">
+        <SidebarProfileTile label="WATCH" href="/watchlist" count={watchCount} />
+        <SidebarProfileTile
+          label="ALERTS"
+          href="/you/alerts"
+          count={unreadAlerts}
+        />
+        <SidebarProfileTile label="DROPS" href="/submit" count={0} />
+        <SidebarProfileTile label="AGENT" href="/agent-commerce" />
+        <SidebarProfileTile label="CLI" href="/cli" />
+        <SidebarProfileTile label="MCP" href="/mcp" />
+      </div>
+    </div>
+  );
+}
+
+function SidebarProfileCardSkeleton() {
+  return (
+    <div
+      aria-hidden
+      className="shrink-0 space-y-2 border-t px-3 py-3"
+      style={{ borderColor: "var(--v4-line-100)" }}
+    >
+      <div
+        className="h-2 w-2/3 rounded-sm"
+        style={{ background: "var(--v4-line-100)" }}
+      />
+      <div className="flex items-center gap-2">
+        <div
+          className="h-8 w-8 rounded-sm"
+          style={{ background: "var(--v4-line-100)" }}
+        />
+        <div className="flex-1 space-y-1.5">
+          <div
+            className="h-2.5 w-1/2 rounded-sm"
+            style={{ background: "var(--v4-line-100)" }}
+          />
+          <div
+            className="h-2 w-1/3 rounded-sm"
+            style={{ background: "var(--v4-line-100)" }}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-1.5">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-10 rounded-sm"
+            style={{ background: "var(--v4-line-100)" }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/SidebarProfileTile.tsx
+++ b/src/components/layout/SidebarProfileTile.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SidebarProfileTileProps {
+  /** Uppercase mono label rendered at the top of the tile (e.g. "WATCH"). */
+  label: string;
+  /** Destination route. */
+  href: string;
+  /** Optional count rendered prominently in the centre. Hidden when undefined. */
+  count?: number;
+  /** Optional icon used when no count is available (link-only tiles). */
+  icon?: ReactNode;
+  /** Override the auto-generated aria-label for the link. */
+  ariaLabel?: string;
+}
+
+export function SidebarProfileTile({
+  label,
+  href,
+  count,
+  icon,
+  ariaLabel,
+}: SidebarProfileTileProps) {
+  const hasCount = typeof count === "number";
+  const computedAriaLabel =
+    ariaLabel ?? (hasCount ? `${label}: ${count}` : label);
+
+  return (
+    <Link
+      href={href}
+      aria-label={computedAriaLabel}
+      className={cn(
+        "group flex flex-col items-start justify-between gap-1",
+        "rounded-sm border px-2 py-1.5 transition-colors",
+        "hover:bg-bg-card-hover",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1",
+      )}
+      style={{
+        borderColor: "var(--v4-line-100)",
+      }}
+    >
+      <span
+        className="font-mono text-[9px] uppercase tracking-[0.16em]"
+        style={{ color: "var(--ink-400)" }}
+      >
+        {label}
+      </span>
+      <span
+        className="text-[14px] font-semibold tabular-nums leading-none"
+        style={{ color: hasCount ? "var(--ink-100)" : "var(--ink-300)" }}
+      >
+        {hasCount ? count : icon ?? "→"}
+      </span>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- **A1.1** Delete the Collections V2NavRow from the EXPLORE section (and the orphaned `Library` lucide import).
- **A1.5** New `SidebarProfileCard` mounted between `</CursorRail>` and `<SidebarFooter>` — anonymous = null, signed-in = beta eyebrow + monogram avatar + handle + static tier badge + 3×2 tiles (WATCH/ALERTS/DROPS/AGENT/CLI/MCP). WATCH from `useWatchlistStore`; ALERTS piggybacks the existing `useSidebarOverlayStore.unreadAlerts` (no new fetch); DROPS=0 stub.
- **A1.2** Recent-viewed widget is fully wired on main (`MarkRepoViewed` → `trackRepoViewed` → setItem + CustomEvent → reader listens to both). Verified by code review; no fix shipped. Operator browser-smoke is the final confirmation.

## Drifts surfaced (separate from this PR)

- `/api/me/submissions/count` endpoint does not exist — DROPS tile ships as 0. Follow-up endpoint needed.
- B3 (Clerk Dashboard webhook) still unconfigured per memory. The card uses client-only Clerk session, so it renders regardless; server-side `tr.profiles` personalization blocked separately.
- Memory `project_db_client_ssl_required.md` updated in this session: the SSL fix shipped to main, not on a branch.

## Verify gates (all green)

- [x] `npm run typecheck`
- [x] `npm run lint:guards`
- [x] `npm run test:hooks` — 333 pass, 1 pre-existing skip
- [x] `npm run build`
- [x] `npx impeccable detect src/components/layout/` — 0 new violations (3 pre-existing in MobileDrawer / sidebar-nav.css)

## Test plan

- [ ] Sign in via header `/sign-in` flow → card appears at bottom of sidebar with handle + watch count + unread alerts
- [ ] Sign out → card disappears; sidebar otherwise unchanged
- [ ] Smoke each tile route: /watchlist, /you/alerts, /submit, /agent-commerce, /cli, /mcp
- [ ] Navigate to `/repo/vercel/next.js` then home → "RECENT" widget surfaces the visit (no code change, regression-check only)
- [ ] Test at 375 / 768 / 1280 — no horizontal overflow, tiles legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)