### PR TITLE
feat(freshness): hide FreshnessBadge + FreshnessChip via env flag

### DIFF
--- a/src/components/home/__tests__/LiveTopTable.test.tsx
+++ b/src/components/home/__tests__/LiveTopTable.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ prefetch: () => {}, push: () => {}, replace: () => {} }),
@@ -11,8 +11,16 @@ import {
   type LiveRow,
 } from "@/components/home/LiveTopTable";
 
+// Production hides FreshnessChip via NEXT_PUBLIC_HIDE_FRESHNESS_BADGES;
+// this test asserts the rendered "Updated 1h ago" chip, so the flag has
+// to be flipped off explicitly for the chip to render.
+beforeEach(() => {
+  vi.stubEnv("NEXT_PUBLIC_HIDE_FRESHNESS_BADGES", "false");
+});
+
 afterEach(() => {
   cleanup();
+  vi.unstubAllEnvs();
 });
 
 const row: LiveRow = {

--- a/src/components/shared/FreshnessBadge.tsx
+++ b/src/components/shared/FreshnessBadge.tsx
@@ -11,6 +11,15 @@
 
 import { classifyFreshness, type NewsSource } from "@/lib/news/freshness";
 
+// Operator decision (2026-05-15): cold/stale chrome reads as honesty
+// theatre, not as useful signal. Hide the indicators by default but
+// keep the classifier intact so a future flip via env can bring them
+// back without touching call sites. Set
+// `NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=false` to render.
+function isFreshnessBadgeHidden(): boolean {
+  return process.env.NEXT_PUBLIC_HIDE_FRESHNESS_BADGES !== "false";
+}
+
 interface FreshnessBadgeProps {
   /** ISO timestamp, epoch ms, or Date — when the underlying data was fetched. */
   lastUpdatedAt: string | number | Date | null | undefined;
@@ -32,6 +41,7 @@ export function FreshnessBadge({
   source,
   nowMs,
 }: FreshnessBadgeProps) {
+  if (isFreshnessBadgeHidden()) return null;
   const iso =
     lastUpdatedAt instanceof Date
       ? lastUpdatedAt.toISOString()

--- a/src/components/shared/FreshnessChip.tsx
+++ b/src/components/shared/FreshnessChip.tsx
@@ -18,6 +18,15 @@
 
 import type { JSX } from "react";
 
+// Operator decision (2026-05-15): cold/stale chrome reads as honesty
+// theatre, not as useful signal. Hide the indicators by default but
+// keep the classifier (and the exported __test seam) intact so a
+// future flip via env can bring them back without touching call sites.
+// Set `NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=false` to render.
+function isFreshnessChipHidden(): boolean {
+  return process.env.NEXT_PUBLIC_HIDE_FRESHNESS_BADGES !== "false";
+}
+
 interface FreshnessChipProps {
   /** ISO timestamp, epoch ms, or Date — when the underlying row was fetched. */
   updatedAt: string | number | Date | null | undefined;
@@ -95,7 +104,8 @@ export function FreshnessChip({
   size = "sm",
   nowMs,
   className,
-}: FreshnessChipProps): JSX.Element {
+}: FreshnessChipProps): JSX.Element | null {
+  if (isFreshnessChipHidden()) return null;
   const now = nowMs ?? Date.now();
   const ts = toMs(updatedAt);
   const ageMs = ts === null ? null : Math.max(0, now - ts);

--- a/src/components/shared/__tests__/FreshnessBadge.test.tsx
+++ b/src/components/shared/__tests__/FreshnessBadge.test.tsx
@@ -1,11 +1,19 @@
 import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+
+// Production hides freshness chrome via NEXT_PUBLIC_HIDE_FRESHNESS_BADGES.
+// These tests assert the rendered output, so they need the flag flipped
+// off for the badge to actually render.
+beforeEach(() => {
+  vi.stubEnv("NEXT_PUBLIC_HIDE_FRESHNESS_BADGES", "false");
+});
 
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 // Anchor "now" so the relative-time math is deterministic regardless of


### PR DESCRIPTION
## Summary

Hide the FRESH/STALE/COLD chrome globally via `NEXT_PUBLIC_HIDE_FRESHNESS_BADGES` (default: hidden). Classifier (`classifyFreshness()`) and component file structure stay intact so a future operator can flip the chrome back via env without touching call sites.

- `FreshnessBadge` and `FreshnessChip` early-return `null` unless the env is explicitly `"false"`.
- Env check is a function inside the component so tests can `vi.stubEnv` per-test.
- Existing FreshnessBadge tests get a `beforeEach` env stub.
- **LiveDot is intentionally untouched** — it's also used for non-freshness "LIVE feed" indicators. Hiding it globally would break unrelated UI. Surface for operator review: hide LiveDot too, or audit per-callsite?

## Drift from plan

Plan listed `LiveDot.tsx` + `freshness.ts` in the file list. Reading the code: LiveDot is a generic status-pip primitive (not freshness-specific), and `freshness.ts` is the classifier (operator decision says keep). Neither needs changes for this PR.

## Verify gates

- [x] `npm run typecheck`
- [x] `npm run test:hooks -- src/components/shared/__tests__/FreshnessBadge.test.tsx` (4/4 pass)
- [x] `npm run lint:guards`
- [x] `npx impeccable detect src/components/shared/` — 0 violations

## Test plan

- [ ] Smoke `/twitter`, `/signals`, `/reddit/trending`, `/repo/vercel/next.js` in prod preview — no FRESH/STALE/COLD pills visible anywhere
- [ ] Set `NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=false` locally → confirm pills come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)