### PR TITLE
feat(ci): auto-merge Dependabot patch/minor bumps only

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge patch/minor
+
+# Auto-merges Dependabot PRs that are patch or minor version bumps.
+# Major version bumps stay open for human review.
+# Triggered by Dependabot's metadata action; uses GH auto-merge so the PR
+# only lands once required checks pass.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor only
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml` that gates GitHub native auto-merge on Dependabot's reported `update-type`.
- Patch (`version-update:semver-patch`) and minor (`version-update:semver-minor`) bumps are enabled for auto-merge once required checks pass.
- Major bumps stay open for human review — closes the gap exposed by PRs #1524-#1527 (v4 to v6, etc.) where we want operator eyes before merge.

## Why this gate
- Follow-up to #1480 (Dependabot enabled for GH Action SHA-pin updates). With weekly Dependabot PRs incoming, manual triage doesn't scale.
- Patch/minor bumps under SemVer should be safe by contract; majors carry breaking-change risk and deserve review.
- `auto-merge-bot.yml` (label-gated) is untouched — humans keep their explicit override, Dependabot patch/minor gets the automated path.

## How it works
1. `pull_request_target` fires on Dependabot PR open/sync/reopen.
2. `dependabot/fetch-metadata` (SHA-pinned to v2.3.0 per repo convention) reports `update-type`.
3. If patch or minor, `gh pr merge --auto --squash` queues the merge — branch protection + required checks still gate the actual merge.
4. Majors hit no step, PR stays open.

## Test plan
- [ ] Wait for the next Dependabot patch/minor PR — confirm auto-merge label/state set and PR lands after CI green.
- [ ] Re-trigger one of #1524-#1527 (or wait for the next major bump) — confirm workflow runs, the auto-merge step is skipped, PR remains open.
- [ ] Verify `auto-merge-bot.yml` label-driven flow still works for non-Dependabot PRs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>