### PR TITLE
fix(ci): step-timeout on collect-twitter to stop 30-min cancellations

### DIFF
--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -138,6 +138,14 @@ jobs:
         if: |
           always() && !cancelled() && github.event.inputs.dry_run != 'true' &&
           (success() || steps.web_fallback.outcome == 'success')
+        # Step-level timeout: the embedded `git-commit-data` action calls
+        # `gh pr merge --auto` which blocks indefinitely on required status
+        # checks. Without this cap, the whole 30-min job timeout fires and
+        # GH Actions cancels the run (see session-G F.2 diagnosis,
+        # 2026-05-16: 10 consecutive cancelled runs caused by this exact
+        # blocker). 5 min is enough to open the PR + enable auto-merge;
+        # the merge itself completes asynchronously via the auto-merge bot.
+        timeout-minutes: 5
         env:
           HUSKY: "0"
         uses: ./.github/actions/git-commit-data


### PR DESCRIPTION
## Summary

- Add \`timeout-minutes: 5\` on the \"Commit updated twitter signals\" step in \`collect-twitter.yml\`
- Lets the workflow exit cleanly after the PR is opened instead of blocking 30 min on \`gh pr merge --auto\`

## Why

\`collect-twitter.yml\` had **10 consecutive cancelled runs** between 2026-05-15 and 2026-05-16. Session-G F.2 diagnosis (2026-05-16T11:30Z) traced the cause:

1. Collector finishes successfully (~2 min) and writes \`.data/twitter-*.jsonl\`
2. \"Commit updated twitter signals\" step calls \`.github/actions/git-commit-data\` which internally runs \`gh pr merge --auto\`
3. \`--auto\` blocks indefinitely waiting for required status checks (\"Typecheck, guards, tests, build, e2e\") which take 5-30 min
4. Job 30-min \`timeout-minutes\` hits → GH Actions cancels the whole run

The auto-merge bot completes the merge asynchronously once checks pass — the collect-twitter job doesn't need to babysit it. A 5-min step cap is enough to open the PR + enable auto-merge; if it can't even do that in 5 min, something else is wrong and we want to fail fast.

## Scope

Same blocker likely affects other workflows using \`git-commit-data\` (collect-funding, scrape-trending, etc.). Rolling the same fix there is left for the operator's call to keep blast radius tight on this PR.

## Test plan

- [ ] After merge, next scheduled run of collect-twitter.yml completes in <10 min (success or fail-fast, not cancelled)
- [ ] \`.data/twitter-repo-signals.jsonl\` continues to grow on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)