### PR TITLE
refactor(agent-commerce): detail page v4 chrome migration

### DIFF
--- a/src/app/agent-commerce/[slug]/page.tsx
+++ b/src/app/agent-commerce/[slug]/page.tsx
@@ -8,6 +8,8 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import { PageHead } from "@/components/ui/PageHead";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 import {
   CapabilityChips,
   PricingBadge,
@@ -16,6 +18,7 @@ import {
   StatusBadges,
 } from "@/components/agent-commerce/AgentCommerceBadges";
 import {
+  getAgentCommerceFile,
   getAgentCommerceItem,
   getAgentCommerceItems,
   refreshAgentCommerceFromStore,
@@ -70,24 +73,26 @@ export default async function AgentCommerceDetailPage({ params }: DetailProps) {
   // exists, the panel renders nothing.
   const repoProfile = item.links.github ? getRepoProfile(item.links.github) : null;
   const aisoScan = repoProfile?.aisoScan ?? null;
+  const file = getAgentCommerceFile();
 
   return (
-    <main className="home-surface ac-detail">
-      <section className="page-head">
-        <div>
-          <div className="crumb">
-            <Link href="/agent-commerce">Agent Commerce</Link> / {item.kind} / {item.category}
-          </div>
-        </div>
-      </section>
+    <main className="home-surface ac-detail max-w-[1600px] mx-auto px-4 md:px-6 py-4 md:py-6">
+      <PageHead
+        crumb={
+          <>
+            <b>AGENT</b> · <Link href="/agent-commerce">AGENT-COMMERCE</Link> / {item.kind} / {item.category}
+          </>
+        }
+        h1={item.name}
+        lede={item.brief}
+        clock={<FreshnessBadge source="mcp" lastUpdatedAt={file.fetchedAt} />}
+      />
 
       <header className="ac-detail-head">
         <div className="ac-logo" style={{ background: getGradient(item.name) }}>
           {getInitials(item.name)}
         </div>
         <div>
-          <h1 className="ac-detail-name">{item.name}</h1>
-          <p className="ac-detail-brief">{item.brief}</p>
           <div style={{ marginTop: 10 }}>
             <ProtocolList protocols={item.protocols} />
           </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6434,20 +6434,6 @@ body::before {
   min-width: 84px;
 }
 
-.ac-detail-name {
-  color: var(--v4-ink-000);
-  font-family: var(--v4-sans);
-  font-size: var(--v4-text-30);
-  letter-spacing: var(--v4-track-tight-h2);
-  line-height: var(--v4-leading-105);
-}
-
-.ac-detail-brief {
-  max-width: 980px;
-  color: var(--v4-ink-200);
-  font-size: var(--v4-text-13);
-  line-height: var(--v4-leading-155);
-}
 
 .ac-detail-grid {
   align-items: start;

--- a/src/components/agent-commerce/agent-commerce.css
+++ b/src/components/agent-commerce/agent-commerce.css
@@ -1079,22 +1079,6 @@
   border-radius: 2px;
 }
 
-.ac-detail-name {
-  font-family: var(--font-sans);
-  font-size: 28px;
-  font-weight: 700;
-  color: var(--color-text-default);
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-
-.ac-detail-brief {
-  margin: 6px 0 0;
-  color: var(--color-text-subtle);
-  font-size: 14px;
-  line-height: 1.5;
-}
-
 .ac-detail-grid {
   display: grid;
   grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);


### PR DESCRIPTION
## Summary

Migrates `/agent-commerce/[slug]` off the legacy `<section className="page-head">` + fixed `font-size: 28px` h1 chrome to the canonical v4 `<PageHead>` primitive used by `/funding`, `/signals`, etc.

- Replaces the legacy breadcrumb section + `h1.ac-detail-name` with `<PageHead crumb h1={item.name} lede={item.brief} clock={<FreshnessBadge .../>} />`.
- `source="mcp"` for `FreshnessBadge` — same 6h worker-fleet cadence as the agent-commerce collector and the closest valid `NewsSource` (`"agent-commerce"` is not a member of the `NewsSource` union).
- Wraps the page body in the canonical `<main className="home-surface ac-detail max-w-[1600px] mx-auto px-4 md:px-6 py-4 md:py-6">` shell.
- Removes the now-orphan `.ac-detail-name` and `.ac-detail-brief` rules from both `src/app/globals.css` and `src/components/agent-commerce/agent-commerce.css` (no remaining consumers — verified via grep).
- Keeps the secondary `<header className="ac-detail-head">` block intact (logo, protocols, ScoreBar, "Visit") — it's the entity-specific hero, not the page chrome.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Visual verification on Vercel Preview: PageHead chrome present, lede renders, FreshnessBadge wires `fetchedAt`
- [ ] No fixed `28px` h1 — H1 inherits v4 type tokens via `PageHead`

3 files changed, 15 insertions(+), 40 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)