### PR TITLE
fix(twitter): reorder nitter instances + add concurrency group to collector

### DIFF
--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -29,6 +29,15 @@ permissions:
   contents: write
   pull-requests: write
 
+# Prevent duplicate concurrent runs from cancelling earlier successful ones.
+# cancel-in-progress: false preserves the older run (which may already be
+# committing data) and queues/cancels the newer trigger. Wired 2026-05-17
+# per session-G W1.B Twitter diagnosis: concurrent dispatches were stomping
+# on each other and reducing usable runs.
+concurrency:
+  group: collect-twitter-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   collect:
     runs-on: ubuntu-latest

--- a/config/nitter-instances.json
+++ b/config/nitter-instances.json
@@ -6,6 +6,16 @@
       "status": "healthy"
     },
     {
+      "url": "https://nitter.adminforge.de",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "healthy"
+    },
+    {
+      "url": "https://nt.vern.cc",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "healthy"
+    },
+    {
       "url": "https://nitter.privacydev.net",
       "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
@@ -26,11 +36,6 @@
       "status": "dead"
     },
     {
-      "url": "https://xcancel.com",
-      "lastChecked": "2026-05-16T06:15:40.782Z",
-      "status": "healthy"
-    },
-    {
       "url": "https://nitter.privacy.com.de",
       "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
@@ -41,19 +46,9 @@
       "status": "dead"
     },
     {
-      "url": "https://nitter.adminforge.de",
-      "lastChecked": "2026-05-16T06:15:40.782Z",
-      "status": "healthy"
-    },
-    {
       "url": "https://nitter.platypush.tech",
       "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
-    },
-    {
-      "url": "https://nt.vern.cc",
-      "lastChecked": "2026-05-16T06:15:40.782Z",
-      "status": "healthy"
     },
     {
       "url": "https://nitter.fdn.fr",
@@ -64,6 +59,11 @@
       "url": "https://nitter.kavin.rocks",
       "lastChecked": "2026-05-16T06:15:40.782Z",
       "status": "dead"
+    },
+    {
+      "url": "https://xcancel.com",
+      "lastChecked": "2026-05-16T06:15:40.782Z",
+      "status": "healthy"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two surgical fixes for session-G W1.B Twitter diagnosis:

- **`config/nitter-instances.json`** — promote 3 healthy instances (`nitter.net`, `nitter.adminforge.de`, `nt.vern.cc`) to the top of the array, demote `xcancel.com` to last. `xcancel.com` is marked `healthy` in the file but the operator's live probe shows 403-blocked, so we deprioritize. **Pure reorder — no URL changes, no field changes.**
- **`.github/workflows/collect-twitter.yml`** — add a top-level `concurrency:` group (`collect-twitter-${{ github.ref }}`) with `cancel-in-progress: false`. Prevents concurrent dispatches from cancelling an earlier run that may be mid-commit. Older run wins; newer trigger queues/cancels itself.

## Before / After

Nitter instance order (first 4):
```
BEFORE: nitter.net, nitter.privacydev.net (dead), nitter.poast.org (dead), nitter.cz (dead)
AFTER:  nitter.net, nitter.adminforge.de,         nt.vern.cc,             nitter.privacydev.net (dead)
```

Last position: `xcancel.com` (operator reports 403).

Workflow concurrency:
```
BEFORE: (no concurrency block; default is per-run, last-write-wins)
AFTER:  group: collect-twitter-${{ github.ref }}, cancel-in-progress: false
```

## Validation

- `node -e "require('./config/nitter-instances.json')"` parses; 13 instances, `nitter.net` first, `xcancel.com` last.
- `js-yaml` parses the workflow; `concurrency.group=collect-twitter-\${{ github.ref }}`, `cancel-in-progress=false`.
- No code paths changed — collector script reads from the same file in the same order, just hits the healthy hosts first.

## Test plan

- [ ] Manual `workflow_dispatch` of `collect-twitter.yml` with concurrency group present, then dispatch a second run while the first is mid-step — second should queue, first should complete.
- [ ] Confirm next scheduled run logs hit `nitter.net` first (and skip dead hosts faster on average).
- [ ] If `xcancel.com` is confirmed permanently 403 by `check-nitter.yml`, follow-up to mark it `status: dead` and trim.