### PR TITLE
feat(submit): A7 — category picker + tag chips + release/demo URL fields

### DIFF
--- a/src/components/submissions/DropRepoCategoryPicker.tsx
+++ b/src/components/submissions/DropRepoCategoryPicker.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+/**
+ * DropRepoCategoryPicker — 3-tile picker for the submission category
+ * (REPO / SKILL / MCP). Operator-mockup 2026-05-15: each tile shows a
+ * short type-badge ("code" / "claude" / "server") + the category name.
+ *
+ * Selection is presentational only at the moment — the
+ * `/api/repo-submissions` schema doesn't accept a category field yet.
+ * Operator extension of the API schema is the unblocking next step.
+ */
+
+import { cn } from "@/lib/utils";
+
+export type DropRepoCategory = "repo" | "skill" | "mcp";
+
+interface DropRepoCategoryPickerProps {
+  value: DropRepoCategory | null;
+  onChange: (next: DropRepoCategory) => void;
+}
+
+const ENTRIES: ReadonlyArray<{
+  key: DropRepoCategory;
+  label: string;
+  badge: string;
+  hint: string;
+}> = [
+  { key: "repo", label: "REPO", badge: "code", hint: "GitHub project" },
+  { key: "skill", label: "SKILL", badge: "claude", hint: "Claude skill" },
+  { key: "mcp", label: "MCP", badge: "server", hint: "MCP server" },
+];
+
+export function DropRepoCategoryPicker({
+  value,
+  onChange,
+}: DropRepoCategoryPickerProps) {
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {ENTRIES.map((entry) => {
+        const active = entry.key === value;
+        return (
+          <button
+            type="button"
+            key={entry.key}
+            onClick={() => onChange(entry.key)}
+            aria-pressed={active}
+            className={cn(
+              "flex flex-col items-start gap-1 rounded-card border px-3 py-2.5 text-left transition-colors",
+              active ? "border-brand bg-brand/5" : "border-border-primary bg-bg-secondary hover:border-border-strong",
+            )}
+          >
+            <span
+              className="font-mono text-[9px] uppercase tracking-[0.18em]"
+              style={{ color: active ? "var(--v3-acc)" : "var(--text-muted)" }}
+            >
+              {entry.badge}
+            </span>
+            <span className="text-sm font-semibold text-text-primary">
+              {entry.label}
+            </span>
+            <span className="text-[11px] text-text-tertiary">{entry.hint}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -13,6 +13,11 @@ import {
 import { ROUTES } from "@/lib/routes";
 import { captureFunnelStep } from "@/lib/analytics/funnel";
 import { DropRepoStepStrip } from "./DropRepoStepStrip";
+import {
+  DropRepoCategoryPicker,
+  type DropRepoCategory,
+} from "./DropRepoCategoryPicker";
+import { DropRepoTagChips, type DropRepoTag } from "./DropRepoTagChips";
 
 const WHY_NOW_MAX_CHARS = 280;
 
@@ -120,6 +125,15 @@ export function DropRepoPage() {
   const [whyNow, setWhyNow] = useState("");
   const [contact, setContact] = useState("");
   const [shareUrl, setShareUrl] = useState("");
+  // 2026-05-15 (A7 mockup): the following four fields ARE collected
+  // client-side but NOT yet sent to /api/repo-submissions — the API
+  // schema doesn't accept them yet. They render the operator-attached
+  // mockup faithfully; backend wiring is a follow-up after schema
+  // extension.
+  const [category, setCategory] = useState<DropRepoCategory | null>(null);
+  const [tags, setTags] = useState<Set<DropRepoTag>>(new Set());
+  const [releaseUrl, setReleaseUrl] = useState("");
+  const [demoUrl, setDemoUrl] = useState("");
   const [queue, setQueue] = useState<QueueSummary>(EMPTY_QUEUE);
   const [submissions, setSubmissions] = useState<PublicRepoSubmission[]>([]);
   const [loading, setLoading] = useState(true);
@@ -217,6 +231,10 @@ export function DropRepoPage() {
         setWhyNow("");
         setContact("");
         setShareUrl("");
+        setCategory(null);
+        setTags(new Set());
+        setReleaseUrl("");
+        setDemoUrl("");
         // Allow `submit_fill` to fire again on the cleared form.
         setFillFired(false);
       }
@@ -294,6 +312,29 @@ export function DropRepoPage() {
               />
             </label>
 
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-text-primary">
+                Category
+              </span>
+              <DropRepoCategoryPicker
+                value={category}
+                onChange={setCategory}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="flex items-center justify-between text-sm font-medium text-text-primary">
+                <span>Tags</span>
+                <span
+                  className="font-mono text-[10px] uppercase tracking-[0.14em]"
+                  style={{ color: "var(--text-muted, #6b7280)" }}
+                >
+                  {tags.size} / 4 max
+                </span>
+              </span>
+              <DropRepoTagChips value={tags} onChange={setTags} />
+            </div>
+
             <label className="flex flex-col gap-2">
               <span className="flex items-center justify-between text-sm font-medium text-text-primary">
                 <span>Why now</span>
@@ -343,6 +384,40 @@ export function DropRepoPage() {
                   value={shareUrl}
                   onChange={(event) => setShareUrl(event.target.value)}
                   placeholder="https://x.com/.../status/..."
+                  className="h-11 rounded-card border border-border-primary bg-bg-secondary px-3 text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-brand/50"
+                  autoComplete="off"
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-col gap-4 md:flex-row">
+              <label className="flex flex-1 flex-col gap-2">
+                <span className="text-sm font-medium text-text-primary">
+                  Release / launch URL{" "}
+                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                    optional
+                  </span>
+                </span>
+                <input
+                  value={releaseUrl}
+                  onChange={(event) => setReleaseUrl(event.target.value)}
+                  placeholder="https://github.com/.../releases/tag/v1.0.0"
+                  className="h-11 rounded-card border border-border-primary bg-bg-secondary px-3 text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-brand/50"
+                  autoComplete="off"
+                />
+              </label>
+
+              <label className="flex flex-1 flex-col gap-2">
+                <span className="text-sm font-medium text-text-primary">
+                  Demo / video URL{" "}
+                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                    optional
+                  </span>
+                </span>
+                <input
+                  value={demoUrl}
+                  onChange={(event) => setDemoUrl(event.target.value)}
+                  placeholder="https://youtu.be/... or https://demo.example.com"
                   className="h-11 rounded-card border border-border-primary bg-bg-secondary px-3 text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-brand/50"
                   autoComplete="off"
                 />

--- a/src/components/submissions/DropRepoTagChips.tsx
+++ b/src/components/submissions/DropRepoTagChips.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * DropRepoTagChips — 12-chip strip for the submission tag set. Max
+ * `maxSelected` selected at once (operator mockup: 4). Selection is
+ * presentational only at the moment — the `/api/repo-submissions`
+ * schema doesn't accept a tags array yet.
+ */
+
+import { cn } from "@/lib/utils";
+
+export type DropRepoTag =
+  | "AGENTS"
+  | "RAG"
+  | "EVAL"
+  | "VECTOR"
+  | "CLI"
+  | "FINETUNE"
+  | "FRAMEWORK"
+  | "INFERENCE"
+  | "DATA"
+  | "VISION"
+  | "VOICE"
+  | "CODEGEN";
+
+export const DROP_REPO_TAGS: ReadonlyArray<DropRepoTag> = [
+  "AGENTS",
+  "RAG",
+  "EVAL",
+  "VECTOR",
+  "CLI",
+  "FINETUNE",
+  "FRAMEWORK",
+  "INFERENCE",
+  "DATA",
+  "VISION",
+  "VOICE",
+  "CODEGEN",
+];
+
+interface DropRepoTagChipsProps {
+  value: ReadonlySet<DropRepoTag>;
+  onChange: (next: Set<DropRepoTag>) => void;
+  maxSelected?: number;
+}
+
+export function DropRepoTagChips({
+  value,
+  onChange,
+  maxSelected = 4,
+}: DropRepoTagChipsProps) {
+  function toggle(tag: DropRepoTag) {
+    const next = new Set(value);
+    if (next.has(tag)) {
+      next.delete(tag);
+    } else if (next.size < maxSelected) {
+      next.add(tag);
+    } else {
+      return;
+    }
+    onChange(next);
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {DROP_REPO_TAGS.map((tag) => {
+        const active = value.has(tag);
+        const disabled = !active && value.size >= maxSelected;
+        return (
+          <button
+            type="button"
+            key={tag}
+            onClick={() => toggle(tag)}
+            disabled={disabled}
+            aria-pressed={active}
+            className={cn(
+              "rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors",
+              active
+                ? "border-brand bg-brand/10 text-text-primary"
+                : "border-border-primary bg-bg-muted text-text-tertiary hover:text-text-primary",
+              disabled && "cursor-not-allowed opacity-40 hover:text-text-tertiary",
+            )}
+          >
+            {tag}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Wave 2 of the /submit rebuild

PR #1327 already shipped:
- Headline \"Drop a repo. Get it ranked.\"
- 4-step funnel strip
- 280-char Why-now limit

This PR fills in the **remaining operator-mockup deltas**:

| Mockup element | Status | Component |
|---|---|---|
| 3-tile category picker (REPO/SKILL/MCP) | ✅ Added | \`DropRepoCategoryPicker\` (NEW) |
| 12 tag chips (AGENTS/RAG/EVAL/VECTOR/CLI/FINETUNE/FRAMEWORK/INFERENCE/DATA/VISION/VOICE/CODEGEN, max 4) | ✅ Added | \`DropRepoTagChips\` (NEW) |
| Release / launch URL | ✅ Added | inline input |
| Demo / video URL | ✅ Added | inline input |

## Scope (visual fidelity only at this stage)

The new fields are **collected client-side** but **NOT sent** to \`/api/repo-submissions\` — the API schema doesn't accept them yet. This makes the form visually faithful to the operator mockup without requiring backend changes to land. When the schema extends (operator decision), the request body shape maps 1:1 onto the new state — \`category\`, \`tags\` (Array.from(set)), \`releaseUrl\`, \`demoUrl\`.

## Verify gates

- [x] \`npm run typecheck\`
- [x] \`npm run lint:guards\`
- [x] \`npx impeccable detect src/components/submissions/\` — 0 violations
- [x] \`npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)