### PR TITLE
fix(worker): tighten devto schedule to every 6h (B1)

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/devto/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/devto/index.ts
@@ -150,7 +150,12 @@ function normalizeArticle(
 
 const fetcher: Fetcher = {
   name: 'devto',
-  schedule: '30 8 * * *',
+  // AUDIT-2026-05-04 fix (Phase B1): tightened from once-daily 08:30 to
+  // every 6h to match the GHA cadence and the 6h freshness budget per
+  // PLAN-FRESHNESS §0. The GHA workflow scrape-devto.yml has been failing
+  // (3.6-day stale data); the worker will now keep devto-mentions /
+  // devto-trending fresh independent of GHA recovery.
+  schedule: '30 */6 * * *',
   async run(ctx: FetcherContext): Promise<RunResult> {
     const startedAt = new Date().toISOString();
     if (ctx.dryRun) {


### PR DESCRIPTION
## Summary

Salvages orphan commit `0472199e0` (Phase B1 from the 2026-05-04 audit). The Railway worker's devto fetcher was scheduled once per day at 08:30 UTC, but the GHA workflow `scrape-devto.yml` runs every 6h. When GHA fails — which is currently the case — the worker is not a useful fallback because it only refreshes once a day.

## Why this matters

- **Symptom:** 3.6-day stale data on `/devto` surfaces (audit 2026-05-04).
- **Root cause:** Worker cadence (`30 8 * * *`, daily) did not match the 6h freshness budget defined in `PLAN-FRESHNESS §0` or the GHA cadence.
- **Fix:** Tighten worker schedule to `30 */6 * * *` (every 6h at minute 30, offset from the GHA's `0 */6 * * *` to avoid hitting the dev.to API simultaneously). Freshness budget now holds even if GHA stays broken.

This is the only remaining genuinely-valuable unreachable commit in the repo per the comprehensive orphan audit. Worker-side only; the GHA workflow is unchanged.

## Files changed

- `apps/trendingrepo-worker/src/fetchers/devto/index.ts` (+6, -1) — schedule literal + audit-reference comment.

## Verification

- [x] `npm run typecheck` — clean (no output, exit 0)
- [x] `npm run lint:guards` — all guards passed (exit 0)
- [x] `npm run test:hooks` — 334 passed, 1 skipped, 42 files (Vitest)

## Origin

Cherry-picked from orphan commit `0472199e0`:

> fix(worker): tighten devto schedule to every 6h (Phase B1)
> 
> Tighten the worker's schedule to '30 */6 * * *' (every 6h at minute 30,
> offset from the GHA's '0 */6 * * *' to avoid hitting dev.to API
> simultaneously) so the freshness budget per PLAN-FRESHNESS §0 holds even
> if GHA stays broken.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>