### PR TITLE
fix(workflows): B1 — wire REDDIT_COLLECTOR_PROVIDER=apify into 3 reddit jobs

### DIFF
--- a/.github/workflows/cron-reddit-daily.yml
+++ b/.github/workflows/cron-reddit-daily.yml
@@ -100,6 +100,10 @@ jobs:
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
           REDDIT_USER_AGENTS: ${{ secrets.REDDIT_USER_AGENTS }}
+          # B1 (2026-05-16): apify proxy path so the daily Reddit run
+          # records real engagement instead of RSS zeros.
+          REDDIT_COLLECTOR_PROVIDER: apify
+          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
         run: npm run scrape:reddit
 
       - name: Compute commit timestamp

--- a/.github/workflows/refresh-reddit-baselines.yml
+++ b/.github/workflows/refresh-reddit-baselines.yml
@@ -45,6 +45,11 @@ jobs:
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
           REDDIT_USER_AGENTS: ${{ secrets.REDDIT_USER_AGENTS }}
+          # B1 (2026-05-16): same Apify proxy path as scrape-trending —
+          # ensures the baseline-refresh job records real engagement
+          # instead of RSS zeros.
+          REDDIT_COLLECTOR_PROVIDER: apify
+          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
         run: node scripts/scrape-reddit.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -62,6 +62,13 @@ jobs:
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
           REDDIT_USER_AGENTS: ${{ secrets.REDDIT_USER_AGENTS }}
+          # B1 (2026-05-16): activate Apify residential-proxy path so the
+          # collector returns real score/num_comments instead of falling
+          # through to the zero-engagement RSS path. Reddit's anti-bot
+          # 403s every GH-runner IP for /r/X/new.json; Apify's
+          # `trudax/reddit-scraper-lite` actor bypasses the block.
+          REDDIT_COLLECTOR_PROVIDER: apify
+          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
           # Dual-write to TOOLBOX signal lake (trending.reddit.mentions).
           # Skipped silently when unset; never blocks the primary write.
           TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}


### PR DESCRIPTION
Activates the Apify proxy path that already exists in code but was never enabled. APIFY_API_TOKEN was set in GHA secrets weeks ago; only the workflow env wiring was missing.