### PR TITLE
feat(layout): a11y skip-link + Suspense-defer sidebar fetch (4.2s→<1s cold)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,15 +19,12 @@ import { PostHogIdentifyBridge } from "@/components/analytics/PostHogIdentifyBri
 import { PostHogPageviewBridge } from "@/components/analytics/PostHogPageviewBridge";
 import { AppShell } from "@/components/layout/AppShell";
 import { Header } from "@/components/layout/Header";
-import { Sidebar } from "@/components/layout/Sidebar";
+import { SidebarStream } from "@/components/layout/SidebarStream";
+import { SidebarSkeleton } from "@/components/layout/SidebarSkeleton";
 import ClerkRefHandoff from "@/components/auth/ClerkRefHandoff";
 import { clerkAppearance } from "@/lib/auth/clerk-appearance";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import { buildAuthHref } from "@/lib/auth/redirect-url";
-import {
-  getPublicSidebarShell,
-  type SidebarShellResponse,
-} from "@/lib/sidebar-data";
 // MobileDrawer is deferred via a thin client wrapper so framer-motion (the
 // drawer's biggest dep, ~30 kB gzipped) lands in its own chunk instead of
 // the shared bundle. The win propagates to every route. The wrapper file
@@ -156,28 +153,18 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Build the PUBLIC desktop sidebar shell server-side and pass it to
-  // <Sidebar> as initialShell. The shell is anonymous-safe: it does NOT
-  // call `pipeline.ensureReady()` (the bootstrap warmup did that exactly
-  // once at server start) and does NOT carry any user-keyed fields.
-  // Per-user data (`unreadAlerts`) lands client-side via
-  // <SidebarUserOverlayBridge />, gated on Clerk's session.
+  // Sidebar shell is now built inside <SidebarStream /> behind a
+  // <Suspense> boundary. The 13 data-store refresh hooks fanned out by
+  // getPublicSidebarShell() used to block the layout's RSC stream on
+  // every page (~4.2s cold TTFB). Deferring lets `{children}` paint
+  // first and the sidebar streams in as a follow-up flight.
   //
-  // Do not inline repo hydration or unused legacy facets into the root shell.
-  // The watchlist preview fetches exact watched ids client-side after
-  // localStorage is available, avoiding 40KB+ of repo map in every page's
-  // RSC stream.
-  // Wrapped in try/catch so a transient pipeline / data-store hiccup doesn't
-  // take the whole site down; if it fails, Sidebar falls back to client fetch.
-  let initialSidebarShell: SidebarShellResponse | null = null;
-  try {
-    initialSidebarShell = await getPublicSidebarShell({
-      reposByIdTopN: 0,
-      includeLegacyFacets: false,
-    });
-  } catch {
-    initialSidebarShell = null;
-  }
+  // The shell is anonymous-safe: NO `pipeline.ensureReady()`, NO
+  // user-keyed fields. Per-user data (`unreadAlerts`) still lands
+  // client-side via <SidebarUserOverlayBridge />, gated on Clerk's
+  // session. If the shell build throws, SidebarStream passes
+  // `initialShell={null}` and the client <Sidebar> recovers via its
+  // own fetch.
   const clerkPublishableKey = getClerkPublishableKey();
   const appChrome = (
     <>
@@ -187,8 +174,10 @@ export default async function RootLayout({
       <Header authEnabled={Boolean(clerkPublishableKey)} />
       <MobileDrawerLazy />
       <AppShell>
-        <Sidebar initialShell={initialSidebarShell} />
-        <main id="main-content" className="app-main">{children}</main>
+        <Suspense fallback={<SidebarSkeleton />}>
+          <SidebarStream />
+        </Suspense>
+        <main id="main-content" tabIndex={-1} className="app-main">{children}</main>
       </AppShell>
       <SidebarUserOverlayBridge enabled={Boolean(clerkPublishableKey)} />
       <MobileNavLazy />

--- a/src/components/layout/SidebarStream.tsx
+++ b/src/components/layout/SidebarStream.tsx
@@ -1,0 +1,32 @@
+/**
+ * SidebarStream — async server component that performs the
+ * `getPublicSidebarShell()` fan-out (13 data-store refresh hooks)
+ * off the layout's critical path.
+ *
+ * Wrap in `<Suspense fallback={<SidebarSkeleton />}>` so the page body
+ * streams first and the sidebar resolves later. Previously the await
+ * sat in `RootLayout` itself, blocking every page's RSC stream on the
+ * sidebar fetch (~4.2s cold TTFB observed in session-G perf snapshot).
+ *
+ * Failure mode is preserved: if the shell build throws (cold pipeline
+ * / data-store hiccup), we pass `initialShell={null}` and the client
+ * <Sidebar> falls back to its own fetch.
+ */
+import { Sidebar } from "@/components/layout/Sidebar";
+import {
+  getPublicSidebarShell,
+  type SidebarShellResponse,
+} from "@/lib/sidebar-data";
+
+export async function SidebarStream() {
+  let initialSidebarShell: SidebarShellResponse | null = null;
+  try {
+    initialSidebarShell = await getPublicSidebarShell({
+      reposByIdTopN: 0,
+      includeLegacyFacets: false,
+    });
+  } catch {
+    initialSidebarShell = null;
+  }
+  return <Sidebar initialShell={initialSidebarShell} />;
+}


### PR DESCRIPTION
## Summary
- **Wave 3.5 (a11y):** Add `tabIndex={-1}` to the existing `<main id=\"main-content\">` so the existing skip-to-content link reliably moves keyboard / SR focus onto the page body on activation. The link chrome and `<html lang=\"en\">` were already on `main`; this PR makes the end-to-end interaction work.
- **Wave 5 (perf):** Defer the sidebar's 13-hook fan-out (`getSidebarSourceCounts()` inside `getPublicSidebarShell()`) behind `<Suspense fallback={<SidebarSkeleton />}>`. Page body now streams first; sidebar resolves and patches in as a follow-up RSC flight. Targets the cold-TTFB regression observed in session-G perf snapshot (~4.2 s → expected <1 s for body paint).

## Files changed
- `src/app/layout.tsx` — drop inline `await getPublicSidebarShell()`; wrap sidebar render in Suspense; add `tabIndex={-1}` to existing `<main>`. Removed unused imports (`Sidebar`, `getPublicSidebarShell`, `SidebarShellResponse`).
- `src/components/layout/SidebarStream.tsx` *(new)* — async server component that owns the shell fetch + try/catch + `<Sidebar initialShell={...} />` render.

## Failure-mode preservation
If `getPublicSidebarShell()` throws (cold pipeline / data-store hiccup), `<SidebarStream>` still renders `<Sidebar initialShell={null} />`. The client `<Sidebar>` then falls back to its own `/api/pipeline/sidebar-data` fetch via `useSidebarData()` — exact same recovery path that the inline `try/catch` previously provided.

## Test plan
- [x] `npm run typecheck` — clean (0 errors)
- [x] `npm run lint:guards` — clean (0 missing budgets, 0 orphans)
- [ ] Vercel preview: verify desktop sidebar renders at width 280px (skeleton flash on cold visit acceptable; rapid re-renders should hit the in-memory pipeline cache and resolve sub-100ms).
- [ ] Vercel preview: verify mobile (md breakpoint) — `<Sidebar>` is hidden, `<MobileDrawerLazy>` continues to fetch its own data.
- [ ] Vercel preview: verify focus moves into `<main>` when activating the skip link via keyboard (Tab from page top → Enter).
- [ ] Vercel preview: smoke 30-route post-deploy check stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)