### PR TITLE
chore(policy): disable all Apify-dependent workflows + adopt free-providers-only policy

### DIFF
--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -61,8 +61,14 @@ jobs:
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
         run: npm --prefix apps/trendingrepo-worker run fetcher -- crunchbase
-      - if: github.event.inputs.dry_run != 'true'
-        name: Refresh X funding side-channel
+      # 2026-05-17: DISABLED — APIFY policy off (see docs/POLICY-NO-APIFY.md).
+      # The x-funding fetcher in apps/trendingrepo-worker uses Apify to scrape
+      # X/Twitter funding mentions. Step is gated `if: false` so the schedule
+      # keeps running for the RSS + Crunchbase + SEC paths (all free) while
+      # the Apify-only step is skipped. Restore by changing `if:` back to the
+      # dry-run guard ONLY after operator sign-off on the Apify budget.
+      - if: false
+        name: Refresh X funding side-channel (DISABLED — Apify off)
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
           APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}

--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -63,13 +63,11 @@ jobs:
           # Provider default flipped to `nitter` 2026-05-08 after the Apify
           # `apidojo/tweet-scraper` actor returned 0 posts on every query for
           # the prior ~2 weeks (last run with non-empty payload was
-          # 2026-04-23; latest scheduled runs all show postsSeen: 0 across
-          # 25 repos × 4 queries). Local probe with provider=nitter on the
-          # same repos returned 19-20 posts/query, confirming the upstream
-          # scraping path is intact and the issue is Apify-side (quota,
-          # actor change, or X anti-bot blocking the residential IPs).
-          # Override with `vars.TWITTER_COLLECTOR_PROVIDER` if the operator
-          # restores Apify access.
+          # 2026-04-23). 2026-05-17: APIFY operator policy off (see
+          # docs/POLICY-NO-APIFY.md) — `nitter` is now the permanent default
+          # and the APIFY_API_TOKEN env below is intentionally a no-op
+          # (stripped). Re-enabling Apify requires reverting this commit AND
+          # operator sign-off.
           TWITTER_COLLECTOR_PROVIDER: ${{ vars.TWITTER_COLLECTOR_PROVIDER || 'nitter' }}
           # "direct" writes to .data/twitter-*.jsonl locally (so we can commit
           # them back to main). "api" would POST to Vercel's ingest endpoint,
@@ -89,8 +87,9 @@ jobs:
           TWITTER_COLLECTOR_REPOS: ${{ github.event.inputs.repos || '' }}
           TWITTER_COLLECTOR_BASE_URL: ${{ vars.TRENDINGREPO_URL || vars.STARSCREENER_URL || 'https://trendingrepo.com' }}
           INTERNAL_AGENT_TOKEN: ${{ secrets.INTERNAL_AGENT_TOKEN }}
-          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
-          APIFY_TWITTER_ACTOR: ${{ vars.APIFY_TWITTER_ACTOR }}
+          # 2026-05-17: APIFY_API_TOKEN + APIFY_TWITTER_ACTOR intentionally
+          # NOT passed (operator policy off — docs/POLICY-NO-APIFY.md). The
+          # collector now relies on nitter primary + cookies-web fallback.
           TWITTER_WEB_ACCOUNTS_JSON: ${{ secrets.TWITTER_WEB_ACCOUNTS_JSON }}
           TWITTER_GRAPHQL_SEARCH_QUERY_ID: ${{ vars.TWITTER_GRAPHQL_SEARCH_QUERY_ID }}
           # TWITTER_WEB_DEBUG: "1"  # uncomment when diagnosing empty responses

--- a/.github/workflows/cron-reddit-daily.yml
+++ b/.github/workflows/cron-reddit-daily.yml
@@ -100,10 +100,11 @@ jobs:
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
           REDDIT_USER_AGENTS: ${{ secrets.REDDIT_USER_AGENTS }}
-          # B1 (2026-05-16): apify proxy path so the daily Reddit run
-          # records real engagement instead of RSS zeros.
-          REDDIT_COLLECTOR_PROVIDER: apify
-          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
+          # 2026-05-17: APIFY DISABLED (operator policy — see
+          # docs/POLICY-NO-APIFY.md). This redundancy run now uses the
+          # public Reddit JSON path; the last-good invariant in
+          # scripts/scrape-reddit.mjs preserves the engaged baseline when
+          # the public path returns 0 rows.
         run: npm run scrape:reddit
 
       - name: Compute commit timestamp

--- a/.github/workflows/refresh-reddit-baselines.yml
+++ b/.github/workflows/refresh-reddit-baselines.yml
@@ -45,11 +45,9 @@ jobs:
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
           REDDIT_USER_AGENTS: ${{ secrets.REDDIT_USER_AGENTS }}
-          # B1 (2026-05-16): same Apify proxy path as scrape-trending —
-          # ensures the baseline-refresh job records real engagement
-          # instead of RSS zeros.
-          REDDIT_COLLECTOR_PROVIDER: apify
-          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
+          # 2026-05-17: APIFY DISABLED (operator policy — see
+          # docs/POLICY-NO-APIFY.md). Baseline-refresh uses the public
+          # Reddit JSON path; last-good invariant preserves engaged data.
         run: node scripts/scrape-reddit.mjs
 
       - name: Compute commit timestamp

--- a/.github/workflows/scrape-trending.yml
+++ b/.github/workflows/scrape-trending.yml
@@ -62,13 +62,14 @@ jobs:
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           REDDIT_USER_AGENT: ${{ secrets.REDDIT_USER_AGENT }}
           REDDIT_USER_AGENTS: ${{ secrets.REDDIT_USER_AGENTS }}
-          # B1 (2026-05-16): activate Apify residential-proxy path so the
-          # collector returns real score/num_comments instead of falling
-          # through to the zero-engagement RSS path. Reddit's anti-bot
-          # 403s every GH-runner IP for /r/X/new.json; Apify's
-          # `trudax/reddit-scraper-lite` actor bypasses the block.
-          REDDIT_COLLECTOR_PROVIDER: apify
-          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
+          # 2026-05-17: APIFY DISABLED (operator policy — see
+          # docs/POLICY-NO-APIFY.md). Reddit collector falls back to the
+          # public `/r/X/new.json` path with the OAuth-app User-Agent
+          # rotation in scrape-reddit.mjs. When that path returns 0 rows
+          # (Reddit anti-bot 403 on data-center IPs), the last-good cache
+          # invariant in scripts/scrape-reddit.mjs keeps the prior
+          # baseline. Re-enabling Apify requires reverting this commit AND
+          # operator sign-off on the residential-proxy budget.
           # Dual-write to TOOLBOX signal lake (trending.reddit.mentions).
           # Skipped silently when unset; never blocks the primary write.
           TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}

--- a/.github/workflows/sweep-cross-source-mentions.yml
+++ b/.github/workflows/sweep-cross-source-mentions.yml
@@ -103,7 +103,10 @@ jobs:
           # Per-channel auth — each is optional; the channel disables itself
           # when its credential is missing (logged as a one-line warn at
           # sweep start, not a failure).
-          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
+          # 2026-05-17: APIFY_API_TOKEN intentionally NOT passed (operator
+          # policy off — see docs/POLICY-NO-APIFY.md). The sweep auto-disables
+          # the Apify-Twitter channel when the token is absent; other channels
+          # (Reddit/HN/Bluesky/dev.to/Lobsters/ProductHunt/Tavily) keep running.
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/docs/POLICY-NO-APIFY.md
+++ b/docs/POLICY-NO-APIFY.md
@@ -1,0 +1,86 @@
+# Policy: No Apify — Free Providers Only
+
+**Effective:** 2026-05-17
+**Owner:** Operator (Mirko / Basil)
+**Status:** ENFORCED — Apify is OFF in every scheduled workflow on `main`
+
+## TL;DR
+
+Apify is permanently disabled across every scheduled GitHub Actions workflow in this repo. Free providers only. Re-enabling Apify in any cron requires:
+
+1. A reverting PR that restores the `APIFY_API_TOKEN` env var and / or `REDDIT_COLLECTOR_PROVIDER=apify` flag
+2. Explicit operator sign-off on the recurring spend
+3. A documented budget ceiling and a dashboard for the burn-rate
+
+There is no "soft" path. If a future agent or workflow tries to enable Apify silently, block the PR.
+
+## Why Apify is off
+
+Apify residential-proxy actor runs cost real money:
+
+- **Reddit (`trudax/reddit-scraper-lite`)** — ~$6.75 per 45-sub scrape. Daily = ~$200/mo. Plan ceiling was $29/mo; the operator was bleeding budget on a single source.
+- **Twitter (`apidojo/tweet-scraper`)** — per-tweet billing; the actor had been returning 0 posts on every query for ~2 weeks before being switched off (last non-empty run 2026-04-23). Cost without signal.
+- **X funding side-channel** (in `apps/trendingrepo-worker`) — same Apify dependency; 2h cadence multiplied the burn.
+
+The aggregate burn was making Apify the single largest line item without producing proportional signal quality, and the residential-proxy path was masking a deeper architectural issue (Reddit anti-bot 403 on data-center IPs).
+
+## What replaces Apify
+
+| Channel | Old (Apify) path | New (free) path |
+| ------- | --- | --- |
+| Reddit | `trudax/reddit-scraper-lite` residential proxy | Public `/r/X/new.json` with OAuth-app User-Agent rotation in `scripts/scrape-reddit.mjs`. Last-good cache invariant prevents 0-row writes from erasing engaged baselines. |
+| Twitter | `apidojo/tweet-scraper` actor | Nitter primary (`TWITTER_COLLECTOR_PROVIDER=nitter`) → cookies-backed `TwitterWebProvider` fallback when nitter 503s |
+| AI / news blogs | n/a (was always RSS) | RSS feeds remain the source for `scrape-funding`, the AI sub-collectors, and the cookbook AI sources |
+| X funding side-channel | `apps/trendingrepo-worker` fetcher `x-funding` (Apify-only) | Step `if: false` in `collect-funding.yml`. Operator must restore manually if needed. |
+| Cross-source sweep — Twitter channel | Apify per-query bundle | Auto-disabled when `APIFY_API_TOKEN` env var is absent (sweep logs a warn, keeps the other 7 channels running) |
+
+The data-store contract is unchanged: every collector still dual-writes file + Redis. Read paths still go through `refreshXxxFromStore()`. The only difference is the provider behind the scrape.
+
+## Workflows touched 2026-05-17
+
+| Workflow | Change |
+| -------- | ------ |
+| `.github/workflows/scrape-trending.yml` | Removed `REDDIT_COLLECTOR_PROVIDER: apify` + `APIFY_API_TOKEN` from "Refresh Reddit mentions" step |
+| `.github/workflows/cron-reddit-daily.yml` | Removed `REDDIT_COLLECTOR_PROVIDER: apify` + `APIFY_API_TOKEN`. Schedule was already disabled (2026-05-09). |
+| `.github/workflows/refresh-reddit-baselines.yml` | Removed `REDDIT_COLLECTOR_PROVIDER: apify` + `APIFY_API_TOKEN` from the baseline-refresh step |
+| `.github/workflows/collect-funding.yml` | "Refresh X funding side-channel" step gated `if: false` (Apify-only path) |
+| `.github/workflows/collect-twitter.yml` | Stripped `APIFY_API_TOKEN` + `APIFY_TWITTER_ACTOR` from the primary collect step. Default provider already `nitter`. |
+| `.github/workflows/sweep-cross-source-mentions.yml` | Stripped `APIFY_API_TOKEN` env var (sweep auto-disables Apify-Twitter channel when missing) |
+
+## Code paths left intact
+
+These files still contain Apify-aware code paths. They are NOT removed because:
+
+- The codepaths are well-tested and serve as documentation of the historical integration
+- The kill switch is workflow-level (no env var → no Apify call), not codepath-level
+- A future operator can opt in for a one-shot manual run by setting the env var locally + dispatching the workflow manually
+
+| File | Why left intact |
+| ---- | --------------- |
+| `scripts/_apify-reddit-provider.mjs` | Reddit provider implementation; only invoked when `REDDIT_COLLECTOR_PROVIDER=apify` |
+| `scripts/_apify-twitter-provider.ts` | Twitter provider implementation; only invoked when `TWITTER_COLLECTOR_PROVIDER=apify` |
+| `scripts/_apify-proxy.mjs` | Shared HTTP wrapper for Apify run-sync endpoint |
+| `scripts/scrape-reddit.mjs` | Branches on `REDDIT_COLLECTOR_PROVIDER` env var; default (empty) = public JSON |
+| `scripts/collect-twitter-signals.ts` | Branches on `TWITTER_COLLECTOR_PROVIDER`; default = nitter |
+| `scripts/_cross-source-search.mjs` | `searchTwitter()` returns `emptyResult` when `APIFY_API_TOKEN` is unset |
+| `scripts/sweep-cross-source-mentions.ts` | Logs `APIFY_API_TOKEN missing — Twitter channel disabled` warn |
+| `src/lib/pool/apify-twitter.ts` | Pool implementation; surfaced via `twitter-fallback.ts` only when the workflow sets the env |
+| `scripts/__tests__/apify-twitter-provider.test.ts` | Unit test exercising the Apify provider — no live network calls |
+
+## `apps/trendingrepo-worker/` — out of scope
+
+`apps/trendingrepo-worker/` is a sister Railway service (per `CLAUDE.md`) and is on the project's no-touch list. It still contains Apify-aware fetchers (notably `x-funding`). The kill switch for that path is `if: false` on the `collect-funding.yml` step that invokes it. If the Railway service has its own cron that runs the Apify-dependent fetchers directly (outside GitHub Actions), that is an operator concern outside this repo's scope.
+
+## Future operator: what to do if you need Apify back
+
+1. Read this doc end-to-end. Confirm the budget reality.
+2. Open a single PR that restores the env vars in exactly one workflow at a time. Do NOT batch all workflows in one PR.
+3. Set a hard `concurrency` budget on the workflow (e.g. once-daily, not 20-min).
+4. Add an Apify-spend dashboard link to the PR description.
+5. Get an explicit "ship" from the operator before merging.
+
+## References
+
+- `CLAUDE.md` — anti-pattern: "Don't use cookie-based Twitter scrapers — dead provider" (this doc updates the broader provider policy)
+- Memory: `~/.claude/projects/c--dev-trendingrepo/memory/project_reddit_apify_pivot.md` (out-of-repo auto-memory; not modifiable from a PR — author's note)
+- Workflow history: see `git log -- .github/workflows/scrape-trending.yml` for the timeline of the Apify-on / Apify-off pivots since 2026-05-08


### PR DESCRIPTION
## Summary

Operator policy 2026-05-17: **Apify is OFF**. Free providers only. Re-enabling requires a deliberate revert + explicit operator sign-off on the recurring spend.

This PR neutralizes every Apify reference in scheduled GitHub Actions workflows on `main`. Code paths in `scripts/_apify-*.mjs` and friends remain intact (well-tested, documented history), but they are inert when their env vars are absent — and after this PR, no scheduled workflow passes the env vars.

## Workflows changed

| Workflow | Change |
| -------- | ------ |
| `scrape-trending.yml` | Removed `REDDIT_COLLECTOR_PROVIDER: apify` + `APIFY_API_TOKEN` from Reddit step (public-JSON fallback + last-good invariant) |
| `cron-reddit-daily.yml` | Stripped Apify env (schedule already disabled 2026-05-09; hardens manual dispatch) |
| `refresh-reddit-baselines.yml` | Stripped Apify env (weekly Monday run was burning ~$27/mo) |
| `collect-funding.yml` | Gated "Refresh X funding side-channel" step `if: false` (Apify-only path in worker) |
| `collect-twitter.yml` | Stripped `APIFY_API_TOKEN` + `APIFY_TWITTER_ACTOR` env vars (default already nitter) |
| `sweep-cross-source-mentions.yml` | Stripped `APIFY_API_TOKEN` (sweep auto-disables the Apify-Twitter channel) |

## Free-provider mapping

- **Reddit:** public `/r/X/new.json` + OAuth UA rotation in `scripts/scrape-reddit.mjs`; last-good cache invariant prevents 0-row writes from erasing engaged baselines
- **Twitter:** Nitter primary → cookies-backed `TwitterWebProvider` fallback
- **X funding side-channel:** disabled; RSS + Crunchbase + SEC still cover the 2h funding loop
- **Cross-source sweep — Twitter channel:** auto-disabled when token missing; 7 other channels keep running

## New documentation

`docs/POLICY-NO-APIFY.md` — 1-page note: why Apify is off, what replaces it per channel, what code paths are intentionally left intact, what a future operator must do to re-enable.

## What's NOT touched

- `apps/trendingrepo-worker/**` — out-of-scope per session rules. The worker's `x-funding` fetcher still imports Apify; the kill switch is at the workflow step that invokes it (`if: false`).
- `scripts/_cross-source-search.mjs`, `scripts/_secret-scrubber.mjs` — on the no-touch list.
- All Apify provider modules (`scripts/_apify-*.mjs`, `src/lib/pool/apify-twitter.ts`) — inert when env vars are absent. Removing them would be a separate decision.

## Test plan

- [x] `npm run typecheck` passes (no code changes; YAML-only + new doc)
- [ ] Operator confirms next scheduled run of `scrape-trending.yml` succeeds with the public-JSON Reddit path (no $$$ Apify burn, last-good baseline preserved)
- [ ] Operator confirms next `collect-funding.yml` run skips the x-funding step (visible in workflow run logs as "Refresh X funding side-channel (DISABLED — Apify off) — skipped")
- [ ] No alerts from `audit-freshness.yml` after a full 2-3 cron cycles