### PR TITLE
perf(repo-detail): raise STATIC_REPO_DETAIL_LIMIT 50 -> 150

### DIFF
--- a/src/app/repo/[owner]/[name]/page.tsx
+++ b/src/app/repo/[owner]/[name]/page.tsx
@@ -105,7 +105,11 @@ export const revalidate = 300;
 export const dynamicParams = true;
 
 const SLUG_PART_PATTERN = /^[A-Za-z0-9._-]+$/;
-const STATIC_REPO_DETAIL_LIMIT = 50;
+// Raised from 50 → 150 (2026-05-16) to shrink the cold-miss tail: repos
+// outside the prerendered set pay a Lambda cold start + 15-source data-store
+// fan-out + canonical profile build on first visit (~5-6s TTFB). Top 150
+// captures the realistic browse surface while keeping build time bounded.
+const STATIC_REPO_DETAIL_LIMIT = 150;
 
 function isGithubUrl(url: string): boolean {
   return /github\.com/i.test(url);


### PR DESCRIPTION
## Summary
- Bump `STATIC_REPO_DETAIL_LIMIT` from 50 to 150 in `src/app/repo/[owner]/[name]/page.tsx` so the top 150 repos are prerendered at build instead of the top 50.
- Updates the constant's comment to record the rationale and date.

## Why
Cold TTFB on `/repo/[owner]/[name]` is 5-6s for repos outside the prerendered set. Each cold miss pays a Lambda cold start + 15-source data-store fan-out + canonical profile build. Tripling the prerendered window covers the realistic browse surface (home lists ~50, sidebar related-repos pulls wider) and shrinks the cold-miss tail by 3x. ISR `stale-while-revalidate` still serves the long tail beyond 150.

## Verification
- [x] `npm run typecheck` — pass
- [ ] Vercel preview build completes (CI gate)
- [ ] Cold-hit /repo/* for a top-100 repo on the preview returns sub-2s TTFB

## Risk
- Build time scales linearly with prerendered page count; +100 pages should add a small constant.
- No runtime behavior change for repos already in the cache or beyond the limit.

## Test plan
- [ ] Wait for Vercel preview to finish building
- [ ] Spot-check 3 routes that were previously cold-miss (e.g. top ~75th repo) on the preview alias for TTFB
- [ ] Confirm prod `/` and `/repo/vercel/next.js` still 200 post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)