### PR TITLE
feat(home): A.5 — RepoLink hover preview on homepage (batch 3a)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ import { Metric, MetricGrid } from "@/components/ui/Metric";
 import { FooterBar } from "@/components/ui/FooterBar";
 import { SectionHead } from "@/components/ui/SectionHead";
 import { EntityLogo } from "@/components/ui/EntityLogo";
+import { RepoLink } from "@/components/repo/RepoLink";
 import {
   GithubIcon,
   HackerNewsIcon,
@@ -519,7 +520,11 @@ function ConsensusRow({ repo, index }: { repo: Repo; index: number }) {
     ? SOURCE_ICONS.filter(({ channel }) => repo.channelStatus?.[channel])
     : SOURCE_ICONS.slice(0, channels);
   return (
-    <a className={`cons-row ${index === 0 ? "first" : ""}`} href={`/repo/${repo.owner}/${repo.name}`}>
+    <RepoLink
+      owner={repo.owner}
+      name={repo.name}
+      className={`cons-row ${index === 0 ? "first" : ""}`}
+    >
       <div className="cons-top">
         <span className="rk">{String(index + 1).padStart(2, "0")}</span>
         <EntityLogo
@@ -561,7 +566,7 @@ function ConsensusRow({ repo, index }: { repo: Repo; index: number }) {
           color="var(--sig-green)"
         />
       </div>
-    </a>
+    </RepoLink>
   );
 }
 
@@ -579,7 +584,11 @@ function BreakoutRow({ repo, index }: { repo: Repo; index: number }) {
         ? "var(--sig-green)"
         : "var(--sig-cyan)";
   return (
-    <a className={`brk-row ${index === 0 ? "first" : ""}`} href={`/repo/${repo.owner}/${repo.name}`}>
+    <RepoLink
+      owner={repo.owner}
+      name={repo.name}
+      className={`brk-row ${index === 0 ? "first" : ""}`}
+    >
       <span className="rk">{String(index + 1).padStart(2, "0")}</span>
       <EntityLogo
         src={repoLogoUrl(repo.fullName, 64)}
@@ -605,7 +614,7 @@ function BreakoutRow({ repo, index }: { repo: Repo; index: number }) {
         {formatDelta(repo.starsDelta24h)}
         {pct !== null ? <span className="pct">+{pct}%</span> : null}
       </span>
-    </a>
+    </RepoLink>
   );
 }
 
@@ -1058,10 +1067,11 @@ export default async function HomePage() {
                 </div>
                 <div className="chart-legend-row">
                   {indexLeaders.map((repo, i) => (
-                    <a
+                    <RepoLink
                       key={repo.id}
+                      owner={repo.owner}
+                      name={repo.name}
                       className="lg"
-                      href={`/repo/${repo.owner}/${repo.name}`}
                     >
                       <span
                         className="pip"
@@ -1078,7 +1088,7 @@ export default async function HomePage() {
                       <span className={`dl ${repo.starsDelta30d < 0 ? "dn" : "up"}`}>
                         {formatDelta(repo.starsDelta30d)}
                       </span>
-                    </a>
+                    </RepoLink>
                   ))}
                 </div>
               </>

--- a/src/lib/repo-submissions.ts
+++ b/src/lib/repo-submissions.ts
@@ -348,7 +348,7 @@ export function validateRepoSubmissionInput(
     category = body.category as RepoSubmissionCategory;
   }
 
-  let tags: RepoSubmissionTag[] = [];
+  const tags: RepoSubmissionTag[] = [];
   if (body.tags !== undefined && body.tags !== null) {
     if (!Array.isArray(body.tags)) {
       return { ok: false, error: "tags must be an array" };


### PR DESCRIPTION
## Summary
- 3 homepage `<a href="/repo/${owner}/${name}">` callsites migrated to `<RepoLink>`: `ConsensusRow`, `BreakoutRow`, `indexLeaders` legend. Hover-card preview now lands on the front-page top-3 surfaces.
- Inline pre-condition: 1-char fix to `src/lib/repo-submissions.ts` (`let tags` → `const tags`) that was failing every build since #1423 (admin-merged through failing CI; #1423 CI rollup attached below).

## What did NOT change
- Three `/repo/${...}` matches at lines 154 / 790 / 1284 — data-prop `href` and JSON-LD URL string, intentionally NOT migrated.
- No new dependencies, no new components, no auth-provider-policy allow-list edits (RepoLink is auth-free).

## Verification
- `npm run typecheck` ✓
- `npm run lint:guards` ✓
- `npm run build` ✓ (was failing on `prefer-const` from #1423 before the inline fix)
- Smoke plan: hover the consensus/breakout/index-leader rows on Vercel preview → card should appear in ≤200ms with real hover-payload data.

## Why now
Track A.5 from the operator handover — finishes off the front-page surfaces with the same hover-card affordance already shipped on /digest, /skills, /producthunt, /npm, sidebar Recent/Watching, FeaturedCard, IdeaCard, SignalTable, RepoMentionsTab, RecentLaunches, RepoProfileColumn (~15 surfaces total). After this PR, homepage joins them; PRs A2+A3 will cover the remaining 9.

## Operator action items still open (not in this PR)
- Apify monthly quota exceeded (Reddit B1 blocked, Twitter B6 on Nitter)
- Clerk webhook signing secret rotation (was pasted in chat)
- /api/repo-submissions schema persistence decision (DB column vs JSONL-only)
- /research broken viewport name if #1436 didn't cover it
- #1214/#1216 TOOLBOX rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)