### PR TITLE
fix(ci): step-timeout pattern rolled out to all git-commit-data callers

### DIFF
--- a/.github/workflows/check-profile-completion.yml
+++ b/.github/workflows/check-profile-completion.yml
@@ -79,6 +79,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -69,6 +69,11 @@ jobs:
         run: npm --prefix apps/trendingrepo-worker run fetcher -- x-funding
       - if: github.event.inputs.dry_run != 'true'
         name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/cron-agent-commerce.yml
+++ b/.github/workflows/cron-agent-commerce.yml
@@ -125,6 +125,11 @@ jobs:
 
       - name: Commit if changed
         id: commit-step
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/cron-freshness-check.yml
+++ b/.github/workflows/cron-freshness-check.yml
@@ -149,6 +149,11 @@ jobs:
         # Commit the flip-file so the *next* run sees the new state.
         # Skipped (by the if: above) when state didn't change — avoids an
         # empty-commit per cycle.
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/cron-reddit-daily.yml
+++ b/.github/workflows/cron-reddit-daily.yml
@@ -114,6 +114,11 @@ jobs:
         # Reuses the same composite action as scrape-trending.yml so the
         # commit-and-PR dance (data-bot branch + auto-merge against main)
         # respects branch protection — direct push to main returns GH006.
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/ping-mcp-liveness.yml
+++ b/.github/workflows/ping-mcp-liveness.yml
@@ -45,6 +45,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/promote-unknown-mentions.yml
+++ b/.github/workflows/promote-unknown-mentions.yml
@@ -46,6 +46,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/refresh-reddit-baselines.yml
+++ b/.github/workflows/refresh-reddit-baselines.yml
@@ -57,6 +57,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/run-shadow-scoring.yml
+++ b/.github/workflows/run-shadow-scoring.yml
@@ -42,6 +42,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit report if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/scrape-awesome-skills.yml
+++ b/.github/workflows/scrape-awesome-skills.yml
@@ -44,6 +44,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/scrape-huggingface-datasets.yml
+++ b/.github/workflows/scrape-huggingface-datasets.yml
@@ -48,6 +48,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/scrape-huggingface-spaces.yml
+++ b/.github/workflows/scrape-huggingface-spaces.yml
@@ -48,6 +48,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/scrape-huggingface.yml
+++ b/.github/workflows/scrape-huggingface.yml
@@ -48,6 +48,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -130,6 +130,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           # Pass DATA_BOT_TOKEN so the auto-PR triggers required status

--- a/.github/workflows/sweep-cross-source-mentions.yml
+++ b/.github/workflows/sweep-cross-source-mentions.yml
@@ -131,6 +131,11 @@ jobs:
 
       - name: Commit if changed
         if: steps.params.outputs.dry_run != 'true'
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/sweep-staleness.yml
+++ b/.github/workflows/sweep-staleness.yml
@@ -51,6 +51,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}

--- a/.github/workflows/sync-trustmrr.yml
+++ b/.github/workflows/sync-trustmrr.yml
@@ -80,6 +80,11 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
+        # which can block indefinitely waiting for required checks. Cap at
+        # 5 min so the rest of the job (which may run other workloads) isn't
+        # starved. Pattern source: #1529 (collect-twitter.yml).
+        timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

- Roll out the `timeout-minutes: 5` step-level cap from #1529 to the **17 remaining workflows** that call `./.github/actions/git-commit-data`.
- The composite invokes `gh pr merge --auto`, which can block indefinitely waiting for required checks. Without a step-cap the whole job's `timeout-minutes` (e.g. 30) eventually fires — but only after starving sibling steps and burning runner budget.
- `collect-twitter.yml` already has the fix (#1529) and is **deliberately not touched** here.

## Files modified (17)

- `.github/workflows/check-profile-completion.yml`
- `.github/workflows/collect-funding.yml`
- `.github/workflows/cron-agent-commerce.yml`
- `.github/workflows/cron-freshness-check.yml`
- `.github/workflows/cron-reddit-daily.yml`
- `.github/workflows/ping-mcp-liveness.yml`
- `.github/workflows/promote-unknown-mentions.yml`
- `.github/workflows/refresh-reddit-baselines.yml`
- `.github/workflows/run-shadow-scoring.yml`
- `.github/workflows/scrape-awesome-skills.yml`
- `.github/workflows/scrape-huggingface-datasets.yml`
- `.github/workflows/scrape-huggingface-spaces.yml`
- `.github/workflows/scrape-huggingface.yml`
- `.github/workflows/scrape-trending.yml`
- `.github/workflows/sweep-cross-source-mentions.yml`
- `.github/workflows/sweep-staleness.yml`
- `.github/workflows/sync-trustmrr.yml`

Each step now carries `timeout-minutes: 5` plus a short comment referencing #1529 as the pattern source. Job-level timeouts (e.g. `timeout-minutes: 30` on collect-funding) are intentionally untouched — the cap is narrow, scoped to the gh-pr-merge-bound step only.

## Test plan

- [ ] CI lint passes (yaml is valid).
- [ ] On next scheduled runs, verify the Commit step in any of the affected workflows still succeeds in the common (auto-merge-bot finishes) path.
- [ ] If a future run actually hits the 5-min cap, the step alone fails red (instead of starving the whole job) — that's the desired behavior; investigate the underlying merge-block, don't bump the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)