### PR TITLE
feat(admin+revenue+watchlist): A.5 — RepoLink hover on 4 admin/revenue surfaces

### DIFF
--- a/src/components/admin/RevenueQueueAdmin.tsx
+++ b/src/components/admin/RevenueQueueAdmin.tsx
@@ -4,7 +4,7 @@
 // ss_admin cookie (server-gated in src/app/admin/revenue-queue/page.tsx and
 // re-checked by verifyAdminAuth on every API call). No token paste.
 
-import Link from "next/link";
+import { RepoLink } from "@/components/repo/RepoLink";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -284,12 +284,12 @@ function ModerationRow({
     >
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <Link
-            href={`/repo/${row.fullName}`}
+          <RepoLink
+            fullName={row.fullName}
             className="font-mono text-base font-semibold text-text-primary hover:underline"
           >
             {row.fullName}
-          </Link>
+          </RepoLink>
           <p className="mt-0.5 text-[11px] text-text-tertiary">
             Submitted {new Date(row.submittedAt).toISOString().slice(0, 16).replace("T", " ")}
             {row.moderatedAt

--- a/src/components/revenue/VerifiedStartupCard.tsx
+++ b/src/components/revenue/VerifiedStartupCard.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import Link from "next/link";
+import { RepoLink } from "@/components/repo/RepoLink";
 import {
   ArrowUpRight,
   BadgeCheck,
@@ -141,13 +141,14 @@ export function VerifiedStartupCard({
               #{rank}
             </span>
             {startup.matchedRepoFullName ? (
-              <Link
-                href={`/repo/${startup.matchedRepoFullName}`}
+              <RepoLink
+                fullName={startup.matchedRepoFullName}
                 className="truncate font-mono text-sm font-semibold text-text-primary hover:underline"
-                title={`Tracked repo: ${startup.matchedRepoFullName}`}
               >
-                {startup.name}
-              </Link>
+                <span title={`Tracked repo: ${startup.matchedRepoFullName}`}>
+                  {startup.name}
+                </span>
+              </RepoLink>
             ) : (
               <span className="truncate font-mono text-sm font-semibold text-text-primary">
                 {startup.name}

--- a/src/components/submissions/DropRevenuePage.tsx
+++ b/src/components/submissions/DropRevenuePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { RepoLink } from "@/components/repo/RepoLink";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   BadgeCheck,
@@ -440,13 +441,13 @@ function SuccessPanel({
         Status: <strong>{submission.status}</strong>
       </p>
       <div className="mt-4 flex flex-wrap gap-3 text-xs">
-        <Link
-          href={`/repo/${submission.fullName}`}
+        <RepoLink
+          fullName={submission.fullName}
           className="inline-flex items-center gap-1 rounded-md border border-border-primary bg-bg-muted px-3 py-1.5 text-text-secondary hover:text-text-primary"
         >
           View repo page
           <ExternalLink className="size-3" aria-hidden />
-        </Link>
+        </RepoLink>
         <a
           href={submission.repoUrl}
           target="_blank"

--- a/src/components/watchlist/WatchlistManager.tsx
+++ b/src/components/watchlist/WatchlistManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { RepoLink } from "@/components/repo/RepoLink";
 import { useEffect, useMemo, useState } from "react";
 import { Eye, Trash2, ArrowRight } from "lucide-react";
 import { BrandStar } from "@/components/shared/BrandStar";
@@ -47,12 +48,13 @@ function WatchedRepoCard({
       <div className="flex items-start justify-between gap-3">
         {/* Left: repo info */}
         <div className="flex-1 min-w-0">
-          <Link
-            href={`/repo/${repo.owner}/${repo.name}`}
+          <RepoLink
+            owner={repo.owner}
+            name={repo.name}
             className="text-text-primary font-semibold hover:text-accent-green transition-colors truncate block"
           >
             {repo.fullName}
-          </Link>
+          </RepoLink>
 
           {/* Stats row */}
           <div className="flex items-center gap-3 mt-2 flex-wrap">


### PR DESCRIPTION
## Summary
4 single-site swaps of \`<Link href=\`/repo/...\`>\` → \`<RepoLink>\` on operator-facing surfaces:

- `src/components/admin/RevenueQueueAdmin.tsx` (queue rows)
- `src/components/submissions/DropRevenuePage.tsx` (submission preview)
- `src/components/revenue/VerifiedStartupCard.tsx` (verified-startup tile)
- `src/components/watchlist/WatchlistManager.tsx` (managed watchlist row)

These were the remaining surfaces from the handover's A.5 list. The `collections/[slug]` and `agent-repos/[slug]` items it also listed are already covered by #1450 (RelatedRepoCard internal refactor).

## What did NOT change
- `DropRevenuePage` and `WatchlistManager` keep their `Link` import — they still use `<Link>` for non-repo URLs (/submit, /revenue, etc.).
- Title attribute on `VerifiedStartupCard` preserved via inner `<span title="...">` since `RepoLink` doesn't pass title through. Semantically equivalent — title is on the visible repo name text.

## Verification
- `npm run typecheck` ✓
- `npm run lint:guards` ✓
- `npm run build` ✓ (compiled successfully in 64s)

## After this PR
With #1447 + #1450 + this PR landing, **all 10 handover-listed A.5 surfaces are covered**, plus 5 incidental surfaces via the RelatedRepoCard refactor. That closes out Track A.5 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)