### PR TITLE
Fix local tool repo labels

### DIFF
--- a/src/app/alerts/new/NewAlertClient.tsx
+++ b/src/app/alerts/new/NewAlertClient.tsx
@@ -25,6 +25,7 @@ import type {
   AlertTriggerType,
 } from "@/lib/pipeline/types";
 import { useWatchlistStore } from "@/lib/store";
+import { watchlistItemFullName } from "@/lib/watchlist-items";
 
 import { ProfileTemplate } from "@/components/templates/ProfileTemplate";
 import { SectionHead } from "@/components/ui/SectionHead";
@@ -233,6 +234,18 @@ export default function NewAlertClient() {
 
   const cfg = TRIGGER_BY_VALUE.get(trigger) ?? TRIGGER_OPTIONS[0];
 
+  const repoLabelsById = useMemo(() => {
+    const labels: Record<string, string> = {};
+    for (const repo of Object.values(reposById)) {
+      labels[repo.id] = repo.fullName;
+    }
+    for (const item of watchlistRepos) {
+      labels[item.repoId] =
+        reposById[item.repoId]?.fullName ?? watchlistItemFullName(item);
+    }
+    return labels;
+  }, [reposById, watchlistRepos]);
+
   const handleTriggerChange = useCallback((next: AlertTriggerType) => {
     setTrigger(next);
     setThreshold(TRIGGER_BY_VALUE.get(next)?.defaultThreshold ?? 0);
@@ -257,7 +270,7 @@ export default function NewAlertClient() {
   );
 
   const previewRepoLabel = repoId
-    ? reposById[repoId]?.fullName ?? repoId
+    ? repoLabelsById[repoId] ?? repoId
     : "all repos";
 
   const handleSubmit = useCallback(
@@ -423,7 +436,7 @@ export default function NewAlertClient() {
                   >
                     {watchlistRepos.map((item) => (
                       <option key={item.repoId} value={item.repoId}>
-                        {reposById[item.repoId]?.fullName ?? item.repoId}
+                        {repoLabelsById[item.repoId] ?? item.repoId}
                       </option>
                     ))}
                   </select>

--- a/src/app/you/YouClient.tsx
+++ b/src/app/you/YouClient.tsx
@@ -27,7 +27,13 @@ import {
   useFilterStore,
   useWatchlistStore,
 } from "@/lib/store";
-import { idToSlug } from "@/lib/utils";
+import type { WatchlistItem } from "@/lib/types";
+import { compareIdToFallbackFullName } from "@/lib/compare-selection";
+import {
+  repoFullNameHref,
+  watchlistItemFullName,
+  watchlistItemHref,
+} from "@/lib/watchlist-items";
 
 import { ProfileTemplate } from "@/components/templates/ProfileTemplate";
 import { SectionHead } from "@/components/ui/SectionHead";
@@ -54,6 +60,7 @@ export default function YouClient({
   const watchlist = useWatchlistStore((s) => s.repos);
   const removeWatched = useWatchlistStore((s) => s.removeRepo);
   const compareIds = useCompareStore((s) => s.repos);
+  const compareFullNamesById = useCompareStore((s) => s.fullNamesById);
   const removeCompare = useCompareStore((s) => s.removeRepo);
   const clearCompare = useCompareStore((s) => s.clearAll);
 
@@ -172,6 +179,7 @@ export default function YouClient({
               hydrated={hydrated}
               watchlist={watchlist}
               compareIds={compareIds}
+              compareFullNamesById={compareFullNamesById}
               onRemoveWatched={removeWatched}
               onRemoveCompare={removeCompare}
               onClearCompare={clearCompare}
@@ -309,13 +317,15 @@ function ActivityPanel({
   hydrated,
   watchlist,
   compareIds,
+  compareFullNamesById,
   onRemoveWatched,
   onRemoveCompare,
   onClearCompare,
 }: {
   hydrated: boolean;
-  watchlist: { repoId: string; addedAt: string; starsAtAdd: number }[];
+  watchlist: WatchlistItem[];
   compareIds: string[];
+  compareFullNamesById: Record<string, string>;
   onRemoveWatched: (repoId: string) => void;
   onRemoveCompare: (repoId: string) => void;
   onClearCompare: () => void;
@@ -367,12 +377,13 @@ function ActivityPanel({
       ) : (
         <ul style={listStyle}>
           {watchlist.map((item) => {
-            const slug = idToSlug(item.repoId);
+            const fullName = watchlistItemFullName(item);
+            const href = watchlistItemHref(item);
             return (
               <li key={item.repoId} style={listRowStyle}>
                 <div style={{ minWidth: 0, flex: 1 }}>
                   <Link
-                    href={`/repo/${slug}`}
+                    href={href === "/" ? "/watchlist" : href}
                     style={{
                       fontFamily: "var(--font-geist-mono), monospace",
                       fontSize: 12,
@@ -384,7 +395,7 @@ function ActivityPanel({
                       whiteSpace: "nowrap",
                     }}
                   >
-                    {slug}
+                    {fullName}
                   </Link>
                   <span style={metaStyle}>
                     added {new Date(item.addedAt).toLocaleDateString()} · @{" "}
@@ -394,7 +405,7 @@ function ActivityPanel({
                 <button
                   type="button"
                   onClick={() => onRemoveWatched(item.repoId)}
-                  aria-label={`Remove ${slug} from watchlist`}
+                  aria-label={`Remove ${fullName} from watchlist`}
                   style={iconBtnStyle}
                 >
                   ✕
@@ -443,11 +454,13 @@ function ActivityPanel({
       ) : (
         <ul style={listStyle}>
           {compareIds.map((id) => {
-            const slug = idToSlug(id);
+            const fullName =
+              compareFullNamesById[id] ?? compareIdToFallbackFullName(id);
+            const href = repoFullNameHref(fullName);
             return (
               <li key={id} style={listRowStyle}>
                 <Link
-                  href={`/repo/${slug}`}
+                  href={href === "/" ? "/compare" : href}
                   style={{
                     fontFamily: "var(--font-geist-mono), monospace",
                     fontSize: 12,
@@ -460,12 +473,12 @@ function ActivityPanel({
                     whiteSpace: "nowrap",
                   }}
                 >
-                  {slug}
+                  {fullName}
                 </Link>
                 <button
                   type="button"
                   onClick={() => onRemoveCompare(id)}
-                  aria-label={`Remove ${slug} from compare`}
+                  aria-label={`Remove ${fullName} from compare`}
                   style={iconBtnStyle}
                 >
                   ✕

--- a/src/components/compare/StarterPackRow.tsx
+++ b/src/components/compare/StarterPackRow.tsx
@@ -10,6 +10,7 @@
 
 import { useMemo } from "react";
 import { useWatchlistStore } from "@/lib/store";
+import { watchlistItemFullName } from "@/lib/watchlist-items";
 import { TIER_LIST_TEMPLATES } from "@/lib/tier-list/templates";
 import { MAX_COMPARE_REPOS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
@@ -36,13 +37,6 @@ const TEMPLATE_PICKS: ReadonlyArray<{
   { key: "local-infer", label: "Local Infer", templateSlug: "local-inference" },
   { key: "mcp", label: "MCP Servers", templateSlug: "mcp-servers" },
 ];
-
-/** Watchlist ids look like "vercel--next-js" — convert back to "vercel/next.js". */
-function repoIdToFullName(id: string): string {
-  const idx = id.indexOf("--");
-  if (idx === -1) return id;
-  return id.slice(0, idx) + "/" + id.slice(idx + 2);
-}
 
 const CHIP_BASE = cn(
   "inline-flex items-center gap-1.5",
@@ -87,7 +81,7 @@ export function StarterPackRow({ onPick, className }: StarterPackRowProps) {
   const watchlistFullNames = useMemo(
     () =>
       watchlistRepos
-        .map((r) => repoIdToFullName(r.repoId))
+        .map((repo) => watchlistItemFullName(repo))
         .slice(0, MAX_COMPARE_REPOS),
     [watchlistRepos],
   );

--- a/src/lib/__tests__/watchlist-items.test.ts
+++ b/src/lib/__tests__/watchlist-items.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  repoFullNameHref,
   watchlistItemFullName,
   watchlistItemHref,
 } from "@/lib/watchlist-items";
@@ -28,4 +29,9 @@ test("watchlist item falls back to legacy repoId when fullName is missing", () =
 
   assert.equal(watchlistItemFullName(item), "owner/repo");
   assert.equal(watchlistItemHref(item), "/repo/owner/repo");
+});
+
+test("repo fullName href helper rejects non repo-shaped names", () => {
+  assert.equal(repoFullNameHref("vercel/next.js"), "/repo/vercel/next.js");
+  assert.equal(repoFullNameHref("skill:some-skill"), "/");
 });

--- a/src/lib/watchlist-items.ts
+++ b/src/lib/watchlist-items.ts
@@ -8,9 +8,12 @@ export function watchlistItemFullName(item: WatchlistItem): string {
   return idToSlug(item.repoId);
 }
 
-export function watchlistItemHref(item: WatchlistItem): string {
-  const fullName = watchlistItemFullName(item);
+export function repoFullNameHref(fullName: string): string {
   const [owner, name] = fullName.split("/");
   if (!owner || !name) return "/";
   return `/repo/${owner}/${name}`;
+}
+
+export function watchlistItemHref(item: WatchlistItem): string {
+  return repoFullNameHref(watchlistItemFullName(item));
 }


### PR DESCRIPTION
## Summary
- Keep exact `owner/name` repo labels when local watchlist items feed `/you`, `/alerts/new`, and compare starter packs.
- Add a shared href helper for canonical repo full names while preserving legacy repoId fallback behavior.
- Cover dotted repo names with a watchlist helper regression test.

## Verification
- `git diff --check HEAD^..HEAD`
- `npx eslint src/app/you/YouClient.tsx src/app/alerts/new/NewAlertClient.tsx src/components/compare/StarterPackRow.tsx src/lib/watchlist-items.ts src/lib/__tests__/watchlist-items.test.ts`
- `npx tsx --test src/lib/__tests__/watchlist-items.test.ts`
- `npm run build`
- `npm run typecheck`
- Local prod Playwright smoke on `http://127.0.0.1:3044`: `/repo/vercel/next.js` add watchlist/compare -> `/you`, `/alerts/new`, and `/compare` + MY STACK all render `vercel/next.js` with no `vercel/next-js` or `vercel--next-js` leakage and no 5xx/429 responses.