### PR TITLE
fix(security): rate-limit + TTL on public mutating endpoints (W5.5 HIGH x2)

### DIFF
--- a/src/app/api/compare/share/route.ts
+++ b/src/app/api/compare/share/route.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 
 import { parseBody } from "@/lib/api/parse-body";
 import { errorEnvelope } from "@/lib/api/error-response";
+import { checkRateLimitAsync } from "@/lib/api/rate-limit";
 import { generateShortId } from "@/lib/compare/short-id";
 import { getDataStore } from "@/lib/data-store";
 import { absoluteUrl } from "@/lib/seo";
@@ -21,6 +22,11 @@ export const dynamic = "force-dynamic";
 
 const SHORT_ID_RETRY_LIMIT = 5;
 const COMPARE_SHARE_KEY_PREFIX = "compare-share";
+const SHARES_PER_HOUR = 30;
+const HOUR_MS = 60 * 60 * 1000;
+// 90-day TTL on each share record — long enough for legitimate share use,
+// short enough to bound storage growth from anonymous writes (W5.5 HIGH).
+const COMPARE_SHARE_TTL_SECONDS = 90 * 24 * 60 * 60;
 
 const FULL_NAME_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 
@@ -49,6 +55,30 @@ function compareShareKey(shortId: string): string {
 }
 
 export async function POST(request: Request) {
+  // Rate-limit anonymous shares per-IP so a bot can't fill the namespace.
+  // (W5.5 HIGH — unauth + no rate-limit + no TTL → storage exhaustion.)
+  const limit = await checkRateLimitAsync(request, {
+    windowMs: HOUR_MS,
+    maxRequests: SHARES_PER_HOUR,
+  });
+  if (!limit.allowed) {
+    return NextResponse.json(
+      errorEnvelope(
+        `rate limit exceeded — try again in ${Math.ceil(
+          limit.retryAfterMs / 1000,
+        )}s`,
+        "RATE_LIMITED",
+      ),
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(Math.ceil(limit.retryAfterMs / 1000)),
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
   const parsed = await parseBody(request, compareShareSchema);
   if (!parsed.ok) return parsed.response;
 
@@ -69,7 +99,9 @@ export async function POST(request: Request) {
         createdAt: now,
       };
 
-      await store.write(compareShareKey(shortId), payload);
+      await store.write(compareShareKey(shortId), payload, {
+        ttlSeconds: COMPARE_SHARE_TTL_SECONDS,
+      });
 
       return NextResponse.json(
         {

--- a/src/app/api/repo-submissions/route.ts
+++ b/src/app/api/repo-submissions/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { verifyCronAuth } from "@/lib/api/auth";
 import { parseBody } from "@/lib/api/parse-body";
+import { checkRateLimitAsync } from "@/lib/api/rate-limit";
 import { readEnv } from "@/lib/env-helpers";
 import { runRepoIntakeForSubmission } from "@/lib/repo-intake";
 import {
@@ -22,6 +23,12 @@ export const runtime = "nodejs";
 // allow-list, repo normalization) lives in validateRepoSubmissionInput
 // because it composes URL parsing helpers used by other call sites.
 const RepoSubmissionsPostSchema = z.record(z.string(), z.unknown());
+
+// Rate-limit anonymous submissions: each accepted POST can trigger a
+// background GitHub intake job, so the budget is tighter than a pure-write
+// endpoint. (W5.5 HIGH — unauth + no rate-limit + GitHub-API burn.)
+const SUBMISSIONS_PER_HOUR = 10;
+const HOUR_MS = 60 * 60 * 1000;
 
 interface RepoSubmissionsListResponse {
   ok: true;
@@ -64,6 +71,24 @@ export async function POST(
 ): Promise<
   NextResponse<RepoSubmissionsCreateResponse | RepoSubmissionsErrorResponse>
 > {
+  const limit = await checkRateLimitAsync(request, {
+    windowMs: HOUR_MS,
+    maxRequests: SUBMISSIONS_PER_HOUR,
+  });
+  if (!limit.allowed) {
+    const retryAfter = Math.ceil(limit.retryAfterMs / 1000);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `rate limit exceeded — try again in ${retryAfter}s`,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(retryAfter) },
+      },
+    );
+  }
+
   const parsedShape = await parseBody(request, RepoSubmissionsPostSchema);
   if (!parsedShape.ok) {
     return parsedShape.response as NextResponse<RepoSubmissionsErrorResponse>;

--- a/src/app/api/submissions/revenue/route.ts
+++ b/src/app/api/submissions/revenue/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { parseBody } from "@/lib/api/parse-body";
+import { checkRateLimitAsync } from "@/lib/api/rate-limit";
 import {
   listRevenueSubmissions,
   submitRevenueToQueue,
@@ -24,6 +25,12 @@ export const runtime = "nodejs";
 
 // Shape gate only — field-level validation lives in validateRevenueSubmissionInput.
 const RevenueSubmissionsPostSchema = z.record(z.string(), z.unknown());
+
+// Rate-limit anonymous revenue claims tightly — they trigger moderation
+// review and accepting them as overlay rows is high-trust.
+// (W5.5 HIGH — unauth + no rate-limit on a moderation-queue write.)
+const REVENUE_SUBMISSIONS_PER_HOUR = 5;
+const HOUR_MS = 60 * 60 * 1000;
 
 interface RevenueSubmissionsListResponse {
   ok: true;
@@ -65,6 +72,24 @@ export async function POST(
     RevenueSubmissionsCreateResponse | RevenueSubmissionsErrorResponse
   >
 > {
+  const limit = await checkRateLimitAsync(request, {
+    windowMs: HOUR_MS,
+    maxRequests: REVENUE_SUBMISSIONS_PER_HOUR,
+  });
+  if (!limit.allowed) {
+    const retryAfter = Math.ceil(limit.retryAfterMs / 1000);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `rate limit exceeded — try again in ${retryAfter}s`,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(retryAfter) },
+      },
+    );
+  }
+
   const parsedShape = await parseBody(request, RevenueSubmissionsPostSchema);
   if (!parsedShape.ok) {
     return parsedShape.response as NextResponse<RevenueSubmissionsErrorResponse>;


### PR DESCRIPTION
## Summary

W5.5.B audit surfaced **two HIGH findings** on three public POST endpoints — all three accept anonymous writes with no per-IP rate-limit, and one has no Redis TTL on the persisted record.

- **HIGH 1** — `/api/compare/share`: unauth + no rate-limit + no TTL -> namespace fill / storage exhaustion.
- **HIGH 2** — `/api/repo-submissions` and `/api/submissions/revenue`: unauth + no rate-limit + can trigger background GitHub-API intake or moderation-queue writes.

All three routes now call `checkRateLimitAsync` at the top of POST (before `parseBody`, after method dispatch) and return `429 Too Many Requests` with `Retry-After` when the per-IP budget is exhausted. Pattern mirrors the existing `/api/tier-lists` reference.

## Changes

| Route                          | Budget (per IP) | Why this budget                                                            |
| ------------------------------ | --------------- | -------------------------------------------------------------------------- |
| `/api/compare/share`           | **30 / hour**   | Matches `/api/tier-lists`; pure write; plus 90-day Redis TTL on each share |
| `/api/repo-submissions`        | **10 / hour**   | Each accepted POST can trigger background GitHub intake — tighter budget   |
| `/api/submissions/revenue`     | **5 / hour**    | High-trust moderation-queue write — tightest budget                        |

### Redis TTL — `/api/compare/share`

Existing `getDataStore().write(key, val, { ttlSeconds })` already supports a TTL — no schema change. Set to `90 * 86400 = 7,776,000s` (90 days): long enough for legitimate share use, short enough to bound storage growth from anonymous writes.

### Preserved

- Zod validation order unchanged.
- Existing error envelopes / response shapes unchanged.
- Rate-limit gate is purely additive at the top of each POST handler.

## Test plan

- [x] `npm run typecheck` — clean.
- [ ] Smoke a 31st request to `/api/compare/share` within an hour from the same IP — expect 429 + `Retry-After`.
- [ ] Smoke 11th `/api/repo-submissions` -> expect 429.
- [ ] Smoke 6th `/api/submissions/revenue` -> expect 429.
- [ ] Verify a `/compare/share` write has `EXPIRE` set on its Redis key (~90 days).

Refs: W5.5.B audit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>