### PR TITLE
refactor(submissions): A7 — extract DropRepoQueueWidget (P1)

### DIFF
--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -2,13 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import {
-  ArrowUpRight,
-  LoaderCircle,
-  Megaphone,
-  Send,
-  Sparkles,
-} from "lucide-react";
+import { ArrowUpRight, LoaderCircle, Send } from "lucide-react";
 
 import { ROUTES } from "@/lib/routes";
 import { captureFunnelStep } from "@/lib/analytics/funnel";
@@ -19,43 +13,18 @@ import {
 } from "./DropRepoCategoryPicker";
 import { DropRepoTagChips, type DropRepoTag } from "./DropRepoTagChips";
 import { DropRepoSubmissionFunnel } from "./DropRepoSubmissionFunnel";
+import {
+  DropRepoQueueWidget,
+  type DropRepoPublicSubmission,
+  type DropRepoQueueSummary,
+  type DropRepoSubmissionStatus,
+} from "./DropRepoQueueWidget";
 
 const WHY_NOW_MAX_CHARS = 280;
 
-interface QueueSummary {
-  pending: number;
-  queued: number;
-  scanning: number;
-  listed: number;
-  failed: number;
-  boosted: number;
-  latestSubmittedAt: string | null;
-}
-
-type SubmissionStatus =
-  | "pending"
-  | "queued"
-  | "scanning"
-  | "ingested"
-  | "matched"
-  | "listed"
-  | "scan_failed";
-
-interface PublicRepoSubmission {
-  id: string;
-  fullName: string;
-  repoUrl: string;
-  whyNow: string | null;
-  shareUrl: string | null;
-  boostedByShare: boolean;
-  status: SubmissionStatus;
-  submittedAt: string;
-  intakeTriggeredAt: string | null;
-  lastScanAt: string | null;
-  lastScanError: string | null;
-  matchesFound: number;
-  repoPath: string | null;
-}
+type QueueSummary = DropRepoQueueSummary;
+type SubmissionStatus = DropRepoSubmissionStatus;
+type PublicRepoSubmission = DropRepoPublicSubmission;
 
 interface SubmissionResult {
   kind: "created" | "duplicate" | "already_tracked";
@@ -101,25 +70,6 @@ const ACTIVE_STATUSES = new Set<SubmissionStatus>([
   "ingested",
   "matched",
 ]);
-
-function statusLabel(status: SubmissionStatus): string {
-  switch (status) {
-    case "pending":
-      return "Pending";
-    case "queued":
-      return "Queued";
-    case "scanning":
-      return "Scanning";
-    case "ingested":
-      return "Ingested";
-    case "matched":
-      return "Matched";
-    case "listed":
-      return "Listed";
-    case "scan_failed":
-      return "Failed";
-  }
-}
 
 export function DropRepoPage() {
   const [repo, setRepo] = useState("");
@@ -504,120 +454,13 @@ export function DropRepoPage() {
         <aside className="flex flex-col gap-6 lg:w-[360px] lg:max-w-[38%] lg:shrink-0">
           <DropRepoSubmissionFunnel queue={queue} loading={loading} />
 
-          <section className="v2-card p-5 sm:p-6">
-            <div className="flex items-center gap-2 text-text-primary">
-              <Sparkles className="h-4 w-4 text-brand" />
-              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
-                Queue signals
-              </h2>
-            </div>
-            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:flex-col">
-              <MetricCard
-                label="Active"
-                value={loading ? "..." : String(queue.pending)}
-              />
-              <MetricCard
-                label="Scanning"
-                value={loading ? "..." : String(queue.scanning)}
-              />
-              <MetricCard
-                label="Listed"
-                value={loading ? "..." : String(queue.listed)}
-              />
-              <MetricCard
-                label="Failed"
-                value={loading ? "..." : String(queue.failed)}
-              />
-              <MetricCard
-                label="Boosted by share"
-                value={loading ? "..." : String(queue.boosted)}
-              />
-            </div>
-            <p className="mt-4 text-sm leading-6 text-text-secondary">
-              Social share can boost priority. It should not be a hard listing
-              gate because the primary decision should still be repo quality and
-              real trend signal.
-            </p>
-          </section>
-
-          <section className="v2-card p-5 sm:p-6">
-            <div className="flex items-center gap-2 text-text-primary">
-              <Megaphone className="h-4 w-4 text-brand" />
-              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
-                Recent submissions
-              </h2>
-            </div>
-
-            <div className="mt-4 flex flex-col gap-3">
-              {submissions.length === 0 && !loading && (
-                <p className="text-sm text-text-secondary">
-                  No queued submissions yet.
-                </p>
-              )}
-
-              {submissions.slice(0, 6).map((submission) => (
-                <div
-                  key={submission.id}
-                  className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <a
-                      href={submission.repoPath ?? submission.repoUrl}
-                      target={submission.repoPath ? undefined : "_blank"}
-                      rel={submission.repoPath ? undefined : "noreferrer"}
-                      className="text-sm font-medium text-text-primary hover:text-brand"
-                    >
-                      {submission.fullName}
-                    </a>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <span className="rounded-full bg-bg-card px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-text-tertiary">
-                        {statusLabel(submission.status)}
-                      </span>
-                      {submission.boostedByShare && (
-                        <span className="rounded-full bg-brand/10 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-brand">
-                          boosted
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  {submission.whyNow && (
-                    <p className="mt-2 text-sm leading-6 text-text-secondary">
-                      {submission.whyNow}
-                    </p>
-                  )}
-                  {submission.matchesFound > 0 && (
-                    <p className="mt-2 text-xs font-mono uppercase tracking-[0.12em] text-text-tertiary">
-                      {submission.matchesFound} source matches found
-                    </p>
-                  )}
-                  {submission.lastScanError && (
-                    <p className="mt-2 text-xs leading-5 text-[var(--v4-red)]">
-                      {submission.lastScanError}
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          </section>
+          <DropRepoQueueWidget
+            queue={queue}
+            submissions={submissions}
+            loading={loading}
+          />
         </aside>
       </div>
-    </div>
-  );
-}
-
-function MetricCard({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
-  return (
-    <div className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3">
-      <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-tertiary">
-        {label}
-      </p>
-      <p className="mt-2 text-2xl font-semibold text-text-primary">{value}</p>
     </div>
   );
 }

--- a/src/components/submissions/DropRepoQueueWidget.tsx
+++ b/src/components/submissions/DropRepoQueueWidget.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Megaphone, Sparkles } from "lucide-react";
+
+export type DropRepoSubmissionStatus =
+  | "pending"
+  | "queued"
+  | "scanning"
+  | "ingested"
+  | "matched"
+  | "listed"
+  | "scan_failed";
+
+export interface DropRepoQueueSummary {
+  pending: number;
+  queued: number;
+  scanning: number;
+  listed: number;
+  failed: number;
+  boosted: number;
+  latestSubmittedAt: string | null;
+}
+
+export interface DropRepoPublicSubmission {
+  id: string;
+  fullName: string;
+  repoUrl: string;
+  whyNow: string | null;
+  shareUrl: string | null;
+  boostedByShare: boolean;
+  status: DropRepoSubmissionStatus;
+  submittedAt: string;
+  intakeTriggeredAt: string | null;
+  lastScanAt: string | null;
+  lastScanError: string | null;
+  matchesFound: number;
+  repoPath: string | null;
+}
+
+export interface DropRepoQueueWidgetProps {
+  queue: DropRepoQueueSummary;
+  submissions: DropRepoPublicSubmission[];
+  loading: boolean;
+}
+
+function statusLabel(status: DropRepoSubmissionStatus): string {
+  switch (status) {
+    case "pending":
+      return "Pending";
+    case "queued":
+      return "Queued";
+    case "scanning":
+      return "Scanning";
+    case "ingested":
+      return "Ingested";
+    case "matched":
+      return "Matched";
+    case "listed":
+      return "Listed";
+    case "scan_failed":
+      return "Failed";
+  }
+}
+
+function MetricCard({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3">
+      <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-tertiary">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-semibold text-text-primary">{value}</p>
+    </div>
+  );
+}
+
+export function DropRepoQueueWidget({
+  queue,
+  submissions,
+  loading,
+}: DropRepoQueueWidgetProps) {
+  return (
+    <>
+      <section className="v2-card p-5 sm:p-6">
+        <div className="flex items-center gap-2 text-text-primary">
+          <Sparkles className="h-4 w-4 text-brand" />
+          <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
+            Queue signals
+          </h2>
+        </div>
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:flex-col">
+          <MetricCard
+            label="Active"
+            value={loading ? "..." : String(queue.pending)}
+          />
+          <MetricCard
+            label="Scanning"
+            value={loading ? "..." : String(queue.scanning)}
+          />
+          <MetricCard
+            label="Listed"
+            value={loading ? "..." : String(queue.listed)}
+          />
+          <MetricCard
+            label="Failed"
+            value={loading ? "..." : String(queue.failed)}
+          />
+          <MetricCard
+            label="Boosted by share"
+            value={loading ? "..." : String(queue.boosted)}
+          />
+        </div>
+        <p className="mt-4 text-sm leading-6 text-text-secondary">
+          Social share can boost priority. It should not be a hard listing
+          gate because the primary decision should still be repo quality and
+          real trend signal.
+        </p>
+      </section>
+
+      <section className="v2-card p-5 sm:p-6">
+        <div className="flex items-center gap-2 text-text-primary">
+          <Megaphone className="h-4 w-4 text-brand" />
+          <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
+            Recent submissions
+          </h2>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {submissions.length === 0 && !loading && (
+            <p className="text-sm text-text-secondary">
+              No queued submissions yet.
+            </p>
+          )}
+
+          {submissions.slice(0, 6).map((submission) => (
+            <div
+              key={submission.id}
+              className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <a
+                  href={submission.repoPath ?? submission.repoUrl}
+                  target={submission.repoPath ? undefined : "_blank"}
+                  rel={submission.repoPath ? undefined : "noreferrer"}
+                  className="text-sm font-medium text-text-primary hover:text-brand"
+                >
+                  {submission.fullName}
+                </a>
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="rounded-full bg-bg-card px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-text-tertiary">
+                    {statusLabel(submission.status)}
+                  </span>
+                  {submission.boostedByShare && (
+                    <span className="rounded-full bg-brand/10 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-brand">
+                      boosted
+                    </span>
+                  )}
+                </div>
+              </div>
+              {submission.whyNow && (
+                <p className="mt-2 text-sm leading-6 text-text-secondary">
+                  {submission.whyNow}
+                </p>
+              )}
+              {submission.matchesFound > 0 && (
+                <p className="mt-2 text-xs font-mono uppercase tracking-[0.12em] text-text-tertiary">
+                  {submission.matchesFound} source matches found
+                </p>
+              )}
+              {submission.lastScanError && (
+                <p className="mt-2 text-xs leading-5 text-[var(--v4-red)]">
+                  {submission.lastScanError}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Pure refactor of `src/components/submissions/DropRepoPage.tsx` — extracts the inline aside content into a packaged `DropRepoQueueWidget` component. **Zero behavior change**; visual output is identical pre/post.

Part of the A7 scoping plan (see handover). Splits the 624-line `DropRepoPage` so the aside (queue signals + recent submissions) lives next to its own data shape, leaving the form section in the parent. The persisted-fields / form-behavior work is the separate **A7-P3** PR.

## What moved

Moved into the new `src/components/submissions/DropRepoQueueWidget.tsx`:

- Aside "Queue signals" section — `Sparkles` icon + `MetricCard` grid (Active / Scanning / Listed / Failed / Boosted by share)
- Aside "Recent submissions" section — `Megaphone` icon + paginated submission rows (max 6)
- `MetricCard` local helper (co-located with the widget that uses it)
- `statusLabel` switch over `SubmissionStatus`
- Type definitions: `DropRepoQueueSummary`, `DropRepoPublicSubmission`, `DropRepoSubmissionStatus`

`DropRepoPage.tsx` now:

- Imports the widget + types from `./DropRepoQueueWidget`
- Re-aliases the new public types as the existing local names (`QueueSummary` / `PublicRepoSubmission` / `SubmissionStatus`) so existing call-sites inside the file stay untouched (K3 surgical)
- Drops the unused `Sparkles` / `Megaphone` icon imports and the trailing `MetricCard` helper
- Renders `<DropRepoQueueWidget queue={queue} submissions={submissions} loading={loading} />` in place of ~100 lines of inline JSX

## Diff stats

```
 src/components/submissions/DropRepoPage.tsx        | 187 ++-------------------
 src/components/submissions/DropRepoQueueWidget.tsx | 186 ++++++++++++++++++++
 2 files changed, 201 insertions(+), 172 deletions(-)
```

`DropRepoPage.tsx` shrinks 624 → 466 lines (-158).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint:guards` — clean (all 14 guards green)
- [x] `npm run test:hooks` — 42 files / 334 tests pass, 1 skipped
- [ ] Visual diff on `/submit/repo` Vercel preview — aside layout should be byte-identical (Queue signals card + Recent submissions card unchanged)

## Scope discipline

- Only touches the two files listed.
- No form-behavior change, no API change, no new persisted fields (those are A7-P3).
- Tags, category, releaseUrl, demoUrl still collected client-side only — unchanged.