### PR TITLE
audit(wave-1): salvage harden + alerts + tier-list from audit/imp-wave-1

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/claude-skills/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/claude-skills/index.ts
@@ -180,6 +180,9 @@ async function searchGitHubTopic(ctx: FetcherContext, topic: string): Promise<Gi
   const token = pickGitHubToken();
   if (token) headers.authorization = `Bearer ${token}`;
 
+  // 30s (above 20s policy default) — GitHub code-search across the topic
+  // index can be slow on cold cache; bumping rather than retrying spares the
+  // token budget.
   const { data } = await ctx.http.json<GitHubSearchResponse>(url, {
     headers,
     timeoutMs: 30_000,

--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
@@ -161,7 +161,7 @@ const fetcher: Fetcher = {
         try {
           const { data } = await ctx.http.json<OssEnvelope<RankingRow>>(url, {
             useEtagCache: false,
-            timeoutMs: 15_000,
+            timeoutMs: 20_000,
           });
           const rows = expectRows<RankingRow>(data, label).map(normalize);
           metrics[metric] = rows;

--- a/apps/trendingrepo-worker/src/fetchers/hn-pulse/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/hn-pulse/index.ts
@@ -64,6 +64,7 @@ const fetcher: Fetcher = {
     // the redis namespace clean of useless tr:etag-body:* entries.
     const { data: ids } = await ctx.http.json<number[]>(TOP_STORIES_URL, {
       useEtagCache: false,
+      timeoutMs: 20_000,
     });
     const top = (Array.isArray(ids) ? ids : [])
       .filter((n): n is number => Number.isFinite(n) && n > 0)
@@ -74,7 +75,10 @@ const fetcher: Fetcher = {
       const batch = top.slice(i, i + FETCH_BATCH);
       const settled = await Promise.allSettled(
         batch.map((id) =>
-          ctx.http.json<FirebaseItem | null>(ITEM_URL(id), { useEtagCache: false }),
+          ctx.http.json<FirebaseItem | null>(ITEM_URL(id), {
+            useEtagCache: false,
+            timeoutMs: 20_000,
+          }),
         ),
       );
       for (let j = 0; j < settled.length; j += 1) {

--- a/apps/trendingrepo-worker/src/fetchers/lobehub-skills/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/lobehub-skills/index.ts
@@ -71,6 +71,9 @@ const fetcher: Fetcher = {
     if (env.FIRECRAWL_API_KEY) {
       mode = 'firecrawl';
       try {
+        // 60s (above 20s policy default) — Firecrawl spins up a headless
+        // browser, waits for client-side hydration (WAIT_MS), then ships
+        // the markdown. The full round-trip routinely exceeds 30s.
         const { data } = await ctx.http.json<FirecrawlScrapeResponse>(`${FIRECRAWL_BASE}/v1/scrape`, {
           method: 'POST',
           headers: { authorization: `Bearer ${env.FIRECRAWL_API_KEY}`, 'content-type': 'application/json' },
@@ -93,6 +96,8 @@ const fetcher: Fetcher = {
       try {
         // ctx.http.text returns { data, cached } since the HTTP-cache wave;
         // parseLobehubHtml only wants the body string.
+        // 30s (above 20s policy default) — lobehub.com's SSR'd skill listing
+        // page can exceed 20s when the origin warms a cold worker.
         const { data: html } = await ctx.http.text(PAGE_URL, {
           timeoutMs: 30_000,
           useEtagCache: false,

--- a/apps/trendingrepo-worker/src/fetchers/lobsters/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/lobsters/index.ts
@@ -143,7 +143,7 @@ const fetcher: Fetcher = {
             accept: 'application/json',
           },
           useEtagCache: false,
-          timeoutMs: 15_000,
+          timeoutMs: 20_000,
         });
         if (!Array.isArray(data)) {
           ctx.log.warn({ url }, 'lobsters: non-array response, skipping');

--- a/apps/trendingrepo-worker/src/fetchers/manual-repos/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/manual-repos/index.ts
@@ -49,6 +49,7 @@ const fetcher: Fetcher = {
       const { data } = await ctx.http.json<ManualReposPayload>(url, {
         useEtagCache: true,
         headers: { accept: 'application/json' },
+        timeoutMs: 20_000,
       });
       payload = data && typeof data === 'object' ? data : { items: [] };
     } catch (err) {

--- a/apps/trendingrepo-worker/src/fetchers/npm-downloads/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/npm-downloads/index.ts
@@ -233,7 +233,7 @@ async function fetchNpmWeekly(pkg: string): Promise<number | null> {
     const data = await fetchJsonWithRetry<NpmDownloadsResponse>(url, {
       attempts: 3,
       retryDelayMs: 1500,
-      timeoutMs: 15_000,
+      timeoutMs: 20_000,
       headers: { 'User-Agent': USER_AGENT },
     });
     return typeof data.downloads === 'number' && Number.isFinite(data.downloads) ? data.downloads : null;
@@ -250,7 +250,7 @@ async function fetchNpmLastRelease(pkg: string): Promise<string | null> {
     const data = await fetchJsonWithRetry<NpmRegistryResponse>(url, {
       attempts: 3,
       retryDelayMs: 1500,
-      timeoutMs: 15_000,
+      timeoutMs: 20_000,
       headers: { 'User-Agent': USER_AGENT, accept: 'application/vnd.npm.install-v1+json' },
     });
     const modified = data.time?.modified;

--- a/apps/trendingrepo-worker/src/fetchers/npm-packages/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/npm-packages/index.ts
@@ -69,6 +69,9 @@ async function fetchPackageDownloadRange(
     `https://api.npmjs.org/downloads/range/${range.start}:${range.end}/` +
     encodePackageName(name);
   try {
+    // 30s (above 20s policy default) — npm range endpoint returns a daily
+    // breakdown spanning multiple weeks; large packages (e.g. react,
+    // typescript) routinely take 15-25s.
     const payload = await fetchJsonWithRetry<NpmRangeResponse>(url, {
       attempts: 4,
       retryDelayMs: 5_000,

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
@@ -131,7 +131,7 @@ const fetcher: Fetcher = {
         try {
           const { data } = await ctx.http.json<OssEnvelope>(url, {
             useEtagCache: false,
-            timeoutMs: 15_000,
+            timeoutMs: 20_000,
           });
           const rows = expectRows<OssRow>(data, label);
           buckets[period]![language] = rows;
@@ -151,7 +151,7 @@ const fetcher: Fetcher = {
     try {
       const { data } = await ctx.http.json<OssEnvelope<HotCollectionRow>>(
         HOT_COLLECTIONS_URL,
-        { useEtagCache: false, timeoutMs: 15_000 },
+        { useEtagCache: false, timeoutMs: 20_000 },
       );
       hotRows = expectRows<HotCollectionRow>(data, 'hot collections').map(
         normalizeHotCollectionRow,

--- a/apps/trendingrepo-worker/src/fetchers/pypi-downloads/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/pypi-downloads/index.ts
@@ -203,7 +203,7 @@ async function fetchPypiWeekly(pkg: string): Promise<number | null> {
     const data = await fetchJsonWithRetry<PyPiStatsRecentResponse>(url, {
       attempts: 3,
       retryDelayMs: 2000,
-      timeoutMs: 15_000,
+      timeoutMs: 20_000,
       headers: { 'User-Agent': USER_AGENT, accept: 'application/json' },
     });
     const v = data.data?.last_week;

--- a/apps/trendingrepo-worker/src/fetchers/recent-repos/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/recent-repos/index.ts
@@ -145,7 +145,7 @@ async function fetchSearchWindow(
     try {
       const { data } = await ctx.http.json<GithubSearchResponse>(url.toString(), {
         headers: requestHeaders(token),
-        timeoutMs: 15_000,
+        timeoutMs: 20_000,
         useEtagCache: false,
       });
       body = data;

--- a/apps/trendingrepo-worker/src/fetchers/revenue-manual-matches/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/revenue-manual-matches/index.ts
@@ -38,6 +38,7 @@ const fetcher: Fetcher = {
       const { data } = await ctx.http.json<Record<string, unknown>>(url, {
         useEtagCache: true,
         headers: { accept: 'application/json' },
+        timeoutMs: 20_000,
       });
       payload = data && typeof data === 'object' ? data : {};
     } catch (err) {

--- a/apps/trendingrepo-worker/src/fetchers/skills-sh/scraper.ts
+++ b/apps/trendingrepo-worker/src/fetchers/skills-sh/scraper.ts
@@ -214,6 +214,9 @@ async function fetchOneViewDirect(
   view: SkillView,
 ): Promise<SkillRow[]> {
   try {
+    // 30s (above 20s policy default) — skills.sh SSR pulls down the full
+    // leaderboard HTML; with all rows + agent metadata it tops 20s on
+    // cold-cache hits.
     const { data: html } = await deps.http.text(url, {
       useEtagCache: false,
       timeoutMs: 30_000,

--- a/apps/trendingrepo-worker/src/fetchers/skills-sh/skill-md.ts
+++ b/apps/trendingrepo-worker/src/fetchers/skills-sh/skill-md.ts
@@ -164,7 +164,7 @@ export async function fetchSkillMd(input: FetchSkillMdInput): Promise<FetchSkill
     try {
       const { data } = await input.http.text(url, {
         useEtagCache: false,
-        timeoutMs: 15_000,
+        timeoutMs: 20_000,
         maxRetries: 1,
       });
       const parsed = parseSkillMd(data);

--- a/apps/trendingrepo-worker/src/fetchers/skillsmp/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/skillsmp/index.ts
@@ -92,6 +92,9 @@ const fetcher: Fetcher = {
     for (let page = 1; page <= MAX_PAGES; page += 1) {
       try {
         const url = `${BASE}?page=${page}&limit=${PAGE_LIMIT}`;
+        // 30s (above 20s policy default) — paginated skill-listing endpoint
+        // routinely tops 20s on full pages; the slow path is the upstream's
+        // GraphQL resolver, not the network.
         const { data } = await ctx.http.json<SkillsmpResponse>(url, {
           timeoutMs: 30_000,
           maxRetries: 3,

--- a/apps/trendingrepo-worker/src/fetchers/smithery-skills/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/smithery-skills/index.ts
@@ -115,6 +115,8 @@ const fetcher: Fetcher = {
     for (let page = 1; page <= MAX_PAGES; page += 1) {
       try {
         const url = `${BASE}?page=${page}&pageSize=${PAGE_SIZE}`;
+        // 30s (above 20s policy default) — Smithery's paginated listing
+        // includes joined metrics; tail-latency runs 20-25s under load.
         const { data } = await ctx.http.json<SmitheryResponse>(url, {
           timeoutMs: 30_000,
           maxRetries: 3,

--- a/src/app/alerts/page.tsx
+++ b/src/app/alerts/page.tsx
@@ -25,6 +25,7 @@ import { KpiBand } from "@/components/ui/KpiBand";
 import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
 import { AlertInbox } from "@/components/alerts/AlertInbox";
 import { AlertTriggerCard } from "@/components/alerts/AlertTriggerCard";
+import { useToggleAlertRule } from "@/lib/hooks/useToggleAlertRule";
 
 const USER_FETCH_INIT: RequestInit = {
   credentials: "include",
@@ -163,16 +164,7 @@ export default function AlertsPage() {
   // Mutations
   // -------------------------------------------------------------------------
 
-  const handleToggleRule = useCallback(
-    (rule: AlertRule, next: boolean) => {
-      // Rules API doesn't expose PUT today; mirror /watchlist and keep the
-      // toggle local for visual affordance only.
-      setRules((prev) =>
-        prev.map((r) => (r.id === rule.id ? { ...r, enabled: next } : r)),
-      );
-    },
-    [],
-  );
+  const handleToggleRule = useToggleAlertRule(setRules);
 
   const handleDeleteRule = useCallback(async (rule: AlertRule) => {
     try {
@@ -599,12 +591,11 @@ function EmptyRulesState() {
           margin: "0 auto 16px",
         }}
       >
-        Track a repo on /watchlist, then configure a star-spike, release, or
-        rank-jump trigger. Rules fire as soon as their thresholds are
-        crossed.
+        Create a star-spike, release, or rank-jump trigger. Rules fire as soon
+        as their thresholds are crossed.
       </p>
       <Link
-        href="/watchlist"
+        href="/alerts/new"
         style={{
           display: "inline-block",
           fontFamily: "var(--font-geist-mono), monospace",
@@ -619,7 +610,7 @@ function EmptyRulesState() {
           letterSpacing: "0.06em",
         }}
       >
-        Configure on /watchlist →
+        Create alert →
       </Link>
     </div>
   );
@@ -657,12 +648,10 @@ function QuickAddCallout() {
           margin: 0,
         }}
       >
-        Rule creation lives next to each tracked repo. Toggle alerts on a
-        watchlist row to mint a default rule, then tune the threshold from
-        the trigger card.
+        Create a rule directly, then tune the threshold from the trigger card.
       </p>
       <Link
-        href="/watchlist"
+        href="/alerts/new"
         style={{
           display: "inline-block",
           fontFamily: "var(--font-geist-mono), monospace",
@@ -677,7 +666,7 @@ function QuickAddCallout() {
           alignSelf: "flex-start",
         }}
       >
-        Open /watchlist →
+        Create alert →
       </Link>
     </div>
   );

--- a/src/app/api/admin/scan/route.ts
+++ b/src/app/api/admin/scan/route.ts
@@ -53,20 +53,16 @@ const AdminScanBodySchema = z.object({
  * deny secrets that don't belong in scrapers (Stripe, session, admin,
  * email delivery). New collectors should add their var name here, not
  * fall back to process.env wholesale.
+ *
+ * WHY no PATH/HOME/locale: the spawned scripts only need these
+ * domain-specific keys; PATH and HOME are inherited via spawn defaults
+ * (Node resolves the `.mjs` entry by absolute path through
+ * `process.execPath`, and none of our collectors reference HOME / LANG /
+ * TZ directly — verified by grep on every script under `scripts/`).
+ * Dropping the generic system vars shrinks the secret blast-radius if
+ * the admin token ever leaks.
  */
 const CHILD_ENV_ALLOW = [
-  // System — needed by every Node child (PATH for npm subbins, HOME for
-  // ssh/git plumbing, locale for date parsing, TMP for fs.mkdtemp).
-  "PATH",
-  "HOME",
-  "USERPROFILE",
-  "TEMP",
-  "TMP",
-  "TMPDIR",
-  "LANG",
-  "LC_ALL",
-  "LC_CTYPE",
-  "TZ",
   "NODE_ENV",
   "NODE_OPTIONS",
   // Data-store dual-write — every collector imports _data-store-write.mjs
@@ -92,6 +88,12 @@ const CHILD_ENV_ALLOW = [
   // Project-local discovery (used by repo-metadata + scoring).
   "STARSCREENER_DATA_DIR",
   "TRENDINGREPO_DATA_DIR",
+  // Sentry release tagging + log level — picked up by _logger.mjs and
+  // any child that initialises Sentry on its own.
+  "SENTRY_DSN",
+  "SENTRY_ENVIRONMENT",
+  "SENTRY_RELEASE",
+  "LOG_LEVEL",
 ];
 
 function buildChildEnv(

--- a/src/app/api/admin/scrape/run/route.ts
+++ b/src/app/api/admin/scrape/run/route.ts
@@ -76,17 +76,12 @@ const LOG_DIR = path.join(process.cwd(), ".data", "admin-scan-runs");
 // Same env allow-list pattern as /api/admin/scan — explicit keys only,
 // no `process.env` blanket pass-through (P0 fix from APP-01). When a
 // new collector needs a credential, add it here and document why.
+//
+// WHY no PATH/HOME/locale: the spawned scripts only need these
+// domain-specific keys; PATH and HOME are inherited via spawn defaults
+// (Node resolves the entrypoint by absolute path through
+// `process.execPath`, and no collector references HOME / LANG / TZ).
 const CHILD_ENV_ALLOW = [
-  "PATH",
-  "HOME",
-  "USERPROFILE",
-  "TEMP",
-  "TMP",
-  "TMPDIR",
-  "LANG",
-  "LC_ALL",
-  "LC_CTYPE",
-  "TZ",
   "NODE_ENV",
   "NODE_OPTIONS",
   "REDIS_URL",
@@ -109,6 +104,11 @@ const CHILD_ENV_ALLOW = [
   "TRENDINGREPO_USER_AGENT",
   "STARSCREENER_DATA_DIR",
   "TRENDINGREPO_DATA_DIR",
+  // Sentry release tagging + log level for _logger.mjs.
+  "SENTRY_DSN",
+  "SENTRY_ENVIRONMENT",
+  "SENTRY_RELEASE",
+  "LOG_LEVEL",
 ] as const;
 
 function buildChildEnv(parent: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/src/app/api/cron/aiso-drain/route.ts
+++ b/src/app/api/cron/aiso-drain/route.ts
@@ -59,6 +59,7 @@ import { z } from "zod";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
 import { parseBody } from "@/lib/api/parse-body";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { persistAisoScan } from "@/lib/aiso-persist";
 import {
   readQueue,
@@ -305,6 +306,9 @@ function sleep(ms: number): Promise<void> {
 export async function POST(request: NextRequest) {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
 
   const parsed = await parseBody(request, DrainRequestSchema, {
     allowEmpty: true,

--- a/src/app/api/cron/alerts/cleanup/route.ts
+++ b/src/app/api/cron/alerts/cleanup/route.ts
@@ -10,6 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { lt } from "drizzle-orm";
 
 import { verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { errorEnvelope } from "@/lib/api/error-response";
 import {
   pruneOldAlertEvents,
@@ -28,6 +29,8 @@ async function handle(req: NextRequest): Promise<NextResponse> {
     const status = verdict.kind === "not_configured" ? 503 : 401;
     return NextResponse.json(errorEnvelope(verdict.kind), { status });
   }
+  const oversize = withBodySizeLimit(req);
+  if (oversize) return oversize;
   const start = Date.now();
   try {
     const pruned = await pruneOldAlertEvents();

--- a/src/app/api/cron/alerts/dispatch/route.ts
+++ b/src/app/api/cron/alerts/dispatch/route.ts
@@ -13,6 +13,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { verifyCronAuth } from "@/lib/api/auth";
+import { errorEnvelope } from "@/lib/api/error-response";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { dispatchPendingAlerts } from "@/lib/alerts/dispatcher";
 
 // lint-allow: no-parsebody - no-body cron endpoint; verifyCronAuth is the trust boundary.
@@ -24,8 +26,10 @@ async function handle(req: NextRequest): Promise<NextResponse> {
   const verdict = verifyCronAuth(req);
   if (verdict.kind !== "ok") {
     const status = verdict.kind === "not_configured" ? 503 : 401;
-    return NextResponse.json({ error: verdict.kind }, { status });
+    return NextResponse.json(errorEnvelope(verdict.kind), { status });
   }
+  const oversize = withBodySizeLimit(req);
+  if (oversize) return oversize;
   const start = Date.now();
   try {
     const metrics = await dispatchPendingAlerts();

--- a/src/app/api/cron/digest/weekly/route.ts
+++ b/src/app/api/cron/digest/weekly/route.ts
@@ -34,6 +34,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, isNotNull, isNull } from "drizzle-orm";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import {
   buildWeeklyDigests,
   loadUserEmailMapFromEnv,
@@ -115,6 +116,9 @@ export async function POST(
 ): Promise<NextResponse<DigestCronResponse | { ok: false; error: string }>> {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny as NextResponse<{ ok: false; error: string }>;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize as NextResponse<{ ok: false; error: string }>;
 
   if (!isEnabled()) {
     return NextResponse.json(

--- a/src/app/api/cron/freshness/state/route.ts
+++ b/src/app/api/cron/freshness/state/route.ts
@@ -9,6 +9,7 @@ import { resolve } from "node:path";
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { getDataStore } from "@/lib/data-store";
 import {
   deriveHealth,
@@ -584,6 +585,9 @@ export async function GET(
   if (deny) {
     return deny as NextResponse<{ ok: false; reason: string }>;
   }
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize as NextResponse<{ ok: false; reason: string }>;
 
   const nowMs = Date.now();
   try {

--- a/src/app/api/cron/llm/aggregate/route.ts
+++ b/src/app/api/cron/llm/aggregate/route.ts
@@ -18,6 +18,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { getDataStore } from "@/lib/data-store";
 import { touchDailyAggregates } from "@/lib/llm/aggregate";
 import { getStreamHandle } from "@/lib/llm/redis-streams";
@@ -55,6 +56,9 @@ interface AggregateResult {
 export async function POST(request: NextRequest) {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
 
   try {
     const result = await runAggregate();

--- a/src/app/api/cron/llm/sync-models/route.ts
+++ b/src/app/api/cron/llm/sync-models/route.ts
@@ -13,6 +13,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { getDataStore } from "@/lib/data-store";
 import { DataStoreFatalError } from "@/lib/errors";
 import type { ModelMeta, ModelMetadataPayload } from "@/lib/llm/types";
@@ -125,6 +126,8 @@ async function syncModels(): Promise<{ count: number; syncedAt: string }> {
 export async function POST(request: NextRequest) {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
   try {
     const result = await syncModels();
     return NextResponse.json(

--- a/src/app/api/cron/mcp/rotate-usage/route.ts
+++ b/src/app/api/cron/mcp/rotate-usage/route.ts
@@ -22,6 +22,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { rotateUsage } from "@/lib/mcp/usage";
 
 export const runtime = "nodejs";
@@ -37,6 +38,9 @@ const RETENTION_MS = RETENTION_DAYS * 24 * 60 * 60 * 1000;
 export async function POST(request: NextRequest) {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
 
   const started = Date.now();
   try {

--- a/src/app/api/cron/news-auto-recover/route.ts
+++ b/src/app/api/cron/news-auto-recover/route.ts
@@ -18,6 +18,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { triggerScanIfStale } from "@/lib/news/auto-rescrape";
 import type { NewsSource } from "@/lib/news/freshness";
 import { blueskyFetchedAt } from "@/lib/bluesky";
@@ -65,6 +66,9 @@ const SKIPPED_SOURCES: { source: string; reason: string }[] = [
 export async function POST(request: NextRequest) {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
 
   const results: Record<string, { triggered: boolean; reason: string }> = {};
 

--- a/src/app/api/cron/referrals/qualify/route.ts
+++ b/src/app/api/cron/referrals/qualify/route.ts
@@ -40,6 +40,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, arrayOverlaps, eq, isNull, lt, sql } from "drizzle-orm";
 
 import { verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { db } from "@/lib/db/client";
 import { profiles } from "@/lib/db/schema/profiles";
 import {
@@ -68,6 +69,9 @@ async function handle(req: NextRequest): Promise<NextResponse> {
     const status = verdict.kind === "not_configured" ? 503 : 401;
     return NextResponse.json({ ok: false, error: verdict.kind }, { status });
   }
+
+  const oversize = withBodySizeLimit(req);
+  if (oversize) return oversize;
 
   const start = Date.now();
   const milestoneCounts: MilestoneCounts = {

--- a/src/app/api/cron/twitter-daily/route.ts
+++ b/src/app/api/cron/twitter-daily/route.ts
@@ -13,6 +13,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { getDerivedRepos } from "@/lib/derived-repos";
 import { listIdeas, toPublicIdea, hotScore } from "@/lib/ideas";
 import {
@@ -95,6 +96,9 @@ export async function POST(
 ): Promise<NextResponse<DailyResponse | ErrorResponse>> {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny as NextResponse<ErrorResponse>;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize as NextResponse<ErrorResponse>;
 
   const startedAt = new Date().toISOString();
   const adapter = selectOutboundAdapter();

--- a/src/app/api/cron/twitter-weekly-recap/route.ts
+++ b/src/app/api/cron/twitter-weekly-recap/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { getDerivedRepos } from "@/lib/derived-repos";
 import { listIdeas, toPublicIdea, hotScore } from "@/lib/ideas";
 import {
@@ -42,6 +43,9 @@ export async function POST(
 ): Promise<NextResponse<WeeklyResponse | ErrorResponse>> {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny as NextResponse<ErrorResponse>;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize as NextResponse<ErrorResponse>;
 
   const startedAt = new Date().toISOString();
   const adapter = selectOutboundAdapter();

--- a/src/app/api/cron/webhooks/flush/route.ts
+++ b/src/app/api/cron/webhooks/flush/route.ts
@@ -29,6 +29,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import {
   appendDeadLetter,
   loadTargets,
@@ -321,6 +322,9 @@ async function runFlush(): Promise<FlushResult> {
 export async function POST(request: NextRequest) {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
 
   try {
     const result = await runFlush();

--- a/src/app/api/cron/webhooks/scan/route.ts
+++ b/src/app/api/cron/webhooks/scan/route.ts
@@ -17,6 +17,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
 import { getDerivedRepos } from "@/lib/derived-repos";
 import {
   getFundingSignals,
@@ -197,6 +198,9 @@ async function runScan(): Promise<ScanResult> {
 export async function POST(request: NextRequest) {
   const deny = authFailureResponse(verifyCronAuth(request));
   if (deny) return deny;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
 
   try {
     const result = await runScan();

--- a/src/app/api/pipeline/alerts/rules/route.ts
+++ b/src/app/api/pipeline/alerts/rules/route.ts
@@ -1,5 +1,6 @@
 // GET    /api/pipeline/alerts/rules                — list AlertRules for caller
 // POST   /api/pipeline/alerts/rules                 — create an AlertRule
+// PATCH  /api/pipeline/alerts/rules?id=<ruleId>     — update an AlertRule
 // DELETE /api/pipeline/alerts/rules?id=<ruleId>     — delete an AlertRule
 //
 // Rules drive the recompute-time alert engine. Each user owns their own set
@@ -39,6 +40,11 @@ export interface RulesListResponse {
 }
 
 export interface RulesCreateResponse {
+  ok: true;
+  rule: AlertRule;
+}
+
+export interface RulesUpdateResponse {
   ok: true;
   rule: AlertRule;
 }
@@ -161,6 +167,53 @@ function parseCreateBody(
   return { ok: true, value: { input } };
 }
 
+type RulePatch = Partial<
+  Pick<AlertRule, "enabled" | "threshold" | "cooldownMinutes">
+>;
+
+function parsePatchBody(
+  raw: unknown,
+): { ok: true; value: RulePatch } | { ok: false; error: string } {
+  if (raw === null || typeof raw !== "object") {
+    return { ok: false, error: "body must be a JSON object" };
+  }
+  const body = raw as Record<string, unknown>;
+  const patch: RulePatch = {};
+
+  if ("enabled" in body) {
+    if (typeof body.enabled !== "boolean") {
+      return { ok: false, error: "enabled must be a boolean" };
+    }
+    patch.enabled = body.enabled;
+  }
+
+  if ("threshold" in body) {
+    if (typeof body.threshold !== "number" || !Number.isFinite(body.threshold)) {
+      return { ok: false, error: "threshold must be a finite number" };
+    }
+    patch.threshold = body.threshold;
+  }
+
+  if ("cooldownMinutes" in body) {
+    if (
+      typeof body.cooldownMinutes !== "number" ||
+      !Number.isFinite(body.cooldownMinutes)
+    ) {
+      return { ok: false, error: "cooldownMinutes must be a finite number" };
+    }
+    patch.cooldownMinutes = body.cooldownMinutes;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return {
+      ok: false,
+      error: "one of enabled, threshold, or cooldownMinutes is required",
+    };
+  }
+
+  return { ok: true, value: patch };
+}
+
 export async function POST(
   request: NextRequest,
 ): Promise<NextResponse<RulesCreateResponse | RulesErrorResponse>> {
@@ -218,6 +271,74 @@ export async function POST(
     const message = err instanceof Error ? err.message : String(err);
     // validateRule failures inside the facade surface as Error messages.
     // Treat them as 400s so API consumers can correct their input.
+    if (message.includes("invalid rule")) {
+      return NextResponse.json(
+        { ok: false, error: message },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+): Promise<NextResponse<RulesUpdateResponse | RulesErrorResponse>> {
+  const auth = verifyUserAuth(request);
+  const deny = userAuthFailureResponse(auth);
+  if (deny) return deny as NextResponse<RulesErrorResponse>;
+  if (auth.kind !== "ok") {
+    return NextResponse.json(
+      { ok: false, error: "unauthorized", code: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+  const { userId } = auth;
+
+  const { searchParams } = request.nextUrl;
+  const id = searchParams.get("id");
+  if (!id || id.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: "id query parameter is required" },
+      { status: 400 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "request body is not valid JSON" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parsePatchBody(raw);
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { ok: false, error: parsed.error },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await pipeline.ensureReady();
+    // 404 not 403 to avoid leaking "this id exists but isn't yours".
+    const rule = pipeline.updateAlertRule(id, userId, parsed.value);
+    if (!rule) {
+      return NextResponse.json(
+        { ok: false, error: "rule not found" },
+        { status: 404 },
+      );
+    }
+    await persistPipeline();
+    return NextResponse.json({ ok: true, rule });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     if (message.includes("invalid rule")) {
       return NextResponse.json(
         { ok: false, error: message },

--- a/src/app/api/pipeline/ingest/route.ts
+++ b/src/app/api/pipeline/ingest/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
 import { pipeline } from "@/lib/pipeline/pipeline";
 import { createGitHubAdapter } from "@/lib/pipeline/ingestion/ingest";
 import { getExtendedSocialAdapters } from "@/lib/pipeline/adapters/extended-social";
@@ -42,6 +43,31 @@ export const maxDuration = 300;
 
 const FULL_NAME_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 const MAX_BATCH_SIZE = 50;
+const FULL_NAME_MAX_LEN = 200;
+
+// Zod schema for the request body. Matches the field structure documented
+// in the GET handler below: `fullNames` is an optional array of owner/repo
+// strings (≤ 50 entries, ≤ 200 chars each, matching FULL_NAME_PATTERN),
+// `useMock` + `recomputeAfter` are optional booleans. Empty / missing
+// `fullNames` falls through to auto-discover (see autoDiscoverFullNames).
+// This gates the inbound POST against oversize batches and malformed
+// strings before any pipeline work is done.
+const BodySchema = z
+  .object({
+    fullNames: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .max(FULL_NAME_MAX_LEN)
+          .regex(FULL_NAME_PATTERN, "must match owner/repo"),
+      )
+      .max(MAX_BATCH_SIZE)
+      .optional(),
+    useMock: z.boolean().optional(),
+    recomputeAfter: z.boolean().optional(),
+  })
+  .strict();
 
 /**
  * When the cron POSTs `{}` (the documented contract — see the GET-handler
@@ -106,53 +132,41 @@ export interface IngestErrorResponse {
  * an auto-discovered batch (see autoDiscoverFullNames above) — which is
  * the case the GH Actions cron has been hitting since 2026-04-17. When
  * provided, it must satisfy the strict-validation contract callers added
- * for the public endpoint. */
+ * for the public endpoint.
+ *
+ * Structural validation runs through `BodySchema` (Zod): enforces array
+ * shape, the 50-entry max, per-entry length + owner/repo regex, and
+ * rejects unknown top-level keys. We then collapse an empty array to
+ * `undefined` so downstream code sees the same "auto-discover" signal
+ * whether the caller omitted the field or sent `[]`.
+ */
 function parseBody(raw: unknown): {
   ok: true;
   value: { fullNames?: string[]; useMock?: boolean; recomputeAfter?: boolean };
 } | { ok: false; error: string; details?: string[] } {
-  if (raw === null || typeof raw !== "object") {
-    return { ok: false, error: "body must be a JSON object" };
-  }
-  const body = raw as Record<string, unknown>;
-
-  const fullNamesRaw = body.fullNames;
-  let fullNames: string[] | undefined;
-  if (fullNamesRaw !== undefined) {
-    if (!Array.isArray(fullNamesRaw)) {
-      return { ok: false, error: "fullNames must be an array of strings" };
-    }
-    if (fullNamesRaw.length > MAX_BATCH_SIZE) {
-      return {
-        ok: false,
-        error: `fullNames must contain at most ${MAX_BATCH_SIZE} entries`,
-      };
-    }
-    const invalid: string[] = [];
-    for (const n of fullNamesRaw) {
-      if (typeof n !== "string" || !FULL_NAME_PATTERN.test(n)) {
-        invalid.push(String(n));
-      }
-    }
-    if (invalid.length > 0) {
-      return {
-        ok: false,
-        error: "fullNames contains invalid entries",
-        details: invalid.map((n) => `"${n}" is not owner/repo`),
-      };
-    }
-    // Empty array → fall through to auto-discover (treat same as missing).
-    if (fullNamesRaw.length > 0) {
-      fullNames = fullNamesRaw as string[];
-    }
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) {
+    const issues = parsed.error.issues;
+    const first = issues[0];
+    const message = first
+      ? `${first.path.length > 0 ? first.path.join(".") + ": " : ""}${first.message}`
+      : "validation failed";
+    return {
+      ok: false,
+      error: message,
+      details: issues.map((issue) =>
+        issue.path.length > 0
+          ? `${issue.path.join(".")}: ${issue.message}`
+          : issue.message,
+      ),
+    };
   }
 
-  const useMock =
-    body.useMock === undefined ? undefined : Boolean(body.useMock);
-  const recomputeAfter =
-    body.recomputeAfter === undefined
-      ? undefined
-      : Boolean(body.recomputeAfter);
+  const { fullNames: fullNamesRaw, useMock, recomputeAfter } = parsed.data;
+
+  // Empty array → fall through to auto-discover (treat same as missing).
+  const fullNames =
+    fullNamesRaw && fullNamesRaw.length > 0 ? fullNamesRaw : undefined;
 
   return {
     ok: true,

--- a/src/app/api/worker/health/route.ts
+++ b/src/app/api/worker/health/route.ts
@@ -25,11 +25,47 @@
 // signal slugs with degraded body shape). This route is the COMPLETE
 // worker-fleet view.
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
 import { getDataStore } from "@/lib/data-store";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+/**
+ * Optional bearer-token gate. When `WORKER_HEALTH_BEARER` is unset (the
+ * default) this route stays fully public — TOOLBOX cron + the operator
+ * dashboard continue to hit `/api/worker/health` with no Authorization
+ * header. When the env var IS set, callers MUST present
+ * `Authorization: Bearer <value>` and the comparison runs in constant
+ * time to avoid leaking the token byte-by-byte.
+ *
+ * Returns the 401 NextResponse on rejection, or `null` to continue.
+ */
+function checkOptionalBearer(request: NextRequest): NextResponse | null {
+  const expected = process.env.WORKER_HEALTH_BEARER?.trim();
+  if (!expected) return null;
+  const header = request.headers.get("authorization")?.trim() ?? "";
+  const prefix = "Bearer ";
+  if (!header.startsWith(prefix)) {
+    return NextResponse.json(
+      { ok: false, error: "unauthorized" },
+      { status: 401, headers: { "WWW-Authenticate": "Bearer" } },
+    );
+  }
+  const supplied = header.slice(prefix.length);
+  const a = Buffer.from(supplied);
+  const b = Buffer.from(expected);
+  // Length must match before timingSafeEqual; otherwise it throws.
+  const match = a.length === b.length && timingSafeEqual(a, b);
+  if (!match) {
+    return NextResponse.json(
+      { ok: false, error: "unauthorized" },
+      { status: 401, headers: { "WWW-Authenticate": "Bearer" } },
+    );
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Slug → expected cadence map
@@ -158,7 +194,12 @@ function classifyAge(
 // Route handler
 // ---------------------------------------------------------------------------
 
-export async function GET(): Promise<NextResponse<HealthResponse>> {
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<HealthResponse> | NextResponse> {
+  const deny = checkOptionalBearer(request);
+  if (deny) return deny;
+
   const store = getDataStore();
   const now = Date.now();
 

--- a/src/app/tierlist/[shortId]/page.tsx
+++ b/src/app/tierlist/[shortId]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from "next/navigation";
 import { TierListEditor } from "@/components/tier-list/TierListEditor";
 import type { PoolItem } from "@/lib/tier-list/client-store";
 import { getDerivedRepoByFullName } from "@/lib/derived-repos";
-import { absoluteUrl, SITE_NAME } from "@/lib/seo";
+import { absoluteUrl } from "@/lib/seo";
 import { isShortId } from "@/lib/tier-list/short-id";
 import { getTierList } from "@/lib/tier-list/store";
 import { encodeTierListUrl, stateHash } from "@/lib/tier-list/url";
@@ -46,11 +46,11 @@ function buildItemMeta(repoIds: string[]): Record<string, PoolItem> {
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
   const { shortId } = await params;
   if (!isShortId(shortId)) {
-    return { title: `Tier list - ${SITE_NAME}` };
+    return { title: "GitHub repo tier list" };
   }
   const payload = await getTierList(shortId);
   if (!payload) {
-    return { title: `Tier list - ${SITE_NAME}` };
+    return { title: "GitHub repo tier list" };
   }
   const hash = stateHash({
     title: payload.title,
@@ -64,7 +64,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
     ? payload.description
     : `${payload.title} - tier list built on TrendingRepo.`;
   return {
-    title: `${payload.title} - ${SITE_NAME}`,
+    title: `${payload.title} GitHub repo tier list`,
     description,
     alternates: {
       canonical: absoluteUrl(`/tierlist/${shortId}`),

--- a/src/app/tierlist/page.tsx
+++ b/src/app/tierlist/page.tsx
@@ -12,7 +12,7 @@ import { absoluteUrl, SITE_NAME } from "@/lib/seo";
 export const dynamic = "force-static";
 
 export const metadata: Metadata = {
-  title: `Tier List Maker - ${SITE_NAME}`,
+  title: "GitHub repo tier list maker",
   description:
     "Drag the AI ecosystem onto a tier list. Search repos, rank them, share the card.",
   alternates: {

--- a/src/components/tier-list/ShareBar.tsx
+++ b/src/components/tier-list/ShareBar.tsx
@@ -13,7 +13,11 @@ import {
 
 import { useTierListEditor } from "@/lib/tier-list/client-store";
 import { toast } from "@/lib/toast";
-import { stateHash } from "@/lib/tier-list/url";
+import {
+  buildTierListShareUrl,
+  encodeTierListUrl,
+  stateHash,
+} from "@/lib/tier-list/url";
 import { buildShareToXUrl } from "@/lib/twitter/outbound/share";
 import type { TierListDraft } from "@/lib/types/tier-list";
 
@@ -92,20 +96,21 @@ export function ShareBar() {
     }
   }
 
+  function shareUrl(): string {
+    if (savedShortId) {
+      return `${window.location.origin}/tierlist/${savedShortId}`;
+    }
+    return buildTierListShareUrl(window.location.origin, draft);
+  }
+
   function copyLink() {
-    const url = savedShortId
-      ? `${window.location.origin}/tierlist/${savedShortId}`
-      : window.location.href;
-    void copyToClipboard(url, "Link copied to clipboard");
+    void copyToClipboard(shareUrl(), "Link copied to clipboard");
   }
 
   function shareOnX() {
-    const url = savedShortId
-      ? `${window.location.origin}/tierlist/${savedShortId}`
-      : window.location.href;
     const intent = buildShareToXUrl({
       text: `${title} - built on @TrendingRepo`,
-      url,
+      url: shareUrl(),
       via: ["TrendingRepo"],
     });
     window.open(intent, "_blank", "noopener,noreferrer");
@@ -166,7 +171,7 @@ export function ShareBar() {
           <span className="ic"><LinkIcon size={13} aria-hidden /></span>
           <span className="body">
             <span className="h">Shareable link</span>
-            <span className="d">copy current page url</span>
+            <span className="d">copy current board state</span>
           </span>
           <span className="ar">copy</span>
         </button>
@@ -228,7 +233,7 @@ function EmbedPanel({
     : `/api/og/tier-list?state=${encodeUnsavedState(draft)}&aspect=h&v=${hash}`;
   const pagePath = savedShortId
     ? `/tierlist/${savedShortId}`
-    : window.location.pathname + window.location.search;
+    : `/tierlist?${encodeTierListUrl(draft).toString()}`;
   const safeTitle = draft.title.replace(/"/g, "'").replace(/\n/g, " ");
 
   const markdown = `[![${safeTitle}](${origin}${ogPath})](${origin}${pagePath})`;

--- a/src/components/tier-list/TierListEditor.tsx
+++ b/src/components/tier-list/TierListEditor.tsx
@@ -8,7 +8,7 @@
 import { useEffect, useRef } from "react";
 
 import { useTierListEditor, type PoolItem } from "@/lib/tier-list/client-store";
-import { decodeTierListUrl } from "@/lib/tier-list/url";
+import { decodeTierListUrl, hasTierListUrlState } from "@/lib/tier-list/url";
 import type { TierRow } from "@/lib/types/tier-list";
 
 import { MobileTierPicker } from "./MobileTierPicker";
@@ -50,7 +50,7 @@ export function TierListEditor({ initial }: TierListEditorProps) {
     }
     if (typeof window !== "undefined" && window.location.search.length > 1) {
       const params = new URLSearchParams(window.location.search);
-      if (params.get("tiers")) {
+      if (hasTierListUrlState(params)) {
         const decoded = decodeTierListUrl(params);
         hydrate({
           title: decoded.title,

--- a/src/lib/__tests__/tier-list.test.ts
+++ b/src/lib/__tests__/tier-list.test.ts
@@ -17,9 +17,11 @@ import {
 } from "../tier-list/schema";
 import { generateShortId, isShortId } from "../tier-list/short-id";
 import {
+  buildTierListShareUrl,
   decodeTierListUrl,
   emptyDraft,
   encodeTierListUrl,
+  hasTierListUrlState,
   stateHash,
 } from "../tier-list/url";
 
@@ -109,6 +111,30 @@ test("decode of empty/missing tiers params falls back to default grid", () => {
   const decoded = decodeTierListUrl(params);
   assert.equal(decoded.title, "Foo");
   assert.equal(decoded.tiers.length, DEFAULT_TIERS.length);
+});
+
+test("pool-only URL state hydrates onto the default grid", () => {
+  const params = new URLSearchParams("pool=vercel%2Fnext.js,openai%2Fcodex");
+  assert.equal(hasTierListUrlState(params), true);
+  const decoded = decodeTierListUrl(params);
+  assert.equal(decoded.tiers.length, DEFAULT_TIERS.length);
+  assert.deepEqual(decoded.unrankedItems, ["vercel/next.js", "openai/codex"]);
+});
+
+test("URL-state detection ignores cache-only params", () => {
+  assert.equal(hasTierListUrlState(new URLSearchParams("v=abcd1234")), false);
+  assert.equal(hasTierListUrlState(new URLSearchParams("title=AI")), true);
+  assert.equal(hasTierListUrlState(new URLSearchParams("tiers=")), true);
+});
+
+test("buildTierListShareUrl serializes the current draft", () => {
+  const draft = emptyDraft();
+  draft.title = "Current board";
+  draft.unrankedItems = ["vercel/next.js"];
+  const url = buildTierListShareUrl("https://trendingrepo.com", draft);
+  assert.ok(url.startsWith("https://trendingrepo.com/tierlist?"));
+  assert.ok(url.includes("title=Current+board"));
+  assert.ok(url.includes("pool=vercel%252Fnext.js"));
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -1,0 +1,47 @@
+// Shared API route helpers.
+//
+// Today this module only exposes `withBodySizeLimit`, the Content-Length
+// guard previously inlined into individual cron routes. Centralising it
+// here keeps the 2MB ceiling in one place — bump it once and every cron
+// inherits the new bound on the next deploy.
+
+import { NextResponse } from "next/server";
+
+/**
+ * Default body-size ceiling for cron / internal routes. 2 MiB is generous
+ * for JSON triggers (Vercel Cron POSTs `{}` and our biggest cron payload —
+ * aiso-drain — caps at ~16 KB). Larger payloads are almost certainly hostile.
+ */
+export const DEFAULT_BODY_LIMIT_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Reject the request with HTTP 413 when its `Content-Length` header exceeds
+ * `maxBytes`. Returns `null` to let the caller continue handling normally.
+ *
+ * Mirrors the inline pattern from
+ * `src/app/api/internal/signals/twitter/v1/ingest/route.ts` so cron + agent
+ * surfaces stay shaped the same way; the helper standardises the error body
+ * shape (`{ ok: false, error: "payload_too_large", maxBytes }`).
+ *
+ * Note: the Content-Length header is the only cheap pre-stream check we
+ * have. A hostile caller can still send a chunked body without a header —
+ * downstream `request.json()` will still allocate it. Pair with router-
+ * level limits (Vercel's `bodyParser.sizeLimit`) for hard enforcement.
+ */
+export function withBodySizeLimit(
+  request: Request,
+  maxBytes: number = DEFAULT_BODY_LIMIT_BYTES,
+): NextResponse | null {
+  const header = request.headers.get("content-length");
+  if (!header) return null;
+  const len = Number.parseInt(header, 10);
+  if (!Number.isFinite(len) || len <= maxBytes) return null;
+  return NextResponse.json(
+    {
+      ok: false,
+      error: "payload_too_large",
+      maxBytes,
+    },
+    { status: 413 },
+  );
+}

--- a/src/lib/hooks/useToggleAlertRule.ts
+++ b/src/lib/hooks/useToggleAlertRule.ts
@@ -1,0 +1,51 @@
+"use client";
+
+// StarScreener — `useToggleAlertRule` hook
+//
+// Optimistic PATCH /api/pipeline/alerts/rules?id=… for the `enabled` field.
+// Rolls back on failure and toasts the error. Same body in both
+// /alerts and /watchlist before extraction.
+
+import { useCallback } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+import type { AlertRule } from "../pipeline/types";
+import { toastAlertError } from "../toast";
+
+export function useToggleAlertRule(
+  setRules: Dispatch<SetStateAction<AlertRule[]>>,
+): (rule: AlertRule, next: boolean) => Promise<void> {
+  return useCallback(
+    async (rule, next) => {
+      setRules((prev) =>
+        prev.map((r) => (r.id === rule.id ? { ...r, enabled: next } : r)),
+      );
+      try {
+        const res = await fetch(
+          `/api/pipeline/alerts/rules?id=${encodeURIComponent(rule.id)}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({ enabled: next }),
+          },
+        );
+        const data = (await res.json().catch(() => ({ ok: false }))) as {
+          ok: boolean;
+          rule?: AlertRule;
+          error?: string;
+        };
+        if (!res.ok || !data.ok || !data.rule) {
+          throw new Error(data.error ?? "failed to update alert");
+        }
+        const fresh = data.rule;
+        setRules((prev) => prev.map((r) => (r.id === rule.id ? fresh : r)));
+      } catch (err) {
+        setRules((prev) => prev.map((r) => (r.id === rule.id ? rule : r)));
+        const msg = err instanceof Error ? err.message : String(err);
+        toastAlertError(msg);
+      }
+    },
+    [setRules],
+  );
+}

--- a/src/lib/pipeline/pipeline.ts
+++ b/src/lib/pipeline/pipeline.ts
@@ -806,6 +806,29 @@ export const pipeline = {
     return alertRuleStore.save(rule);
   },
 
+  /**
+   * Update an alert rule by id, scoped to the given owner. Returns null when
+   * the rule doesn't exist or belongs to another user — collapsing the
+   * existence + ownership checks into a single scan.
+   */
+  updateAlertRule: (
+    ruleId: string,
+    userId: string,
+    patch: Partial<Pick<AlertRule, "enabled" | "threshold" | "cooldownMinutes">>,
+  ): AlertRule | null => {
+    ensureSeeded();
+    const existing = alertRuleStore.listAll().find((rule) => rule.id === ruleId);
+    if (!existing || existing.userId !== userId) return null;
+    const rule: AlertRule = { ...existing, ...patch };
+    const validation = validateRule(rule);
+    if (!validation.valid) {
+      throw new Error(
+        `updateAlertRule: invalid rule — ${validation.errors.join("; ")}`,
+      );
+    }
+    return alertRuleStore.save(rule);
+  },
+
   /** Delete an alert rule by id. Returns whether anything was deleted. */
   deleteAlertRule: (ruleId: string): boolean => {
     ensureSeeded();

--- a/src/lib/tier-list/url.ts
+++ b/src/lib/tier-list/url.ts
@@ -71,6 +71,10 @@ export interface EncodableDraft {
   unrankedItems: string[];
 }
 
+export function hasTierListUrlState(params: URLSearchParams): boolean {
+  return params.has("title") || params.has("tiers") || params.has("pool");
+}
+
 /** Serialise an editor draft into URLSearchParams. */
 export function encodeTierListUrl(draft: EncodableDraft): URLSearchParams {
   const params = new URLSearchParams();


### PR DESCRIPTION
## Summary

Clean salvage of the 4 truly-new feature/hardening commits from the rolling \`audit/imp-wave-1\` branch, plus 1 missing companion commit that was orphaned in git's reflog. Cherry-picked onto a fresh branch off latest \`main\`.

### Why a salvage PR

\`audit/imp-wave-1\` was the head branch for PR #1230 (merged 2026-05-14 as squash commit \`dab8041f7\`), then re-used for new work without being reset. Result: 12 commits ahead of main, but ~6 were the source commits behind PR #1230 (would reappear as "new" in any fresh PR). A direct PR from that branch would re-introduce already-shipped content.

### Commits on this PR (5 in dependency order)

| SHA | Commit |
|---|---|
| \`93d27e5f4\` | \`harden(worker)\`: explicit 20s timeoutMs on outbound HTTP across 16 fetchers |
| \`e8150eb04\` | \`harden(api)\`: apply withBodySizeLimit + Zod input validation on 18 mutation routes |
| \`a644a8eb7\` | \`feat(alerts)\`: ownership-scoped updateAlertRule + useToggleAlertRule hook |
| \`81c7842e8\` | \`feat(tier-list)\`: hasTierListUrlState helper + share-bar polish |
| \`8d75add60\` | \`fix(api-helpers)\`: land withBodySizeLimit helper missed by the harden(api) commit |

### Commits skipped (and why)

- \`f3bf9da4e\` \`feat(toolbox)\`: dual-write HN + Reddit mentions — **already shipped via PR #1019** (\`546036f4d feat(scrape): dual-write HN + Reddit repo-mentions to TOOLBOX signal lake\`). Subsequent PRs (#1025/#1031/#1038/#1043/#1186) added the same pattern to more sources. Cherry-pick conflicted on \`.env.example\`, \`scripts/_toolbox-ingest.mjs\`, \`scripts/scrape-{hackernews,reddit}.mjs\`, \`scripts/__tests__/toolbox-ingest.test.mjs\` — all evidence the work is already in production.
- \`0dd44ff55\` \`audit(wave-1)\`: SEO titles + tier-list URL state + search filter contract — heavy conflicts in \`next.config.ts\`, \`src/app/page.tsx\`, \`src/components/repo-detail/ProjectSurfaceMap.tsx\` from main drift over the past 9 days. Three loosely-related changes bundled in one commit; suggest re-doing as 3 separate small PRs against current main rather than trying to resolve mechanically.

### Recovered orphan: \`8d75add60\`

The original \`harden(api)\` commit (\`6226c1aa3\` → cherry-picked as \`e8150eb04\` here) imported \`@/lib/api-helpers\` for \`withBodySizeLimit\`, but the helper file was never staged on \`audit/imp-wave-1\` — that commit alone would never have compiled. The handover referenced a companion fix commit \`8639b70d5\` claimed to be on the branch; it isn't on any reachable ref but it IS in git's reflog. Cherry-picked the orphan to make \`e8150eb04\` compile.

## Test plan

- [x] \`npm run typecheck\` — exit 0
- [x] \`npm run lint:guards\` — all 4 guards (pool-bypass, img-lazy, keep-last-50, routes-config) OK
- [x] \`npm run test:hooks\` — 42 files / 334 passed / 1 skipped
- [ ] CI \`Typecheck, guards, tests, build, e2e\` (full suite — auto-runs on push)
- [ ] Gitleaks workspace scan
- [ ] Operator smoke: invoke a mutation route to confirm withBodySizeLimit + Zod rejects oversized/malformed bodies; toggle an alert rule via useToggleAlertRule

## Files changed
44 files / +468 -113 (\`git diff origin/main..HEAD --stat\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)