### PR TITLE
feat(polish): healthz ISR + ErrorPanel Sentry route-tag + keywords + aiso Redis limiter

### DIFF
--- a/src/app/api/healthz/route.ts
+++ b/src/app/api/healthz/route.ts
@@ -9,7 +9,6 @@
 import { NextResponse } from "next/server";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
 
 export async function GET() {
   return NextResponse.json({

--- a/src/app/funding/page.tsx
+++ b/src/app/funding/page.tsx
@@ -33,6 +33,14 @@ export const metadata: Metadata = {
   title: "TrendingRepo — Funding Radar",
   description:
     "AI and tech startup funding rounds aggregated from TechCrunch, VentureBeat, and more. Structured extraction with confidence scoring.",
+  keywords: [
+    "startup funding",
+    "venture capital",
+    "seed",
+    "series A",
+    "AI funding",
+    "fundraising signals",
+  ],
   alternates: { canonical: "/funding" },
 };
 

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -34,6 +34,13 @@ export const metadata: Metadata = {
   title: "Research - TrendingRepo",
   description:
     "HuggingFace trending models + arXiv cs.AI / cs.CL / cs.LG recent papers, with cross-links to tracked GitHub repos.",
+  keywords: [
+    "arXiv papers",
+    "Hugging Face models",
+    "AI research",
+    "ML papers",
+    "research trending",
+  ],
   alternates: { canonical: "/research" },
 };
 

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -29,6 +29,13 @@ export function generateMetadata(): Metadata {
   return {
     title: HUB_TITLE,
     description: HUB_DESCRIPTION,
+    keywords: [
+      "GitHub star history",
+      "revenue estimator",
+      "repo treemap",
+      "developer tools",
+      "GitHub analytics",
+    ],
     alternates: { canonical: absoluteUrl("/tools") },
     openGraph: {
       title: HUB_TITLE,

--- a/src/app/twitter/page.tsx
+++ b/src/app/twitter/page.tsx
@@ -45,6 +45,13 @@ export const metadata: Metadata = {
   title: "Trending Repos on X",
   description:
     "TrendingRepo-ranked repositories with real X/Twitter mentions in the last 24 hours.",
+  keywords: [
+    "GitHub repos on Twitter",
+    "X mentions",
+    "developer social",
+    "AI Twitter buzz",
+    "trending repos",
+  ],
   alternates: { canonical: "/twitter" },
 };
 

--- a/src/components/ui/ErrorPanel.tsx
+++ b/src/components/ui/ErrorPanel.tsx
@@ -6,7 +6,7 @@
 // GitHub issue with the error digest pre-filled). Used by both
 // src/app/error.tsx and src/app/global-error.tsx.
 
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import Link from "next/link";
 import { AlertOctagon, RefreshCw, Home, Bug } from "lucide-react";
 
@@ -14,6 +14,30 @@ interface Props {
   error: Error & { digest?: string };
   reset: () => void;
   variant?: "default" | "compact";
+}
+
+// Sentry capture with route tag. Centralized here so every route error.tsx
+// consumer gets per-route grouping automatically — the existing 74 route
+// error.tsx files still call captureException themselves (Sentry deduplicates
+// by fingerprint within a short window, so the double-capture is harmless and
+// lets us centralize incrementally).
+function reportToSentryWithRouteTag(error: Error & { digest?: string }): void {
+  if (typeof window === "undefined") return;
+  const sentry = (
+    window as unknown as {
+      Sentry?: {
+        captureException: (
+          e: Error,
+          ctx?: { tags?: Record<string, string> },
+        ) => void;
+      };
+    }
+  ).Sentry;
+  if (sentry?.captureException) {
+    sentry.captureException(error, {
+      tags: { route: window.location.pathname },
+    });
+  }
 }
 
 const BTN_PRIMARY =
@@ -26,6 +50,10 @@ export function ErrorPanel({
   reset,
   variant = "default",
 }: Props): ReactNode {
+  useEffect(() => {
+    reportToSentryWithRouteTag(error);
+  }, [error]);
+
   const digest = error.digest;
   const isProd = process.env.NODE_ENV === "production";
   const isCompact = variant === "compact";


### PR DESCRIPTION
Four surgical polish items batched into one PR. **Items 1-3 shipped; item 4 surfaced for follow-up** — see the per-item breakdown below.

## Summary

- **Item 1** — Drop `force-dynamic` from `/api/healthz`. The probe returns `{ok, service, version, ts}` with no auth or DB; static-with-revalidate is appropriate for a liveness endpoint.
- **Item 2** — Centralize Sentry capture with a route tag inside `ErrorPanel`. Adds `useEffect` that calls `window.Sentry.captureException(error, { tags: { route: window.location.pathname } })` so every consumer of the 74 route `error.tsx` files automatically gets per-route grouping. Existing per-route `captureException` calls are **left in place** — Sentry deduplicates by fingerprint within a short window, so the double-capture is harmless and lets us centralize incrementally. (Reviewer suggestion from #1584.)
- **Item 3** — Keywords differentiation for the 4 metadata-fallback routes:
  - `/funding` → startup funding, venture capital, seed, series A, AI funding, fundraising signals
  - `/twitter` → GitHub repos on Twitter, X mentions, developer social, AI Twitter buzz, trending repos
  - `/research` → arXiv papers, Hugging Face models, AI research, ML papers, research trending
  - `/tools` → GitHub star history, revenue estimator, repo treemap, developer tools, GitHub analytics
- **Item 4 — DEFERRED**. Migrating `/api/repos/[owner]/[name]/aiso` POST from per-Lambda in-memory rate-limit → `checkRateLimitAsync` is more invasive than a function swap. The existing limiter is wired into a test-only reset hook on `globalThis` (`Symbol.for("trendingrepo.aiso.test.reset")`) and has custom size-based pruning plus a non-standard error envelope (`{ ok: false, error: "Rate limited — one rescan per 60s per IP", retryAfterMs }`). The `aiso-endpoint.test.ts` suite (~10 tests) reaches into the symbol hook in `beforeEach` to reset module-scoped state. A safe migration needs:
  1. Replace the in-memory limiter with `checkRateLimitAsync({ windowMs: 60_000, maxRequests: 1 })`
  2. Rewire `resetRateLimit()` in the test suite to call `_resetRateLimitForTests` + `_setStoreForTests`
  3. Decide whether to keep the bespoke error envelope or move to the standard `errorEnvelope("...", "RATE_LIMITED")` shape used by `/api/tier-lists`
  
  Per operator instruction ("if the existing aiso rate-limit logic is complex, SURFACE the diff + ship ONLY items 1-3"), this is its own follow-up PR.

## Verification

- ✅ `npm run typecheck` → 0 errors
- ✅ `npm run lint:guards` → all 5 guards pass (route-config, runtime-drift, zod-mutating, error-envelopes, perf-budgets)
- 6 files touched, 58 insertions, 2 deletions

## Files changed

- `src/app/api/healthz/route.ts` (-1)
- `src/components/ui/ErrorPanel.tsx` (+25)
- `src/app/funding/page.tsx` (+8)
- `src/app/twitter/page.tsx` (+7)
- `src/app/research/page.tsx` (+7)
- `src/app/tools/page.tsx` (+7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)