### PR TITLE
fix(mobile): 375px overflow on / and /githubrepo (D3, AGN-723/725)

### DIFF
--- a/src/app/githubrepo/page.tsx
+++ b/src/app/githubrepo/page.tsx
@@ -552,12 +552,12 @@ export default async function GithubRepoPage() {
       />
       <div className="home-surface">
         <section className="page-head">
-          <div>
+          <div className="min-w-0">
             <div className="crumb">
               <b>TREND</b> / TERMINAL / GITHUB REPOS
             </div>
-            <h1>Top 50 trending GitHub repos — right now.</h1>
-            <p className="lede">
+            <h1 className="min-w-0 break-words">Top 50 trending GitHub repos — right now.</h1>
+            <p className="lede min-w-0 break-words">
               Default ranking fuses our <b>Curated</b> + <b>Engagement</b>
               feeds. Switch tabs for either source raw, or our composite
               Momentum score.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -860,12 +860,12 @@ export default async function HomePage() {
       <FunnelMount step="home_view" flow="discover-repo" />
       <div className="home-surface">
         <section className="page-head">
-          <div>
+          <div className="min-w-0">
             <div className="crumb">
               <b>TREND</b> / TERMINAL / FRONT PAGE
             </div>
-            <h1>One live ranking for open-source breakouts.</h1>
-            <p className="lede">
+            <h1 className="min-w-0 break-words">One live ranking for open-source breakouts.</h1>
+            <p className="lede min-w-0 break-words">
               Repos, skills, and MCP servers ranked by cross-source agreement,
               star velocity, and fresh community attention.
             </p>


### PR DESCRIPTION
## Summary
- At 375px viewport, home (`/`) and `/githubrepo` page-head wrappers let h1/lede push `document.scrollWidth` past 375 by ~11px. The existing global `overflow-x: clip` (globals.css:2349-2363) hides the visual scrollbar but does NOT fix `scrollWidth`, which is what AGN-723 asserts.
- Mirrors the canonical pattern from `62a370132` (arXiv title link on `/research`): add `min-w-0 break-words` per-component, no globals.css touched.
- Touched only `src/app/page.tsx` and `src/app/githubrepo/page.tsx`. 6 insertions / 6 deletions total.

## What changed (per file, per element)
- `src/app/page.tsx` — page-head wrapper `<div>` gets `min-w-0`; h1 + `.lede` get `min-w-0 break-words`.
- `src/app/githubrepo/page.tsx` — same three additions on the parallel page-head subtree.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint:guards` — clean
- [x] `npm run test:hooks` — 334 pass / 1 skipped
- [ ] Post-deploy smoke (workflow probes `/` and `/githubrepo` at 200)
- [ ] Manual: open Chrome DevTools mobile (375×667), measure `document.documentElement.scrollWidth` on `/` and `/githubrepo` — expect ≤375 after deploy.

Refs: AGN-723, AGN-725, D3 (track AGN-723 sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)