### PR TITLE
feat(repo-hover): migrate digest / skills / producthunt to RepoLink

### DIFF
--- a/src/app/digest/[date]/page.tsx
+++ b/src/app/digest/[date]/page.tsx
@@ -8,6 +8,8 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { RepoLink } from "@/components/repo/RepoLink";
+
 import {
   getDigestForDate,
   isValidDigestDate,
@@ -139,12 +141,12 @@ function DigestRow({ entry }: { entry: DigestEntry }) {
         {entry.rank}
       </td>
       <td className="py-2 px-3">
-        <Link
-          href={`/repo/${entry.fullName}`}
+        <RepoLink
+          fullName={entry.fullName}
           className="text-sm font-medium text-text-primary hover:text-brand transition-colors"
         >
           {entry.fullName}
-        </Link>
+        </RepoLink>
         {entry.description && (
           <div className="text-xs text-text-tertiary line-clamp-1 mt-0.5 max-w-md">
             {entry.description}

--- a/src/app/producthunt/page.tsx
+++ b/src/app/producthunt/page.tsx
@@ -11,6 +11,7 @@ import { EntityLogo } from "@/components/ui/EntityLogo";
 import Link from "next/link";
 import { MessageSquare, ChevronUp } from "lucide-react";
 import { LaunchLinkIcons } from "@/components/producthunt/LaunchLinkIcons";
+import { RepoLink } from "@/components/repo/RepoLink";
 import {
   getAiLaunches,
   getProducthuntFetchedAt,
@@ -405,12 +406,13 @@ function CrossLinkedReposPanel({ launches }: { launches: Launch[] }) {
                   {launch.name}
                 </a>
                 <span className="text-[10px] text-text-tertiary">→</span>
-                <Link
-                  href={`/repo/${repo.owner}/${repo.name}`}
+                <RepoLink
+                  owner={repo.owner}
+                  name={repo.name}
                   className="text-xs text-text-tertiary font-mono hover:text-functional transition-colors truncate"
                 >
                   {repo.fullName}
-                </Link>
+                </RepoLink>
               </span>
               <span
                 className="text-xs tabular-nums inline-flex items-center gap-1"

--- a/src/app/skills/[slug]/page.tsx
+++ b/src/app/skills/[slug]/page.tsx
@@ -15,6 +15,8 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { RepoLink } from "@/components/repo/RepoLink";
+
 import {
   getSkillsSignalData,
   type EcosystemLeaderboardItem,
@@ -279,12 +281,12 @@ export default async function SkillDetailPage({ params }: PageProps) {
                   Open source ↗
                 </a>
                 {repoFullName ? (
-                  <Link
-                    href={`/repo/${repoFullName}`}
+                  <RepoLink
+                    fullName={repoFullName}
                     style={{ color: "var(--v4-acc)" }}
                   >
                     /repo/{repoFullName}
-                  </Link>
+                  </RepoLink>
                 ) : null}
               </div>
             </div>
@@ -532,15 +534,15 @@ function SkillIdentity({
             </span>
           ) : null}
           {linkedRepo ? (
-            <Link
-              href={`/repo/${linkedRepo}`}
+            <RepoLink
+              fullName={linkedRepo}
               style={{
                 color: "var(--v4-acc)",
                 textDecoration: "none",
               }}
             >
               /repo/{linkedRepo}
-            </Link>
+            </RepoLink>
           ) : null}
           <a
             href={url}

--- a/src/components/producthunt/RecentLaunches.tsx
+++ b/src/components/producthunt/RecentLaunches.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { getAiLaunches, producthuntCold } from "@/lib/producthunt";
 import { getDerivedRepoByFullName } from "@/lib/derived-repos";
+import { RepoLink } from "@/components/repo/RepoLink";
 
 interface RecentLaunchesProps {
   limit?: number;
@@ -127,12 +128,13 @@ export function RecentLaunches({
                       </span>
                     ))}
                     {trackedRepo ? (
-                      <Link
-                        href={`/repo/${trackedRepo.owner}/${trackedRepo.name}`}
+                      <RepoLink
+                        owner={trackedRepo.owner}
+                        name={trackedRepo.name}
                         className="font-mono text-[10px] text-functional hover:text-functional/80 transition-colors"
                       >
                         View repo on TrendingRepo →
-                      </Link>
+                      </RepoLink>
                     ) : l.githubUrl ? (
                       <a
                         href={l.githubUrl}


### PR DESCRIPTION
## Summary

Wave 2 of RepoLink migrations (PR #1324 was wave 1 with 10 sites). Four more public surfaces get the hover-card preview on desktop:

| Surface | File | Notes |
|---|---|---|
| `/digest/[date]` | `src/app/digest/[date]/page.tsx` | trend tape rows |
| `/skills/[slug]` | `src/app/skills/[slug]/page.tsx` | breadcrumb + linkedRepo footer (2 sites) |
| `/producthunt` | `src/app/producthunt/page.tsx` | per-launch linked-repo |
| Recent Launches | `src/components/producthunt/RecentLaunches.tsx` | homepage card |

## Skipped (deliberate)

- **`/npm`** has a LOCAL function named `RepoLink` (`function RepoLink({ pkg }) { ... }`) that would name-clash with the imported wrapper. Tracked as a follow-up — needs a small rename to land cleanly.

## Verify gates

- [x] `npm run typecheck`
- [x] `npm run lint:guards`

Total RepoLink consumer count after this PR: **14 surfaces** (10 from #1324 + 4 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)