### PR TITLE
feat(agent-commerce): A8 — 2-col body layout (P4, builds on #1501+#1508)

### DIFF
--- a/src/app/agent-commerce/page.tsx
+++ b/src/app/agent-commerce/page.tsx
@@ -539,14 +539,22 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
         </div>
       ) : (
         <>
-          {/* ========== 01 — COMPOSITE MOVERS BOARD ========== */}
-          <AgentCommerceMoversBoard movers={movers} />
-
-          {/* ========== 02 — ACTIVITY PULSE ========== */}
-          <AgentCommerceActivityPulse
-            activitySeries={activitySeries}
-            stats={stats}
-          />
+          {/* ========== 01+02 — MOVERS BOARD (L) + ACTIVITY PULSE (R) ==========
+            * A8-P4: 2-col body grid. Stacks at <1024px, splits ~65/35 above.
+            * Each column wraps its own .sec-head + content so the grid cell
+            * spans the section title and the section body.
+            */}
+          <div className="ac-body-grid">
+            <div>
+              <AgentCommerceMoversBoard movers={movers} />
+            </div>
+            <div>
+              <AgentCommerceActivityPulse
+                activitySeries={activitySeries}
+                stats={stats}
+              />
+            </div>
+          </div>
 
           {/* ========== 03 — SCORE DISTRIBUTION ========== */}
           <div className="sec-head">

--- a/src/components/agent-commerce/agent-commerce.css
+++ b/src/components/agent-commerce/agent-commerce.css
@@ -1173,6 +1173,27 @@
   color: var(--color-accent);
 }
 
+/* ── Body 2-col layout (A8-P4) ────────────────────────────────────────────
+ * Pairs the Composite Movers board (denser, ~65% width) with the Activity
+ * Pulse (sparkline + protocol rows, ~35% width) on wide viewports. Stacks
+ * vertically below 1024px so each section keeps its own .sec-head + content
+ * intact at narrow widths. Mirrors the .ac-detail-grid 2fr/1fr pattern used
+ * elsewhere on the page.
+ * ----------------------------------------------------------------------- */
+
+.ac-body-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  align-items: start;
+}
+
+@media (min-width: 1024px) {
+  .ac-body-grid {
+    grid-template-columns: minmax(0, 1.85fr) minmax(0, 1fr);
+  }
+}
+
 /* ── Empty / cold states ──────────────────────────────────────────────── */
 
 .ac-empty {


### PR DESCRIPTION
## Summary

Stacked on top of #1501 (component extract) + #1508 (hero band). Reshapes the section right below the hero into a 2-column body grid.

- **Left col (~65%):** `<AgentCommerceMoversBoard />` — denser visual, 12-row leaderboard with sparklines + rich per-row meta.
- **Right col (~35%):** `<AgentCommerceActivityPulse />` — 12-week growth spark + 4-row protocol pulse strip.

Layout-only. No component internals were touched. Sections 03+ keep their existing single-column flow.

## Layout strategy

CSS Grid (matches `.ac-detail-grid`, `.ac-grid`, `.grid` patterns already in the stylesheet). Single new class `.ac-body-grid` appended to `src/components/agent-commerce/agent-commerce.css`.

- **<1024px:** `grid-template-columns: 1fr` — sections stack vertically, each retains its full-width `.sec-head` + content.
- **≥1024px:** `grid-template-columns: minmax(0, 1.85fr) minmax(0, 1fr)` — ~65/35 split, `align-items: start` so unequal heights don't stretch the shorter column.
- `gap: 14px` to match `.agent-commerce-page` gap.
- Each component is wrapped in its own `<div>` cell so the fragment's `.sec-head` + content land together inside the column.

## Stacking order

Merge after #1501 and #1508. PR base is set to `feat/agent-commerce-hero-reshape-A8-P3`, so once that branch merges to `main`, this PR's base will retarget cleanly to `main`.

## Files changed

- `src/app/agent-commerce/page.tsx` — wrap the movers + pulse pair with `<div className="ac-body-grid">…</div>`.
- `src/components/agent-commerce/agent-commerce.css` — add `.ac-body-grid` class with the responsive grid + `@media (min-width: 1024px)` breakpoint.

## Verification

- `npm run typecheck` — pass
- `npm run lint:guards` — pass (all 17 guard checks)
- `npm run test:hooks` — pass (42 files / 334 tests)

## Test plan

- [ ] CI green
- [ ] Visual: Preview deploy renders 2-col at ≥1024px, stacks below
- [ ] Visual: section headings (`// 01 Composite movers`, `// 02 Activity pulse`) sit inside their respective columns
- [ ] Visual: Activity pulse's internal Card grid (`.grid` with col-8 + col-4 inside the right column) still reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)