### PR TITLE
perf(sidebar): request-scoped dedup via React cache() on getSidebarSourceCounts

### DIFF
--- a/src/lib/sidebar-source-counts.ts
+++ b/src/lib/sidebar-source-counts.ts
@@ -14,6 +14,8 @@
 // in JSONL append-only logs, not a single trending payload — surfacing
 // a "fresh tweets" count requires its own aggregation pass.
 
+import { cache } from "react";
+
 import { getHnTrendingFile, refreshHackernewsTrendingFromStore } from "./hackernews-trending";
 import { getLobstersTrendingFile, refreshLobstersTrendingFromStore } from "./lobsters-trending";
 import { getDevtoTrendingFile, refreshDevtoTrendingFromStore } from "./devto-trending";
@@ -100,7 +102,7 @@ async function safeAsync<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
   }
 }
 
-export async function getSidebarSourceCounts(): Promise<SidebarSourceCounts> {
+export const getSidebarSourceCounts = cache(async function getSidebarSourceCountsImpl(): Promise<SidebarSourceCounts> {
   // Fire all refresh hooks in parallel. Each one is rate-limited to 30s
   // internally and will return { source: "memory", ... } when fresh.
   // Skills + MCP signal-data getters do their own internal store reads
@@ -173,7 +175,7 @@ export async function getSidebarSourceCounts(): Promise<SidebarSourceCounts> {
     arxivPapers,
     citedRepos,
   };
-}
+});
 
 export function emptySidebarSourceCounts(): SidebarSourceCounts {
   return { ...ZERO_COUNTS };


### PR DESCRIPTION
## Summary

Wraps `getSidebarSourceCounts()` in React's `cache()` so concurrent callers within a single request reuse one Promise instead of independently firing 13 refresh hooks + 3 snapshot reads.

## What changes

- `src/lib/sidebar-source-counts.ts` — adds `import { cache } from \"react\"` and changes the export shape from `export async function getSidebarSourceCounts(...)` to `export const getSidebarSourceCounts = cache(async function getSidebarSourceCountsImpl(...) { ... })`.
- Net diff: +4 lines / -2 lines.

## Why

Every server component that touches the sidebar (header, footer fallback nav, side rail, etc.) re-invokes the helper independently. Today each invocation:

1. `Promise.allSettled` of 13 `refreshXxxFromStore()` hooks (each dedupes internally on a 30s timer, but the per-call allocation + tick still costs).
2. `Promise.all` of 3 `safeAsync` snapshot reads (skills, MCP, twitter overview stats).
3. A handful of `safe(...)` synchronous snapshot reads.

`cache()` keys on the function reference (no args), so within one request all callers share the same Promise. The first caller does the work; the rest get the cached Promise back. Outside a request (build prerender) `cache()` degrades to a no-op, which is the correct behavior for static rendering.

## Safety

- Return type preserved: `Promise<SidebarSourceCounts>`.
- Function body preserved verbatim.
- Call shape preserved — the const is still callable as `getSidebarSourceCounts()`.
- One internal caller in `src/lib/sidebar-data.ts` (lines 39, 192-193) imports by name and invokes as a function — transparent to the const-vs-declaration switch.

## Test plan

- [x] `npm install` clean
- [x] `npm run typecheck` clean
- [ ] Vercel preview smoke: load `/`, `/twitter`, `/funding` and confirm sidebar count chips render with non-zero values
- [ ] Spot-check that the first request after a deploy still warms each refresh hook (the cache is request-scoped, not process-scoped)

## Refs

- Session-G W1.A — surgical perf win on the sidebar render path.
- React `cache()` docs: https://react.dev/reference/react/cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)