### PR TITLE
Fix saved watchlist fallback rendering

### DIFF
--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -415,6 +415,7 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
             cited: item.derivativeRepoCount ?? 0,
             sparklineData: linked?.sparklineData ?? [],
             trackingId: linked?.id ?? `skill:${item.id}`,
+            trackingFullName: linked?.fullName,
           };
         });
         if (skillRows.length === 0) {

--- a/src/app/watchlist/page.tsx
+++ b/src/app/watchlist/page.tsx
@@ -24,6 +24,10 @@ import type {
 import { useWatchlistStore } from "@/lib/store";
 import { formatNumber, getRelativeTime } from "@/lib/utils";
 import {
+  watchlistItemFullName,
+  watchlistItemHref,
+} from "@/lib/watchlist-items";
+import {
   toastAlertDeleted,
   toastAlertError,
 } from "@/lib/toast";
@@ -223,29 +227,33 @@ export default function WatchlistPage() {
     }
   }, []);
 
-  // Pair watched items with hydrated repos in original add-order. Drop
-  // entries we couldn't resolve (the repo may have left the catalog).
-  const watchedRepos = useMemo(() => {
-    return watchlist
-      .map((item) => {
-        const repo = reposById[item.repoId];
-        return repo ? { item, repo } : null;
-      })
-      .filter(
-        (entry): entry is { item: (typeof watchlist)[number]; repo: Repo } =>
-          entry !== null,
-      );
+  // Pair watched items with hydrated repos in original add-order. Keep saved
+  // entries visible even when the current derived corpus cannot resolve repoId.
+  const watchedEntries = useMemo(() => {
+    return watchlist.map((item) => {
+      const repo = reposById[item.repoId] ?? null;
+      return {
+        item,
+        repo,
+        fullName: repo?.fullName ?? watchlistItemFullName(item),
+        href: repo ? `/repo/${repo.owner}/${repo.name}` : watchlistItemHref(item),
+      };
+    });
   }, [watchlist, reposById]);
 
   // Fast lookup id → fullName for alert primitives.
   const repoNamesById = useMemo(() => {
     const map: Record<string, string> = {};
     for (const r of Object.values(reposById)) map[r.id] = r.fullName;
+    for (const item of watchlist) {
+      map[item.repoId] =
+        reposById[item.repoId]?.fullName ?? watchlistItemFullName(item);
+    }
     return map;
-  }, [reposById]);
+  }, [reposById, watchlist]);
 
   // KpiBand metrics.
-  const tracked = watchedRepos.length;
+  const tracked = watchlist.length;
   const activeRules = rules.filter((r) => r.enabled).length;
   const reposFiringThisWeek = useMemo(() => {
     const weekMs = 7 * 86_400_000;
@@ -271,10 +279,21 @@ export default function WatchlistPage() {
   // "Most active" repo = highest-stars repo in watchlist (proxy for the
   // most actively tracked one). Falls back gracefully when empty.
   const mostActive = useMemo(() => {
-    if (watchedRepos.length === 0) return null;
-    return [...watchedRepos].sort((a, b) => b.repo.stars - a.repo.stars)[0]
-      .repo;
-  }, [watchedRepos]);
+    const resolved = watchedEntries.filter(
+      (
+        entry,
+      ): entry is {
+        item: (typeof watchlist)[number];
+        repo: Repo;
+        fullName: string;
+        href: string;
+      } => entry.repo !== null,
+    );
+    if (resolved.length === 0) return null;
+    return [...resolved].sort(
+      (a, b) => b.repo.stars - a.repo.stars,
+    )[0].repo;
+  }, [watchedEntries]);
 
   const verdictTone = tracked === 0 ? "amber" : "acc";
 
@@ -423,7 +442,7 @@ export default function WatchlistPage() {
               >
                 {"// LOADING WATCHLIST…"}
               </div>
-            ) : watchedRepos.length === 0 ? (
+            ) : watchedEntries.length === 0 ? (
               <EmptyTrackedState />
             ) : (
               <div
@@ -434,25 +453,28 @@ export default function WatchlistPage() {
                   gap: 12,
                 }}
               >
-                {watchedRepos.map(({ item, repo }) => (
+                {watchedEntries.map(({ item, repo, fullName, href }) => (
                   <RelatedRepoCard
                     key={item.repoId}
-                    fullName={repo.fullName}
-                    description={repo.description ?? undefined}
-                    language={
-                      repo.language
-                        ? repo.language.toUpperCase()
-                        : undefined
+                    fullName={fullName}
+                    description={
+                      repo?.description ??
+                      "Saved locally. Live metadata is outside the current tracked corpus."
                     }
-                    stars={formatNumber(repo.stars)}
+                    language={
+                      repo?.language ? repo.language.toUpperCase() : "SAVED"
+                    }
+                    stars={formatNumber(repo?.stars ?? item.starsAtAdd)}
                     similarity={
-                      repo.starsDelta24h !== 0
+                      repo && repo.starsDelta24h !== 0
                         ? `${repo.starsDelta24h > 0 ? "+" : ""}${formatNumber(
                             repo.starsDelta24h,
                           )} 24H`
-                        : "STABLE"
+                        : repo
+                          ? "STABLE"
+                          : "SAVED"
                     }
-                    href={`/repo/${repo.owner}/${repo.name}`}
+                    href={href}
                   />
                 ))}
               </div>

--- a/src/components/home/LiveTopTable.tsx
+++ b/src/components/home/LiveTopTable.tsx
@@ -272,7 +272,7 @@ function ActionCell({
     e.stopPropagation();
     e.preventDefault();
     const wasWatched = isWatched;
-    toggleWatch(repoId, stars);
+    toggleWatch(repoId, stars, repoName);
     if (wasWatched) toastWatchRemoved(repoName);
     else toastWatchAdded(repoName);
   };

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -24,6 +24,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useWatchlistStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
+import { watchlistItemFullName } from "@/lib/watchlist-items";
 import { SidebarContent } from "./SidebarContent";
 import { SidebarProfileBox } from "./SidebarProfileBox";
 import { SidebarSkeleton } from "./SidebarSkeleton";
@@ -146,15 +147,19 @@ export function useWatchlistPreview(
     Record<string, SidebarDataRepo>
   >({});
 
-  const newestWatchIds = useMemo(
+  const newestWatchItems = useMemo(
     () =>
       [...watchlist]
         .sort((a, b) =>
           a.addedAt < b.addedAt ? 1 : a.addedAt > b.addedAt ? -1 : 0,
         )
-        .slice(0, 5)
-        .map((item) => item.repoId),
+        .slice(0, 5),
     [watchlist],
+  );
+
+  const newestWatchIds = useMemo(
+    () => newestWatchItems.map((item) => item.repoId),
+    [newestWatchItems],
   );
 
   const mergedReposById = useMemo(
@@ -188,10 +193,27 @@ export function useWatchlistPreview(
 
   return useMemo(
     () =>
-      newestWatchIds
-        .map((id) => mergedReposById[id])
+      newestWatchItems
+        .map((item) => {
+          const repo = mergedReposById[item.repoId];
+          if (repo) return repo;
+
+          const fullName = watchlistItemFullName(item);
+          const separator = fullName.indexOf("/");
+          if (separator <= 0 || separator >= fullName.length - 1) return null;
+
+          return {
+            id: item.repoId,
+            fullName,
+            owner: fullName.slice(0, separator),
+            name: fullName.slice(separator + 1),
+            ownerAvatarUrl: "",
+            starsDelta24h: 0,
+            starsDelta24hMissing: true,
+          };
+        })
         .filter((repo): repo is SidebarWatchlistPreviewRepo => Boolean(repo)),
-    [mergedReposById, newestWatchIds],
+    [mergedReposById, newestWatchItems],
   );
 }
 

--- a/src/components/repo-detail/RepoActionRow.tsx
+++ b/src/components/repo-detail/RepoActionRow.tsx
@@ -41,7 +41,7 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
 
   const handleWatch = useCallback(() => {
     const wasWatched = isWatched;
-    toggleWatch(repo.id, repo.stars);
+    toggleWatch(repo.id, repo.stars, repo.fullName);
     if (wasWatched) {
       toastWatchRemoved(repo.fullName);
     } else {
@@ -105,6 +105,11 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
           isWatched ? "v2-btn-primary" : "v2-btn-ghost",
         )}
         aria-pressed={isWatched}
+        aria-label={
+          isWatched
+            ? `Remove ${repo.fullName} from watchlist`
+            : `Add ${repo.fullName} to watchlist`
+        }
       >
         {isWatched ? (
           <EyeOff size={14} aria-hidden style={{ marginRight: 8 }} />
@@ -133,6 +138,13 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
           compareDisabled && "cursor-not-allowed opacity-50",
         )}
         aria-pressed={isComparing}
+        aria-label={
+          isComparing
+            ? `Remove ${repo.fullName} from compare`
+            : compareDisabled
+              ? "Compare is full"
+              : `Add ${repo.fullName} to compare`
+        }
       >
         <GitCompareArrows size={14} aria-hidden style={{ marginRight: 8 }} />
         {isComparing ? "IN COMPARE" : "COMPARE"}
@@ -141,6 +153,7 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
       <Link
         href={revenueHref}
         className="v2-btn v2-btn-ghost min-h-[44px]"
+        aria-label={`Claim revenue data for ${repo.fullName}`}
       >
         <BadgeDollarSign size={14} aria-hidden style={{ marginRight: 8 }} />
         CLAIM REVENUE
@@ -152,6 +165,7 @@ export function RepoActionRow({ repo }: RepoActionRowProps) {
         rel="noopener noreferrer"
         onClick={handleGithubClick}
         className="v2-btn v2-btn-ghost ml-auto min-h-[44px]"
+        aria-label={`Open ${repo.fullName} on GitHub`}
       >
         <ExternalLink size={14} aria-hidden style={{ marginRight: 8 }} />
         OPEN ON GITHUB

--- a/src/components/skills/SkillsTopTable.tsx
+++ b/src/components/skills/SkillsTopTable.tsx
@@ -51,6 +51,8 @@ export interface SkillRow {
   sparklineData: number[];
   /** Used by the Watch / Compare action buttons. */
   trackingId: string;
+  /** Canonical backing repo full name, when this skill is linked to one. */
+  trackingFullName?: string;
 }
 
 interface SkillsTopTableProps {
@@ -151,10 +153,12 @@ function SortHeader({
 
 function ActionCell({
   trackingId,
+  trackingFullName,
   name,
   stars,
 }: {
   trackingId: string;
+  trackingFullName?: string;
   name: string;
   stars: number;
 }) {
@@ -173,7 +177,7 @@ function ActionCell({
     e.stopPropagation();
     e.preventDefault();
     const wasWatched = isWatched;
-    toggleWatch(trackingId, stars);
+    toggleWatch(trackingId, stars, trackingFullName);
     if (wasWatched) toastWatchRemoved(name);
     else toastWatchAdded(name);
   };
@@ -190,7 +194,7 @@ function ActionCell({
       toastCompareFull();
       return;
     }
-    addCompare(trackingId);
+    addCompare(trackingId, trackingFullName);
     toastCompareAdded(useCompareStore.getState().repos.length);
   };
 
@@ -447,6 +451,7 @@ export function SkillsTopTable({
                   </td>
                   <ActionCell
                     trackingId={row.trackingId}
+                    trackingFullName={row.trackingFullName}
                     name={row.title}
                     stars={row.stars}
                   />

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -268,7 +268,7 @@ export function Terminal({
           const r = repos[focusedIndex];
           if (!r) return;
           const wasWatched = useWatchlistStore.getState().isWatched(r.id);
-          toggleWatch(r.id, r.stars);
+          toggleWatch(r.id, r.stars, r.fullName);
           if (wasWatched) toastWatchRemoved(r.fullName);
           else toastWatchAdded(r.fullName);
           break;
@@ -290,7 +290,7 @@ export function Terminal({
             toastCompareFull();
             break;
           }
-          addCompare(r.id);
+          addCompare(r.id, r.fullName);
           toastCompareAdded(useCompareStore.getState().repos.length);
           break;
         }

--- a/src/components/terminal/TerminalMobileCard.tsx
+++ b/src/components/terminal/TerminalMobileCard.tsx
@@ -169,7 +169,7 @@ export function TerminalMobileCard({
             onClick={(e) => {
               e.stopPropagation();
               const wasWatched = isWatched;
-              toggleWatch(repo.id, repo.stars);
+              toggleWatch(repo.id, repo.stars, repo.fullName);
               if (wasWatched) toastWatchRemoved(repo.fullName);
               else toastWatchAdded(repo.fullName);
             }}
@@ -205,7 +205,7 @@ export function TerminalMobileCard({
                 toastCompareFull();
                 return;
               }
-              addCompare(repo.id);
+              addCompare(repo.id, repo.fullName);
               toastCompareAdded(useCompareStore.getState().repos.length);
             }}
             aria-label={

--- a/src/components/terminal/TerminalRow.tsx
+++ b/src/components/terminal/TerminalRow.tsx
@@ -58,7 +58,7 @@ function TerminalRowBase({
 
   const onToggleWatch = useCallback(() => {
     const wasWatched = isWatched;
-    toggleWatch(repo.id, repo.stars);
+    toggleWatch(repo.id, repo.stars, repo.fullName);
     if (wasWatched) toastWatchRemoved(repo.fullName);
     else toastWatchAdded(repo.fullName);
   }, [isWatched, toggleWatch, repo.id, repo.stars, repo.fullName]);
@@ -74,10 +74,10 @@ function TerminalRowBase({
       toastCompareFull();
       return;
     }
-    addCompare(repo.id);
+    addCompare(repo.id, repo.fullName);
     const count = useCompareStore.getState().repos.length;
     toastCompareAdded(count);
-  }, [isComparing, removeCompare, addCompare, repo.id]);
+  }, [isComparing, removeCompare, addCompare, repo.id, repo.fullName]);
 
   const rowContext: RowContext = useMemo(
     () => ({

--- a/src/components/watchlist/WatchlistManager.tsx
+++ b/src/components/watchlist/WatchlistManager.tsx
@@ -6,6 +6,10 @@ import { Eye, Trash2, ArrowRight } from "lucide-react";
 import { BrandStar } from "@/components/shared/BrandStar";
 import { useWatchlistStore } from "@/lib/store";
 import { cn, formatNumber, getRelativeTime } from "@/lib/utils";
+import {
+  watchlistItemFullName,
+  watchlistItemHref,
+} from "@/lib/watchlist-items";
 import { Sparkline } from "@/components/shared/Sparkline";
 import { DeltaBadge } from "@/components/shared/DeltaBadge";
 import { MomentumBadge } from "@/components/shared/MomentumBadge";
@@ -99,6 +103,66 @@ function WatchedRepoCard({
   );
 }
 
+function SavedRepoFallbackCard({
+  item,
+  index,
+}: {
+  item: WatchlistItem;
+  index: number;
+}) {
+  const removeRepo = useWatchlistStore((s) => s.removeRepo);
+  const fullName = watchlistItemFullName(item);
+
+  return (
+    <div
+      className={cn(
+        "bg-bg-card border border-border-primary rounded-[var(--radius-card)] p-4",
+        "hover:bg-bg-card-hover hover:border-accent-green/30",
+        "transition-all duration-200",
+        "animate-[slide-up_0.35s_ease-out_forwards] opacity-0",
+      )}
+      style={{ animationDelay: `${index * 60}ms` }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <Link
+            href={watchlistItemHref(item)}
+            className="text-text-primary font-semibold hover:text-accent-green transition-colors truncate block"
+          >
+            {fullName}
+          </Link>
+          <div className="flex items-center gap-3 mt-2 flex-wrap">
+            <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
+              <BrandStar size={13} className="text-accent-amber shrink-0" />
+              <span className="font-mono text-text-primary">
+                {formatNumber(item.starsAtAdd)}
+              </span>
+            </span>
+            <span className="font-mono text-xs text-text-tertiary">
+              Saved locally
+            </span>
+          </div>
+          <div className="flex items-center gap-3 mt-2 text-xs text-text-tertiary">
+            <span>Added {getRelativeTime(item.addedAt)}</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => removeRepo(item.repoId)}
+          className={cn(
+            "shrink-0 p-2 rounded-[var(--radius-button)]",
+            "text-text-tertiary hover:text-accent-red hover:bg-accent-red/10",
+            "transition-colors duration-150 cursor-pointer",
+          )}
+          aria-label={`Remove ${fullName} from watchlist`}
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Empty state
 // ---------------------------------------------------------------------------
@@ -183,14 +247,13 @@ export function WatchlistManager() {
     return <EmptyWatchlist />;
   }
 
-  // Pair each watchlist item with its resolved Repo; drop items we
-  // couldn't hydrate (e.g. the repo was removed from the store).
+  // Pair each watchlist item with its resolved Repo. Keep saved entries
+  // visible even when the current derived corpus cannot resolve repoId.
   const watchedRepos = watchlist
     .map((item) => {
-      const repo = reposById[item.repoId];
-      return repo ? { item, repo } : null;
-    })
-    .filter(Boolean) as { item: WatchlistItem; repo: Repo }[];
+      const repo = reposById[item.repoId] ?? null;
+      return { item, repo };
+    });
 
   if (watchedRepos.length === 0) {
     // If still loading, show a subtle skeleton. Otherwise the live API
@@ -213,7 +276,11 @@ export function WatchlistManager() {
   return (
     <div className="flex flex-col gap-3">
       {watchedRepos.map(({ item, repo }, i) => (
-        <WatchedRepoCard key={item.repoId} item={item} repo={repo} index={i} />
+        repo ? (
+          <WatchedRepoCard key={item.repoId} item={item} repo={repo} index={i} />
+        ) : (
+          <SavedRepoFallbackCard key={item.repoId} item={item} index={i} />
+        )
       ))}
     </div>
   );

--- a/src/lib/__tests__/watchlist-items.test.ts
+++ b/src/lib/__tests__/watchlist-items.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  watchlistItemFullName,
+  watchlistItemHref,
+} from "@/lib/watchlist-items";
+import type { WatchlistItem } from "@/lib/types";
+
+test("watchlist item keeps exact fullName for dotted repos", () => {
+  const item: WatchlistItem = {
+    repoId: "vercel--next-js",
+    fullName: "vercel/next.js",
+    addedAt: "2026-05-15T00:00:00.000Z",
+    starsAtAdd: 139_000,
+  };
+
+  assert.equal(watchlistItemFullName(item), "vercel/next.js");
+  assert.equal(watchlistItemHref(item), "/repo/vercel/next.js");
+});
+
+test("watchlist item falls back to legacy repoId when fullName is missing", () => {
+  const item: WatchlistItem = {
+    repoId: "owner--repo",
+    addedAt: "2026-05-15T00:00:00.000Z",
+    starsAtAdd: 42,
+  };
+
+  assert.equal(watchlistItemFullName(item), "owner/repo");
+  assert.equal(watchlistItemHref(item), "/repo/owner/repo");
+});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -21,10 +21,14 @@ import {
 
 interface WatchlistState {
   repos: WatchlistItem[];
-  addRepo: (repoId: string, stars: number) => void;
+  addRepo: (repoId: string, stars: number, fullName?: string) => void;
   removeRepo: (repoId: string) => void;
   isWatched: (repoId: string) => boolean;
-  toggleWatch: (repoId: string, stars: number) => void;
+  toggleWatch: (repoId: string, stars: number, fullName?: string) => void;
+}
+
+function isUsableWatchlistFullName(value: string | undefined): value is string {
+  return typeof value === "string" && value.includes("/");
 }
 
 export const useWatchlistStore = create<WatchlistState>()(
@@ -32,18 +36,19 @@ export const useWatchlistStore = create<WatchlistState>()(
     (set, get) => ({
       repos: [],
 
-      addRepo: (repoId, stars) => {
+      addRepo: (repoId, stars, fullName) => {
         const { repos } = get();
         if (repos.some((r) => r.repoId === repoId)) return;
+        const item: WatchlistItem = {
+          repoId,
+          addedAt: new Date().toISOString(),
+          starsAtAdd: stars,
+        };
+        if (isUsableWatchlistFullName(fullName)) {
+          item.fullName = fullName;
+        }
         set({
-          repos: [
-            ...repos,
-            {
-              repoId,
-              addedAt: new Date().toISOString(),
-              starsAtAdd: stars,
-            },
-          ],
+          repos: [...repos, item],
         });
       },
 
@@ -55,12 +60,12 @@ export const useWatchlistStore = create<WatchlistState>()(
         return get().repos.some((r) => r.repoId === repoId);
       },
 
-      toggleWatch: (repoId, stars) => {
+      toggleWatch: (repoId, stars, fullName) => {
         const { isWatched, addRepo, removeRepo } = get();
         if (isWatched(repoId)) {
           removeRepo(repoId);
         } else {
-          addRepo(repoId, stars);
+          addRepo(repoId, stars, fullName);
         }
       },
     }),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -404,6 +404,9 @@ export interface WhyMoving {
 
 export interface WatchlistItem {
   repoId: string;
+  /** Canonical "owner/name" saved at click time. Lets user tools render
+   * watched repos even when the current derived corpus cannot resolve repoId. */
+  fullName?: string;
   addedAt: string;
   starsAtAdd: number;
 }

--- a/src/lib/watchlist-items.ts
+++ b/src/lib/watchlist-items.ts
@@ -1,0 +1,16 @@
+import type { WatchlistItem } from "@/lib/types";
+import { idToSlug } from "@/lib/utils";
+
+export function watchlistItemFullName(item: WatchlistItem): string {
+  if (item.fullName && item.fullName.includes("/")) {
+    return item.fullName;
+  }
+  return idToSlug(item.repoId);
+}
+
+export function watchlistItemHref(item: WatchlistItem): string {
+  const fullName = watchlistItemFullName(item);
+  const [owner, name] = fullName.split("/");
+  if (!owner || !name) return "/";
+  return `/repo/${owner}/${name}`;
+}


### PR DESCRIPTION
## Summary
- Persist canonical `owner/name` on watchlist adds so dotted repos like `vercel/next.js` survive local storage hydration.
- Keep unresolved saved watchlist items visible on `/watchlist`, the sidebar preview, and watchlist manager surfaces.
- Pass canonical full names through repo, terminal, home, and linked skills watch/compare actions.

## Verification
- `git diff --check HEAD^..HEAD`
- `npx tsx --test src/lib/__tests__/watchlist-items.test.ts`
- `npm run typecheck`
- `npm run build`
- Local prod Playwright flow: `/repo/vercel/next.js` -> click watch -> `/watchlist`; verified no boundary/digest, `fullName` persisted, `1 TRACKED`, sidebar lists `vercel/next.js`, fallback card renders. Local auth/alert APIs returned 503 without production secrets but did not affect rendering.