### PR TITLE
Fix sidebar overlay when auth is disabled

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -190,7 +190,7 @@ export default async function RootLayout({
         <Sidebar initialShell={initialSidebarShell} />
         <main id="main-content" className="app-main">{children}</main>
       </AppShell>
-      <SidebarUserOverlayBridge />
+      <SidebarUserOverlayBridge enabled={Boolean(clerkPublishableKey)} />
       <MobileNavLazy />
       <IdleMount>
         <BrowserAlertBridgeLazy />

--- a/src/components/layout/SidebarUserOverlayBridge.tsx
+++ b/src/components/layout/SidebarUserOverlayBridge.tsx
@@ -26,10 +26,14 @@ interface OverlayResponse {
   unreadAlerts?: number;
 }
 
-const CLERK_PUBLIC_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+interface SidebarUserOverlayBridgeProps {
+  enabled: boolean;
+}
 
-export function SidebarUserOverlayBridge() {
-  if (!CLERK_PUBLIC_KEY) return null;
+export function SidebarUserOverlayBridge({
+  enabled,
+}: SidebarUserOverlayBridgeProps) {
+  if (!enabled) return null;
   return <SidebarUserOverlayBridgeInner />;
 }
 

--- a/src/lib/__tests__/auth-provider-policy.test.ts
+++ b/src/lib/__tests__/auth-provider-policy.test.ts
@@ -28,8 +28,17 @@ test("root layout owns the only ClerkProvider", () => {
 });
 
 test("sidebar user overlay fetch waits for a signed-in Clerk user", () => {
+  const layout = source("src/app/layout.tsx");
+  assert.match(
+    layout,
+    /<SidebarUserOverlayBridge enabled=\{Boolean\(clerkPublishableKey\)\} \/>/,
+    "sidebar overlay bridge must not mount Clerk hooks when ClerkProvider is disabled",
+  );
+
   const body = source("src/components/layout/SidebarUserOverlayBridge.tsx");
   assert.match(body, /import \{ useAuth \} from "@clerk\/nextjs";/);
+  assert.match(body, /enabled: boolean/);
+  assert.match(body, /if \(!enabled\) return null;/);
   assert.match(body, /const \{ isLoaded, userId \} = useAuth\(\);/);
   assert.match(body, /if \(!isLoaded\) \{\s*return;\s*\}/);
   assert.match(body, /if \(!userId\) \{[\s\S]*?reset\(\);[\s\S]*?return;\s*\}/);


### PR DESCRIPTION
## Summary
- Pass the server-side Clerk enabled decision into `SidebarUserOverlayBridge`.
- Prevent `useAuth()` from running when `ClerkProvider` is intentionally absent due to unsafe Production Clerk env.
- Add a regression assertion for the layout-to-bridge wiring.

## Verification
- `git diff --check`
- `npx eslint src/app/layout.tsx src/components/layout/SidebarUserOverlayBridge.tsx src/lib/__tests__/auth-provider-policy.test.ts`
- `npx tsx --test src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/clerk-config.test.ts src/lib/__tests__/auth-url.test.ts`
- `npm run typecheck`
- `npm run build`
- Local prod smoke on `http://127.0.0.1:3046` with `VERCEL_ENV=production`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_*`, and blank `CLERK_SECRET_KEY`: `/sign-in`, `/sign-up`, and `/you/refer` render `Auth unavailable`, with no `useAuth`/missing-provider console error, no `Something went sideways`, no development-mode UI, and no 4xx/5xx.