### PR TITLE
fix(health): widen dev.to stale threshold from 2h to 4h grace

### DIFF
--- a/src/lib/source-health-thresholds.ts
+++ b/src/lib/source-health-thresholds.ts
@@ -11,8 +11,8 @@ export const FAST_DATA_STALE_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 /** ProductHunt: 16h budget (slower cadence). */
 export const PRODUCTHUNT_STALE_THRESHOLD_MS = 16 * 60 * 60 * 1000;
 
-/** Dev.to: 26h budget. */
-export const DEVTO_STALE_THRESHOLD_MS = 26 * 60 * 60 * 1000;
+/** Dev.to: 28h budget (24h collector cadence + 4h grace to absorb GH Actions queue churn, matches FAST_DATA safety margin). */
+export const DEVTO_STALE_THRESHOLD_MS = 28 * 60 * 60 * 1000;
 
 /** npm: 50h budget. */
 export const NPM_STALE_THRESHOLD_MS = 50 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- Bump `DEVTO_STALE_THRESHOLD_MS` from **26h → 28h** in `src/lib/source-health-thresholds.ts`.
- Grace over the 24h collector cadence grows from **2h → 4h**.
- Matches the 4h `FAST_DATA_STALE_THRESHOLD_MS` safety margin used for Reddit/HN/Bluesky/Lobsters.

## Why
Per the health-threshold audit, dev.to's 26h stale window left only 2h of slack over its 24h cron cadence. GitHub Actions queue churn can exceed that window, which flips `/api/health` to 503 even while the next collector run is already in flight. Widening to 28h absorbs the same kind of runner-queue latency that the 4h FAST_DATA budget already absorbs for the hourly sources.

## Scope
- One-line value change (`26` → `28`) + adjacent comment update.
- Constant lives in the shared client/server thresholds module; `source-health.ts` re-exports it, so all callers (incl. `FreshnessBadge` via `news/freshness.ts`) pick up the new value automatically.

## Test plan
- [x] `npm run typecheck` — clean.
- [ ] Post-merge: confirm `/api/health` no longer reports `devto: stale` during the GH-Actions cron-queue window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)