### PR TITLE
feat(og): add dynamic OG endpoints + metadata for /mcp /devto /reddit /signals /agent-commerce

### DIFF
--- a/src/app/agent-commerce/page.tsx
+++ b/src/app/agent-commerce/page.tsx
@@ -58,11 +58,25 @@ import type {
 export const revalidate = 1200;
 
 export const metadata: Metadata = {
-  title: "TrendingRepo · Agent Commerce",
+  title: "Agent Commerce — TrendingRepo",
   description:
-    "x402 services, agent wallets, MCP servers, agent-callable APIs and marketplaces. The DefiLlama for the M2M economy.",
-  alternates: { canonical: "/agent-commerce" },
-  robots: { index: false, follow: true },
+    "Live x402 on-chain + AI agent commerce activity — Base, Solana, Dune protocols ranked by 24h volume.",
+  alternates: { canonical: "https://trendingrepo.com/agent-commerce" },
+  openGraph: {
+    title: "Agent Commerce — TrendingRepo",
+    description:
+      "Live x402 on-chain + AI agent commerce activity — Base, Solana, Dune protocols ranked by 24h volume.",
+    url: "https://trendingrepo.com/agent-commerce",
+    type: "website",
+    images: [{ url: "/api/og/agent-commerce", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Agent Commerce — TrendingRepo",
+    description: "Live x402 on-chain + AI agent commerce activity.",
+    images: ["/api/og/agent-commerce"],
+  },
+  robots: { index: true, follow: true },
 };
 
 interface PageProps {

--- a/src/app/api/og/agent-commerce/route.tsx
+++ b/src/app/api/og/agent-commerce/route.tsx
@@ -1,0 +1,52 @@
+// GET /api/og/agent-commerce — Branded share card for /agent-commerce.
+//
+// Static headline composition (no data-driven rows) — the goal is a
+// consistent unfurl, not a live snapshot. Mirrors the simpler tier-list
+// fallback pattern: brand wordmark + headline + subline + accent strip.
+
+import { ImageResponse } from "next/og";
+
+import { AccentStrip, CardFrame, Wordmark } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            Agent Commerce
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            On-chain x402 + AI agent commerce trackers — Base, Solana, Dune protocols ranked by 24h volume.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { width: 1200, height: 630, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/api/og/devto/route.tsx
+++ b/src/app/api/og/devto/route.tsx
@@ -1,0 +1,52 @@
+// GET /api/og/devto — Branded share card for the /devto trending surface.
+//
+// Static headline composition (no data-driven rows) — the goal is a
+// consistent unfurl, not a live snapshot. Mirrors the simpler tier-list
+// fallback pattern: brand wordmark + headline + subline + accent strip.
+
+import { ImageResponse } from "next/og";
+
+import { AccentStrip, CardFrame, Wordmark } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            dev.to trending
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            What developers are reading, writing, and shipping right now — ranked by engagement velocity.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { width: 1200, height: 630, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/api/og/mcp/route.tsx
+++ b/src/app/api/og/mcp/route.tsx
@@ -1,0 +1,52 @@
+// GET /api/og/mcp — Branded share card for the /mcp leaderboard.
+//
+// Static headline composition (no data-driven rows) — the goal is a
+// consistent unfurl, not a live snapshot. Mirrors the simpler tier-list
+// fallback pattern: brand wordmark + headline + subline + accent strip.
+
+import { ImageResponse } from "next/og";
+
+import { AccentStrip, CardFrame, Wordmark } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            MCP Server Leaderboard
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            Live MCP server discovery — ranked by adoption signals across Anthropic, Smithery, MCP Hub, and direct registration.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { width: 1200, height: 630, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/api/og/reddit/route.tsx
+++ b/src/app/api/og/reddit/route.tsx
@@ -1,0 +1,52 @@
+// GET /api/og/reddit — Branded share card for the /reddit trending surface.
+//
+// Static headline composition (no data-driven rows) — the goal is a
+// consistent unfurl, not a live snapshot. Mirrors the simpler tier-list
+// fallback pattern: brand wordmark + headline + subline + accent strip.
+
+import { ImageResponse } from "next/og";
+
+import { AccentStrip, CardFrame, Wordmark } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            Reddit trending
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            Top developer + AI subreddits: r/programming, r/MachineLearning, r/LocalLLaMA, r/aiagents — ranked by engagement.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { width: 1200, height: 630, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/api/og/signals/route.tsx
+++ b/src/app/api/og/signals/route.tsx
@@ -1,0 +1,52 @@
+// GET /api/og/signals — Branded share card for the /signals newsroom.
+//
+// Static headline composition (no data-driven rows) — the goal is a
+// consistent unfurl, not a live snapshot. Mirrors the simpler tier-list
+// fallback pattern: brand wordmark + headline + subline + accent strip.
+
+import { ImageResponse } from "next/og";
+
+import { AccentStrip, CardFrame, Wordmark } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <CardFrame>
+        <Wordmark />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            marginTop: 48,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: OG_COLORS.textPrimary,
+              lineHeight: 1.05,
+            }}
+          >
+            Cross-source signals
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: OG_COLORS.textTertiary,
+              maxWidth: 920,
+            }}
+          >
+            Eight-source live signal terminal — Hacker News, X, Reddit, Bluesky, dev.to, Claude RSS, OpenAI RSS, GitHub.
+          </div>
+        </div>
+        <AccentStrip />
+      </CardFrame>
+    ),
+    { width: 1200, height: 630, headers: OG_CACHE_HEADERS },
+  );
+}

--- a/src/app/devto/page.tsx
+++ b/src/app/devto/page.tsx
@@ -59,11 +59,13 @@ export const metadata: Metadata = {
     description: "Top developer-written articles by velocity, plus mentioned repos.",
     url: "/devto",
     type: "website",
+    images: [{ url: "/api/og/devto", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Trending on Dev.to — TrendingRepo",
     description: "Top developer-written articles by velocity, plus mentioned repos.",
+    images: ["/api/og/devto"],
   },
 };
 

--- a/src/app/mcp/page.tsx
+++ b/src/app/mcp/page.tsx
@@ -44,6 +44,12 @@ export const metadata: Metadata = {
     description:
       "A live leaderboard for Model Context Protocol servers across MCP registries.",
     url: absoluteUrl("/mcp"),
+    type: "website",
+    images: [{ url: "/api/og/mcp", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: ["/api/og/mcp"],
   },
 };
 

--- a/src/app/reddit/page.tsx
+++ b/src/app/reddit/page.tsx
@@ -33,11 +33,13 @@ export const metadata: Metadata = {
     description: "GitHub repos breaking out across the tech subreddits, live-scored.",
     url: "/reddit",
     type: "website",
+    images: [{ url: "/api/og/reddit", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Repos Trending on Reddit — TrendingRepo",
     description: "GitHub repos breaking out across the tech subreddits, live-scored.",
+    images: ["/api/og/reddit"],
   },
 };
 

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -126,11 +126,13 @@ export const metadata: Metadata = {
     description: "Eight-source live signal terminal with volume, consensus, and tag-momentum.",
     url: "/signals",
     type: "website",
+    images: [{ url: "/api/og/signals", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Signals — Cross-Source Newsroom — TrendingRepo",
     description: "Eight-source live signal terminal with volume, consensus, and tag-momentum.",
+    images: ["/api/og/signals"],
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds 5 new branded OG share-card endpoints under `/api/og/` for the data-heavy routes: `/mcp`, `/devto`, `/reddit`, `/signals`, `/agent-commerce`.
- Each endpoint renders a simple wordmark + headline + subline + accent strip using the shared `CardFrame`/`Wordmark`/`AccentStrip` primitives (mirrors the tier-list fallback composition — consistent unfurl, no per-request data fetch).
- Wires each consuming page's metadata to point `openGraph.images` + `twitter.images` at its new endpoint.
- For `/agent-commerce` specifically: replaces the prior minimal noindex metadata with a full export (title, description, canonical, openGraph, twitter, robots: index) — W0.D follow-up baked in.

## Files
- `src/app/api/og/mcp/route.tsx` (new)
- `src/app/api/og/devto/route.tsx` (new)
- `src/app/api/og/reddit/route.tsx` (new)
- `src/app/api/og/signals/route.tsx` (new)
- `src/app/api/og/agent-commerce/route.tsx` (new)
- `src/app/mcp/page.tsx` (metadata)
- `src/app/devto/page.tsx` (metadata)
- `src/app/reddit/page.tsx` (metadata)
- `src/app/signals/page.tsx` (metadata)
- `src/app/agent-commerce/page.tsx` (full metadata rewrite)

## Test plan
- [x] `npm run typecheck` — clean
- [ ] Visual: hit `/api/og/mcp`, `/api/og/devto`, `/api/og/reddit`, `/api/og/signals`, `/api/og/agent-commerce` on the Vercel preview — each renders a 1200x630 PNG with the correct headline + subline.
- [ ] Curl `/mcp`, `/devto`, `/reddit`, `/signals`, `/agent-commerce` HTML on preview — confirm `<meta property="og:image">` + `<meta name="twitter:image">` resolve to the new endpoint URLs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)