### PR TITLE
ci(smoke): expand post-deploy smoke from 16 to 30 routes

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -22,11 +22,19 @@ jobs:
       - name: Wait for deploy propagation
         run: sleep 30
 
-      - name: Synthetic curl checks (17 critical routes)
+      - name: Synthetic curl checks (29 critical routes)
         id: smoke
         shell: bash
         run: |
           set +e
+          # Coverage strategy (2026-05-15 expansion): probe every route
+          # marked `warmupOnDeploy: true` in perf/routes.json (25 canonical
+          # surfaces — see scripts/check-routes-config.mjs for the contract)
+          # plus 4 extras the smoke caught regressions on historically:
+          # /trends, /agent-commerce, /agent-commerce/facilitator, and the
+          # long-tail /repo/anthropics/anthropic-cookbook (covers the
+          # cold-miss live-fetch fallback path).
+          #
           # /repo/* + /agent-commerce/* + /trends added 2026-05-10. Why:
           # the pre-existing /repo/* 500 P0 (since d81856ad) bled for days
           # because no smoke probe covered detail pages. vercel/next.js is
@@ -40,21 +48,38 @@ jobs:
           # but stable repo here so any future regression on that branch
           # surfaces in CI within a deploy, not by a user 4 days later.
           routes=(
+            # canonical warmup set (perf/routes.json)
             "/"
-            "/signals"
-            "/twitter"
-            "/top10"
+            "/githubrepo"
             "/skills"
             "/mcp"
+            "/reddit/trending"
+            "/hackernews/trending"
+            "/lobsters"
+            "/devto"
+            "/bluesky/trending"
+            "/twitter"
+            "/signals"
+            "/top10"
+            "/compare"
             "/funding"
             "/revenue"
             "/arxiv/trending"
             "/producthunt"
+            "/huggingface"
+            "/npm"
+            "/breakouts"
+            "/categories"
+            "/methodology"
+            "/research"
+            "/tools/revenue-estimate"
+            "/repo/vercel/next.js"
+            # smoke extras (historically regression-prone)
             "/trends"
             "/agent-commerce"
             "/agent-commerce/facilitator"
-            "/repo/vercel/next.js"
             "/repo/anthropics/anthropic-cookbook"
+            # health probe
             "/api/health?soft=1"
           )
 


### PR DESCRIPTION
## Summary

Expand `.github/workflows/post-deploy-smoke.yml` to probe every route marked `warmupOnDeploy: true` in `perf/routes.json` (25 canonical surfaces) plus the 4 historical-regression extras already in the workflow and the `/api/health` probe — 30 routes total, up from 16.

### New coverage

`/githubrepo`, `/reddit/trending`, `/hackernews/trending`, `/lobsters`, `/devto`, `/bluesky/trending`, `/compare`, `/huggingface`, `/npm`, `/breakouts`, `/categories`, `/methodology`, `/research`, `/tools/revenue-estimate`.

### Why

The prior 16-route smoke missed half the public canonical surface. Pages like `/research`, `/breakouts`, `/huggingface`, the social-trending pages, and the tools pages could all 500 in prod for hours before ops noticed via Sentry or a manual sweep. Aligning smoke with the `perf/routes.json` contract makes the smoke alert the canonical fast-feedback channel after every deploy.

### Self-heal still applies

The pass-2 revalidate-and-re-probe path operates on whatever routes failed in pass 1. Adding more routes to the probe set automatically extends self-heal coverage — same logic, longer `stuck_paths` array.

### Timeout

~30 routes × ~2s curl average + self-heal pass-2 + 30s deploy-propagation wait fits comfortably inside the existing 10-minute job timeout.

## Verify gates

- [x] YAML syntactically valid (bash heredoc + array literal unchanged)
- [x] No new tokens / secrets / env vars introduced

## Test plan

- [ ] Manual `workflow_dispatch` on the branch → confirm all 30 routes probe + report renders cleanly
- [ ] Pass 1 should be 30/30 on a healthy deploy; pass 2 only runs if any route fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)