### PR TITLE
feat(errors): add error.tsx boundaries to 10 missing routes

### DIFF
--- a/src/app/about/error.tsx
+++ b/src/app/about/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/contact/error.tsx
+++ b/src/app/contact/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/githubrepo/error.tsx
+++ b/src/app/githubrepo/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/methodology/error.tsx
+++ b/src/app/methodology/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/privacy/error.tsx
+++ b/src/app/privacy/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/refer/leaderboard/error.tsx
+++ b/src/app/refer/leaderboard/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/sign-in/[[...sign-in]]/error.tsx
+++ b/src/app/sign-in/[[...sign-in]]/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/sign-up/[[...sign-up]]/error.tsx
+++ b/src/app/sign-up/[[...sign-up]]/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/terms/error.tsx
+++ b/src/app/terms/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/trends/error.tsx
+++ b/src/app/trends/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}


### PR DESCRIPTION
## Summary

Adds branded `ErrorPanel`-based error boundaries to 10 routes that previously fell through to the Next.js framework default error UI. Each new `error.tsx` uses the canonical W2.A template — client component, Sentry capture via `window.Sentry` feature-detect, `ErrorPanel variant="default"`.

## New files

- `src/app/about/error.tsx`
- `src/app/contact/error.tsx`
- `src/app/githubrepo/error.tsx`
- `src/app/methodology/error.tsx`
- `src/app/privacy/error.tsx`
- `src/app/refer/leaderboard/error.tsx`
- `src/app/sign-in/[[...sign-in]]/error.tsx`
- `src/app/sign-up/[[...sign-up]]/error.tsx`
- `src/app/terms/error.tsx`
- `src/app/trends/error.tsx`

## Intentionally excluded

Routes that already inherit a parent `error.tsx`:
- `admin/health`, `admin/keys`, `admin/pool-aggregate`, `admin/referrals`, `admin/scrapes`, `admin/sweep-cost` → covered by `src/app/admin/error.tsx`
- `you/alerts`, `you/refer` → covered by `src/app/you/error.tsx`
- `huggingface/models` → covered by `src/app/huggingface/error.tsx`
- `agent-commerce/facilitator` → covered by `src/app/agent-commerce/error.tsx`

`api/**` routes are excluded by definition (no error.tsx applicable to route handlers).

## Test plan

- [x] `npm run typecheck` — clean
- [ ] Trigger a throw on `/about` / `/sign-in` / `/trends` on the preview deploy → verify the `ErrorPanel` chrome (refresh / home / report-bug buttons) renders instead of the default framework page
- [ ] Confirm Sentry capture fires for an unhandled throw (sentry.io receives the event with the digest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)