### PR TITLE
refactor(errors): migrate route error.tsx to shared ErrorPanel (-3.7 kLOC duplication)

### DIFF
--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/admin/ideas-queue/error.tsx
+++ b/src/app/admin/ideas-queue/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminIdeasQueueError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN/IDEAS-QUEUE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/admin/login/error.tsx
+++ b/src/app/admin/login/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminLoginError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN/LOGIN"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/admin/pool/error.tsx
+++ b/src/app/admin/pool/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminPoolError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN/POOL"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/admin/revenue-queue/error.tsx
+++ b/src/app/admin/revenue-queue/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminRevenueQueueError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN/REVENUE-QUEUE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/admin/scoring-shadow/error.tsx
+++ b/src/app/admin/scoring-shadow/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminScoringShadowError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN/SCORING-SHADOW"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/admin/staleness/error.tsx
+++ b/src/app/admin/staleness/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminStalenessError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN/STALENESS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/admin/unknown-mentions/error.tsx
+++ b/src/app/admin/unknown-mentions/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AdminUnknownMentionsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ADMIN/UNKNOWN-MENTIONS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/agent-commerce/[slug]/error.tsx
+++ b/src/app/agent-commerce/[slug]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AgentCommerceSlugError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · AGENT-COMMERCE/[SLUG]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/agent-commerce/error.tsx
+++ b/src/app/agent-commerce/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AgentCommerceError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · AGENT-COMMERCE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/agent-commerce/facilitator/[name]/error.tsx
+++ b/src/app/agent-commerce/facilitator/[name]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function FacilitatorError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · AGENT-COMMERCE/FACILITATOR"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/agent-repos/[slug]/error.tsx
+++ b/src/app/agent-repos/[slug]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AgentReposSlugError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · AGENT-REPOS/[SLUG]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/agent-repos/error.tsx
+++ b/src/app/agent-repos/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AgentReposError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · AGENT-REPOS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/alerts/error.tsx
+++ b/src/app/alerts/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AlertsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ALERTS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/alerts/new/error.tsx
+++ b/src/app/alerts/new/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AlertsNewError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ALERTS/NEW"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/arxiv/trending/error.tsx
+++ b/src/app/arxiv/trending/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ArxivTrendingError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · ARXIV/TRENDING"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/bluesky/trending/error.tsx
+++ b/src/app/bluesky/trending/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function BlueskyTrendingError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · BLUESKY/TRENDING"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/breakouts/error.tsx
+++ b/src/app/breakouts/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function BreakoutsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · BREAKOUTS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/categories/[slug]/error.tsx
+++ b/src/app/categories/[slug]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function CategoriesSlugError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · CATEGORIES/[SLUG]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/categories/error.tsx
+++ b/src/app/categories/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function CategoriesError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · CATEGORIES"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/cli/error.tsx
+++ b/src/app/cli/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function CliError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · CLI"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/collections/[slug]/error.tsx
+++ b/src/app/collections/[slug]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function CollectionsSlugError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · COLLECTIONS/[SLUG]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/collections/error.tsx
+++ b/src/app/collections/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function CollectionsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · COLLECTIONS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/compare/error.tsx
+++ b/src/app/compare/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function CompareError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · COMPARE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/consensus/[owner]/[name]/error.tsx
+++ b/src/app/consensus/[owner]/[name]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ConsensusRepoError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · CONSENSUS/[OWNER]/[NAME]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/consensus/error.tsx
+++ b/src/app/consensus/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ConsensusError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · CONSENSUS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/design-lab/primitives/error.tsx
+++ b/src/app/design-lab/primitives/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function DesignLabPrimitivesError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · DESIGN-LAB/PRIMITIVES"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/devto/error.tsx
+++ b/src/app/devto/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function DevtoError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · DEVTO"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/digest/[date]/error.tsx
+++ b/src/app/digest/[date]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function DigestDateError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · DIGEST/[DATE]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/digest/error.tsx
+++ b/src/app/digest/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function DigestError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · DIGEST"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/embed/top10/error.tsx
+++ b/src/app/embed/top10/error.tsx
@@ -1,57 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-// Embed surface — kept ultra-minimal so the iframe degrades cleanly.
-// No site chrome, no home link (host page provides nav).
-export default function EmbedTop10Error({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div
-      style={{
-        padding: 16,
-        fontFamily: "ui-monospace, monospace",
-        fontSize: 12,
-        color: "var(--v4-ink-300)",
-      }}
-    >
-      <p style={{ color: "var(--v4-red)", marginBottom: 8 }}>
-        {"// EMBED · ERROR"}
-      </p>
-      <p style={{ marginBottom: 8 }}>Failed to render embed.</p>
-      {error.digest && (
-        <p style={{ fontSize: 10, color: "var(--v4-ink-400)" }}>
-          {"// DIGEST: "}
-          {error.digest}
-        </p>
-      )}
-      <button
-        type="button"
-        onClick={reset}
-        style={{
-          marginTop: 8,
-          padding: "4px 8px",
-          border: "1px solid var(--v4-line-200)",
-          background: "transparent",
-          color: "var(--v4-ink-000)",
-          fontFamily: "inherit",
-          fontSize: 11,
-          textTransform: "uppercase",
-          cursor: "pointer",
-        }}
-      >
-        Retry
-      </button>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/funding/error.tsx
+++ b/src/app/funding/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function FundingError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · FUNDING"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/funding/sec/error.tsx
+++ b/src/app/funding/sec/error.tsx
@@ -1,73 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function FundingSecError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · FUNDING · SEC"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head back to the funding
-        radar.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/funding" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO FUNDING
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/hackernews/trending/error.tsx
+++ b/src/app/hackernews/trending/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function HackerNewsTrendingError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · HACKERNEWS/TRENDING"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/huggingface/datasets/error.tsx
+++ b/src/app/huggingface/datasets/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function HuggingfaceDatasetsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · HUGGINGFACE/DATASETS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/huggingface/error.tsx
+++ b/src/app/huggingface/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function HuggingfaceError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · HUGGINGFACE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/huggingface/spaces/error.tsx
+++ b/src/app/huggingface/spaces/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function HuggingfaceSpacesError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · HUGGINGFACE/SPACES"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/huggingface/trending/error.tsx
+++ b/src/app/huggingface/trending/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function HuggingfaceTrendingError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · HUGGINGFACE/TRENDING"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/ideas/[id]/error.tsx
+++ b/src/app/ideas/[id]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function IdeaDetailError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · IDEAS/[ID]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/ideas/error.tsx
+++ b/src/app/ideas/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function IdeasError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · IDEAS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/lobsters/error.tsx
+++ b/src/app/lobsters/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function LobstersError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · LOBSTERS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/mcp/[slug]/error.tsx
+++ b/src/app/mcp/[slug]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function McpSlugError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · MCP/[SLUG]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/mcp/error.tsx
+++ b/src/app/mcp/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function McpError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · MCP"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/model-usage/error.tsx
+++ b/src/app/model-usage/error.tsx
@@ -1,51 +1,22 @@
 "use client";
 
-// Route-segment error boundary for /model-usage.
-//
-// We deliberately keep this minimal — admin-only surface, internal users,
-// raw error text is fine and helpful when something blows up in the
-// aggregator pipeline.
-
 import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ModelUsageError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
-    console.error("[model-usage] render error", error);
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <main style={{ padding: 32, fontFamily: "ui-monospace, monospace", fontSize: 13 }}>
-      <h1 style={{ fontSize: 18, marginBottom: 8 }}>Model usage failed to render</h1>
-      <pre style={{ whiteSpace: "pre-wrap", color: "var(--color-text-secondary, #8b9097)" }}>
-        {error.message}
-        {error.digest ? `\n\ndigest: ${error.digest}` : null}
-      </pre>
-      <button
-        type="button"
-        onClick={() => reset()}
-        style={{
-          marginTop: 16,
-          padding: "8px 14px",
-          border: "1px solid var(--color-border-subtle, #1f2329)",
-          background: "transparent",
-          color: "var(--color-text-default, #eef0f2)",
-          fontFamily: "inherit",
-          fontSize: 12,
-          textTransform: "uppercase",
-          letterSpacing: 0.4,
-          cursor: "pointer",
-        }}
-      >
-        Try again
-      </button>
-    </main>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/npm/error.tsx
+++ b/src/app/npm/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function NpmError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · NPM"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/papers/error.tsx
+++ b/src/app/papers/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function PapersError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · PAPERS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/portal/docs/error.tsx
+++ b/src/app/portal/docs/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function PortalDocsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · PORTAL/DOCS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/pricing/error.tsx
+++ b/src/app/pricing/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function PricingError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · PRICING"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/producthunt/error.tsx
+++ b/src/app/producthunt/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ProducthuntError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · PRODUCTHUNT"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/reddit/error.tsx
+++ b/src/app/reddit/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function RedditError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · REDDIT"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/reddit/trending/error.tsx
+++ b/src/app/reddit/trending/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function RedditTrendingError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · REDDIT/TRENDING"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/repo/[owner]/[name]/error.tsx
+++ b/src/app/repo/[owner]/[name]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function RepoProfileError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · REPO/[OWNER]/[NAME]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/repo/[owner]/[name]/star-activity/error.tsx
+++ b/src/app/repo/[owner]/[name]/star-activity/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function StarActivityError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · REPO/STAR-ACTIVITY"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/research/error.tsx
+++ b/src/app/research/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ResearchError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · RESEARCH"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/revenue/error.tsx
+++ b/src/app/revenue/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function RevenueError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · REVENUE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/s/[shortId]/error.tsx
+++ b/src/app/s/[shortId]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ShortLinkError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · S/[SHORTID]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/search/error.tsx
+++ b/src/app/search/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function SearchError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · SEARCH"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/signals/error.tsx
+++ b/src/app/signals/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function SignalsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · SIGNALS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/skills/[slug]/error.tsx
+++ b/src/app/skills/[slug]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function SkillsSlugError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · SKILLS/[SLUG]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/skills/error.tsx
+++ b/src/app/skills/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function SkillsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · SKILLS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/submit/error.tsx
+++ b/src/app/submit/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function SubmitError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · SUBMIT"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/submit/revenue/error.tsx
+++ b/src/app/submit/revenue/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function SubmitRevenueError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · SUBMIT/REVENUE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/tierlist/[shortId]/error.tsx
+++ b/src/app/tierlist/[shortId]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function TierlistShortError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TIERLIST/[SHORTID]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/tierlist/error.tsx
+++ b/src/app/tierlist/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function TierlistError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TIERLIST"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/tools/error.tsx
+++ b/src/app/tools/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ToolsError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TOOLS"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/tools/revenue-estimate/error.tsx
+++ b/src/app/tools/revenue-estimate/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ToolsRevenueEstimateError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TOOLS/REVENUE-ESTIMATE"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/tools/star-history/error.tsx
+++ b/src/app/tools/star-history/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ToolsStarHistoryError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TOOLS/STAR-HISTORY"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/tools/treemap/error.tsx
+++ b/src/app/tools/treemap/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function ToolsTreemapError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TOOLS/TREEMAP"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/top/error.tsx
+++ b/src/app/top/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function TopError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TOP"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/top10/[date]/error.tsx
+++ b/src/app/top10/[date]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function Top10DateError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TOP10/[DATE]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/top10/error.tsx
+++ b/src/app/top10/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function Top10Error({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · TOP10"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/u/[handle]/error.tsx
+++ b/src/app/u/[handle]/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function UserHandleError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · U/[HANDLE]"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/watchlist/error.tsx
+++ b/src/app/watchlist/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function WatchlistError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · WATCHLIST"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }

--- a/src/app/you/error.tsx
+++ b/src/app/you/error.tsx
@@ -1,72 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { RefreshCw, Home } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function YouError({ error, reset }: ErrorProps) {
+export default function RouteError({ error, reset }: ErrorProps) {
   useEffect(() => {
-    void import("@sentry/nextjs").then((Sentry) => {
-      Sentry.captureException(error);
-    });
+    if (typeof window !== "undefined") {
+      const sentry = (
+        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
+      ).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
   }, [error]);
 
-  return (
-    <div className="max-w-[640px] mx-auto px-4 md:px-6 py-16 md:py-24 text-center">
-      <p
-        className="v2-mono mb-3"
-        style={{ fontSize: 11, color: "var(--v4-red)" }}
-      >
-        {"// ERROR · YOU"}
-      </p>
-      <h1
-        style={{
-          fontFamily: "var(--font-geist), Inter, sans-serif",
-          fontSize: "clamp(24px, 3.5vw, 32px)",
-          fontWeight: 510,
-          letterSpacing: "-0.022em",
-          color: "var(--v4-ink-000)",
-          lineHeight: 1.1,
-          marginBottom: 12,
-        }}
-      >
-        Something went wrong.
-      </h1>
-      <p
-        className="leading-relaxed mb-5"
-        style={{ fontSize: 14, color: "var(--v4-ink-300)" }}
-      >
-        This surface failed to render. Try again, or head home if it keeps erroring.
-      </p>
-      {error.digest && (
-        <p
-          className="v2-mono mb-5"
-          style={{ fontSize: 11, color: "var(--v4-ink-400)" }}
-        >
-          {"// DIGEST: "}
-          <span style={{ color: "var(--v4-ink-300)" }}>{error.digest}</span>
-        </p>
-      )}
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <button
-          type="button"
-          onClick={reset}
-          className={cn("v2-btn v2-btn-primary inline-flex")}
-        >
-          <RefreshCw className="h-4 w-4" style={{ marginRight: 8 }} />
-          TRY AGAIN
-        </button>
-        <Link href="/" className="v2-btn v2-btn-ghost inline-flex">
-          <Home className="h-4 w-4" style={{ marginRight: 8 }} />
-          BACK TO HOME
-        </Link>
-      </div>
-    </div>
-  );
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
 }


### PR DESCRIPTION
## Summary

Collapses 74 route `error.tsx` files onto the shared `<ErrorPanel>` component and the canonical `window.Sentry` feature-detect pattern. Net: **666 insertions, 4331 deletions** across 74 files (~3.7 kLOC removed).

After #1540 wired Sentry capture into every route boundary, all 74 non-twitter route `error.tsx` files still carried ~50 lines of duplicated inline v2-mono JSX (header, digest line, two buttons). The root `src/app/error.tsx` had already moved to `<ErrorPanel>` with a `window.Sentry` feature-detect, and #1528 set the same precedent for `/twitter` via the shared `TwitterEmptyState` pattern.

## Canonical template

\`\`\`tsx
\"use client\";

import { useEffect } from \"react\";
import { ErrorPanel } from \"@/components/ui/ErrorPanel\";

interface ErrorProps {
  error: Error & { digest?: string };
  reset: () => void;
}

export default function RouteError({ error, reset }: ErrorProps) {
  useEffect(() => {
    if (typeof window !== \"undefined\") {
      const sentry = (
        window as unknown as { Sentry?: { captureException: (e: Error) => void } }
      ).Sentry;
      if (sentry?.captureException) sentry.captureException(error);
    }
  }, [error]);

  return <ErrorPanel error={error} reset={reset} variant=\"default\" />;
}
\`\`\`

## Excluded by design

- `src/app/error.tsx` — already canonical
- `src/app/global-error.tsx` — root `<html><body>` shell, different concern
- `src/app/brief/[owner]/[name]/error.tsx` — no Sentry capture wanted (minimal retry UI)
- `src/app/twitter/**` — handled in #1528

## Design rationale

- **Single source of truth** for error UX (`ErrorPanel`): branded `AlertOctagon`, refresh / home / report-bug actions, prod-vs-dev stack reveal, deep-link to GitHub issue with pre-filled digest.
- **Feature-detect instead of dynamic-import.** `void import(\"@sentry/nextjs\").then(...)` would pull a fresh SDK reference inside the error boundary; the `window.Sentry` accessor reuses the global init that's already running.
- **No behavior loss.** Sentry capture continues to fire via the `@sentry/nextjs` Next.js plugin which exposes `window.Sentry` at boot.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Trigger a deliberate render error on at least 3 surfaces (e.g. `/repo/[owner]/[name]`, `/admin`, `/funding`) and confirm `<ErrorPanel>` renders with refresh button, digest line, report-bug link
- [ ] Check Sentry dashboard for capture on a preview deploy after triggering an error
- [ ] Visual diff between preview and prod on `/admin/error` and `/funding/error` (intentional throw)

Refs: #1540 (Sentry rollout), #1528 (twitter precedent).