### PR TITLE
chore(sprint-2.1): move ci.yml 'gate' job to TOOLBOX self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
   gate:
     name: Typecheck, guards, tests, build, e2e
     needs: classify
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, toolbox]  # Sprint 2.1: was ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Data-only fast path


### PR DESCRIPTION
Flips heavy 'gate' job (typecheck + guards + tests + build + e2e) to `[self-hosted, linux, x64, toolbox]`. Light jobs stay on ubuntu-latest. Consolidates CI minutes onto VPS we control. Sprint 2.1 of TOOLBOX unification audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)