### PR TITLE
feat(og): add static OG cards for /about /trends /tools /tierlist

### DIFF
--- a/src/app/about/opengraph-image.tsx
+++ b/src/app/about/opengraph-image.tsx
@@ -1,0 +1,51 @@
+import { ImageResponse } from "next/og";
+import { CardFrame, Wordmark, AccentStrip } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+export const dynamic = "force-static";
+export const alt = "TrendingRepo — About TrendingRepo";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function AboutOGImage() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            About TrendingRepo
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            Real-time trend discovery across GitHub, Hacker News, Reddit,
+            Bluesky, ProductHunt, Dev.to, npm, arXiv, and Hugging Face. Surface
+            what&apos;s breaking out — before it goes mainstream.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { ...size, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/tierlist/opengraph-image.tsx
+++ b/src/app/tierlist/opengraph-image.tsx
@@ -1,0 +1,50 @@
+import { ImageResponse } from "next/og";
+import { CardFrame, Wordmark, AccentStrip } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+export const dynamic = "force-static";
+export const alt = "TrendingRepo — Tier lists";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function TierlistOGImage() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            Tier lists
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            Rank repos head-to-head. Build, share, and export tier lists from
+            the live dataset.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { ...size, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/tools/opengraph-image.tsx
+++ b/src/app/tools/opengraph-image.tsx
@@ -1,0 +1,50 @@
+import { ImageResponse } from "next/og";
+import { CardFrame, Wordmark, AccentStrip } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+export const dynamic = "force-static";
+export const alt = "TrendingRepo — Builder tools";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function ToolsOGImage() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            Builder tools
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            Star history, revenue estimator, treemap, and more — all powered by
+            the TrendingRepo signal layer.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { ...size, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/trends/opengraph-image.tsx
+++ b/src/app/trends/opengraph-image.tsx
@@ -1,0 +1,51 @@
+import { ImageResponse } from "next/og";
+import { CardFrame, Wordmark, AccentStrip } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+export const dynamic = "force-static";
+export const alt = "TrendingRepo — Trending across 9 sources";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function TrendsOGImage() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            Trending across 9 sources
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            Live cross-source momentum on dev tools, AI, and SaaS. Hacker News,
+            Reddit, Bluesky, arXiv, Hugging Face, Dev.to, npm, ProductHunt,
+            Lobsters.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { ...size, headers: OG_CACHE_HEADERS },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds 4 new `opengraph-image.tsx` routes that previously fell back to the root OG image.
- Each renders a 1200x630 share card with `runtime = "nodejs"` + `dynamic = "force-static"`, reusing `CardFrame` / `Wordmark` / `AccentStrip` + `OG_COLORS` so the cards stay on-brand without duplicating layout.
- `OG_CACHE_HEADERS` (5min s-maxage, 1h SWR) is applied — crawler unfurls hit the edge cache instead of re-rendering Lambda.

## Files
- `src/app/about/opengraph-image.tsx` — "About TrendingRepo"
- `src/app/trends/opengraph-image.tsx` — "Trending across 9 sources"
- `src/app/tools/opengraph-image.tsx` — "Builder tools"
- `src/app/tierlist/opengraph-image.tsx` — "Tier lists"

## Test plan
- [x] `npm run typecheck` clean
- [ ] Vercel Preview unfurl probes for all 4 routes return 200 with `Content-Type: image/png`
- [ ] Visually inspect the preview cards (Twitter Card Validator / OpenGraph debugger)