### PR TITLE
perf(routes): raise revalidate windows on slow cold-TTFB routes

### DIFF
--- a/src/app/agent-commerce/page.tsx
+++ b/src/app/agent-commerce/page.tsx
@@ -55,7 +55,7 @@ import type {
   AgentCommerceProtocol,
 } from "@/lib/agent-commerce/types";
 
-export const revalidate = 600;
+export const revalidate = 1200;
 
 export const metadata: Metadata = {
   title: "TrendingRepo · Agent Commerce",

--- a/src/app/producthunt/page.tsx
+++ b/src/app/producthunt/page.tsx
@@ -45,10 +45,11 @@ function parseTab(raw: string | string[] | undefined): PhTab {
     : DEFAULT_TAB;
 }
 
-// ISR with 10-min revalidate. Each `?tab=...` variant gets its own cache
+// ISR with 30-min revalidate. Each `?tab=...` variant gets its own cache
 // entry (ISR keys by URL incl. query string), so tab switching still works
-// while popular tabs serve from edge cache.
-export const revalidate = 600;
+// while popular tabs serve from edge cache. ProductHunt launches are 7-day
+// snapshots so a longer window is safe.
+export const revalidate = 1800;
 
 export const metadata: Metadata = {
   title: "TrendingRepo — ProductHunt Launches",

--- a/src/app/reddit/trending/page.tsx
+++ b/src/app/reddit/trending/page.tsx
@@ -68,7 +68,7 @@ import { InventoryBand } from "@/components/ui/InventoryBand";
 import { buildRedditInventoryStats } from "@/components/ui/inventory-stats";
 import { RedditIcon } from "@/components/brand/BrandIcons";
 
-export const revalidate = 300;
+export const revalidate = 1800;
 
 // SSR safety net — when the in-memory cache is empty (Redis returned `missing`
 // AND the per-Lambda module cache hasn't been seeded yet) the page used to


### PR DESCRIPTION
## Summary

Per session-G slow-route deep-dive findings (2026-05-16T13:00Z), three routes have cold TTFB above 3s with revalidate windows shorter than their data-freshness budgets. Raising the windows reduces cold-miss rebuild frequency with no freshness regression.

| Route | Cold TTFB | Before | After | Rationale |
|---|---|---|---|---|
| `/reddit/trending` | 3.2s | `revalidate=300` (5min) | `revalidate=1800` (30min) | Reddit posts follow 6-24h news cycles. Collector runs once-daily via `cron-reddit-daily.yml` — 5min cache churn serves no freshness purpose. |
| `/producthunt` | 3.1s | `revalidate=600` (10min) | `revalidate=1800` (30min) | PH launches are 7-day snapshots, daily scrape cadence. 30min cache is well within the freshness budget; tab variants still keyed by URL. |
| `/agent-commerce` | 4.2s | `revalidate=600` (10min) | `revalidate=1200` (20min) | Lower-traffic surface, hourly worker updates. 20min strikes the balance for a developing surface. |

## Why this is safe

- Each collector cadence is significantly longer than the new revalidate window, so no user request will see stale-er data than before.
- ISR variants by query string (`?tab=...` on producthunt) preserved.
- Per session-G diagnosis, these are the three biggest cold-TTFB offenders in the slow-route triage list.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Vercel preview build green
- [ ] Spot-check `/reddit/trending`, `/producthunt`, `/agent-commerce` on the preview alias return 200 with expected content
- [ ] Post-deploy smoke probes pass on prod alias after merge

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>