### PR TITLE
feat(storybook): add stories for 16 v4 components (E3 audit)

### DIFF
--- a/src/components/ui/ChartShell.stories.tsx
+++ b/src/components/ui/ChartShell.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import {
+  ChartLegend,
+  ChartShell,
+  ChartStat,
+  ChartStats,
+  ChartWrap,
+} from "./ChartShell";
+
+const meta: Meta<typeof ChartShell> = {
+  title: "UI/ChartShell",
+  component: ChartShell,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: ["chart", "map", "matrix", "heatmap", "market", "treemap"],
+    },
+    as: {
+      control: { type: "select" },
+      options: ["section", "div"],
+    },
+  },
+  args: {
+    variant: "chart",
+    as: "section",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChartShell>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <ChartWrap variant="chart">
+        <div style={{ padding: 24, color: "var(--v4-ink-300, #8a8a8a)" }}>
+          [chart canvas]
+        </div>
+      </ChartWrap>
+    ),
+  },
+};
+
+export const WithLegendAndStats: Story = {
+  args: {
+    variant: "market",
+    children: (
+      <>
+        <ChartLegend variant="market" right={<span>24h</span>}>
+          <span>Reddit</span>
+          <span>HN</span>
+          <span>Bluesky</span>
+        </ChartLegend>
+        <ChartWrap variant="market">
+          <div style={{ padding: 24, color: "var(--v4-ink-300, #8a8a8a)" }}>
+            [market canvas]
+          </div>
+        </ChartWrap>
+        <ChartStats columns={4}>
+          <ChartStat label="Signals" value="42,184" sub="+18.2%" />
+          <ChartStat label="Sources" value="8 / 8" sub="all live" />
+          <ChartStat label="Repos" value="1,247" sub="tracked" />
+          <ChartStat label="Tag" value="claude-skills" sub="hot" />
+        </ChartStats>
+      </>
+    ),
+  },
+};

--- a/src/components/ui/Chip.stories.tsx
+++ b/src/components/ui/Chip.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Chip } from "./Chip";
+
+const meta: Meta<typeof Chip> = {
+  title: "UI/Chip",
+  component: Chip,
+  tags: ["autodocs"],
+  argTypes: {
+    on: { control: "boolean" },
+    tone: {
+      control: { type: "select" },
+      options: ["default", "acc"],
+    },
+    as: {
+      control: { type: "select" },
+      options: ["button", "span"],
+    },
+    disabled: { control: "boolean" },
+    swatch: { control: "text" },
+    count: { control: "text" },
+  },
+  args: {
+    children: "ALL",
+    on: false,
+    tone: "default",
+    as: "button",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {
+  args: { children: "ALL" },
+};
+
+export const On: Story = {
+  args: { children: "REPOS", on: true },
+};
+
+export const WithSwatch: Story = {
+  args: { children: "HN", swatch: "var(--v4-src-hn, #ff6600)" },
+};
+
+export const WithCount: Story = {
+  args: { children: "REPOS", on: true, count: 42 },
+};
+
+export const Accent: Story = {
+  args: { children: "24H", tone: "acc", on: true },
+};

--- a/src/components/ui/ConfirmDialog.stories.tsx
+++ b/src/components/ui/ConfirmDialog.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ConfirmDialog } from "./ConfirmDialog";
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: "UI/ConfirmDialog",
+  component: ConfirmDialog,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    open: { control: "boolean" },
+    tone: {
+      control: { type: "select" },
+      options: ["danger", "warning", "neutral"],
+    },
+    busy: { control: "boolean" },
+  },
+  args: {
+    open: true,
+    title: "Delete this item?",
+    description: "This action cannot be undone.",
+    confirmLabel: "Delete",
+    cancelLabel: "Cancel",
+    tone: "danger",
+    busy: false,
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmDialog>;
+
+export const Danger: Story = {
+  args: {
+    title: "Delete this repository?",
+    description: "Removing this from the tracker is permanent.",
+    confirmLabel: "Delete",
+    tone: "danger",
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    title: "Mark as stale?",
+    description: "The repo will drop out of the live feed.",
+    confirmLabel: "Mark stale",
+    tone: "warning",
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    title: "Continue?",
+    description: undefined,
+    confirmLabel: "Continue",
+    tone: "neutral",
+  },
+};
+
+export const Busy: Story = {
+  args: {
+    busy: true,
+    confirmLabel: "Deleting…",
+  },
+};

--- a/src/components/ui/DataList.stories.tsx
+++ b/src/components/ui/DataList.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { DataList, DataRow } from "./DataList";
+
+const meta: Meta<typeof DataList> = {
+  title: "UI/DataList",
+  component: DataList,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DataList>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        <DataRow first>
+          <span>anthropic/claude-code</span>
+        </DataRow>
+        <DataRow>
+          <span>openai/openai-python</span>
+        </DataRow>
+        <DataRow>
+          <span>vercel/next.js</span>
+        </DataRow>
+      </>
+    ),
+  },
+};
+
+export const WithHeader: Story = {
+  args: {
+    header: <span>REPOS · TOP 3</span>,
+    children: (
+      <>
+        <DataRow first>
+          <span>anthropic/claude-code · 4.81</span>
+        </DataRow>
+        <DataRow>
+          <span>openai/openai-python · 4.62</span>
+        </DataRow>
+        <DataRow>
+          <span>vercel/next.js · 4.48</span>
+        </DataRow>
+      </>
+    ),
+  },
+};

--- a/src/components/ui/EntityLogo.stories.tsx
+++ b/src/components/ui/EntityLogo.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { EntityLogo } from "./EntityLogo";
+
+const meta: Meta<typeof EntityLogo> = {
+  title: "UI/EntityLogo",
+  component: EntityLogo,
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: [16, 20, 24, 28, 32, 40, 48],
+    },
+    shape: {
+      control: { type: "select" },
+      options: ["square", "circle"],
+    },
+    src: { control: "text" },
+    name: { control: "text" },
+    alt: { control: "text" },
+  },
+  args: {
+    name: "anthropic",
+    size: 32,
+    shape: "square",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EntityLogo>;
+
+export const Monogram: Story = {
+  args: { name: "anthropic" },
+};
+
+export const Circle: Story = {
+  args: { name: "vercel", shape: "circle", size: 40 },
+};
+
+export const WithImageFallback: Story = {
+  args: {
+    name: "openai",
+    src: "https://example.invalid/missing.png",
+    size: 32,
+  },
+};
+
+export const Small: Story = {
+  args: { name: "hashicorp", size: 16 },
+};

--- a/src/components/ui/FooterBar.stories.tsx
+++ b/src/components/ui/FooterBar.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { FooterBar, FooterLink } from "./FooterBar";
+
+const meta: Meta<typeof FooterBar> = {
+  title: "UI/FooterBar",
+  component: FooterBar,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    as: {
+      control: { type: "select" },
+      options: ["footer", "div"],
+    },
+  },
+  args: {
+    as: "footer",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FooterBar>;
+
+export const Default: Story = {
+  args: {
+    meta: <span>// FOOTER · TRENDINGREPO · 2026</span>,
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    meta: <span>// FOOTER · 30 sources · last sync 1m ago</span>,
+    actions: (
+      <>
+        <FooterLink href="/about">About</FooterLink>
+        <FooterLink href="https://github.com" external>
+          GitHub
+        </FooterLink>
+      </>
+    ),
+  },
+};

--- a/src/components/ui/GaugeStrip.stories.tsx
+++ b/src/components/ui/GaugeStrip.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { GaugeStrip } from "./GaugeStrip";
+
+const meta: Meta<typeof GaugeStrip> = {
+  title: "UI/GaugeStrip",
+  component: GaugeStrip,
+  tags: ["autodocs"],
+  argTypes: {
+    cellWidth: { control: { type: "number", min: 4, max: 30 } },
+    cellHeight: { control: { type: "number", min: 4, max: 30 } },
+    gap: { control: { type: "number", min: 0, max: 8 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GaugeStrip>;
+
+export const Consensus8Cell: Story = {
+  args: {
+    cells: [
+      { state: "on", title: "HN · 124 mentions" },
+      { state: "on" },
+      { state: "on" },
+      { state: "on" },
+      { state: "on" },
+      { state: "weak" },
+      { state: "off" },
+      { state: "off" },
+    ],
+  },
+};
+
+export const RepoDetail5Cell: Story = {
+  args: {
+    cells: [
+      { state: "on" },
+      { state: "on" },
+      { state: "weak" },
+      { state: "off" },
+      { state: "off" },
+    ],
+  },
+};
+
+export const AllWeak: Story = {
+  args: {
+    cells: Array.from({ length: 8 }, () => ({ state: "weak" as const })),
+  },
+};

--- a/src/components/ui/KpiBand.stories.tsx
+++ b/src/components/ui/KpiBand.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { KpiBand } from "./KpiBand";
+
+const meta: Meta<typeof KpiBand> = {
+  title: "UI/KpiBand",
+  component: KpiBand,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj<typeof KpiBand>;
+
+export const Default: Story = {
+  args: {
+    cells: [
+      {
+        label: "Signal volume · 24h",
+        value: "42,184",
+        delta: "+18.2%",
+        sub: "vs prev 24h",
+      },
+      {
+        label: "Sources · live",
+        value: "8 / 8",
+        sub: "all healthy",
+      },
+      {
+        label: "Top tag",
+        value: "#claude-skills",
+        tone: "acc",
+        sub: "+312% · 6,401",
+      },
+      {
+        label: "Data freshness",
+        value: "1m 12s",
+        tone: "money",
+        sub: "→ realtime",
+        pip: "var(--v4-acc, #ff6a00)",
+      },
+    ],
+  },
+};
+
+export const SingleCell: Story = {
+  args: {
+    cells: [
+      {
+        label: "Total tracked repos",
+        value: "1,247",
+        tone: "default",
+        sub: "across 8 sources",
+      },
+    ],
+  },
+};

--- a/src/components/ui/Metric.stories.tsx
+++ b/src/components/ui/Metric.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Metric, MetricGrid } from "./Metric";
+
+const meta: Meta<typeof Metric> = {
+  title: "UI/Metric",
+  component: Metric,
+  tags: ["autodocs"],
+  argTypes: {
+    tone: {
+      control: { type: "select" },
+      options: [
+        "neutral",
+        "accent",
+        "positive",
+        "negative",
+        "warning",
+        "consensus",
+        "early",
+        "divergence",
+        "external",
+      ],
+    },
+    pip: { control: "boolean" },
+    live: { control: "boolean" },
+  },
+  args: {
+    label: "Signals · 24h",
+    value: "42,184",
+    sub: "vs prev 24h",
+    tone: "neutral",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Metric>;
+
+export const Default: Story = {};
+
+export const Positive: Story = {
+  args: { tone: "positive", value: "+312%", delta: "▲ 6.4K", sub: "growth" },
+};
+
+export const LiveWithPip: Story = {
+  args: { live: true, pip: true, value: "8 / 8", sub: "all healthy" },
+};
+
+export const Grid: Story = {
+  render: () => (
+    <MetricGrid columns={4}>
+      <Metric label="Repos" value="1,247" sub="tracked" />
+      <Metric label="Sources" value="8 / 8" tone="positive" live pip />
+      <Metric label="Top tag" value="claude-skills" tone="accent" />
+      <Metric label="Freshness" value="1m 12s" tone="consensus" sub="realtime" />
+    </MetricGrid>
+  ),
+};

--- a/src/components/ui/PageHead.stories.tsx
+++ b/src/components/ui/PageHead.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PageHead } from "./PageHead";
+
+const meta: Meta<typeof PageHead> = {
+  title: "UI/PageHead",
+  component: PageHead,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    noBorder: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PageHead>;
+
+export const Default: Story = {
+  args: {
+    crumb: (
+      <>
+        <b>SIGNAL</b> · TERMINAL · /SIGNALS
+      </>
+    ),
+    h1: "The newsroom for AI & dev tooling.",
+    lede: "Eight sources, one editorial layer — signal volume scored across every channel that matters.",
+    clock: <span style={{ fontFamily: "monospace" }}>06:29:14 UTC</span>,
+  },
+};
+
+export const WithLogo: Story = {
+  args: {
+    crumb: (
+      <>
+        <b>SOURCE</b> · LOBSTERS
+      </>
+    ),
+    h1: "Lobsters · trending today",
+    logo: (
+      <span
+        style={{
+          display: "inline-block",
+          width: 32,
+          height: 32,
+          background: "var(--v4-src-lobsters, #ac130d)",
+          borderRadius: 4,
+        }}
+      />
+    ),
+    lede: "Top stories from the Lobsters community across the last 24 hours.",
+  },
+};
+
+export const NoBorder: Story = {
+  args: {
+    crumb: "// TERMINAL",
+    h1: "Compact header",
+    noBorder: true,
+  },
+};

--- a/src/components/ui/PanelHead.stories.tsx
+++ b/src/components/ui/PanelHead.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PanelHead } from "./PanelHead";
+
+const meta: Meta<typeof PanelHead> = {
+  title: "UI/PanelHead",
+  component: PanelHead,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    corner: { control: "boolean" },
+  },
+  args: {
+    k: "// 01 SIGNAL VOLUME",
+    corner: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PanelHead>;
+
+export const Default: Story = {};
+
+export const WithSubtitle: Story = {
+  args: {
+    k: "// 01 SIGNAL VOLUME",
+    sub: "STACKED · 24H · BY SOURCE",
+  },
+};
+
+export const WithRight: Story = {
+  args: {
+    k: "REPOS · TOP GAINERS",
+    right: <span>7 / 1,247</span>,
+  },
+};
+
+export const NoCorner: Story = {
+  args: {
+    k: "// SUB-HEAD",
+    sub: "QUIETER FRAME",
+    corner: false,
+  },
+};

--- a/src/components/ui/RankRow.stories.tsx
+++ b/src/components/ui/RankRow.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { RankRow } from "./RankRow";
+
+const meta: Meta<typeof RankRow> = {
+  title: "UI/RankRow",
+  component: RankRow,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    first: { control: "boolean" },
+    rank: { control: "text" },
+  },
+  args: {
+    rank: 1,
+    title: (
+      <>
+        anthropic <span className="o">/</span> claude-code
+      </>
+    ),
+    desc: "Agentic coding tool that lives in your terminal",
+    arrow: "›",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RankRow>;
+
+export const FirstRow: Story = {
+  args: {
+    first: true,
+    metric: { value: "4.81", label: "/ 5.0" },
+    delta: { value: "+18%", direction: "up" },
+  },
+};
+
+export const Standard: Story = {
+  args: {
+    rank: 2,
+    title: (
+      <>
+        openai <span className="o">/</span> openai-python
+      </>
+    ),
+    desc: "Official Python client for the OpenAI API",
+    metric: { value: "4.62", label: "/ 5.0" },
+    delta: { value: "+9%", direction: "up" },
+  },
+};
+
+export const Downward: Story = {
+  args: {
+    rank: 7,
+    title: "vercel / next.js",
+    metric: { value: "4.10", label: "/ 5.0" },
+    delta: { value: "-3%", direction: "down" },
+  },
+};
+
+export const AsLink: Story = {
+  args: {
+    rank: 3,
+    title: "huggingface / transformers",
+    href: "#",
+    metric: { value: "4.48" },
+  },
+};

--- a/src/components/ui/SectionHead.stories.tsx
+++ b/src/components/ui/SectionHead.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SectionHead } from "./SectionHead";
+
+const meta: Meta<typeof SectionHead> = {
+  title: "UI/SectionHead",
+  component: SectionHead,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    as: {
+      control: { type: "select" },
+      options: ["h2", "h3"],
+    },
+  },
+  args: {
+    num: "// 01",
+    title: "Trending now · top 7 by category",
+    as: "h2",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SectionHead>;
+
+export const Default: Story = {};
+
+export const WithMeta: Story = {
+  args: {
+    num: "// 04",
+    title: "Featured · curated this week",
+    meta: (
+      <>
+        editor · <b>3</b> picks
+      </>
+    ),
+  },
+};
+
+export const SubSection: Story = {
+  args: {
+    num: "// 04.2",
+    title: "Sub-section",
+    as: "h3",
+  },
+};

--- a/src/components/ui/TabBar.stories.tsx
+++ b/src/components/ui/TabBar.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { TabBar, type TabItem } from "./TabBar";
+
+const meta: Meta<typeof TabBar> = {
+  title: "UI/TabBar",
+  component: TabBar,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj<typeof TabBar>;
+
+const items: TabItem[] = [
+  { id: "all", label: "ALL", count: 14 },
+  { id: "repos", label: "REPOS", count: 7 },
+  { id: "skills", label: "SKILLS", count: 3 },
+  { id: "mcp", label: "MCP", count: 4 },
+];
+
+export const Default: Story = {
+  render: () => {
+    const Wrapper = () => {
+      const [active, setActive] = useState("all");
+      return <TabBar items={items} active={active} onChange={setActive} />;
+    };
+    return <Wrapper />;
+  },
+};
+
+export const WithDisabled: Story = {
+  render: () => {
+    const Wrapper = () => {
+      const [active, setActive] = useState("repos");
+      const withDisabled: TabItem[] = items.map((item) =>
+        item.id === "mcp" ? { ...item, disabled: true } : item,
+      );
+      return (
+        <TabBar items={withDisabled} active={active} onChange={setActive} />
+      );
+    };
+    return <Wrapper />;
+  },
+};
+
+export const LinkMode: Story = {
+  args: {
+    items: [
+      { id: "/", label: "TREND" },
+      { id: "/signals", label: "SIGNAL" },
+      { id: "/consensus", label: "CONSENSUS" },
+    ],
+    active: "/signals",
+    hrefs: {
+      "/": "/",
+      "/signals": "/signals",
+      "/consensus": "/consensus",
+    },
+  },
+};
+
+export const WithRightSlot: Story = {
+  render: () => {
+    const Wrapper = () => {
+      const [active, setActive] = useState("all");
+      return (
+        <TabBar
+          items={items}
+          active={active}
+          onChange={setActive}
+          rightSlot={<span>Sort · momentum</span>}
+        />
+      );
+    };
+    return <Wrapper />;
+  },
+};

--- a/src/components/ui/Toaster.stories.tsx
+++ b/src/components/ui/Toaster.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Toaster } from "./Toaster";
+
+// The Toaster is a portal-based provider re-exported from
+// components/feedback/ToasterLazy. The Default story renders the surface
+// mounted; firing toasts is exercised in the parent app, not in Storybook.
+
+const meta: Meta<typeof Toaster> = {
+  title: "UI/Toaster",
+  component: Toaster,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj<typeof Toaster>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ minHeight: 240, padding: 24, color: "var(--v4-ink-300, #8a8a8a)" }}>
+      Toaster mounted. Toasts appear via the sonner provider; this story
+      proves the surface renders without crashing.
+      <Toaster />
+    </div>
+  ),
+};

--- a/src/components/ui/VerdictRibbon.stories.tsx
+++ b/src/components/ui/VerdictRibbon.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { VerdictRibbon } from "./VerdictRibbon";
+
+const meta: Meta<typeof VerdictRibbon> = {
+  title: "UI/VerdictRibbon",
+  component: VerdictRibbon,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    tone: {
+      control: { type: "select" },
+      options: ["acc", "money", "amber"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VerdictRibbon>;
+
+export const Accent: Story = {
+  args: {
+    tone: "acc",
+    stamp: {
+      eyebrow: "// STAMP",
+      headline: "28 APR · 06:29 UTC",
+      sub: "computed 4m ago",
+    },
+    text: (
+      <>
+        14 <b>strong consensus picks</b> today led by anthropic/skills (8/8) and
+        openai/python.
+      </>
+    ),
+    actionHref: "/consensus/methodology",
+    actionLabel: "METHODOLOGY",
+  },
+};
+
+export const Money: Story = {
+  args: {
+    tone: "money",
+    stamp: {
+      eyebrow: "// TODAY'S TAPE",
+      headline: "28 APR · 06:29 UTC",
+      sub: "computed 2m ago · 142 deals · 24h",
+    },
+    text: (
+      <>
+        $<b>4.82B raised</b> across 142 deals in the last 24h.
+      </>
+    ),
+    actionHref: "/funding/methodology",
+    actionLabel: "METHODOLOGY",
+  },
+};
+
+export const Amber: Story = {
+  args: {
+    tone: "amber",
+    stamp: {
+      eyebrow: "// STALE",
+      headline: "28 APR · 06:29 UTC",
+      sub: "last sync 47m ago",
+    },
+    text: <>Signal layer is operating on cached data — verdicts may lag.</>,
+  },
+};


### PR DESCRIPTION
## Summary

Closes Track E3 Storybook coverage gap from the handover. Adds minimal `Default + variant` stories for the 16 v4 components that lacked `*.stories.tsx` siblings.

All stories follow the existing repo convention (mirrors `Badge.stories.tsx` / `Button.stories.tsx`):
- `Meta<typeof X>` + `StoryObj<typeof X>` typing
- `title: "UI/<Name>"`
- `tags: ["autodocs"]`
- One `Default` story plus 1-3 prop variants

## Components covered (16)

| Component | Stories |
| --- | --- |
| `ChartShell` | `Default`, `WithLegendAndStats` (variant: `chart`/`market` + `ChartLegend` + `ChartStats`) |
| `Chip` | `Default`, `On`, `WithSwatch`, `WithCount`, `Accent` (on, tone, swatch, count) |
| `ConfirmDialog` | `Danger`, `Warning`, `Neutral`, `Busy` (tone, busy) |
| `DataList` | `Default`, `WithHeader` (header slot, `DataRow first`) |
| `EntityLogo` | `Monogram`, `Circle`, `WithImageFallback`, `Small` (size, shape, src fallback) |
| `FooterBar` | `Default`, `WithActions` (meta, actions slot, `FooterLink`) |
| `GaugeStrip` | `Consensus8Cell`, `RepoDetail5Cell`, `AllWeak` (cell states: on/weak/off) |
| `KpiBand` | `Default`, `SingleCell` (cells array, tones, pip) |
| `Metric` | `Default`, `Positive`, `LiveWithPip`, `Grid` (tone, live, pip, `MetricGrid`) |
| `PageHead` | `Default`, `WithLogo`, `NoBorder` (crumb, h1, logo, lede, clock, noBorder) |
| `PanelHead` | `Default`, `WithSubtitle`, `WithRight`, `NoCorner` (k, sub, right, corner) |
| `RankRow` | `FirstRow`, `Standard`, `Downward`, `AsLink` (rank, metric, delta direction, href) |
| `SectionHead` | `Default`, `WithMeta`, `SubSection` (num, meta, as=h2/h3) |
| `TabBar` | `Default`, `WithDisabled`, `LinkMode`, `WithRightSlot` (items, hrefs, rightSlot) |
| `Toaster` | `Default` (provider surface — toasts fire from app) |
| `VerdictRibbon` | `Accent`, `Money`, `Amber` (tone, stamp, action) |

## Verification

- `npm run typecheck` — pass
- `npm run lint:guards` — pass (all 11 guards green)
- Component source files untouched (only `.stories.tsx` siblings added)

## Notes

- `Toaster` is a re-export of the lazy-loaded sonner provider — its story renders the surface mounted (toasts are fired from app code, not Storybook).
- `TabBar` lives at `src/components/ui/TabBar.tsx`; the sibling `src/components/terminal/TabBar.tsx` is a separate component and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)