### PR TITLE
feat(submit): headline + 4-step funnel strip + 280-char Why-now limit

### DIFF
--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -12,6 +12,9 @@ import {
 
 import { ROUTES } from "@/lib/routes";
 import { captureFunnelStep } from "@/lib/analytics/funnel";
+import { DropRepoStepStrip } from "./DropRepoStepStrip";
+
+const WHY_NOW_MAX_CHARS = 280;
 
 interface QueueSummary {
   pending: number;
@@ -239,13 +242,15 @@ export function DropRepoPage() {
           </div>
 
           <h1 className="mt-4 font-display text-3xl font-bold text-text-primary sm:text-4xl">
-            Submit a repo to the trend queue
+            Drop a repo. Get it ranked.
           </h1>
           <p className="mt-3 max-w-2xl text-sm leading-6 text-text-secondary sm:text-base">
             Anyone can submit. We dedupe against tracked repos, keep a pending
             queue, and review boosted submissions first when they include a real
             X share link.
           </p>
+
+          <DropRepoStepStrip />
 
           <div className="mt-4 flex flex-wrap items-center gap-3 rounded-card border border-up/30 bg-up/5 px-4 py-3 text-sm">
             <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-[var(--v4-money)]">
@@ -290,14 +295,28 @@ export function DropRepoPage() {
             </label>
 
             <label className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-text-primary">
-                Why now
+              <span className="flex items-center justify-between text-sm font-medium text-text-primary">
+                <span>Why now</span>
+                <span
+                  className="font-mono text-[10px] uppercase tracking-[0.14em]"
+                  style={{
+                    color:
+                      whyNow.length > WHY_NOW_MAX_CHARS
+                        ? "var(--v4-red, #ef4444)"
+                        : "var(--text-muted, #6b7280)",
+                  }}
+                >
+                  {whyNow.length} / {WHY_NOW_MAX_CHARS}
+                </span>
               </span>
               <textarea
                 value={whyNow}
-                onChange={(event) => setWhyNow(event.target.value)}
+                onChange={(event) =>
+                  setWhyNow(event.target.value.slice(0, WHY_NOW_MAX_CHARS))
+                }
                 placeholder="Short reason this repo should be reviewed now."
                 rows={5}
+                maxLength={WHY_NOW_MAX_CHARS}
                 className="min-h-32 rounded-card border border-border-primary bg-bg-secondary px-3 py-3 text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-brand/50"
               />
             </label>

--- a/src/components/submissions/DropRepoStepStrip.tsx
+++ b/src/components/submissions/DropRepoStepStrip.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * DropRepoStepStrip — 4-card funnel row showing the lifecycle a submission
+ * runs through after the form is submitted. Operator-attached mockup
+ * (2026-05-15): SUBMIT 30s → AUTO-SCAN 2min → REVIEW 14min → LISTED.
+ *
+ * Pure presentational — no props. Numbers + copy come from the typical
+ * historical funnel (operator-reviewed). If/when we surface live medians
+ * we can promote those values to props.
+ */
+
+import type { ReactNode } from "react";
+import { Clock, Search, Send, Sparkles } from "lucide-react";
+
+interface StepCardProps {
+  num: string;
+  label: string;
+  duration: string;
+  icon: ReactNode;
+  active?: boolean;
+}
+
+function StepCard({ num, label, duration, icon, active = false }: StepCardProps) {
+  return (
+    <div
+      className="flex min-w-0 flex-1 flex-col gap-1 rounded-card border px-3 py-2.5"
+      style={{
+        borderColor: active
+          ? "var(--v3-acc, var(--border-primary, #2a2a30))"
+          : "var(--border-primary, #2a2a30)",
+        background: "var(--bg-secondary, #0c0c10)",
+      }}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          className="font-mono text-[9px] uppercase tracking-[0.16em]"
+          style={{ color: "var(--text-muted, #6b7280)" }}
+        >
+          {num}
+        </span>
+        <span
+          className="font-mono text-[10px] uppercase tracking-[0.16em]"
+          style={{ color: active ? "var(--v3-acc, #fb923c)" : "var(--text-secondary, #9ca3af)" }}
+        >
+          {label}
+        </span>
+        <span className="ml-auto" style={{ color: active ? "var(--v3-acc, #fb923c)" : "var(--text-muted, #6b7280)" }}>
+          {icon}
+        </span>
+      </div>
+      <div
+        className="font-mono text-[11px]"
+        style={{ color: "var(--text-secondary, #9ca3af)" }}
+      >
+        ~{duration}
+      </div>
+    </div>
+  );
+}
+
+export function DropRepoStepStrip() {
+  return (
+    <div
+      role="list"
+      aria-label="Submission funnel"
+      className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4"
+    >
+      <StepCard
+        num="// 01"
+        label="Submit"
+        duration="30s"
+        icon={<Send className="h-3.5 w-3.5" />}
+        active
+      />
+      <StepCard
+        num="// 02"
+        label="Auto-scan"
+        duration="2 min"
+        icon={<Search className="h-3.5 w-3.5" />}
+      />
+      <StepCard
+        num="// 03"
+        label="Review"
+        duration="14 min"
+        icon={<Clock className="h-3.5 w-3.5" />}
+      />
+      <StepCard
+        num="// 04"
+        label="Listed"
+        duration="ranked"
+        icon={<Sparkles className="h-3.5 w-3.5" />}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three focused changes on `/submit` per the operator-attached mockup:

1. **Headline** — "Submit a repo to the trend queue" → "Drop a repo. Get it ranked."
2. **`DropRepoStepStrip` (NEW)** — 4-card funnel showing the lifecycle: Submit 30s → Auto-scan 2 min → Review 14 min → Listed. Card 01 active (accent-bordered).
3. **"Why now" 280-char limit** — live `n / 280` counter, red over limit, `slice` on input + `maxLength` on textarea.

## Scope (deferred)

The full mockup also includes: category picker (REPO/SKILL/MCP), tag chips strip (12 categories, max 4 selectable), release/demo URL fields, right-rail funnel breakdown. Those require backend extensions to the `repo-submissions` API schema and a separate operator review on which categories/tags ship. Tracked as a follow-up PR after the API is extended.

## Verify gates

- [x] `npm run typecheck`
- [x] `npm run lint:guards`
- [x] `npx impeccable detect src/components/submissions/` — 0 violations

## Test plan

- [ ] Visit `/submit` — confirm new headline + 4-step strip renders at 375 / 768 / 1280
- [ ] Type more than 280 chars in Why now → counter turns red + input stops accepting

🤖 Generated with [Claude Code](https://claude.com/claude-code)