### PR TITLE
feat(seo): trim /signals + /githubrepo descriptions to <160 chars (JSON-LD already shipped)

### DIFF
--- a/src/app/githubrepo/page.tsx
+++ b/src/app/githubrepo/page.tsx
@@ -72,7 +72,7 @@ export const revalidate = 60;
 const PAGE_PATH = "/githubrepo";
 const PAGE_TITLE = "Top 50 trending GitHub repos — live";
 const PAGE_DESCRIPTION =
-  "Live momentum-ranked list of the top 50 trending GitHub repositories with cross-source mention chips (Hacker News, Reddit, Bluesky, dev.to, Lobsters, npm, Hugging Face, arXiv, X). Refreshes every minute.";
+  "Live momentum-ranked top 50 trending GitHub repos with cross-source mention chips: Hacker News, Reddit, Bluesky, dev.to, npm, Hugging Face, arXiv, X.";
 const PAGE_OG_TITLE = `${PAGE_TITLE} — ${SITE_NAME}`;
 
 export const metadata: Metadata = {

--- a/src/app/signals/page.tsx
+++ b/src/app/signals/page.tsx
@@ -119,7 +119,7 @@ export const revalidate = 1800;
 export const metadata: Metadata = {
   title: "Signals — Cross-Source Newsroom",
   description:
-    "Eight-source live signal terminal: Hacker News, GitHub, X, Reddit, Bluesky, Dev.to, Claude RSS, OpenAI RSS — plus volume, consensus stories, and tag-momentum.",
+    "Eight-source live signal terminal: Hacker News, GitHub, X, Reddit, Bluesky, Dev.to, Claude RSS, OpenAI RSS — plus volume and consensus stories.",
   alternates: { canonical: "/signals" },
   openGraph: {
     title: "Signals — Cross-Source Newsroom — TrendingRepo",


### PR DESCRIPTION
## Summary

W0.D flagged two meta descriptions overshooting Google's 160-char SERP truncation threshold:

- **`/signals`**: 162 -> **143** chars (dropped ", and tag-momentum" tail)
- **`/githubrepo`**: 203 -> **149** chars (dropped "Refreshes every minute." tail + tightened framing, removed less-relevant "Lobsters" chip from preview)

Both now sit comfortably under the 160-char SERP snippet line.

## JSON-LD scope note (no-op half)

The task also asked to add `<script type=\"application/ld+json\">` JSON-LD to `/repo/[owner]/[name]`. Verification against `src/app/repo/[owner]/[name]/page.tsx:384-407` shows this surface **already emits a richer schema graph** via `buildRepoPageSchemas` in `src/lib/seo-repo-schemas.ts`:

- `SoftwareSourceCode` (with codeRepository, programmingLanguage, license, dateModified, dateCreated, keywords)
- `SoftwareApplication` (with applicationCategory, offers, sameAs)
- `BreadcrumbList` (Home > {owner} > {name})
- `AggregateRating` (when momentum + stars present; 0-100 -> 1-5 scale)

All anchored to global `#organization` + `#website` entities. Adding the simpler proposed `SoftwareSourceCode` template on top would create a duplicate `@type` and dilute Google's rich-snippet signal. JSON-LD half = no-op against current main.

## Test plan

- [x] `npm run typecheck` clean
- [x] Char counts verified: signals=143, githubrepo=149 (both < 160)
- [ ] Post-merge: re-run W0.D to confirm both surfaces drop off the overshoot list
- [ ] Post-merge: Vercel Preview SERP-snippet probe (optional)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>