### PR TITLE
fix(observability): add Sentry release tag to trendingrepo-worker init

### DIFF
--- a/apps/trendingrepo-worker/src/lib/sentry.ts
+++ b/apps/trendingrepo-worker/src/lib/sentry.ts
@@ -10,6 +10,7 @@ export function initSentry(): void {
   Sentry.init({
     dsn: env.SENTRY_DSN,
     environment: env.NODE_ENV,
+    release: process.env.SENTRY_RELEASE ?? process.env.GIT_SHA ?? undefined,
     tracesSampleRate: 0.05,
     sendDefaultPii: false,
     maxBreadcrumbs: 50,


### PR DESCRIPTION
## Summary
Fixes the audit-found gap (Phase 6 §6.1) where `trendingrepo-worker`'s `Sentry.init({})` omitted the `release` field, leaving worker errors unbucketed by deploy SHA.

Pattern matches the app-side Sentry init (which reads `VERCEL_GIT_COMMIT_SHA`). Falls back from `SENTRY_RELEASE` → `GIT_SHA` → `undefined` (Sentry handles missing `release` gracefully).

## Sprint context
Part of Sprint 2.6 of the TOOLBOX unification audit. Full sentry-cli source-map upload pipeline (Phase 6 row #24) is a separate follow-up PR — this lands the smallest, lowest-risk piece first.

## Test plan
- [ ] After merge + redeploy, confirm worker-emitted errors in Sentry are tagged with the commit SHA (Settings → Releases tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)