### PR TITLE
fix(ci): exclude docs/handoffs + archive from no-gabagool lint

### DIFF
--- a/.github/workflows/no-gabagool.yml
+++ b/.github/workflows/no-gabagool.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Forbid legacy gabagool* literals
         run: |
           # Exclude this workflow file itself — it must mention the literal to forbid it.
+          # Exclude doc-history directories: handovers and worklogs legitimately
+          # reference the historical name when describing the purge migration
+          # (e.g. PR #1471). Source/config files have no business mentioning it.
           if grep -rIE "gabagool" \
             --exclude-dir=node_modules \
             --exclude-dir=.git \
@@ -30,6 +33,8 @@ jobs:
             --exclude-dir=dist \
             --exclude-dir=.audits \
             --exclude-dir=data \
+            --exclude-dir=handoffs \
+            --exclude-dir=archive \
             --exclude=no-gabagool.yml \
             .; then
             echo "::error::Found legacy 'gabagool' reference. Use 'toolbox' instead."


### PR DESCRIPTION
## Summary

- Extend `no-gabagool.yml`'s grep `--exclude-dir` list with `handoffs` + `archive` (basename match → covers `docs/handoffs/**` and `docs/archive/**`)
- Add a comment explaining the rule: source/config still forbidden, documentation describing the migration is allowed

## Why

After PR #1518 (FULL-HANDOVER doc) merged to main, the `no-gabagool` lint workflow (#1471) flags the handover's legitimate reference to PR #1471 ("purge legacy gabagool-* references") and fails CI on **every PR** built from main.

Currently failing on this:
- #1508 (A8-P3 hero band, rebased + green typecheck, only this lint failing)
- #1480 (SHA-pin Actions, rebased + green typecheck, only this lint failing)
- Every future PR until this is on main

## Verification

```bash
cd <worktree>
grep -rIE "gabagool" \
  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.next \
  --exclude-dir=dist --exclude-dir=.audits --exclude-dir=data \
  --exclude-dir=handoffs --exclude-dir=archive \
  --exclude=no-gabagool.yml .
# returns no matches
```

## Test plan

- [ ] CI green on this PR (the new exclude lets the lint find no matches)
- [ ] #1508 + #1480 turn from UNSTABLE to MERGEABLE after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)