### PR TITLE
fix(security): gate error.message in Report-bug URL behind isProd (W2.C MEDIUM)

### DIFF
--- a/src/components/ui/ErrorPanel.tsx
+++ b/src/components/ui/ErrorPanel.tsx
@@ -30,11 +30,13 @@ export function ErrorPanel({
   const isProd = process.env.NODE_ENV === "production";
   const isCompact = variant === "compact";
   const issueTitle = "Error: " + (digest ?? "unknown");
-  const issueBody =
-    "Error digest: " +
-    (digest ?? "n/a") +
-    "\nMessage: " +
-    (error.message ?? "(no message)");
+  const issueBody = [
+    "Error digest: " + (digest ?? "n/a"),
+    !isProd && error.message ? "\nMessage: " + error.message : "",
+    !isProd && error.stack ? "\nStack:\n" + error.stack : "",
+  ]
+    .filter(Boolean)
+    .join("");
   const issueHref =
     "https://github.com/0motionguy/starscreener/issues/new?title=" +
     encodeURIComponent(issueTitle) +


### PR DESCRIPTION
## Summary

Fixes W2.C MEDIUM security finding from the session-G audit.

`src/components/ui/ErrorPanel.tsx` previously embedded `error.message` unconditionally in the GitHub issue body URL on the Report-bug button. In production this leaked server-side error details (DB column names, internal paths, potential PII) to clients via the visible deep-link URL on every error page.

The component already gated `<pre>` rendering of the stack/message behind `!isProd` (line 75). This change applies the same gate to the URL `issueBody` construction.

## Behavior

| Env | Before | After |
| --- | --- | --- |
| prod | digest + full `error.message` in URL | digest only |
| dev/staging | digest + `error.message` in URL | digest + `error.message` + `error.stack` in URL |

## Diff

```diff
-  const issueBody =
-    "Error digest: " +
-    (digest ?? "n/a") +
-    "\nMessage: " +
-    (error.message ?? "(no message)");
+  const issueBody = [
+    "Error digest: " + (digest ?? "n/a"),
+    !isProd && error.message ? "\nMessage: " + error.message : "",
+    !isProd && error.stack ? "\nStack:\n" + error.stack : "",
+  ]
+    .filter(Boolean)
+    .join("");
```

## Test plan
- [x] `npm run typecheck` clean
- [ ] Verify prod build: open `/` while throwing in a route, click Report-bug, confirm URL body contains only `Error digest: <hash>`
- [ ] Verify dev build: same flow, confirm URL body still has full message + stack pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)