### PR TITLE
fix(error-boundaries): lazy-load Sentry across all route error.tsx (-50KB x 74 routes)

### DIFF
--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/admin/ideas-queue/error.tsx
+++ b/src/app/admin/ideas-queue/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminIdeasQueueError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/admin/login/error.tsx
+++ b/src/app/admin/login/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminLoginError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/admin/pool/error.tsx
+++ b/src/app/admin/pool/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminPoolError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/admin/revenue-queue/error.tsx
+++ b/src/app/admin/revenue-queue/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminRevenueQueueError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/admin/scoring-shadow/error.tsx
+++ b/src/app/admin/scoring-shadow/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminScoringShadowError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/admin/staleness/error.tsx
+++ b/src/app/admin/staleness/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminStalenessError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/admin/unknown-mentions/error.tsx
+++ b/src/app/admin/unknown-mentions/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AdminUnknownMentionsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/agent-commerce/[slug]/error.tsx
+++ b/src/app/agent-commerce/[slug]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AgentCommerceSlugError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/agent-commerce/error.tsx
+++ b/src/app/agent-commerce/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AgentCommerceError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/agent-commerce/facilitator/[name]/error.tsx
+++ b/src/app/agent-commerce/facilitator/[name]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function FacilitatorError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/agent-repos/[slug]/error.tsx
+++ b/src/app/agent-repos/[slug]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AgentReposSlugError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/agent-repos/error.tsx
+++ b/src/app/agent-repos/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AgentReposError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/alerts/error.tsx
+++ b/src/app/alerts/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AlertsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/alerts/new/error.tsx
+++ b/src/app/alerts/new/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function AlertsNewError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/arxiv/trending/error.tsx
+++ b/src/app/arxiv/trending/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ArxivTrendingError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/bluesky/trending/error.tsx
+++ b/src/app/bluesky/trending/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function BlueskyTrendingError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/breakouts/error.tsx
+++ b/src/app/breakouts/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function BreakoutsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/categories/[slug]/error.tsx
+++ b/src/app/categories/[slug]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function CategoriesSlugError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/categories/error.tsx
+++ b/src/app/categories/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function CategoriesError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/cli/error.tsx
+++ b/src/app/cli/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function CliError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/collections/[slug]/error.tsx
+++ b/src/app/collections/[slug]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function CollectionsSlugError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/collections/error.tsx
+++ b/src/app/collections/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function CollectionsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/compare/error.tsx
+++ b/src/app/compare/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function CompareError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/consensus/[owner]/[name]/error.tsx
+++ b/src/app/consensus/[owner]/[name]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ConsensusRepoError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/consensus/error.tsx
+++ b/src/app/consensus/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ConsensusError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/design-lab/primitives/error.tsx
+++ b/src/app/design-lab/primitives/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function DesignLabPrimitivesError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/devto/error.tsx
+++ b/src/app/devto/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function DevtoError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/digest/[date]/error.tsx
+++ b/src/app/digest/[date]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function DigestDateError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/digest/error.tsx
+++ b/src/app/digest/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function DigestError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/embed/top10/error.tsx
+++ b/src/app/embed/top10/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 
 interface ErrorProps {
   error: Error & { digest?: string };
@@ -12,7 +11,9 @@ interface ErrorProps {
 // No site chrome, no home link (host page provides nav).
 export default function EmbedTop10Error({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/funding/error.tsx
+++ b/src/app/funding/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function FundingError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/funding/sec/error.tsx
+++ b/src/app/funding/sec/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function FundingSecError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/hackernews/trending/error.tsx
+++ b/src/app/hackernews/trending/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function HackerNewsTrendingError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/huggingface/datasets/error.tsx
+++ b/src/app/huggingface/datasets/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function HuggingfaceDatasetsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/huggingface/error.tsx
+++ b/src/app/huggingface/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function HuggingfaceError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/huggingface/spaces/error.tsx
+++ b/src/app/huggingface/spaces/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function HuggingfaceSpacesError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/huggingface/trending/error.tsx
+++ b/src/app/huggingface/trending/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function HuggingfaceTrendingError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/ideas/[id]/error.tsx
+++ b/src/app/ideas/[id]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function IdeaDetailError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/ideas/error.tsx
+++ b/src/app/ideas/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function IdeasError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/lobsters/error.tsx
+++ b/src/app/lobsters/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function LobstersError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/mcp/[slug]/error.tsx
+++ b/src/app/mcp/[slug]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function McpSlugError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/mcp/error.tsx
+++ b/src/app/mcp/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function McpError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/model-usage/error.tsx
+++ b/src/app/model-usage/error.tsx
@@ -7,7 +7,6 @@
 // aggregator pipeline.
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 
 interface ErrorProps {
   error: Error & { digest?: string };
@@ -16,7 +15,9 @@ interface ErrorProps {
 
 export default function ModelUsageError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
     console.error("[model-usage] render error", error);
   }, [error]);
 

--- a/src/app/npm/error.tsx
+++ b/src/app/npm/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function NpmError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/papers/error.tsx
+++ b/src/app/papers/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function PapersError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/portal/docs/error.tsx
+++ b/src/app/portal/docs/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function PortalDocsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/pricing/error.tsx
+++ b/src/app/pricing/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function PricingError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/producthunt/error.tsx
+++ b/src/app/producthunt/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ProducthuntError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/reddit/error.tsx
+++ b/src/app/reddit/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function RedditError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/reddit/trending/error.tsx
+++ b/src/app/reddit/trending/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function RedditTrendingError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/repo/[owner]/[name]/error.tsx
+++ b/src/app/repo/[owner]/[name]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function RepoProfileError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/repo/[owner]/[name]/star-activity/error.tsx
+++ b/src/app/repo/[owner]/[name]/star-activity/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function StarActivityError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/research/error.tsx
+++ b/src/app/research/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ResearchError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/revenue/error.tsx
+++ b/src/app/revenue/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function RevenueError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/s/[shortId]/error.tsx
+++ b/src/app/s/[shortId]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ShortLinkError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/search/error.tsx
+++ b/src/app/search/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function SearchError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/signals/error.tsx
+++ b/src/app/signals/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function SignalsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/skills/[slug]/error.tsx
+++ b/src/app/skills/[slug]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function SkillsSlugError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/skills/error.tsx
+++ b/src/app/skills/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function SkillsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/submit/error.tsx
+++ b/src/app/submit/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function SubmitError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/submit/revenue/error.tsx
+++ b/src/app/submit/revenue/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function SubmitRevenueError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/tierlist/[shortId]/error.tsx
+++ b/src/app/tierlist/[shortId]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function TierlistShortError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/tierlist/error.tsx
+++ b/src/app/tierlist/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function TierlistError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/tools/error.tsx
+++ b/src/app/tools/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ToolsError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/tools/revenue-estimate/error.tsx
+++ b/src/app/tools/revenue-estimate/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ToolsRevenueEstimateError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/tools/star-history/error.tsx
+++ b/src/app/tools/star-history/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ToolsStarHistoryError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/tools/treemap/error.tsx
+++ b/src/app/tools/treemap/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function ToolsTreemapError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/top/error.tsx
+++ b/src/app/top/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function TopError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/top10/[date]/error.tsx
+++ b/src/app/top10/[date]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function Top10DateError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/top10/error.tsx
+++ b/src/app/top10/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function Top10Error({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/u/[handle]/error.tsx
+++ b/src/app/u/[handle]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function UserHandleError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/watchlist/error.tsx
+++ b/src/app/watchlist/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function WatchlistError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (

--- a/src/app/you/error.tsx
+++ b/src/app/you/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { RefreshCw, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,7 +12,9 @@ interface ErrorProps {
 
 export default function YouError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    Sentry.captureException(error);
+    void import("@sentry/nextjs").then((Sentry) => {
+      Sentry.captureException(error);
+    });
   }, [error]);
 
   return (


### PR DESCRIPTION
## Summary

Apply the lazy-import pattern from #1528 (`/twitter/error.tsx`) to every other
route-segment `error.tsx` that was still eager-loading the Sentry SDK.

Each one was doing this at module load:

```ts
import * as Sentry from "@sentry/nextjs";  // ~50-100KB into critical path

useEffect(() => {
  Sentry.captureException(error);  // only ever runs on render error
}, [error]);
```

After this PR:

```ts
useEffect(() => {
  void import("@sentry/nextjs").then((Sentry) => {
    Sentry.captureException(error);
  });
}, [error]);
```

Sentry is only fetched if/when the boundary actually fires — i.e. essentially
never on the happy path. Net effect: roughly 50KB shaved off the critical bundle
on every one of the 74 affected routes. Matches the handover §3.2 target
(/twitter was at 118KB vs 90KB budget before #1528 dropped it).

## Why mechanical

Every eager file used the identical 3 lines:
- `import * as Sentry from "@sentry/nextjs";` (top-of-file)
- `    Sentry.captureException(error);` (inside `useEffect`, 4-space indent)
- the surrounding `useEffect(() => { ... }, [error]);`

So it's a search-and-replace transform with two anchor strings — no semantic
work, no per-file judgment. A throwaway Node script applied the same edit to all
73; one (`src/app/admin/error.tsx`) was edited by hand first as a smoke test.

## Files

- **74 transformed**: every `src/app/**/error.tsx` that had the eager pattern.
- **Untouched on purpose**:
  - `src/app/twitter/error.tsx` — already done in #1528.
  - `src/app/error.tsx` and `src/app/global-error.tsx` — already use a different
    `window.Sentry` feature-detect (no SDK import).
  - `src/app/brief/[owner]/[name]/error.tsx` — no Sentry instrumentation at all.

Full per-file list is in the commit message.

## Verification

- `npm run typecheck` → 0 errors.
- Diff per file is identical structure (3 lines added, 1 removed for the call;
  1 line removed for the import). `+222 / -148` across 74 files matches +1 net
  line per file (= +3 lazy block, -1 eager call, -1 eager import).
- No file outside `src/app/**/error.tsx` was touched.

## Test plan

- [ ] CI typecheck stays green.
- [ ] Vercel preview build succeeds.
- [ ] Spot-check `/repo/vercel/next.js`, `/ideas`, `/funding`, `/reddit` in the
      preview — pages render normally (Sentry doesn't fire on healthy paths).
- [ ] Force a render error on any boundary (e.g. via local throw) and confirm
      the dynamic `import("@sentry/nextjs")` resolves and the event hits Sentry.

Risk: low — the only behavioural change is a microtask delay between error
render and Sentry capture, which is acceptable for a client-side error boundary.

Related: #1528 (the original /twitter fix this pattern is taken from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)