### PR TITLE
Fix auth-disabled prerender crash

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -184,7 +184,7 @@ export default async function RootLayout({
       <IdleMount>
         <ClerkRefHandoff />
       </IdleMount>
-      <Header clerkPublishableKey={clerkPublishableKey} />
+      <Header authEnabled={Boolean(clerkPublishableKey)} />
       <MobileDrawerLazy />
       <AppShell>
         <Sidebar initialShell={initialSidebarShell} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,10 +7,10 @@ import { HamburgerButton } from "@/components/layout/HamburgerButton";
 import { HeaderAccount } from "@/components/layout/HeaderAccount";
 
 interface HeaderProps {
-  clerkPublishableKey?: string;
+  authEnabled: boolean;
 }
 
-export function Header({ clerkPublishableKey }: HeaderProps) {
+export function Header({ authEnabled }: HeaderProps) {
   return (
     <header className="topbar">
       <div className="topbar-shimmer" aria-hidden="true"></div>
@@ -86,7 +86,7 @@ export function Header({ clerkPublishableKey }: HeaderProps) {
         </Link>
 
         <span className="tb-div" aria-hidden="true"></span>
-        <HeaderAccount publishableKey={clerkPublishableKey} />
+        <HeaderAccount authEnabled={authEnabled} />
       </div>
     </header>
   );

--- a/src/components/layout/HeaderAccount.tsx
+++ b/src/components/layout/HeaderAccount.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Link from "next/link";
-import { useUser } from "@clerk/nextjs";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { buildAuthHref } from "@/lib/auth/redirect-url";
 import { captureFunnelStep } from "@/lib/analytics/funnel";
 
 interface HeaderAccountProps {
-  publishableKey?: string;
+  authEnabled: boolean;
 }
 
 function accountInitials(input: string): string {
@@ -90,47 +90,35 @@ function SignedOutAccountLink() {
   );
 }
 
-function HeaderAccountLoaded() {
-  const { isLoaded, isSignedIn, user } = useUser();
-
-  if (!isLoaded) {
-    return (
-      <span
-        className="btn-signup"
-        aria-label="Loading account"
-        aria-busy="true"
-      >
-        <span>Account</span>
-      </span>
-    );
-  }
-
-  if (!isSignedIn || !user) {
-    return <SignedOutAccountLink />;
-  }
-
-  const label =
-    user.fullName ||
-    user.username ||
-    user.primaryEmailAddress?.emailAddress ||
-    user.id;
-
+export function HeaderAccountLoading() {
   return (
-    <Link
-      href="/you"
-      className="profile focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent focus-visible:rounded"
-      title="Your account"
-      aria-label="Your account"
+    <span
+      className="btn-signup"
+      aria-label="Loading account"
+      aria-busy="true"
     >
-      <div className="av">{accountInitials(label)}</div>
-    </Link>
+      <span>Account</span>
+    </span>
   );
 }
 
-export function HeaderAccount({ publishableKey }: HeaderAccountProps) {
-  if (!publishableKey) {
+const HeaderAccountLoaded = dynamic(
+  () =>
+    import("@/components/layout/HeaderAccountLoaded").then(
+      (mod) => mod.HeaderAccountLoaded,
+    ),
+  { ssr: false, loading: HeaderAccountLoading },
+);
+
+export function HeaderAccount({ authEnabled }: HeaderAccountProps) {
+  if (!authEnabled) {
     return <SignedOutAccountLink />;
   }
 
-  return <HeaderAccountLoaded />;
+  return (
+    <HeaderAccountLoaded
+      fallback={<SignedOutAccountLink />}
+      getInitials={accountInitials}
+    />
+  );
 }

--- a/src/components/layout/HeaderAccountLoaded.tsx
+++ b/src/components/layout/HeaderAccountLoaded.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { useUser } from "@clerk/nextjs";
+import { useEffect, useState, type ReactNode } from "react";
+
+interface HeaderAccountLoadedProps {
+  fallback: ReactNode;
+  getInitials: (input: string) => string;
+}
+
+export function HeaderAccountLoaded({
+  fallback,
+  getInitials,
+}: HeaderAccountLoadedProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <HeaderAccountLoading />;
+  }
+
+  return (
+    <HeaderAccountClerkState fallback={fallback} getInitials={getInitials} />
+  );
+}
+
+function HeaderAccountLoading() {
+  return (
+    <span
+      className="btn-signup"
+      aria-label="Loading account"
+      aria-busy="true"
+    >
+      <span>Account</span>
+    </span>
+  );
+}
+
+function HeaderAccountClerkState({
+  fallback,
+  getInitials,
+}: HeaderAccountLoadedProps) {
+  const { isLoaded, isSignedIn, user } = useUser();
+
+  if (!isLoaded) {
+    return <HeaderAccountLoading />;
+  }
+
+  if (!isSignedIn || !user) {
+    return fallback;
+  }
+
+  const label =
+    user.fullName ||
+    user.username ||
+    user.primaryEmailAddress?.emailAddress ||
+    user.id;
+
+  return (
+    <Link
+      href="/you"
+      className="profile focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent focus-visible:rounded"
+      title="Your account"
+      aria-label="Your account"
+    >
+      <div className="av">{getInitials(label)}</div>
+    </Link>
+  );
+}

--- a/src/lib/__tests__/auth-provider-policy.test.ts
+++ b/src/lib/__tests__/auth-provider-policy.test.ts
@@ -15,6 +15,7 @@ test("root layout owns the only ClerkProvider", () => {
 
   for (const path of [
     "src/components/layout/HeaderAccount.tsx",
+    "src/components/layout/HeaderAccountLoaded.tsx",
     "src/app/sign-in/[[...sign-in]]/page.tsx",
     "src/app/sign-up/[[...sign-up]]/page.tsx",
   ]) {
@@ -44,6 +45,41 @@ test("sidebar user overlay fetch waits for a signed-in Clerk user", () => {
   assert.match(body, /if \(!userId\) \{[\s\S]*?reset\(\);[\s\S]*?return;\s*\}/);
   assert.match(body, /new URLSearchParams\(\{ userId \}\)/);
   assert.match(body, /\/api\/pipeline\/sidebar-overlay\?\$\{params\.toString\(\)\}/);
+});
+
+test("header account Clerk hook is client-only and auth gated", () => {
+  const layout = source("src/app/layout.tsx");
+  assert.match(
+    layout,
+    /<Header authEnabled=\{Boolean\(clerkPublishableKey\)\} \/>/,
+    "header account must receive the resolved server auth state",
+  );
+
+  const header = source("src/components/layout/Header.tsx");
+  assert.match(header, /authEnabled: boolean/);
+  assert.match(header, /<HeaderAccount authEnabled=\{authEnabled\} \/>/);
+
+  const account = source("src/components/layout/HeaderAccount.tsx");
+  assert.doesNotMatch(account, /@clerk\/nextjs/);
+  assert.doesNotMatch(account, /useUser\(\)/);
+  assert.match(account, /authEnabled: boolean/);
+  assert.match(account, /if \(!authEnabled\) \{/);
+  assert.match(account, /ssr: false/);
+  assert.match(account, /HeaderAccountLoaded/);
+
+  const loaded = source("src/components/layout/HeaderAccountLoaded.tsx");
+  assert.match(loaded, /const \[mounted, setMounted\] = useState\(false\);/);
+  assert.match(loaded, /if \(!mounted\) \{/);
+  assert.match(loaded, /HeaderAccountClerkState/);
+  assert.match(loaded, /import \{ useUser \} from "@clerk\/nextjs";/);
+  assert.match(loaded, /const \{ isLoaded, isSignedIn, user \} = useUser\(\);/);
+});
+
+test("sidebar chrome does not mount Clerk profile hooks during prerender", () => {
+  const content = source("src/components/layout/SidebarContent.tsx");
+  assert.doesNotMatch(content, /SidebarProfileCard/);
+  assert.doesNotMatch(content, /@clerk\/nextjs/);
+  assert.doesNotMatch(content, /useUser\(\)/);
 });
 
 test("hosted Clerk form waits for client-only referral state", () => {


### PR DESCRIPTION
## Summary
- pass the resolved Clerk auth-enabled state into the global header account chrome
- keep global header Clerk hooks behind a client-only loaded account component
- preserve #1349's removal of the sidebar profile card so this PR does not reintroduce that production crash path
- add auth policy assertions for header Clerk hook gating and sidebar no-Clerk prerender safety

## Validation
- npx eslint src/app/layout.tsx src/components/layout/Header.tsx src/components/layout/HeaderAccount.tsx src/components/layout/HeaderAccountLoaded.tsx src/components/layout/SidebarUserOverlayBridge.tsx src/lib/__tests__/auth-provider-policy.test.ts
- npx tsx --test src/lib/__tests__/auth-provider-policy.test.ts src/lib/__tests__/clerk-config.test.ts src/lib/__tests__/auth-url.test.ts
- npm run typecheck
- VERCEL_ENV=production NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_local_bad_shape CLERK_SECRET_KEY= npm run build