### PR TITLE
feat(submissions): A7 — DropRepoQueueWidget polish + responsive sweep (P2+P4)

### DIFF
--- a/src/components/submissions/DropRepoCategoryPicker.tsx
+++ b/src/components/submissions/DropRepoCategoryPicker.tsx
@@ -5,9 +5,9 @@
  * (REPO / SKILL / MCP). Operator-mockup 2026-05-15: each tile shows a
  * short type-badge ("code" / "claude" / "server") + the category name.
  *
- * Selection is presentational only at the moment — the
- * `/api/repo-submissions` schema doesn't accept a category field yet.
- * Operator extension of the API schema is the unblocking next step.
+ * Selected state uses the v4 accent wash + accent border so the choice
+ * reads at the bottom-of-form glance. Hover lifts the border one step on
+ * the line scale.
  */
 
 import { cn } from "@/lib/utils";
@@ -35,7 +35,7 @@ export function DropRepoCategoryPicker({
   onChange,
 }: DropRepoCategoryPickerProps) {
   return (
-    <div className="grid grid-cols-3 gap-2">
+    <div className="grid grid-cols-3 gap-2 sm:gap-2.5">
       {ENTRIES.map((entry) => {
         const active = entry.key === value;
         return (
@@ -45,20 +45,32 @@ export function DropRepoCategoryPicker({
             onClick={() => onChange(entry.key)}
             aria-pressed={active}
             className={cn(
-              "flex flex-col items-start gap-1 rounded-card border px-3 py-2.5 text-left transition-colors",
-              active ? "border-brand bg-brand/5" : "border-border-primary bg-bg-secondary hover:border-border-strong",
+              "flex min-w-0 flex-col items-start gap-1 rounded-card border px-3 py-2.5 text-left transition-colors",
+              active ? "shadow-[0_0_0_1px_var(--v4-acc-soft)]" : "",
             )}
+            style={{
+              borderColor: active ? "var(--v4-acc)" : "var(--v4-line-200)",
+              background: active ? "var(--v4-acc-wash)" : "var(--v4-bg-025)",
+            }}
           >
             <span
               className="font-mono text-[9px] uppercase tracking-[0.18em]"
-              style={{ color: active ? "var(--v3-acc)" : "var(--text-muted)" }}
+              style={{ color: active ? "var(--v4-acc)" : "var(--v4-ink-400)" }}
             >
               {entry.badge}
             </span>
-            <span className="text-sm font-semibold text-text-primary">
+            <span
+              className="truncate text-sm font-semibold"
+              style={{ color: "var(--v4-ink-100)" }}
+            >
               {entry.label}
             </span>
-            <span className="text-[11px] text-text-tertiary">{entry.hint}</span>
+            <span
+              className="truncate text-[11px]"
+              style={{ color: active ? "var(--v4-ink-200)" : "var(--v4-ink-300)" }}
+            >
+              {entry.hint}
+            </span>
           </button>
         );
       })}

--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -2,13 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import {
-  ArrowUpRight,
-  LoaderCircle,
-  Megaphone,
-  Send,
-  Sparkles,
-} from "lucide-react";
+import { ArrowUpRight, LoaderCircle, Send } from "lucide-react";
 
 import { ROUTES } from "@/lib/routes";
 import { captureFunnelStep } from "@/lib/analytics/funnel";
@@ -19,43 +13,18 @@ import {
 } from "./DropRepoCategoryPicker";
 import { DropRepoTagChips, type DropRepoTag } from "./DropRepoTagChips";
 import { DropRepoSubmissionFunnel } from "./DropRepoSubmissionFunnel";
+import {
+  DropRepoQueueWidget,
+  type DropRepoPublicSubmission,
+  type DropRepoQueueSummary,
+  type DropRepoSubmissionStatus,
+} from "./DropRepoQueueWidget";
 
 const WHY_NOW_MAX_CHARS = 280;
 
-interface QueueSummary {
-  pending: number;
-  queued: number;
-  scanning: number;
-  listed: number;
-  failed: number;
-  boosted: number;
-  latestSubmittedAt: string | null;
-}
-
-type SubmissionStatus =
-  | "pending"
-  | "queued"
-  | "scanning"
-  | "ingested"
-  | "matched"
-  | "listed"
-  | "scan_failed";
-
-interface PublicRepoSubmission {
-  id: string;
-  fullName: string;
-  repoUrl: string;
-  whyNow: string | null;
-  shareUrl: string | null;
-  boostedByShare: boolean;
-  status: SubmissionStatus;
-  submittedAt: string;
-  intakeTriggeredAt: string | null;
-  lastScanAt: string | null;
-  lastScanError: string | null;
-  matchesFound: number;
-  repoPath: string | null;
-}
+type QueueSummary = DropRepoQueueSummary;
+type SubmissionStatus = DropRepoSubmissionStatus;
+type PublicRepoSubmission = DropRepoPublicSubmission;
 
 interface SubmissionResult {
   kind: "created" | "duplicate" | "already_tracked";
@@ -101,25 +70,6 @@ const ACTIVE_STATUSES = new Set<SubmissionStatus>([
   "ingested",
   "matched",
 ]);
-
-function statusLabel(status: SubmissionStatus): string {
-  switch (status) {
-    case "pending":
-      return "Pending";
-    case "queued":
-      return "Queued";
-    case "scanning":
-      return "Scanning";
-    case "ingested":
-      return "Ingested";
-    case "matched":
-      return "Matched";
-    case "listed":
-      return "Listed";
-    case "scan_failed":
-      return "Failed";
-  }
-}
 
 export function DropRepoPage() {
   const [repo, setRepo] = useState("");
@@ -504,120 +454,13 @@ export function DropRepoPage() {
         <aside className="flex flex-col gap-6 lg:w-[360px] lg:max-w-[38%] lg:shrink-0">
           <DropRepoSubmissionFunnel queue={queue} loading={loading} />
 
-          <section className="v2-card p-5 sm:p-6">
-            <div className="flex items-center gap-2 text-text-primary">
-              <Sparkles className="h-4 w-4 text-brand" />
-              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
-                Queue signals
-              </h2>
-            </div>
-            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:flex-col">
-              <MetricCard
-                label="Active"
-                value={loading ? "..." : String(queue.pending)}
-              />
-              <MetricCard
-                label="Scanning"
-                value={loading ? "..." : String(queue.scanning)}
-              />
-              <MetricCard
-                label="Listed"
-                value={loading ? "..." : String(queue.listed)}
-              />
-              <MetricCard
-                label="Failed"
-                value={loading ? "..." : String(queue.failed)}
-              />
-              <MetricCard
-                label="Boosted by share"
-                value={loading ? "..." : String(queue.boosted)}
-              />
-            </div>
-            <p className="mt-4 text-sm leading-6 text-text-secondary">
-              Social share can boost priority. It should not be a hard listing
-              gate because the primary decision should still be repo quality and
-              real trend signal.
-            </p>
-          </section>
-
-          <section className="v2-card p-5 sm:p-6">
-            <div className="flex items-center gap-2 text-text-primary">
-              <Megaphone className="h-4 w-4 text-brand" />
-              <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
-                Recent submissions
-              </h2>
-            </div>
-
-            <div className="mt-4 flex flex-col gap-3">
-              {submissions.length === 0 && !loading && (
-                <p className="text-sm text-text-secondary">
-                  No queued submissions yet.
-                </p>
-              )}
-
-              {submissions.slice(0, 6).map((submission) => (
-                <div
-                  key={submission.id}
-                  className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <a
-                      href={submission.repoPath ?? submission.repoUrl}
-                      target={submission.repoPath ? undefined : "_blank"}
-                      rel={submission.repoPath ? undefined : "noreferrer"}
-                      className="text-sm font-medium text-text-primary hover:text-brand"
-                    >
-                      {submission.fullName}
-                    </a>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <span className="rounded-full bg-bg-card px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-text-tertiary">
-                        {statusLabel(submission.status)}
-                      </span>
-                      {submission.boostedByShare && (
-                        <span className="rounded-full bg-brand/10 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-brand">
-                          boosted
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  {submission.whyNow && (
-                    <p className="mt-2 text-sm leading-6 text-text-secondary">
-                      {submission.whyNow}
-                    </p>
-                  )}
-                  {submission.matchesFound > 0 && (
-                    <p className="mt-2 text-xs font-mono uppercase tracking-[0.12em] text-text-tertiary">
-                      {submission.matchesFound} source matches found
-                    </p>
-                  )}
-                  {submission.lastScanError && (
-                    <p className="mt-2 text-xs leading-5 text-[var(--v4-red)]">
-                      {submission.lastScanError}
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          </section>
+          <DropRepoQueueWidget
+            queue={queue}
+            submissions={submissions}
+            loading={loading}
+          />
         </aside>
       </div>
-    </div>
-  );
-}
-
-function MetricCard({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
-  return (
-    <div className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3">
-      <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-tertiary">
-        {label}
-      </p>
-      <p className="mt-2 text-2xl font-semibold text-text-primary">{value}</p>
     </div>
   );
 }

--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -203,18 +203,25 @@ export function DropRepoPage() {
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
-        <section className="v2-card p-5 sm:p-6 lg:min-w-0 lg:flex-1">
-          <div className="flex flex-wrap items-center gap-3">
-            <span className="inline-flex items-center gap-2 rounded-full border border-border-primary bg-bg-secondary px-3 py-1 text-[11px] font-mono uppercase tracking-[0.14em] text-text-tertiary">
-              <Send className="h-3.5 w-3.5" />
+        <section className="v2-card min-w-0 p-5 sm:p-6 lg:flex-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+            <span
+              className="inline-flex items-center gap-2 rounded-full border px-3 py-1 font-mono text-[11px] uppercase tracking-[0.14em]"
+              style={{
+                borderColor: "var(--v4-line-200)",
+                background: "var(--v4-bg-025)",
+                color: "var(--v4-ink-300)",
+              }}
+            >
+              <Send className="h-3.5 w-3.5" aria-hidden />
               Drop your repo
             </span>
-            <span className="text-sm font-mono text-text-tertiary">
+            <span className="font-mono text-sm text-text-tertiary">
               {queueLabel}
             </span>
           </div>
 
-          <h1 className="mt-4 font-display text-3xl font-bold text-text-primary sm:text-4xl">
+          <h1 className="mt-4 font-display text-3xl font-bold leading-tight text-text-primary sm:text-4xl">
             Drop a repo. Get it ranked.
           </h1>
           <p className="mt-3 max-w-2xl text-sm leading-6 text-text-secondary sm:text-base">
@@ -225,17 +232,17 @@ export function DropRepoPage() {
 
           <DropRepoStepStrip />
 
-          <div className="mt-4 flex flex-wrap items-center gap-3 rounded-card border border-up/30 bg-up/5 px-4 py-3 text-sm">
+          <div className="mt-5 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 rounded-card border border-up/30 bg-up/5 px-4 py-3 text-sm">
             <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-[var(--v4-money)]">
               Founders
             </span>
-            <span className="text-text-secondary">
+            <span className="min-w-0 flex-1 break-words text-text-secondary">
               Making money on this repo? Add a verified revenue signal to your
               repo page.
             </span>
             <Link
               href="/submit/revenue"
-              className="ml-auto inline-flex items-center gap-1 font-mono text-xs font-semibold text-text-primary hover:underline"
+              className="inline-flex shrink-0 items-center gap-1 font-mono text-xs font-semibold text-text-primary hover:underline sm:ml-auto"
             >
               Claim or submit revenue
               <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
@@ -281,8 +288,13 @@ export function DropRepoPage() {
               <span className="flex items-center justify-between text-sm font-medium text-text-primary">
                 <span>Tags</span>
                 <span
-                  className="font-mono text-[10px] uppercase tracking-[0.14em]"
-                  style={{ color: "var(--text-muted, #6b7280)" }}
+                  className="font-mono text-[10px] uppercase tracking-[0.14em] tabular-nums"
+                  style={{
+                    color:
+                      tags.size >= 4
+                        ? "var(--v4-amber)"
+                        : "var(--v4-ink-400)",
+                  }}
                 >
                   {tags.size} / 4 max
                 </span>
@@ -294,12 +306,14 @@ export function DropRepoPage() {
               <span className="flex items-center justify-between text-sm font-medium text-text-primary">
                 <span>Why now</span>
                 <span
-                  className="font-mono text-[10px] uppercase tracking-[0.14em]"
+                  className="font-mono text-[10px] uppercase tracking-[0.14em] tabular-nums"
                   style={{
                     color:
                       whyNow.length > WHY_NOW_MAX_CHARS
-                        ? "var(--v4-red, #ef4444)"
-                        : "var(--text-muted, #6b7280)",
+                        ? "var(--v4-red)"
+                        : whyNow.length > WHY_NOW_MAX_CHARS * 0.85
+                          ? "var(--v4-amber)"
+                          : "var(--v4-ink-400)",
                   }}
                 >
                   {whyNow.length} / {WHY_NOW_MAX_CHARS}
@@ -349,7 +363,10 @@ export function DropRepoPage() {
               <label className="flex flex-1 flex-col gap-2">
                 <span className="text-sm font-medium text-text-primary">
                   Release / launch URL{" "}
-                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                  <span
+                    className="font-mono text-[10px] uppercase tracking-[0.12em]"
+                    style={{ color: "var(--v4-ink-400)" }}
+                  >
                     optional
                   </span>
                 </span>
@@ -365,7 +382,10 @@ export function DropRepoPage() {
               <label className="flex flex-1 flex-col gap-2">
                 <span className="text-sm font-medium text-text-primary">
                   Demo / video URL{" "}
-                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                  <span
+                    className="font-mono text-[10px] uppercase tracking-[0.12em]"
+                    style={{ color: "var(--v4-ink-400)" }}
+                  >
                     optional
                   </span>
                 </span>
@@ -451,7 +471,7 @@ export function DropRepoPage() {
           )}
         </section>
 
-        <aside className="flex flex-col gap-6 lg:w-[360px] lg:max-w-[38%] lg:shrink-0">
+        <aside className="flex min-w-0 flex-col gap-6 lg:w-[360px] lg:max-w-[38%] lg:shrink-0">
           <DropRepoSubmissionFunnel queue={queue} loading={loading} />
 
           <DropRepoQueueWidget

--- a/src/components/submissions/DropRepoQueueWidget.tsx
+++ b/src/components/submissions/DropRepoQueueWidget.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Megaphone, Sparkles } from "lucide-react";
+import { Clock3, Megaphone, Sparkles } from "lucide-react";
+
+import { RelativeTime } from "@/components/ui/RelativeTime";
 
 export type DropRepoSubmissionStatus =
   | "pending"
@@ -70,13 +72,41 @@ function MetricCard({
   value: string;
 }) {
   return (
-    <div className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3">
-      <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-tertiary">
+    <div
+      className="min-w-0 flex-1 rounded-card border px-4 py-3"
+      style={{
+        borderColor: "var(--v4-line-200)",
+        background: "var(--v4-bg-025)",
+      }}
+    >
+      <p
+        className="text-[11px] font-mono uppercase tracking-[0.14em]"
+        style={{ color: "var(--v4-ink-300)" }}
+      >
         {label}
       </p>
-      <p className="mt-2 text-2xl font-semibold text-text-primary">{value}</p>
+      <p
+        className="mt-2 truncate text-2xl font-semibold"
+        style={{ color: "var(--v4-ink-100)" }}
+      >
+        {value}
+      </p>
     </div>
   );
+}
+
+/**
+ * Resolve the most recent submission timestamp. Prefer the queue summary
+ * (server-authoritative) and fall back to the first item in `submissions`
+ * for clients that never received the summary field.
+ */
+function resolveLatestSubmittedAt(
+  queue: DropRepoQueueSummary,
+  submissions: DropRepoPublicSubmission[],
+): string | null {
+  if (queue.latestSubmittedAt) return queue.latestSubmittedAt;
+  const head = submissions[0];
+  return head?.submittedAt ?? null;
 }
 
 export function DropRepoQueueWidget({
@@ -84,16 +114,39 @@ export function DropRepoQueueWidget({
   submissions,
   loading,
 }: DropRepoQueueWidgetProps) {
+  const latestSubmittedAt = resolveLatestSubmittedAt(queue, submissions);
+
   return (
     <>
       <section className="v2-card p-5 sm:p-6">
-        <div className="flex items-center gap-2 text-text-primary">
-          <Sparkles className="h-4 w-4 text-brand" />
+        <div className="flex flex-wrap items-center gap-2 text-text-primary">
+          <Sparkles className="h-4 w-4 text-brand" aria-hidden />
           <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
             Queue signals
           </h2>
+          {latestSubmittedAt && !loading && (
+            <span
+              className="ml-auto inline-flex min-w-0 items-center gap-1.5 rounded-full px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em]"
+              style={{
+                background: "var(--v4-bg-025)",
+                border: "1px solid var(--v4-line-200)",
+                color: "var(--v4-ink-300)",
+              }}
+              title={`Latest submission at ${latestSubmittedAt}`}
+            >
+              <Clock3 className="h-3 w-3 shrink-0" aria-hidden />
+              <span className="truncate">
+                Latest{" "}
+                <RelativeTime
+                  iso={latestSubmittedAt}
+                  className="font-mono"
+                  title={`Latest submission at ${latestSubmittedAt}`}
+                />
+              </span>
+            </span>
+          )}
         </div>
-        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:flex-col">
+        <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-1">
           <MetricCard
             label="Active"
             value={loading ? "..." : String(queue.pending)}
@@ -115,7 +168,10 @@ export function DropRepoQueueWidget({
             value={loading ? "..." : String(queue.boosted)}
           />
         </div>
-        <p className="mt-4 text-sm leading-6 text-text-secondary">
+        <p
+          className="mt-4 text-sm leading-6"
+          style={{ color: "var(--v4-ink-200)" }}
+        >
           Social share can boost priority. It should not be a hard listing
           gate because the primary decision should still be repo quality and
           real trend signal.
@@ -124,7 +180,7 @@ export function DropRepoQueueWidget({
 
       <section className="v2-card p-5 sm:p-6">
         <div className="flex items-center gap-2 text-text-primary">
-          <Megaphone className="h-4 w-4 text-brand" />
+          <Megaphone className="h-4 w-4 text-brand" aria-hidden />
           <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
             Recent submissions
           </h2>
@@ -132,7 +188,10 @@ export function DropRepoQueueWidget({
 
         <div className="mt-4 flex flex-col gap-3">
           {submissions.length === 0 && !loading && (
-            <p className="text-sm text-text-secondary">
+            <p
+              className="text-sm"
+              style={{ color: "var(--v4-ink-300)" }}
+            >
               No queued submissions yet.
             </p>
           )}
@@ -140,40 +199,57 @@ export function DropRepoQueueWidget({
           {submissions.slice(0, 6).map((submission) => (
             <div
               key={submission.id}
-              className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3"
+              className="min-w-0 rounded-card border px-4 py-3"
+              style={{
+                borderColor: "var(--v4-line-200)",
+                background: "var(--v4-bg-025)",
+              }}
             >
-              <div className="flex items-center justify-between gap-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <a
                   href={submission.repoPath ?? submission.repoUrl}
                   target={submission.repoPath ? undefined : "_blank"}
                   rel={submission.repoPath ? undefined : "noreferrer"}
-                  className="text-sm font-medium text-text-primary hover:text-brand"
+                  className="min-w-0 flex-1 truncate text-sm font-medium text-text-primary transition-colors hover:text-brand"
+                  title={submission.fullName}
                 >
                   {submission.fullName}
                 </a>
                 <div className="flex shrink-0 items-center gap-2">
-                  <span className="rounded-full bg-bg-card px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-text-tertiary">
+                  <span
+                    className="rounded-full px-2 py-1 font-mono text-[11px] uppercase tracking-[0.12em]"
+                    style={{
+                      background: "var(--v4-bg-050)",
+                      color: "var(--v4-ink-300)",
+                    }}
+                  >
                     {statusLabel(submission.status)}
                   </span>
                   {submission.boostedByShare && (
-                    <span className="rounded-full bg-brand/10 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-brand">
+                    <span className="rounded-full bg-brand/10 px-2 py-1 font-mono text-[11px] uppercase tracking-[0.12em] text-brand">
                       boosted
                     </span>
                   )}
                 </div>
               </div>
               {submission.whyNow && (
-                <p className="mt-2 text-sm leading-6 text-text-secondary">
+                <p
+                  className="mt-2 break-words text-sm leading-6"
+                  style={{ color: "var(--v4-ink-200)" }}
+                >
                   {submission.whyNow}
                 </p>
               )}
               {submission.matchesFound > 0 && (
-                <p className="mt-2 text-xs font-mono uppercase tracking-[0.12em] text-text-tertiary">
+                <p
+                  className="mt-2 font-mono text-xs uppercase tracking-[0.12em]"
+                  style={{ color: "var(--v4-ink-300)" }}
+                >
                   {submission.matchesFound} source matches found
                 </p>
               )}
               {submission.lastScanError && (
-                <p className="mt-2 text-xs leading-5 text-[var(--v4-red)]">
+                <p className="mt-2 break-words text-xs leading-5 text-[var(--v4-red)]">
                   {submission.lastScanError}
                 </p>
               )}

--- a/src/components/submissions/DropRepoQueueWidget.tsx
+++ b/src/components/submissions/DropRepoQueueWidget.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Megaphone, Sparkles } from "lucide-react";
+
+export type DropRepoSubmissionStatus =
+  | "pending"
+  | "queued"
+  | "scanning"
+  | "ingested"
+  | "matched"
+  | "listed"
+  | "scan_failed";
+
+export interface DropRepoQueueSummary {
+  pending: number;
+  queued: number;
+  scanning: number;
+  listed: number;
+  failed: number;
+  boosted: number;
+  latestSubmittedAt: string | null;
+}
+
+export interface DropRepoPublicSubmission {
+  id: string;
+  fullName: string;
+  repoUrl: string;
+  whyNow: string | null;
+  shareUrl: string | null;
+  boostedByShare: boolean;
+  status: DropRepoSubmissionStatus;
+  submittedAt: string;
+  intakeTriggeredAt: string | null;
+  lastScanAt: string | null;
+  lastScanError: string | null;
+  matchesFound: number;
+  repoPath: string | null;
+}
+
+export interface DropRepoQueueWidgetProps {
+  queue: DropRepoQueueSummary;
+  submissions: DropRepoPublicSubmission[];
+  loading: boolean;
+}
+
+function statusLabel(status: DropRepoSubmissionStatus): string {
+  switch (status) {
+    case "pending":
+      return "Pending";
+    case "queued":
+      return "Queued";
+    case "scanning":
+      return "Scanning";
+    case "ingested":
+      return "Ingested";
+    case "matched":
+      return "Matched";
+    case "listed":
+      return "Listed";
+    case "scan_failed":
+      return "Failed";
+  }
+}
+
+function MetricCard({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3">
+      <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-tertiary">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-semibold text-text-primary">{value}</p>
+    </div>
+  );
+}
+
+export function DropRepoQueueWidget({
+  queue,
+  submissions,
+  loading,
+}: DropRepoQueueWidgetProps) {
+  return (
+    <>
+      <section className="v2-card p-5 sm:p-6">
+        <div className="flex items-center gap-2 text-text-primary">
+          <Sparkles className="h-4 w-4 text-brand" />
+          <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
+            Queue signals
+          </h2>
+        </div>
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap lg:flex-col">
+          <MetricCard
+            label="Active"
+            value={loading ? "..." : String(queue.pending)}
+          />
+          <MetricCard
+            label="Scanning"
+            value={loading ? "..." : String(queue.scanning)}
+          />
+          <MetricCard
+            label="Listed"
+            value={loading ? "..." : String(queue.listed)}
+          />
+          <MetricCard
+            label="Failed"
+            value={loading ? "..." : String(queue.failed)}
+          />
+          <MetricCard
+            label="Boosted by share"
+            value={loading ? "..." : String(queue.boosted)}
+          />
+        </div>
+        <p className="mt-4 text-sm leading-6 text-text-secondary">
+          Social share can boost priority. It should not be a hard listing
+          gate because the primary decision should still be repo quality and
+          real trend signal.
+        </p>
+      </section>
+
+      <section className="v2-card p-5 sm:p-6">
+        <div className="flex items-center gap-2 text-text-primary">
+          <Megaphone className="h-4 w-4 text-brand" />
+          <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-text-secondary">
+            Recent submissions
+          </h2>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {submissions.length === 0 && !loading && (
+            <p className="text-sm text-text-secondary">
+              No queued submissions yet.
+            </p>
+          )}
+
+          {submissions.slice(0, 6).map((submission) => (
+            <div
+              key={submission.id}
+              className="rounded-card border border-border-primary bg-bg-secondary px-4 py-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <a
+                  href={submission.repoPath ?? submission.repoUrl}
+                  target={submission.repoPath ? undefined : "_blank"}
+                  rel={submission.repoPath ? undefined : "noreferrer"}
+                  className="text-sm font-medium text-text-primary hover:text-brand"
+                >
+                  {submission.fullName}
+                </a>
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="rounded-full bg-bg-card px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-text-tertiary">
+                    {statusLabel(submission.status)}
+                  </span>
+                  {submission.boostedByShare && (
+                    <span className="rounded-full bg-brand/10 px-2 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-brand">
+                      boosted
+                    </span>
+                  )}
+                </div>
+              </div>
+              {submission.whyNow && (
+                <p className="mt-2 text-sm leading-6 text-text-secondary">
+                  {submission.whyNow}
+                </p>
+              )}
+              {submission.matchesFound > 0 && (
+                <p className="mt-2 text-xs font-mono uppercase tracking-[0.12em] text-text-tertiary">
+                  {submission.matchesFound} source matches found
+                </p>
+              )}
+              {submission.lastScanError && (
+                <p className="mt-2 text-xs leading-5 text-[var(--v4-red)]">
+                  {submission.lastScanError}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/components/submissions/DropRepoStepStrip.tsx
+++ b/src/components/submissions/DropRepoStepStrip.tsx
@@ -26,32 +26,34 @@ function StepCard({ num, label, duration, icon, active = false }: StepCardProps)
     <div
       className="flex min-w-0 flex-1 flex-col gap-1 rounded-card border px-3 py-2.5"
       style={{
-        borderColor: active
-          ? "var(--v3-acc, var(--border-primary, #2a2a30))"
-          : "var(--border-primary, #2a2a30)",
-        background: "var(--bg-secondary, #0c0c10)",
+        borderColor: active ? "var(--v4-acc)" : "var(--v4-line-200)",
+        background: active ? "var(--v4-acc-wash)" : "var(--v4-bg-025)",
       }}
     >
-      <div className="flex items-center gap-1.5">
+      <div className="flex min-w-0 items-center gap-1.5">
         <span
-          className="font-mono text-[9px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--text-muted, #6b7280)" }}
+          className="shrink-0 font-mono text-[9px] uppercase tracking-[0.16em]"
+          style={{ color: "var(--v4-ink-400)" }}
         >
           {num}
         </span>
         <span
-          className="font-mono text-[10px] uppercase tracking-[0.16em]"
-          style={{ color: active ? "var(--v3-acc, #fb923c)" : "var(--text-secondary, #9ca3af)" }}
+          className="min-w-0 truncate font-mono text-[10px] uppercase tracking-[0.16em]"
+          style={{ color: active ? "var(--v4-acc)" : "var(--v4-ink-200)" }}
         >
           {label}
         </span>
-        <span className="ml-auto" style={{ color: active ? "var(--v3-acc, #fb923c)" : "var(--text-muted, #6b7280)" }}>
+        <span
+          className="ml-auto shrink-0"
+          style={{ color: active ? "var(--v4-acc)" : "var(--v4-ink-300)" }}
+          aria-hidden
+        >
           {icon}
         </span>
       </div>
       <div
-        className="font-mono text-[11px]"
-        style={{ color: "var(--text-secondary, #9ca3af)" }}
+        className="truncate font-mono text-[11px]"
+        style={{ color: active ? "var(--v4-ink-100)" : "var(--v4-ink-200)" }}
       >
         ~{duration}
       </div>

--- a/src/components/submissions/DropRepoTagChips.tsx
+++ b/src/components/submissions/DropRepoTagChips.tsx
@@ -2,9 +2,10 @@
 
 /**
  * DropRepoTagChips — 12-chip strip for the submission tag set. Max
- * `maxSelected` selected at once (operator mockup: 4). Selection is
- * presentational only at the moment — the `/api/repo-submissions`
- * schema doesn't accept a tags array yet.
+ * `maxSelected` selected at once (operator mockup: 4). When the cap is
+ * reached a v4-amber "max" chip surfaces inline so the user understands
+ * why further taps don't register without scrolling back to the field
+ * label counter.
  */
 
 import { cn } from "@/lib/utils";
@@ -49,6 +50,8 @@ export function DropRepoTagChips({
   onChange,
   maxSelected = 4,
 }: DropRepoTagChipsProps) {
+  const atCap = value.size >= maxSelected;
+
   function toggle(tag: DropRepoTag) {
     const next = new Set(value);
     if (next.has(tag)) {
@@ -62,10 +65,10 @@ export function DropRepoTagChips({
   }
 
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div className="flex flex-wrap items-center gap-1.5">
       {DROP_REPO_TAGS.map((tag) => {
         const active = value.has(tag);
-        const disabled = !active && value.size >= maxSelected;
+        const disabled = !active && atCap;
         return (
           <button
             type="button"
@@ -85,6 +88,20 @@ export function DropRepoTagChips({
           </button>
         );
       })}
+      {atCap && (
+        <span
+          aria-live="polite"
+          className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em]"
+          style={{
+            borderColor: "var(--v4-amber)",
+            background: "var(--v4-amber-soft)",
+            color: "var(--v4-amber)",
+          }}
+          title={`Max ${maxSelected} tags. Deselect one to add another.`}
+        >
+          Max {maxSelected}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Visual + responsive polish on the Drop-a-Repo submission surface. Zero behavior change — only design tokens, breakpoint hardening, and one new presentational chip. Combines A7-P2 (widget polish) + A7-P4 (impeccable / responsive sweep) into a single PR.

Builds atop PR #1496 (P1 widget extraction). That commit is included on this branch so the PR is self-sufficient; it will de-dupe cleanly if #1496 merges first.

## Visual changes per file

### `src/components/submissions/DropRepoQueueWidget.tsx`
- New **Latest …** chip in the *Queue signals* heading row. Wired to `queue.latestSubmittedAt` (falls back to `submissions[0].submittedAt` for clients without the summary field). Uses the existing `RelativeTime` primitive — no new fresh chrome, no hardcoded `FEED LIVE` theatre.
- Switched MetricCard + submission rows to direct v4 tokens (`var(--v4-line-200)`, `var(--v4-bg-025)`, `var(--v4-ink-100/200/300)`).
- MetricCard layout → grid (2 → 3 → 1 col across sm/lg) so metrics never blow out on narrow viewports.
- `min-w-0` + `truncate` on submission `fullName`; `break-words` on `whyNow` / `lastScanError` so long repo paths or error blobs no longer overflow the aside.

### `src/components/submissions/DropRepoStepStrip.tsx`
- Replaced `var(--v3-acc, …)` fallbacks with `var(--v4-acc)` + `var(--v4-acc-wash)` directly. The accent wash backs the active card so the funnel reads at-a-glance.
- `min-w-0` + `truncate` on label + duration so the 4-up collapses cleanly at 375px.

### `src/components/submissions/DropRepoCategoryPicker.tsx`
- Tile border + background → inline v4 tokens. Selected state gets the accent wash + a soft accent ring shadow.
- `min-w-0` + `truncate` so badge / label / hint collapse cleanly at narrow widths.

### `src/components/submissions/DropRepoTagChips.tsx`
- New inline **Max N** amber pill that surfaces as soon as the selection hits the cap. Uses `var(--v4-amber)` + `--v4-amber-soft`, with `aria-live=\"polite\"`.

### `src/components/submissions/DropRepoPage.tsx`
- Header pill + queue label → v4 tokens.
- Founders revenue ribbon → `min-w-0` + `break-words` on the copy block, `shrink-0` on the link; the ribbon wraps cleanly at narrow widths instead of pushing the CTA off-screen.
- Tags counter flips to `var(--v4-amber)` at 4/4. Why-now counter gets a v4-amber *approaching cap* state at > 85% of `WHY_NOW_MAX_CHARS`.
- *optional* micro-label → `var(--v4-ink-400)`.
- Aside + form column both gained `min-w-0` so a long `fullName` in the recent-submissions list never forces horizontal scroll on `lg`.

## Verification

- `npm run typecheck` — clean
- `npm run lint:guards` — clean (every guard reports OK)
- `npm run test:hooks` — **42 files, 334 passed, 1 skipped** (pre-existing skip, unrelated)

## Test plan

- [ ] Open `/submit/repo` on Vercel preview, verify the Drop-a-Repo surface renders identically pre/post at desktop
- [ ] Resize to 1280 / 768 / 375 in DevTools, confirm:
  - aside doesn't overflow form column at any breakpoint
  - long fullName in *Recent submissions* truncates with title tooltip
  - 4-up step strip collapses to 2-up at sm and back to 4-up at sm+
  - Founders ribbon wraps the CTA below the copy on narrow widths
- [ ] Select 4 tags → the amber **Max 4** pill appears inline and the tags counter flips amber
- [ ] Type 240/280 chars in *Why now* → counter shifts amber; type 285 (over cap) → counter shifts red
- [ ] Submit at least one repo → confirm the **Latest …** chip appears next to *Queue signals* with the freshly-submitted relative time

🤖 Generated with [Claude Code](https://claude.com/claude-code)