### PR TITLE
feat(nitter): A10 — expand instance pool from 5 to 13

### DIFF
--- a/config/nitter-instances.json
+++ b/config/nitter-instances.json
@@ -24,6 +24,46 @@
       "url": "https://nitter.unixfox.eu",
       "lastChecked": "2026-05-13T06:42:44.579Z",
       "status": "dead"
+    },
+    {
+      "url": "https://xcancel.com",
+      "lastChecked": null,
+      "status": "unknown"
+    },
+    {
+      "url": "https://nitter.privacy.com.de",
+      "lastChecked": null,
+      "status": "unknown"
+    },
+    {
+      "url": "https://nitter.tiekoetter.com",
+      "lastChecked": null,
+      "status": "unknown"
+    },
+    {
+      "url": "https://nitter.adminforge.de",
+      "lastChecked": null,
+      "status": "unknown"
+    },
+    {
+      "url": "https://nitter.platypush.tech",
+      "lastChecked": null,
+      "status": "unknown"
+    },
+    {
+      "url": "https://nt.vern.cc",
+      "lastChecked": null,
+      "status": "unknown"
+    },
+    {
+      "url": "https://nitter.fdn.fr",
+      "lastChecked": null,
+      "status": "unknown"
+    },
+    {
+      "url": "https://nitter.kavin.rocks",
+      "lastChecked": null,
+      "status": "unknown"
     }
   ]
 }


### PR DESCRIPTION
Adds 8 known Nitter instances (xcancel.com fork + 7 community mirrors) as status:'unknown' so next health check probes them. Removes the nitter.net single-point-of-failure for the Twitter fallback path.