### PR TITLE
chore: nitter health update

### DIFF
--- a/config/nitter-instances.json
+++ b/config/nitter-instances.json
@@ -2,68 +2,68 @@
   "instances": [
     {
       "url": "https://nitter.net",
-      "lastChecked": "2026-05-13T06:42:44.579Z",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "healthy"
     },
     {
       "url": "https://nitter.privacydev.net",
-      "lastChecked": "2026-05-13T06:42:44.579Z",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
     },
     {
       "url": "https://nitter.poast.org",
-      "lastChecked": "2026-05-13T06:42:44.579Z",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
     },
     {
       "url": "https://nitter.cz",
-      "lastChecked": "2026-05-13T06:42:44.579Z",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
     },
     {
       "url": "https://nitter.unixfox.eu",
-      "lastChecked": "2026-05-13T06:42:44.579Z",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
     },
     {
       "url": "https://xcancel.com",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "healthy"
     },
     {
       "url": "https://nitter.privacy.com.de",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "dead"
     },
     {
       "url": "https://nitter.tiekoetter.com",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "dead"
     },
     {
       "url": "https://nitter.adminforge.de",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "healthy"
     },
     {
       "url": "https://nitter.platypush.tech",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "dead"
     },
     {
       "url": "https://nt.vern.cc",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "healthy"
     },
     {
       "url": "https://nitter.fdn.fr",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "dead"
     },
     {
       "url": "https://nitter.kavin.rocks",
-      "lastChecked": null,
-      "status": "unknown"
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "dead"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `nitter-health-check`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/25954742692

Auto-merge enabled — merges once required status checks pass.