### PR TITLE
feat(tools): route badges on each ToolTile

### DIFF
--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -179,13 +179,20 @@ function previewFor(title: string) {
   }
 }
 
-function ToolGrid({ tools }: { tools: ToolEntry[] }) {
+function ToolGrid({
+  tools,
+  routeBadge,
+}: {
+  tools: ToolEntry[];
+  routeBadge: string;
+}) {
   return (
     <div className="grid">
       {tools.map((tool) => (
         <div className="col-6" key={`${tool.title}-${tool.href}`}>
           <ToolTile
             num={tool.status === "soon" ? `${tool.num} · SOON` : tool.num}
+            routeBadge={routeBadge}
             title={tool.title}
             desc={tool.desc}
             preview={previewFor(tool.title)}
@@ -242,21 +249,21 @@ export default function ToolsPage() {
           </>
         }
       />
-      <ToolGrid tools={CHART_TOOLS} />
+      <ToolGrid tools={CHART_TOOLS} routeBadge="CHART" />
 
       <SectionHead
         num="// 02"
         title="Estimators"
         meta={<>ARR overlays · TrustMRR claims</>}
       />
-      <ToolGrid tools={ESTIMATOR_TOOLS} />
+      <ToolGrid tools={ESTIMATOR_TOOLS} routeBadge="ESTIMATOR" />
 
       <SectionHead
         num="// 03"
         title="Contribute"
         meta={<>self-reported · verified surfaces</>}
       />
-      <ToolGrid tools={CONTRIBUTE_TOOLS} />
+      <ToolGrid tools={CONTRIBUTE_TOOLS} routeBadge="CONTRIBUTE" />
     </main>
   );
 }

--- a/src/components/tools/ToolTile.tsx
+++ b/src/components/tools/ToolTile.tsx
@@ -32,6 +32,10 @@ export interface ToolTileProps {
   foot?: ReactNode;
   /** When provided, tile renders as <a> instead of <div>. */
   href?: string;
+  /** Small uppercase route badge rendered between `num` and `title` — e.g.
+   * "CHART", "ESTIMATOR", "CONTRIBUTE". Lets a tile be self-descriptive
+   * when viewed in isolation (e.g., share screenshots). */
+  routeBadge?: ReactNode;
   className?: string;
 }
 
@@ -43,6 +47,7 @@ export function ToolTile({
   preview,
   foot,
   href,
+  routeBadge,
   className,
 }: ToolTileProps) {
   const Tag = href ? "a" : "div";
@@ -57,6 +62,9 @@ export function ToolTile({
       )}
     >
       <div className="v4-tool-tile__num">{num}</div>
+      {routeBadge ? (
+        <div className="v4-tool-tile__route-badge">{routeBadge}</div>
+      ) : null}
       <div className="v4-tool-tile__title">{title}</div>
       <div className="v4-tool-tile__desc">{desc}</div>
       {foot ? <div className="v4-tool-tile__foot">{foot}</div> : null}

--- a/src/components/ui/v4.css
+++ b/src/components/ui/v4.css
@@ -1576,6 +1576,24 @@
 .v4-tool-tile--active .v4-tool-tile__num {
   color: var(--v4-acc);
 }
+.v4-tool-tile__route-badge {
+  display: inline-block;
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 2px 6px;
+  border: var(--v4-stroke-1) solid var(--v4-line-200);
+  border-radius: 2px;
+  background: var(--v4-bg-050);
+  font-family: var(--v4-mono);
+  font-size: var(--v4-text-9-5);
+  letter-spacing: var(--v4-track-20);
+  color: var(--v4-ink-300);
+  text-transform: uppercase;
+}
+.v4-tool-tile--active .v4-tool-tile__route-badge {
+  border-color: var(--v4-acc);
+  color: var(--v4-acc);
+}
 .v4-tool-tile__title {
   font-family: var(--v4-sans);
   font-size: var(--v4-text-18);


### PR DESCRIPTION
## Summary

Add a small uppercase route badge inside each tile on `/tools` — CHART / ESTIMATOR / CONTRIBUTE — between the num eyebrow and the title. The tile now reads correctly in isolation (a screenshot or embed shows the category, not just the title).

- New optional `routeBadge` prop on `ToolTile`.
- Token-only CSS for `.v4-tool-tile__route-badge`; recolours under `--active`.
- Per-section labels wired in `/tools/page.tsx` via a `routeBadge` prop on `ToolGrid`.

## Verify gates

- [x] `npm run typecheck`
- [x] `npm run lint:guards`
- [x] `npx impeccable detect src/components/tools/` — 0 violations
- [x] `npm run test:hooks -- src/components/tools/__tests__/v4-tools.test.tsx` (14/14 pass)

## Test plan

- [ ] Visit `/tools` — confirm CHART badge above Star History + Treemap, ESTIMATOR above Revenue Estimate, CONTRIBUTE above Submit Revenue
- [ ] 375 / 768 / 1280 — badge stays inline, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)