### PR TITLE
feat(ci): 2 lint guards — no-secret-env-in-client + no-secret-fields-in-response-types

### DIFF
--- a/.github/workflows/lint-no-secret-env-in-client.yml
+++ b/.github/workflows/lint-no-secret-env-in-client.yml
@@ -1,0 +1,25 @@
+name: lint-no-secret-env-in-client
+
+# Defense-in-depth: no server secret should ever be read inside a
+# "use client" file. NEXT_PUBLIC_* and NODE_ENV are the only allowed
+# client-side env reads. Added 2026-05-17 after session-G W5.5.C audit.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Lint client env reads
+        run: node scripts/lint-no-secret-env-in-client.mjs

--- a/.github/workflows/lint-no-secret-fields-in-response-types.yml
+++ b/.github/workflows/lint-no-secret-fields-in-response-types.yml
@@ -1,0 +1,26 @@
+name: lint-no-secret-fields-in-response-types
+
+# Defense-in-depth: no exported API response interface should declare a
+# field name shaped like a raw secret (matches /secret|password|hash|pat|token/i)
+# unless the name is on a vetted allowlist (e.g. tokenLast4, hasWebhookSecret).
+# Added 2026-05-17 after session-G W5.5.C audit.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Lint response-type field names
+        run: node scripts/lint-no-secret-fields-in-response-types.mjs

--- a/scripts/lint-no-secret-env-in-client.mjs
+++ b/scripts/lint-no-secret-env-in-client.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Lint guard: fail CI if any "use client" file reads process.env.<SECRET>
+ * where SECRET is NOT NEXT_PUBLIC_* or NODE_ENV.
+ *
+ * Why: server secrets MUST stay server-side. Client-bundled env reads
+ * leak the value into the browser bundle. Next.js statically inlines
+ * NEXT_PUBLIC_* at build time (intentionally public). Anything else
+ * read inside "use client" code is either a leak or a bug.
+ *
+ * Added 2026-05-17 after session-G W5.5.C security audit.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOTS = ["src/app", "src/components", "src/lib", "src/hooks"];
+const VIOLATIONS = [];
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry.startsWith(".")) continue;
+      walk(full);
+      continue;
+    }
+    if (!/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(entry)) continue;
+    const body = readFileSync(full, "utf8");
+    // Quick skip: file must have "use client" directive on its first
+    // non-blank line (Next.js requirement). We accept either quote style.
+    if (
+      !/^[\s\n]*"use client"/.test(body) &&
+      !/^[\s\n]*'use client'/.test(body)
+    )
+      continue;
+    const matches = body.matchAll(/process\.env\.([A-Z_][A-Z0-9_]*)/g);
+    for (const m of matches) {
+      const name = m[1];
+      if (name === "NODE_ENV") continue;
+      if (name.startsWith("NEXT_PUBLIC_")) continue;
+      VIOLATIONS.push({ file: full, env: name });
+    }
+  }
+}
+
+for (const root of ROOTS) {
+  try {
+    walk(root);
+  } catch {
+    // Root may not exist (e.g. src/hooks on some checkouts) — skip silently.
+  }
+}
+
+if (VIOLATIONS.length > 0) {
+  console.error(
+    `::error::Found ${VIOLATIONS.length} client-side reads of non-public env vars:`,
+  );
+  for (const v of VIOLATIONS) {
+    console.error(`  ${v.file}: process.env.${v.env}`);
+  }
+  console.error(
+    `Server secrets must NOT be read inside "use client" files. ` +
+      `Use NEXT_PUBLIC_* for client-bundled values, or move the read to a server-only file.`,
+  );
+  process.exit(1);
+}
+
+console.log("OK - no secret env reads in client files.");

--- a/scripts/lint-no-secret-fields-in-response-types.mjs
+++ b/scripts/lint-no-secret-fields-in-response-types.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Lint guard: fail CI if any exported interface in
+ *   src/app/api/**\/route.ts
+ *   src/app/api/**\/*.types.ts
+ * has a field name matching /secret|password|hash|pat|token/i UNLESS the
+ * field name is on the allowlist below.
+ *
+ * Why: API response shapes are the most common place where a secret
+ * accidentally leaks to the client. Naming hygiene catches the leak at
+ * type-definition time, before the field is even populated.
+ *
+ * Allowlist policy: the allowlisted names all describe SAFE-TO-RETURN
+ * derivatives — last-4 token suffixes, boolean "does the secret exist"
+ * flags, content-addressable digests, request idempotency keys — none
+ * of which are the secret itself. Adding a new allowlist entry should
+ * require a code review that confirms the field is a safe derivative.
+ *
+ * Added 2026-05-17 after session-G W5.5.C security audit.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "src/app/api";
+
+// Words that look like a raw secret when they appear as a camelCase
+// component of a field name. Matching is on camelCase word boundaries
+// (split `fooBarBaz` → `foo`, `Bar`, `Baz`, lowercase, compare) so we
+// don't false-positive on substrings like "pat" inside "pattern" or
+// "path". Add a new word only after confirming no legitimate field
+// name uses it as a substring.
+const SECRET_WORDS = new Set(["secret", "password", "hash", "pat", "token"]);
+
+// Allowlist: full field names that LOOK like they might be secrets but
+// are confirmed safe-to-return derivatives (last-4 suffix, presence
+// boolean, content digest, idempotency key, hashed identifier). Match
+// is case-sensitive — prefer the existing casing when adding a new
+// entry so the diff is obvious in review.
+const ALLOWLIST = new Set([
+  "tokenLast4",
+  "mcpTokenLast4",
+  "hasWebhookSecret",
+  "webhookSecretHash",
+  "digest",
+  "idempotencyKey",
+  "ipHash",
+]);
+
+/**
+ * Split a camelCase / PascalCase identifier into lowercase word tokens.
+ *   "fooBarBaz" → ["foo", "bar", "baz"]
+ *   "IPHash"    → ["ip", "hash"]
+ *   "tokenLast4" → ["token", "last4"]
+ *   "fullNamePattern" → ["full", "name", "pattern"]
+ */
+function splitCamel(name) {
+  return name
+    // Insert a boundary before an uppercase letter that follows a
+    // lowercase letter or digit: fooBar → foo|Bar
+    .replace(/([a-z0-9])([A-Z])/g, "$1|$2")
+    // Insert a boundary between a run of uppercase and a lowercase:
+    // IPHash → IP|Hash, JSONParser → JSON|Parser
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1|$2")
+    .split("|")
+    .map((s) => s.toLowerCase())
+    .filter(Boolean);
+}
+
+function hasSecretToken(name) {
+  for (const tok of splitCamel(name)) {
+    if (SECRET_WORDS.has(tok)) return true;
+  }
+  return false;
+}
+
+const VIOLATIONS = [];
+
+/**
+ * Return true when the given path is one we should scan:
+ *   - .../route.ts
+ *   - .../foo.types.ts
+ */
+function shouldScan(file) {
+  if (file.endsWith("/route.ts") || file.endsWith("\\route.ts")) return true;
+  if (file.endsWith(".types.ts")) return true;
+  return false;
+}
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry.startsWith(".")) continue;
+      walk(full);
+      continue;
+    }
+    if (!shouldScan(full)) continue;
+    scanFile(full);
+  }
+}
+
+/**
+ * Extract `export interface Foo { ... }` blocks and check each field name
+ * inside. We deliberately keep the parser dumb: regex-bound interface
+ * blocks + a simple field-name regex. The cost of a false positive is one
+ * allowlist entry; the cost of a false negative is a leaked secret.
+ */
+function scanFile(file) {
+  const body = readFileSync(file, "utf8");
+
+  // Match `export interface Name [extends X] { ... }`. The body is
+  // delimited by a balanced pair of braces — but we only need the
+  // top-level brace, so a non-greedy `[\s\S]*?` plus the next unmatched
+  // `}` is good enough for the response-type shapes we hold ourselves
+  // to. Nested types inside an interface are still scanned because the
+  // inner brace pairs survive the match.
+  const interfaceRe = /export\s+interface\s+(\w+)[^\{]*\{([\s\S]*?)\n\}/g;
+
+  let match;
+  while ((match = interfaceRe.exec(body)) !== null) {
+    const interfaceName = match[1];
+    const interfaceBody = match[2];
+    // Field declarations: `<name>[?]: <type>;` — capture the name. We
+    // also accept readonly and quoted keys.
+    const fieldRe = /(?:^|\n)\s*(?:readonly\s+)?["']?([a-zA-Z_$][\w$]*)["']?\s*\??\s*:/g;
+    let fmatch;
+    while ((fmatch = fieldRe.exec(interfaceBody)) !== null) {
+      const fieldName = fmatch[1];
+      if (!hasSecretToken(fieldName)) continue;
+      if (ALLOWLIST.has(fieldName)) continue;
+      VIOLATIONS.push({ file, interfaceName, fieldName });
+    }
+  }
+}
+
+try {
+  walk(ROOT);
+} catch (err) {
+  // Root may not exist on a fresh checkout — that's not a violation.
+  if (err && err.code !== "ENOENT") {
+    console.error(`::warning::scan failed: ${err.message}`);
+  }
+}
+
+if (VIOLATIONS.length > 0) {
+  console.error(
+    `::error::Found ${VIOLATIONS.length} exported interface field(s) that look like secrets:`,
+  );
+  for (const v of VIOLATIONS) {
+    console.error(`  ${v.file}: interface ${v.interfaceName} -> ${v.fieldName}`);
+  }
+  console.error(
+    `Response types must not expose raw secrets. Use a safe derivative ` +
+      `(e.g. tokenLast4, hasWebhookSecret) and add the name to the allowlist ` +
+      `in scripts/lint-no-secret-fields-in-response-types.mjs after a security review.`,
+  );
+  process.exit(1);
+}
+
+console.log("OK - no secret-shaped fields in exported response types.");


### PR DESCRIPTION
## Summary

Two CI guards that prevent the categories of bugs caught in session-G's
W5.5.C security audits. Both ship as `scripts/*.mjs` + a matching
`.github/workflows/*.yml`, run on every PR + push to `main`, and fail
CI on any violation.

### Guard 1 — `lint-no-secret-env-in-client.mjs`

Fail if any `"use client"` file reads `process.env.<SECRET>` where
`SECRET` is **not** `NEXT_PUBLIC_*` or `NODE_ENV`.

**Why:** Next.js inlines `NEXT_PUBLIC_*` at build time (intentionally
public). Anything else read inside `"use client"` code lands in the
browser bundle — that's either a leak or a bug.

Walks `src/app`, `src/components`, `src/lib`, `src/hooks`. Skips files
without a top-line `"use client"` directive for speed.

### Guard 2 — `lint-no-secret-fields-in-response-types.mjs`

Fail if any exported `interface` in `src/app/api/**/route.ts` or
sibling `*.types.ts` has a field name whose camelCase tokens include
`secret | password | hash | pat | token`, unless the full name is on
the vetted allowlist:

- `tokenLast4`, `mcpTokenLast4` — last-4 token suffix, safe by design
- `hasWebhookSecret` — presence boolean, no secret value
- `webhookSecretHash` — hashed digest, not the raw value
- `digest` — content-addressable identifier
- `idempotencyKey` — request idempotency token, not auth
- `ipHash` — already-hashed IP, not the raw IP

**Why:** API response shapes are the most common place a secret
leaks. Naming hygiene catches it at type-definition time.

Implementation note: regex matching on the raw field name produced 4
false positives (`repoPath`, `signedUpAt`, `ipHash`, `fullNamePattern`
— "pat" inside "Path"/"upat"/"Pattern", "hash" inside "ipHash"). Fixed
by splitting the field name into camelCase tokens and comparing each
lowercased token against the secret-word set. `ipHash` is then
allowlisted because the field is already a hashed identifier safe to
return.

## Dry-run on origin/main

```
$ node scripts/lint-no-secret-env-in-client.mjs
OK - no secret env reads in client files.

$ node scripts/lint-no-secret-fields-in-response-types.mjs
OK - no secret-shaped fields in exported response types.
```

Both PASS.

## Test plan

- [ ] CI run on this PR shows both new workflows green
- [ ] To verify guard 1 catches violations, temporarily add
      `const x = process.env.MY_SECRET;` to a `"use client"` file →
      expect CI red.
- [ ] To verify guard 2 catches violations, temporarily add
      `secretValue: string;` to an exported interface in a `route.ts`
      → expect CI red.
- [ ] Hand-merge with `main` later; the guards stay green because
      both pass on the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)