### PR TITLE
fix(security): rate-limit /api/newsletter + /api/auth/session + /api/mcp + admin-login secondary counter

### DIFF
--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -36,6 +36,21 @@ export const dynamic = "force-dynamic";
 // the rate-limit store is Upstash-backed when configured. Audit finding APP-11.
 const LOGIN_RATE_LIMIT = { windowMs: 60_000, maxRequests: 5 } as const;
 
+// Secondary global counter. Single-admin assumption: total wrong-password
+// attempts across ALL IPs trip a slow-down at N=20/min. Stops distributed
+// credential-stuffing where an attacker rotates IPs to stay under the per-IP
+// budget. The store key derives from the request IP, so we pass a synthetic
+// request with a stable sentinel forwarded-for header to force a single
+// shared bucket. W5.5.B MEDIUM finding follow-up.
+const LOGIN_GLOBAL_RATE_LIMIT = { windowMs: 60_000, maxRequests: 20 } as const;
+const LOGIN_GLOBAL_SENTINEL_IP = "admin-login-global";
+
+function buildGlobalLoginRateRequest(): Request {
+  return new Request("https://internal/admin-login-global", {
+    headers: { "x-forwarded-for": LOGIN_GLOBAL_SENTINEL_IP },
+  });
+}
+
 interface LoginOk {
   ok: true;
   username: string;
@@ -84,6 +99,39 @@ export async function POST(
         status: 429,
         headers: {
           "Retry-After": String(Math.ceil(rate.retryAfterMs / 1000)),
+        },
+      },
+    );
+  }
+
+  // Secondary global counter. Counts every attempt, not just wrong ones —
+  // an attacker who's already inside the per-IP budget can still trip this
+  // by rotating IPs. Single-admin assumption: 20 attempts/min across the
+  // whole deployment is well above any legitimate operator behavior.
+  const globalRate = await checkRateLimitAsync(
+    buildGlobalLoginRateRequest(),
+    LOGIN_GLOBAL_RATE_LIMIT,
+  );
+  if (!globalRate.allowed) {
+    const err = new AdminQuarantineError(
+      "admin login denied: global rate limited",
+    );
+    Sentry.captureException(err, {
+      tags: {
+        ...engineErrorTags(err),
+        auth_surface: "admin-login",
+      },
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        reason: "rate_limited",
+        error: "too many login attempts; try again shortly",
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(Math.ceil(globalRate.retryAfterMs / 1000)),
         },
       },
     );

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -23,6 +23,7 @@ import {
   SESSION_COOKIE_NAME,
 } from "@/lib/api/auth";
 import { parseBody } from "@/lib/api/parse-body";
+import { checkRateLimitAsync } from "@/lib/api/rate-limit";
 import {
   deriveUserId,
   signSession,
@@ -37,6 +38,14 @@ export const dynamic = "force-dynamic";
 // Keep in sync with SESSION_MAX_AGE_MS in session.ts (30 days, in seconds).
 const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
 const SESSION_CACHE_HEADERS = { "Cache-Control": "private, no-store" };
+
+// Per-IP rate-limit on session minting. 30/hour is plenty for legitimate
+// rotation (tab reload, multi-tab open, dev-server restart) while blocking
+// a determined cookie-mint grinder. W5.5.B MEDIUM finding follow-up.
+const SESSION_RATE_LIMIT = {
+  windowMs: 60 * 60 * 1_000,
+  maxRequests: 30,
+} as const;
 
 interface SessionProbeOk {
   ok: true;
@@ -130,6 +139,22 @@ export async function GET(
 export async function POST(
   request: NextRequest,
 ): Promise<NextResponse<SessionIssuedOk | SessionError>> {
+  // Per-IP rate-limit BEFORE the secret-configured / body-parse paths so a
+  // mint-grinder still hits the budget even when the server returns 503.
+  const rate = await checkRateLimitAsync(request, SESSION_RATE_LIMIT);
+  if (!rate.allowed) {
+    const headers = new Headers(SESSION_CACHE_HEADERS);
+    headers.set("Retry-After", String(Math.ceil(rate.retryAfterMs / 1000)));
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Too many requests",
+        code: "RATE_LIMITED",
+      },
+      { status: 429, headers },
+    );
+  }
+
   // Dev fallback: SESSION_SECRET unset. Return the "local" identity without
   // setting a cookie — AlertConfig's existing dev path picks this up.
   if (!isSecretConfigured()) {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -28,6 +28,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 
+import { checkRateLimitAsync } from "@/lib/api/rate-limit";
+
 import {
   ERR_INVALID_REQUEST,
   ERR_PARSE,
@@ -50,8 +52,46 @@ const RESPONSE_HEADERS = {
   "Content-Type": "application/json",
 } as const;
 
+// Per-IP rate-limit for JSON-RPC dispatch. 60/min keeps the public read API
+// usable for a single client while blunting batch-flood abuse. W5.5.B MEDIUM
+// finding follow-up.
+const MCP_RATE_LIMIT = {
+  windowMs: 60_000,
+  maxRequests: 60,
+} as const;
+
+// Hard cap on the number of requests in a single JSON-RPC batch. 20 covers
+// every legitimate MCP client we've seen (Claude Desktop, Cursor, Continue
+// each issue <=5 in their initialize handshake) while keeping a single POST
+// from amplifying the per-IP rate-limit by orders of magnitude.
+const MCP_BATCH_CAP = 20;
+
 // lint-allow: no-parsebody — JSON-RPC 2.0 dispatch; body shape is method-dependent so a single Zod schema doesn't apply. Validation lives per-method in ./_dispatcher.
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Per-IP rate-limit BEFORE JSON parse so a flood of garbage payloads also
+  // consumes the budget. JSON-RPC clients are expected to batch where they
+  // can, so 60 POSTs/min/IP is the right gate. Surfaced as a JSON-RPC
+  // error envelope so MCP clients can branch on `error.code`.
+  const rate = await checkRateLimitAsync(request, MCP_RATE_LIMIT);
+  if (!rate.allowed) {
+    return NextResponse.json(
+      rpcError(
+        null,
+        ERR_INVALID_REQUEST,
+        `rate limit exceeded — try again in ${Math.ceil(
+          (rate.retryAfterMs ?? 0) / 1000,
+        )}s`,
+      ),
+      {
+        status: 429,
+        headers: {
+          ...RESPONSE_HEADERS,
+          "Retry-After": String(Math.ceil((rate.retryAfterMs ?? 0) / 1000)),
+        },
+      },
+    );
+  }
+
   let payload: unknown;
   try {
     payload = await request.json();
@@ -65,6 +105,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Batch support — JSON-RPC 2.0 allows an array of requests in one POST.
   if (Array.isArray(payload)) {
+    if (payload.length > MCP_BATCH_CAP) {
+      return NextResponse.json(
+        rpcError(
+          null,
+          ERR_INVALID_REQUEST,
+          `batch too large: ${payload.length} > ${MCP_BATCH_CAP}`,
+        ),
+        { status: 400, headers: RESPONSE_HEADERS },
+      );
+    }
     const results: JsonRpcResponse[] = [];
     for (const item of payload) {
       const rpc = item as JsonRpcRequest;

--- a/src/app/api/newsletter/subscribe/route.ts
+++ b/src/app/api/newsletter/subscribe/route.ts
@@ -38,6 +38,7 @@ import { resolveEmailFrom, sendEmail } from "@/lib/email/send";
 import { renderNewsletterConfirmEmail } from "@/lib/email/templates/newsletter-confirm";
 import { errorEnvelope, serverError } from "@/lib/api/error-response";
 import { parseBody } from "@/lib/api/parse-body";
+import { checkRateLimitAsync } from "@/lib/api/rate-limit";
 import {
   mintConfirmToken,
   mintUnsubToken,
@@ -52,6 +53,15 @@ const POST_CACHE_HEADERS = {
 
 /** 1-hour soft rate-limit per email between confirmation re-sends. */
 const RESEND_RATE_LIMIT_MS = 60 * 60 * 1_000;
+
+// Per-IP rate-limit on the subscribe endpoint itself. 5 subscribes per hour
+// per IP is plenty for a real user toggling between addresses; well below
+// the threshold an attacker would need to burn the Resend quota / amplify
+// cost via a flood of confirmation sends. W5.5.B MEDIUM finding follow-up.
+const SUBSCRIBE_RATE_LIMIT = {
+  windowMs: 60 * 60 * 1_000,
+  maxRequests: 5,
+} as const;
 
 const SubscribeSchema = z.object({
   email: z.string().email().max(254),
@@ -100,6 +110,26 @@ async function sendConfirmationEmail(
 export async function POST(
   request: NextRequest,
 ): Promise<NextResponse<SubscribeOk | { ok: false; error: string; code?: string }>> {
+  // Per-IP rate-limit BEFORE Zod parse so a flood of bad payloads also
+  // counts toward the budget. Defense against Resend-quota cost-amplification.
+  const rate = await checkRateLimitAsync(request, SUBSCRIBE_RATE_LIMIT);
+  if (!rate.allowed) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Too many requests",
+        code: "RATE_LIMITED",
+      },
+      {
+        status: 429,
+        headers: {
+          ...POST_CACHE_HEADERS,
+          "Retry-After": String(Math.ceil(rate.retryAfterMs / 1000)),
+        },
+      },
+    );
+  }
+
   const parsed = await parseBody(request, SubscribeSchema, {
     publicMessage: "invalid email",
     includeDetails: false,


### PR DESCRIPTION
## Summary

Closes the four MEDIUM-severity findings from the session-G W5.5.B audit by adding `checkRateLimitAsync` gates + a JSON-RPC batch cap. Same Upstash-backed store, same envelope conventions as #1591.

### Per-route budgets

| Route | Before | After |
| --- | --- | --- |
| `POST /api/newsletter/subscribe` | unlimited per IP (only per-email 1/hr re-send) | **5/hr/IP** + existing per-email gate untouched |
| `POST /api/auth/session` | unlimited (free cookie mint) | **30/hr/IP** — GET probe unchanged |
| `POST /api/mcp` | unlimited + unbounded JSON-RPC batches | **60/min/IP** + **batch.length <= 20** |
| `POST /api/admin/login` | 5/min/IP only | 5/min/IP **plus** **20/min global** (sentinel-IP counter; defeats IP-rotation credential-stuffing) |

### Rationale per gate

- **newsletter/subscribe** — defense against Resend-quota cost-amplification. 5 subscribes/hour from one IP covers every legitimate user (toggling between addresses, fixing a typo) while making a sustained flood expensive.
- **auth/session** — defense against cookie-mint grinding. 30/hour is well above legitimate tab-reload / dev-restart behavior.
- **mcp** — defense against JSON-RPC batch abuse. 60 POSTs/min/IP with a per-envelope cap of 20 makes batch-flooding a non-amplifier. Rate-limit response uses `rpcError` so MCP clients can branch on `error.code`.
- **admin/login secondary counter** — `checkRateLimitAsync` derives its key from the request IP, so a stable sentinel-IP synthetic Request gives us a single shared bucket. Single-admin assumption documented in code; 20 attempts/min across the whole deployment is well above any legitimate operator behavior.

### Verification

- `npm run typecheck` — zero errors
- `npm run lint:guards` — all 12 meta-lint guards pass (error-envelope guard caught a bare `{error:...}` return in `/api/mcp` on first pass; reshaped to use `rpcError` for MCP-native semantics)
- Existing logic preserved on every route: Zod schemas, auth check, Sentry capture for admin-login, JSON-RPC dispatch, dev `SESSION_SECRET` fallback all untouched

### Test plan

- [ ] `npm run typecheck` clean (verified locally)
- [ ] `npm run lint:guards` clean (verified locally)
- [ ] Vercel preview build green
- [ ] Manual probe per route: 6th newsletter subscribe inside 1h returns 429, 31st session POST inside 1h returns 429, 61st MCP POST inside 1min returns 429, 21st admin-login (any IP) inside 1min returns 429
- [ ] Soft probe of `Retry-After` header on each 429

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>