### PR TITLE
fix(security): add CSP + X-Frame + Referrer-Policy + Permissions-Policy baseline

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -194,6 +194,68 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // Baseline security headers applied to every route. HSTS is deliberately
+  // omitted here — it is delivered by Vercel's platform layer for the
+  // trendingrepo.com apex, and re-asserting it from the app would risk a
+  // weaker `max-age` if this file drifted ahead of platform defaults. The
+  // existing Cache-Control headers on ISR routes are also untouched; only
+  // additive policy headers are listed below.
+  //
+  // CSP allowlist rationale:
+  //   - script-src: `'unsafe-inline'` covers the inline pre-paint bootstrap
+  //     and storage-migration shims in `src/app/layout.tsx`. `'unsafe-eval'`
+  //     is needed by a small subset of dynamic-import vendors (ECharts
+  //     option compilation, recharts in dev). `*.clerk.dev` /  `*.clerk.com`
+  //     ship the SignIn/SignUp widget assets; Clerk loads Cloudflare
+  //     Turnstile inline as a bot challenge, hence `challenges.cloudflare.com`.
+  //     `*.vercel-analytics.com` is allow-listed proactively so we can opt in
+  //     to Vercel Analytics later without another CSP roll.
+  //   - connect-src: `https:` covers PostHog (us.i.posthog.com), Sentry
+  //     (which actually tunnels through our same-origin /api/_sentry-tunnel
+  //     so this is belt-and-braces), and the various JSON APIs the client
+  //     hits. `wss:` covers any future websocket transport (none active
+  //     today). `data:` is needed for blob-source EventStreams used by
+  //     the markdown renderer.
+  //   - frame-src: Clerk SignIn renders Turnstile inside an iframe served
+  //     from `challenges.cloudflare.com`; without it the bot challenge fails
+  //     to load and signups stall. Clerk hosted pages (`*.clerk.com`,
+  //     `*.clerk.dev`) embed account-management surfaces.
+  //   - img-src: `https:` + `data:` + `blob:` covers GitHub/Twitter/PH
+  //     avatars (already enumerated in `images.remotePatterns`), data-URI
+  //     SVG icons, and `URL.createObjectURL()` previews.
+  //   - frame-ancestors 'none' is the X-Frame-Options DENY equivalent; both
+  //     are emitted because some scanners only check the legacy header.
+  async headers() {
+    const csp = [
+      "default-src 'self'",
+      "img-src 'self' data: https: blob:",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.dev https://*.clerk.com https://challenges.cloudflare.com https://*.vercel-analytics.com",
+      "style-src 'self' 'unsafe-inline'",
+      "font-src 'self' data:",
+      "connect-src 'self' https: wss: data:",
+      "frame-src 'self' https://*.clerk.dev https://*.clerk.com https://challenges.cloudflare.com",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self' https://*.clerk.dev https://*.clerk.com",
+    ].join("; ");
+
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value:
+              "geolocation=(), microphone=(), camera=(), interest-cohort=()",
+          },
+          { key: "Content-Security-Policy", value: csp },
+        ],
+      },
+    ];
+  },
 };
 
 // Sentry wrap — outermost so source-map upload + auto-instrumentation


### PR DESCRIPTION
## Summary

A.2 smoke audit found `https://trendingrepo.com` ships `Strict-Transport-Security` (from Vercel platform) but no other defence-in-depth headers — no CSP, no `X-Frame-Options`, no `Referrer-Policy`, no `Permissions-Policy`. This PR adds a single global `async headers()` block in `next.config.ts` so every route emits the missing baseline.

## What lands per response

| Header | Value | Why |
| --- | --- | --- |
| `X-Frame-Options` | `DENY` | Legacy clickjacking defence — kept alongside `frame-ancestors 'none'` because some scanners only check the old header. |
| `X-Content-Type-Options` | `nosniff` | Prevent MIME-type sniffing on user-uploaded blobs and `data:` images. |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Send origin (no path) on cross-origin requests; full referrer same-origin. Default in Chrome but not all UAs. |
| `Permissions-Policy` | `geolocation=(), microphone=(), camera=(), interest-cohort=()` | Deny powerful APIs the app never asks for; opt out of FLoC. |
| `Content-Security-Policy` | see below | Restrict script/connect/frame origins to the integrations we actually use. |

## CSP allowlist rationale

Searched `src/` for each library's domain literal before allow-listing:

- **`*.clerk.dev` / `*.clerk.com`** — Clerk ClerkProvider + SignIn/SignUp widget in `src/app/layout.tsx` and `src/components/auth/ClerkAuthForm.tsx`. Added to `script-src`, `frame-src`, `form-action`.
- **`challenges.cloudflare.com`** — Cloudflare Turnstile iframe injected by Clerk as a bot challenge during sign-up. Required in `script-src` AND `frame-src`; without the `frame-src` entry, signups stall on the captcha step.
- **`*.vercel-analytics.com`** — proactive allow-list so we can opt in to Vercel Analytics later without another CSP roll. Not currently in use (no `@vercel/analytics` import found in `src/`).
- **PostHog (`us.i.posthog.com`)** — `src/lib/analytics/posthog-config.ts:1`. Loaded as a bundled module (`posthog-js/dist/module.slim`) with `disable_external_dependency_loading: true`, so it only needs `connect-src` reach, satisfied by `connect-src https:`.
- **Sentry** — `tunnelRoute: "/api/_sentry-tunnel"` in `next.config.ts` means all Sentry traffic is same-origin; `connect-src 'self'` covers it.
- **Stripe** — configured but not billing yet (per CLAUDE.md); no Stripe JS loaded yet, so no `js.stripe.com` allow-list needed today. To be added when checkout ships.

Full CSP value emitted:

```
default-src 'self'; img-src 'self' data: https: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.dev https://*.clerk.com https://challenges.cloudflare.com https://*.vercel-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' https: wss: data:; frame-src 'self' https://*.clerk.dev https://*.clerk.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://*.clerk.dev https://*.clerk.com
```

## What this PR does NOT touch

- `Strict-Transport-Security` — still ships from Vercel's platform layer. Re-emitting from the app would risk a weaker `max-age` if this file drifted ahead of platform defaults.
- `Cache-Control` on ISR routes — purely additive change.
- `vercel.json`, `src/middleware.ts` — kept on a single mechanism (`next.config.ts`) instead of fragmenting headers across three configs.

## Verification

- `npm run typecheck` clean.
- One file changed: `next.config.ts` (+62 / -0).
- No package-lock changes staged.

## Risk

Low. The `script-src` keeps `'unsafe-inline'` and `'unsafe-eval'` so existing inline bootstrap scripts (theme/surface pre-paint, storage-migration shim) and dynamic-import vendors (ECharts) continue to work. The only behavioural change a user could see is if a not-yet-discovered integration loads JS from a host outside the allowlist — those would surface as console CSP violations rather than broken pages.

Rollback: revert the single commit.