### PR TITLE
feat(related-card+u): A.5 — RepoLink hover on RelatedRepoCard + activity feed

### DIFF
--- a/src/app/u/[handle]/page.tsx
+++ b/src/app/u/[handle]/page.tsx
@@ -48,6 +48,7 @@ import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
 import { KpiBand, type KpiCell } from "@/components/ui/KpiBand";
 import { PanelHead } from "@/components/ui/PanelHead";
 import { RelatedRepoCard } from "@/components/repo-detail/RelatedRepoCard";
+import { RepoLink } from "@/components/repo/RepoLink";
 import { IdeaCard } from "@/components/ideas/IdeaCard";
 import { getDerivedRepoByFullName } from "@/lib/derived-repos";
 import type { Repo } from "@/lib/types";
@@ -584,20 +585,37 @@ function RecentActivityFeed({
             >
               {event.objectType}
             </span>
-            <Link
-              href={href}
-              style={{
-                color: "var(--v4-ink-100)",
-                textDecoration: "none",
-                flex: 1,
-                minWidth: 0,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {event.objectId}
-            </Link>
+            {event.objectType === "repo" ? (
+              <RepoLink
+                fullName={event.objectId}
+                style={{
+                  color: "var(--v4-ink-100)",
+                  textDecoration: "none",
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {event.objectId}
+              </RepoLink>
+            ) : (
+              <Link
+                href={href}
+                style={{
+                  color: "var(--v4-ink-100)",
+                  textDecoration: "none",
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {event.objectId}
+              </Link>
+            )}
             <span
               style={{
                 color: "var(--v4-ink-400)",

--- a/src/components/repo-detail/RelatedRepoCard.tsx
+++ b/src/components/repo-detail/RelatedRepoCard.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 import { BrandStar } from "@/components/shared/BrandStar";
+import { RepoLink } from "@/components/repo/RepoLink";
 
 export interface RelatedRepoCardProps {
   /** Repo full name e.g. "abhigyanpatwari/GitNexus". */
@@ -16,7 +17,7 @@ export interface RelatedRepoCardProps {
   stars?: ReactNode;
   /** Similarity score (e.g. "SIM 0.86") rendered right-aligned in caps. */
   similarity?: ReactNode;
-  /** Optional href - renders as <a>. */
+  /** Optional href - renders as <a> via RepoLink when interactive. */
   href?: string;
   className?: string;
 }
@@ -31,12 +32,13 @@ export function RelatedRepoCard({
   href,
   className,
 }: RelatedRepoCardProps) {
-  const Tag = href ? "a" : "div";
-  return (
-    <Tag
-      {...(href ? { href } : {})}
-      className={cn("v4-related-card", href && "v4-related-card--interactive", className)}
-    >
+  const cardClass = cn(
+    "v4-related-card",
+    href && "v4-related-card--interactive",
+    className,
+  );
+  const inner = (
+    <>
       <header className="v4-related-card__head">
         {avatar ? (
           <span className="v4-related-card__avatar">{avatar}</span>
@@ -62,6 +64,14 @@ export function RelatedRepoCard({
           <span className="v4-related-card__why">{similarity}</span>
         ) : null}
       </footer>
-    </Tag>
+    </>
+  );
+  if (!href) {
+    return <div className={cardClass}>{inner}</div>;
+  }
+  return (
+    <RepoLink fullName={fullName} href={href} className={cardClass}>
+      {inner}
+    </RepoLink>
   );
 }

--- a/src/lib/repo-submissions.ts
+++ b/src/lib/repo-submissions.ts
@@ -348,7 +348,7 @@ export function validateRepoSubmissionInput(
     category = body.category as RepoSubmissionCategory;
   }
 
-  let tags: RepoSubmissionTag[] = [];
+  const tags: RepoSubmissionTag[] = [];
   if (body.tags !== undefined && body.tags !== null) {
     if (!Array.isArray(body.tags)) {
       return { ok: false, error: "tags must be an array" };


### PR DESCRIPTION
## Summary
Bigger leverage than the planned 3-file batch: refactors `RelatedRepoCard` to use `<RepoLink>` internally, which lights up hover-preview on **5 surfaces in one change**:

- `/agent-repos/[slug]` (related repos grid)
- `/categories/[slug]` (per-category repo grid)
- `/collections/[slug]` (collection's repo grid)
- `/u/[handle]` (TopRepoGrid)
- `/watchlist` (FeaturedRow + TopReacted lists)

Plus a second-commit edit to the `/u/[handle]` activity feed so the per-event `<Link>` becomes `<RepoLink>` when the event is a repo (falls through to plain `<Link>` for ideas events where there's no repo-detail target).

## What did NOT change
- `RelatedRepoCard` non-interactive variant (no href) still renders plain `<div>` — no client island when not interactive.
- The component is still server-renderable; only the RepoLink island within is "use client".
- Test contract preserved: `v4-home-repo.test 'href is preserved on the rendered anchor'` still passes (RepoLink renders `<Link>` → `<a>`, className passes through, explicit href honored). All 14 RelatedRepoCard tests green, 334/335 of `npm run test:hooks` pass (1 pre-existing skip).

## Why this approach
The planned A2 was 3 file edits (watchlist + u/[handle] + you/YouClient). On inspection: `you/YouClient` has zero repo links to migrate, and both watchlist + u/[handle] pass href through `RelatedRepoCard` as a component prop. Refactoring the card itself covers BOTH plus 3 other consumer pages I'd otherwise hit separately. Single change, broader effect.

## Verification
- `npm run typecheck` ✓
- `npm run lint:guards` ✓
- `npm run test:hooks` ✓ (334 pass, 1 pre-existing skip; specifically the 14 RelatedRepoCard tests including the href-preservation assertion)
- `npm run build` ✓

## PR ordering
First commit (`fix(submissions): prefer const for tags accumulator`) is identical to the one in #1447. If #1447 lands first, this dedupes automatically on rebase. If this lands first, no harm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)