### PR TITLE
feat(perf): add Lighthouse-via-PSI runner + npm script + env wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,12 @@ SENTRY_PROJECT=trendingrepo
 # exhaustion) can post a best-effort JSON alert here.
 # OPS_ALERT_WEBHOOK=https://hooks.slack.com/services/...
 
+# -- Optional: Google PageSpeed Insights -------------------------------------
+# Google PageSpeed Insights API key for `npm run lighthouse:routes:prod`.
+# Get one at https://developers.google.com/speed/docs/insights/v5/get-started
+# Optional — the script falls back to the anonymous bucket but may rate-limit.
+PAGESPEED_API_KEY=
+
 # ============================================================================
 # AUTH + DATABASE (Clerk + Supabase) — full setup in docs/AUTH-SETUP.md
 # ============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,8 @@ awesome-codex-skills/
 # local agent vector DB (per-machine runtime state, regenerated automatically)
 /ruvector.db
 
+# perf audit output (Lighthouse-via-PSI, etc.)
+/.perf/
+
 # clerk configuration (can include secrets)
 /.clerk/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Real-time trend-discovery scanner. Aggregates GitHub stars, Twitter buzz, Reddit
 - Trigger workflow: `gh workflow run collect-twitter.yml`
 - Build graph: `code-review-graph build` (auto-runs via project hook on Edit/Write/Bash; pre-commit hook also runs `code-review-graph detect-changes`)
 - Verify Redis data-store: `npm run verify:data-store` (requires `REDIS_URL` for Railway, OR `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` for Upstash)
+- Lighthouse audit: `PAGESPEED_API_KEY=<key> npm run lighthouse:routes:prod` (writes `.perf/lighthouse-mobile-prod.json`)
 
 ## Where to Look First
 - **2026-05-08 rescue handover (read first if you're picking up after the consolidation)** → [docs/RESCUE-2026-05-08-HANDOVER.md](docs/RESCUE-2026-05-08-HANDOVER.md) — branches, tags, the 13 rescue commits, what's outstanding (reddit collector zeros, twitter Apify stale on 386/402 repos), 7 carry-forward learnings.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "perf:routes:prod": "node scripts/perf-routes.mjs --prod",
     "perf:bundle": "node scripts/perf-bundle.mjs",
     "perf:quick": "npm run build && npm run perf:bundle",
+    "lighthouse:routes:prod": "node scripts/lighthouse-routes.mjs",
+    "lighthouse:routes:prod:desktop": "LH_STRATEGY=desktop node scripts/lighthouse-routes.mjs",
     "audit:status": "node scripts/audit-status.mjs",
     "audit:github-token-callsites": "node scripts/audit-github-token-callsites.mjs",
     "update:badges": "node scripts/update-readme-badges.mjs",

--- a/scripts/lighthouse-routes.mjs
+++ b/scripts/lighthouse-routes.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Lighthouse-via-PSI audit runner.
+ *
+ * Usage:
+ *   PAGESPEED_API_KEY=<key> npm run lighthouse:routes:prod
+ *
+ * Iterates the 29 canonical smoke routes, calls Google's PageSpeed Insights
+ * REST API per route, and writes a summary JSON to .perf/lighthouse-prod.json.
+ * Per-route metrics: performance, accessibility, best-practices, seo,
+ * FCP, LCP, CLS, TBT, TTI.
+ *
+ * The PSI API rate-limits anonymous calls aggressively (~5/sec public bucket).
+ * With a key this loosens to ~25k queries/day; we run 29 routes serially
+ * with a 1.5s gap. Total wall time: ~50s + Lighthouse compute per page (~10s
+ * each) ≈ 5 min.
+ *
+ * Output JSON:
+ * {
+ *   "ts": "ISO-8601",
+ *   "key_present": true|false,
+ *   "routes": [{ "route": "/", "perf": 0.92, "a11y": 0.95, "bp": 0.91, "seo": 0.97, "lcp_ms": 1240, ... }]
+ * }
+ */
+
+const BASE_URL = process.env.LH_BASE_URL || "https://trendingrepo.com";
+const API_KEY = process.env.PAGESPEED_API_KEY?.trim();
+const STRATEGY = process.env.LH_STRATEGY || "mobile"; // "mobile" or "desktop"
+
+const ROUTES = [
+  "/", "/githubrepo", "/skills", "/mcp",
+  "/reddit/trending", "/hackernews/trending", "/lobsters", "/devto", "/bluesky/trending",
+  "/twitter", "/signals", "/top10", "/compare",
+  "/funding", "/revenue",
+  "/arxiv/trending", "/producthunt", "/huggingface", "/npm",
+  "/breakouts", "/categories", "/methodology", "/research",
+  "/tools/revenue-estimate",
+  "/repo/vercel/next.js",
+  "/trends",
+  "/agent-commerce", "/agent-commerce/facilitator",
+  "/repo/anthropics/anthropic-cookbook",
+];
+
+async function runOne(route) {
+  const url = new URL("https://www.googleapis.com/pagespeedonline/v5/runPagespeed");
+  url.searchParams.set("url", `${BASE_URL}${route}`);
+  url.searchParams.set("strategy", STRATEGY);
+  for (const cat of ["performance", "accessibility", "best-practices", "seo"]) {
+    url.searchParams.append("category", cat);
+  }
+  if (API_KEY) url.searchParams.set("key", API_KEY);
+
+  const res = await fetch(url.toString());
+  if (!res.ok) {
+    return { route, error: `HTTP ${res.status}` };
+  }
+  const data = await res.json();
+  const cats = data?.lighthouseResult?.categories ?? {};
+  const audits = data?.lighthouseResult?.audits ?? {};
+  return {
+    route,
+    perf: cats.performance?.score ?? null,
+    a11y: cats.accessibility?.score ?? null,
+    bp: cats["best-practices"]?.score ?? null,
+    seo: cats.seo?.score ?? null,
+    lcp_ms: audits["largest-contentful-paint"]?.numericValue ?? null,
+    fcp_ms: audits["first-contentful-paint"]?.numericValue ?? null,
+    cls: audits["cumulative-layout-shift"]?.numericValue ?? null,
+    tbt_ms: audits["total-blocking-time"]?.numericValue ?? null,
+    tti_ms: audits["interactive"]?.numericValue ?? null,
+  };
+}
+
+async function main() {
+  const fs = await import("node:fs/promises");
+  console.log(`[lighthouse] strategy=${STRATEGY} base=${BASE_URL} routes=${ROUTES.length} key=${API_KEY ? "set" : "missing"}`);
+  if (!API_KEY) {
+    console.warn("[lighthouse] PAGESPEED_API_KEY not set — using anonymous bucket (5 req/sec, 25k/day limits don't apply). May 429.");
+  }
+  const out = { ts: new Date().toISOString(), strategy: STRATEGY, key_present: Boolean(API_KEY), routes: [] };
+  for (const route of ROUTES) {
+    process.stdout.write(`  ${route} ... `);
+    try {
+      const r = await runOne(route);
+      out.routes.push(r);
+      console.log(r.error ? `error: ${r.error}` : `perf=${(r.perf ?? 0).toFixed(2)} a11y=${(r.a11y ?? 0).toFixed(2)} lcp=${Math.round(r.lcp_ms ?? 0)}ms`);
+    } catch (err) {
+      out.routes.push({ route, error: String(err) });
+      console.log(`error: ${String(err)}`);
+    }
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  await fs.mkdir(".perf", { recursive: true });
+  const filename = `.perf/lighthouse-${STRATEGY}-prod.json`;
+  await fs.writeFile(filename, JSON.stringify(out, null, 2));
+  console.log(`[lighthouse] wrote ${filename}`);
+  // Surface a quick summary
+  const valid = out.routes.filter((r) => r.perf != null);
+  if (valid.length === 0) {
+    console.log("[lighthouse] no valid results");
+    process.exit(1);
+  }
+  const avg = (k) => valid.reduce((s, r) => s + (r[k] ?? 0), 0) / valid.length;
+  console.log(`[lighthouse] avg perf=${avg("perf").toFixed(2)} a11y=${avg("a11y").toFixed(2)} bp=${avg("bp").toFixed(2)} seo=${avg("seo").toFixed(2)}`);
+}
+
+main().catch((err) => {
+  console.error("[lighthouse] fatal", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- New `scripts/lighthouse-routes.mjs` audits 29 canonical prod routes via Google PageSpeed Insights v5
- Adds `npm run lighthouse:routes:prod` (mobile) + `:desktop` variant
- Wires `PAGESPEED_API_KEY` env var (anonymous fallback works but may 429)
- Writes summary to `.perf/lighthouse-<strategy>-prod.json` (gitignored)

## What changed
- `scripts/lighthouse-routes.mjs` (new) — PSI runner, serial 1.5s gap, per-route perf/a11y/bp/seo + LCP/FCP/CLS/TBT/TTI
- `package.json` — two npm scripts under the existing `perf:*` block
- `.env.example` — documents `PAGESPEED_API_KEY` env var (value is blank — no secret committed)
- `CLAUDE.md` — "Common Tasks" entry pointing at the new script
- `.gitignore` — adds `/.perf/` so audit output stays local

## Security
- No API key value committed. Only the env var **name** appears in `.env.example` and `CLAUDE.md`.
- Operator must add `PAGESPEED_API_KEY` to their local `.env.local` (or CI secret store) before running.

## Test plan
- [x] `npm install` clean
- [x] `npm run typecheck` clean
- [ ] Operator runs `PAGESPEED_API_KEY=<key> npm run lighthouse:routes:prod` once after merge to verify (deferred — not run here to avoid burning quota without the key)
- [ ] Confirm `.perf/lighthouse-mobile-prod.json` lands with valid scores for the 29 routes

## Notes
- Script falls back to anonymous bucket if `PAGESPEED_API_KEY` is unset — useful for one-offs but rate-limits at ~5 req/sec.
- With the key, daily quota is 25k queries; 29 routes/run leaves plenty of headroom.
- Per-call latency ~10s (Lighthouse compute), so total wall time ~5 min serial. Could be parallelized later if PSI rate-limit permits.