### PR TITLE
fix(agent-commerce): facilitator drilldown — use data-store getters (kill readFileSync anti-pattern)

### DIFF
--- a/src/app/agent-commerce/facilitator/[name]/page.tsx
+++ b/src/app/agent-commerce/facilitator/[name]/page.tsx
@@ -1,55 +1,29 @@
 // /agent-commerce/facilitator/[name] — per-facilitator drilldown.
 //
 // Aggregates a single x402 facilitator's settlement history across both
-// Base and Solana on-chain indexer outputs. RSC; reads JSON files via
-// the inline require("fs") pattern that already exists in the parent
-// agent-commerce/page.tsx — yes it's an anti-pattern, but it matches
-// the current convention so this drilldown stays consistent until the
-// parallel cleanup lands.
+// Base and Solana on-chain indexer outputs. RSC; reads via the canonical
+// data-store accessors (Redis → bundled file → in-memory LKG), matching
+// the parent /agent-commerce page. Replaces the previous `require("fs")`
+// inline readFileSync — see CLAUDE.md anti-pattern note (commit 87e3f4e).
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import {
+  getBaseX402Onchain,
+  refreshBaseX402OnchainFromStore,
+} from "@/lib/base-x402-onchain";
+import {
+  getSolanaX402Onchain,
+  refreshSolanaX402OnchainFromStore,
+} from "@/lib/solana-x402-onchain";
 
 interface PageProps {
   params: Promise<{ name: string }>;
 }
 
 type ChainKey = "base" | "solana";
-
-interface BaseSample {
-  facilitator: string;
-  txHash: string;
-  from?: string;
-  to?: string;
-  timestamp: string;
-  blockNumber?: number;
-}
-
-interface SolSample {
-  facilitator: string;
-  txSig: string;
-  from?: string | null;
-  to?: string | null;
-  blockTime: string | null;
-  slot?: number | null;
-}
-
-interface OnchainShape<TSample> {
-  fetchedAt?: string;
-  totalSettlements?: number;
-  byFacilitator?: Record<
-    string,
-    { addressCount: number; totalTxs: number; x402Settlements: number }
-  >;
-  byDay?: Record<
-    string,
-    { txs: number; byFacilitator: Record<string, number> }
-  >;
-  samples?: TSample[];
-  facilitatorAddresses?: Record<string, string[]>;
-}
 
 const FAC_COLOR: Record<string, string> = {
   Coinbase: "#3b82f6",
@@ -62,22 +36,6 @@ const CHAIN_COLOR: Record<ChainKey, string> = {
   base: "#3b82f6",
   solana: "#22d3ee",
 };
-
-function readChain<TSample>(file: string): OnchainShape<TSample> | null {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const fs = require("fs") as typeof import("fs");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const path = require("path") as typeof import("path");
-  try {
-    const raw = fs.readFileSync(
-      path.resolve(process.cwd(), `.data/${file}`),
-      "utf8",
-    );
-    return JSON.parse(raw) as OnchainShape<TSample>;
-  } catch {
-    return null;
-  }
-}
 
 export async function generateMetadata({
   params,
@@ -93,8 +51,12 @@ export async function generateMetadata({
 export default async function FacilitatorDrilldownPage({ params }: PageProps) {
   const { name } = await params;
 
-  const base = readChain<BaseSample>("base-x402-onchain.json");
-  const sol = readChain<SolSample>("solana-x402-onchain.json");
+  await Promise.all([
+    refreshBaseX402OnchainFromStore(),
+    refreshSolanaX402OnchainFromStore(),
+  ]);
+  const base = getBaseX402Onchain();
+  const sol = getSolanaX402Onchain();
 
   const baseFac = base?.byFacilitator?.[name] ?? null;
   const solFac = sol?.byFacilitator?.[name] ?? null;


### PR DESCRIPTION
## Summary

`src/app/agent-commerce/facilitator/[name]/page.tsx` was reading
`.data/base-x402-onchain.json` and `.data/solana-x402-onchain.json` directly via
an inline `require("fs").readFileSync(...)` block. That violates the documented
anti-pattern in CLAUDE.md:

> Don't `readFileSync(process.cwd(), "data", ...)` for new data sources —
> use the data-store. The reason filesystem reads worked at all is that
> bundled JSON is baked into each Vercel deploy; that coupled data freshness
> to deploys and caused 17–34 deploys/day from data churn alone
> (commit `87e3f4e`, 2026-04-26).

This PR swaps the inline fs read for the canonical pair of accessors that
already drive the parent `/agent-commerce` page:

- `refreshBaseX402OnchainFromStore()` + `getBaseX402Onchain()`
- `refreshSolanaX402OnchainFromStore()` + `getSolanaX402Onchain()`

Both expose the same three-tier read (Redis → bundled file → in-memory
last-known-good) with 30s rate-limit + in-flight dedupe, so the drilldown now
sees the same fresh data as the parent page.

## Before / after

- Dropped the local `BaseSample`, `SolSample`, `OnchainShape<T>` interfaces —
  canonical types now flow in from `@/lib/base-x402-onchain` and
  `@/lib/solana-x402-onchain` (shape is identical for every field the page
  actually renders).
- Dropped the local `readChain<T>` helper.
- Added the `await Promise.all([refreshBaseX402OnchainFromStore(), refreshSolanaX402OnchainFromStore()])` call at the top of the RSC, matching the parent.
- Net: `1 file changed, 18 insertions(+), 56 deletions(-)`.

## Verification

- `npm run typecheck` — clean (no errors)
- No behavior change: same `byFacilitator` / `byDay` / `samples` surface, same
  rendering, same `notFound()` semantics when neither chain has the
  facilitator.

## Risk

Low. RSC-only change, no schema change, types narrow strictly (lib types are a
subset of the local `OnchainShape` — the dropped fields `to` / `from` /
`facilitatorAddresses` are never read by this page).