### PR TITLE
feat(twitter): remove SCORE column, widen Repo

### DIFF
--- a/src/app/twitter/page.tsx
+++ b/src/app/twitter/page.tsx
@@ -473,7 +473,7 @@ function TwitterLeaderboardTable({
     >
       <div>
         <div
-          className="v2-mono grid h-9 grid-cols-[30px_48px_minmax(0,1fr)_64px_70px] items-center gap-2 px-2 text-[10px] uppercase tracking-[0.18em] md:grid-cols-[36px_56px_minmax(320px,2fr)_72px_72px_72px_72px_88px] md:gap-3 md:px-3"
+          className="v2-mono grid h-9 grid-cols-[30px_48px_minmax(0,1fr)_64px_70px] items-center gap-2 px-2 text-[10px] uppercase tracking-[0.18em] md:grid-cols-[36px_56px_minmax(380px,3fr)_72px_72px_72px_88px] md:gap-3 md:px-3"
           style={{
             borderBottom: "1px solid var(--v4-line-100)",
             background: "var(--v4-bg-025)",
@@ -486,7 +486,6 @@ function TwitterLeaderboardTable({
           <div className="text-right">Mentions</div>
           <div className="hidden text-right md:block">Likes</div>
           <div className="hidden text-right md:block">Reposts</div>
-          <div className="hidden text-right md:block">Score</div>
           <div>Badge</div>
         </div>
         <ol>
@@ -525,7 +524,7 @@ function TwitterLeaderboardTable({
             return (
               <li
                 key={row.repoId}
-                className="v2-row group grid grid-cols-[30px_48px_minmax(0,1fr)_64px_70px] items-center gap-2 px-2 py-2 md:grid-cols-[36px_56px_minmax(320px,2fr)_72px_72px_72px_72px_88px] md:gap-3 md:px-3"
+                className="v2-row group grid grid-cols-[30px_48px_minmax(0,1fr)_64px_70px] items-center gap-2 px-2 py-2 md:grid-cols-[36px_56px_minmax(380px,3fr)_72px_72px_72px_88px] md:gap-3 md:px-3"
                 style={{
                   borderBottom: "1px dashed var(--v4-line-100)",
                   animation:
@@ -609,12 +608,6 @@ function TwitterLeaderboardTable({
                   style={{ color: "var(--v4-ink-100)" }}
                 >
                   {formatNumber(row.totalReposts24h)}
-                </div>
-                <div
-                  className="hidden text-right text-xs font-semibold tabular-nums md:block"
-                  style={{ color: "var(--v4-acc)" }}
-                >
-                  {row.finalTwitterScore.toFixed(1)}
                 </div>
                 <div>
                   <span


### PR DESCRIPTION
## Summary

- Remove the desktop-only `SCORE` column from the `/twitter` table. Mentions/Likes/Reposts already give the reader the inputs to `finalTwitterScore`, and the composite was overloading the row.
- Reclaim the freed 72px by widening the Repo grid track from `minmax(320px,2fr)` to `minmax(380px,3fr)` so long repo names stop truncating at 1024-1280 widths.
- Grid count: 8 desktop columns → 7. Mobile grid (5 cols) is unchanged.

## Verify gates

- [x] `npm run typecheck`
- [x] `npm run lint:guards`
- [x] `npx impeccable detect src/app/twitter/` — 0 violations

## Test plan

- [ ] Visual smoke at 375 / 768 / 1024 / 1280 — confirm 7 columns on md+, Repo column wider, long names readable
- [ ] Mobile (<md) still shows 5 cols (`#/Top/Repo/Mentions/Badge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)