### PR TITLE
feat(funding): A6 — FundingSourcePillRow with per-source bars

### DIFF
--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -20,6 +20,7 @@ import { KpiBand } from "@/components/ui/KpiBand";
 import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
 import { MoverRow, type FundingStage } from "@/components/funding/MoverRow";
 import { WindowedFundingBoard } from "@/components/funding/WindowedFundingBoard";
+import { FundingSourcePillRow } from "@/components/funding/FundingSourcePillRow";
 import { companyLogoUrl } from "@/lib/logos";
 import { resolveLogoUrl } from "@/lib/logo-url";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
@@ -445,16 +446,15 @@ export default async function FundingPage() {
               <CardHeader showCorner right={<span>{sources.length} sources</span>}>
                 Source mix
               </CardHeader>
-              {sources.slice(0, 8).map((source, index) => (
-                <div className="stock-row" key={source.source}>
-                  <span className={`col-pip sd-f${(index % 6) + 1}`} />
-                  <span className="nm">{sourceName(source.source)}</span>
-                  <span className="px">{source.count}</span>
-                  <span className="ch up">
-                    {Math.round((source.count / Math.max(1, signals.length)) * 100)}%
-                  </span>
-                </div>
-              ))}
+              <FundingSourcePillRow
+                rows={sources.map((source) => ({
+                  source: source.source,
+                  count: source.count,
+                  label: sourceName(source.source),
+                }))}
+                total={signals.length}
+                limit={8}
+              />
             </Card>
           </div>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6657,3 +6657,82 @@ body::before {
   outline: none;
   box-shadow: 0 0 0 2px var(--v4-acc);
 }
+
+/* ---------------------------------------------------------------------------
+   FundingSourcePillRow — per-source pills + bars (A6 mockup 2026-05-16).
+   Replaces the original .stock-row tabular layout on /funding's "Source mix"
+   card with denser pill-on-the-left + proportional-bar-in-the-middle rows.
+   --------------------------------------------------------------------------- */
+.funding-page .fnd-pill-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.funding-page .fnd-pill-row {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr) 40px 38px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line-100);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-md);
+}
+
+.funding-page .fnd-pill-row:last-child {
+  border-bottom: none;
+}
+
+.funding-page .fnd-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+}
+
+.funding-page .fnd-pill__dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.55;
+}
+
+.funding-page .fnd-pill__label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.funding-page .fnd-pill__bar {
+  display: block;
+  height: 6px;
+  background: var(--bg-100);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.funding-page .fnd-pill__bar > i {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--sig-green), var(--acc));
+  border-radius: 4px;
+}
+
+.funding-page .fnd-pill__count {
+  font-size: 11px;
+  color: var(--ink-200);
+  text-align: right;
+}
+
+.funding-page .fnd-pill__share {
+  font-size: 10px;
+  color: var(--ink-300);
+  text-align: right;
+}

--- a/src/components/funding/FundingSourcePillRow.tsx
+++ b/src/components/funding/FundingSourcePillRow.tsx
@@ -1,0 +1,68 @@
+/**
+ * FundingSourcePillRow — per-source pill row with proportional bars
+ * for the funding radar's "Source mix" card. Operator mockup (2026-05-16):
+ * each source renders as a small pill on the left + a horizontal share
+ * bar + the raw count on the right, replacing the original three-column
+ * tabular layout for denser visual weight.
+ */
+
+import { cn } from "@/lib/utils";
+
+export interface FundingSourceRow {
+  source: string;
+  count: number;
+  /** Optional pre-resolved label. Falls back to `source` when absent. */
+  label?: string;
+}
+
+interface FundingSourcePillRowProps {
+  rows: FundingSourceRow[];
+  /** Total signals (denominator for the share %). */
+  total: number;
+  /** Cap on the rendered row count. Default 8. */
+  limit?: number;
+  className?: string;
+}
+
+/** Cycle through 6 accent tones so adjacent rows are visually distinct. */
+const PIP_TONE = (index: number): string => `sd-f${(index % 6) + 1}`;
+
+export function FundingSourcePillRow({
+  rows,
+  total,
+  limit = 8,
+  className,
+}: FundingSourcePillRowProps) {
+  const visible = rows.slice(0, limit);
+  const max = Math.max(1, ...visible.map((r) => r.count));
+
+  return (
+    <div className={cn("fnd-pill-rows", className)}>
+      {visible.map((row, index) => {
+        const share = total > 0 ? Math.round((row.count / total) * 100) : 0;
+        const bar = Math.max(4, Math.round((row.count / max) * 100));
+        const label = row.label ?? row.source;
+        return (
+          <div className="fnd-pill-row" key={row.source}>
+            <span className={cn("fnd-pill", "col-pip", PIP_TONE(index))}>
+              <span className="fnd-pill__dot" aria-hidden />
+              <span className="fnd-pill__label">{label}</span>
+            </span>
+            <span
+              className="fnd-pill__bar"
+              role="progressbar"
+              aria-valuenow={share}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${label} share: ${share}%`}
+            >
+              <i style={{ width: `${bar}%` }} />
+            </span>
+            <span className="fnd-pill__count tabular-nums">{row.count}</span>
+            <span className="fnd-pill__share tabular-nums">{share}%</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Operator-mockup deferral from 2026-05-15. Replaces the tabular Source mix layout on /funding with a pill + proportional bar row. New `FundingSourcePillRow` component (a11y-progressbar). Token-only CSS appended under `.funding-page` scope.