### PR TITLE
fix(tier-list): remove duplicate crewAI template entry

### DIFF
--- a/src/lib/tier-list/templates.ts
+++ b/src/lib/tier-list/templates.ts
@@ -32,7 +32,6 @@ export const TIER_LIST_TEMPLATES: ReadonlyArray<TierListTemplate> = [
       "openai/swarm",
       "Significant-Gravitas/AutoGPT",
       "stanfordnlp/dspy",
-      "joaomdmoura/crewAI",
       "langfuse/langfuse",
       "deepset-ai/haystack",
     ],


### PR DESCRIPTION
## Summary
- Drops `joaomdmoura/crewAI` (old org name, pre-relocation) from the AI Agent Frameworks tier-list template.
- Keeps `crewAIInc/crewAI` (current org, line 28).
- Both entries pointed to the same project. `addToPool` dedupes by exact fullName only, so a user picking this template got the same project twice in their pool.

## Test plan
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint:guards` — all 4 guards (pool-bypass, img-lazy, keep-last-50, routes-config) OK
- [x] `npm run test:hooks` — 42 files / 334 passed / 1 skipped (no new failures)
- [ ] Operator visual smoke: open tier-list editor, pick "AI Agent Frameworks" template, confirm crewAI appears exactly once in the pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)