### PR TITLE
Fail closed on production Clerk test keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,8 +123,10 @@ DATABASE_URL=
 DIRECT_URL=
 
 # -- Clerk (auth provider) ---------------------------------------------------
-# clerk.com → API Keys → copy pk_test_… (browser-public) and sk_test_…
-# (server-only). Roll keys if any have leaked into chat / commits.
+# clerk.com → API Keys → use pk_test_/sk_test_ locally and in Preview.
+# Vercel Production must use a matched pk_live_/sk_live_ pair; the app
+# refuses to mount Clerk in Production with test keys or a blank secret.
+# Roll keys if any have leaked into chat / commits.
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
 # clerk.com → Webhooks → Add endpoint
@@ -149,4 +151,3 @@ FOUNDER_DISCORD_INVITE=
 # Tables created: profiles, watchlists, watchlist_items, newsletter_subscribers,
 #   alert_rules, alert_events, alert_delivery_log, referral_codes, referrals,
 #   referral_milestones.
-

--- a/docs/AUTH-SETUP.md
+++ b/docs/AUTH-SETUP.md
@@ -9,6 +9,8 @@ Append to `.env.local` (and Vercel + Railway envs):
 ```bash
 # -- User accounts (Clerk) ---------------------------------------------------
 # Dashboard: https://dashboard.clerk.com → API Keys
+# Use pk_test_/sk_test_ locally and in Preview.
+# Use pk_live_/sk_live_ in Vercel Production.
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxx
 CLERK_SECRET_KEY=sk_test_xxxxxxxxxxxx
 
@@ -67,7 +69,8 @@ FOUNDER_DISCORD_INVITE=
 
 ## Production checklist
 
-- [ ] Vercel env vars set across Production / Preview / Development scopes.
+- [ ] Vercel Production uses a matched `pk_live_` / `sk_live_` Clerk key pair.
+- [ ] Vercel Preview / Development use `pk_test_` / `sk_test_` Clerk keys.
 - [ ] Railway worker env updated with `DATABASE_URL`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY` (worker runs schedulers that touch the DB).
 - [ ] DKIM/SPF/DMARC records on the sending domain (`alerts@trendingrepo.com` or wherever `EMAIL_FROM` points). Resend dashboard shows DNS verification status.
 - [ ] Clerk webhook endpoint pointing at the live domain (NOT ngrok).

--- a/src/lib/__tests__/clerk-config.test.ts
+++ b/src/lib/__tests__/clerk-config.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test("Clerk publishable key allows local test keys outside Vercel Production", () => {
+  process.env.VERCEL_ENV = "preview";
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_local";
+  process.env.CLERK_SECRET_KEY = "sk_test_local";
+
+  assert.equal(getClerkPublishableKey(), "pk_test_local");
+});
+
+test("Clerk publishable key is disabled in Vercel Production without a live key pair", () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (message?: unknown) => {
+    warnings.push(String(message));
+  };
+
+  try {
+    process.env.VERCEL_ENV = "production";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_wrong";
+    process.env.CLERK_SECRET_KEY = "";
+
+    assert.equal(getClerkPublishableKey(), undefined);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0] ?? "", /pk_live_\*/);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("Clerk publishable key allows Vercel Production with a live key pair", () => {
+  process.env.VERCEL_ENV = "production";
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_ready";
+  process.env.CLERK_SECRET_KEY = "sk_live_ready";
+
+  assert.equal(getClerkPublishableKey(), "pk_live_ready");
+});

--- a/src/lib/auth/clerk-config.ts
+++ b/src/lib/auth/clerk-config.ts
@@ -1,9 +1,30 @@
 // Clerk publishable key resolver shared between layout, middleware, and
-// sign-in / sign-up pages. Returns undefined when the env var is unset or
-// blank, so callers can render a degraded "Auth unavailable" surface
-// instead of throwing during build (CI / local without Clerk keys).
+// sign-in / sign-up pages. Returns undefined when auth is not safe to mount,
+// so callers can render a degraded "Auth unavailable" surface instead of
+// throwing during build or showing a development auth instance in production.
+
+function isVercelProduction(): boolean {
+  return process.env.VERCEL_ENV === "production";
+}
+
+function hasLiveClerkKeyPair(): boolean {
+  const publicKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim();
+  const secretKey = process.env.CLERK_SECRET_KEY?.trim();
+  return Boolean(
+    publicKey?.startsWith("pk_live_") && secretKey?.startsWith("sk_live_"),
+  );
+}
 
 export function getClerkPublishableKey(): string | undefined {
   const key = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim();
-  return key ? key : undefined;
+  if (!key) return undefined;
+
+  if (isVercelProduction() && !hasLiveClerkKeyPair()) {
+    console.warn(
+      "[auth] Clerk disabled: Vercel Production requires NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_* and CLERK_SECRET_KEY=sk_live_*.",
+    );
+    return undefined;
+  }
+
+  return key;
 }


### PR DESCRIPTION
## Summary
- Refuse to mount Clerk in Vercel Production unless `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is `pk_live_*` and `CLERK_SECRET_KEY` is `sk_live_*`.
- Keep local/Preview test-key behavior unchanged.
- Document the Production vs Preview Clerk key split and add regression coverage.

## Current production env finding
- Vercel Production currently has `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` present with a `pk_test_` prefix.
- Vercel Production currently has `CLERK_SECRET_KEY` present but empty.
- No secret values were printed or committed.

## Verification
- `git diff --check HEAD^..HEAD`
- `npx eslint src/lib/auth/clerk-config.ts src/lib/__tests__/clerk-config.test.ts`
- `npx tsx --test src/lib/__tests__/clerk-config.test.ts src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/auth-url.test.ts`
- `npm run typecheck`
- `npm run build`
- Local prod smoke on `http://127.0.0.1:3045` with `VERCEL_ENV=production`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_*`, and blank `CLERK_SECRET_KEY`: `/sign-in`, `/sign-up`, and `/you/refer` render `Auth unavailable`, with no Clerk development-mode UI, no Clerk dev-key console warning, no 4xx/5xx, and no error boundary.