### PR TITLE
feat(agent-commerce): full v4 rebuild — kill fake growth curve, extract 6 components, cache fix B

### DIFF
--- a/src/app/agent-commerce/page.tsx
+++ b/src/app/agent-commerce/page.tsx
@@ -1,25 +1,47 @@
 // /agent-commerce — Agent Commerce radar (M2M economy: x402, MCP, wallets, APIs).
 //
-// RSC entry. Tabs + filters live entirely in URL state, parsed at top.
-// Mirrors the Signal/Funding page composition: refresh hook, sync getters,
-// server-side filter/sort, deterministic render.
+// V4 rebuild (2026-05-17). Replaces a 2293-line monolith that:
+//   - Used V2/V3 design tokens while every neighbor (/funding, /signals) was V4.
+//   - Synthesised a fake growth curve via Math.pow(frac, 1.4) and rendered it
+//     as the headline trend chart — freshness-honesty violation.
+//   - Awaited searchParams in the RSC, forcing full-dynamic rendering and
+//     breaking ISR.
+//   - Hand-rolled 111 inline style blocks + 61 hardcoded hexes.
+//
+// The new shell:
+//   - Renders the static v4 chrome (PageHead / KpiBand / VerdictRibbon /
+//     SectionHead) on the server, with `revalidate=1200`.
+//   - Delegates tabs + filter bar + browse grid to a client island
+//     (AgentCommerceFilteredContent) that reads useSearchParams() — so the
+//     RSC stays ISR-cacheable.
+//   - Drops the synthetic Sparkline + MiniBoard + growthCurve. Surfaces only
+//     real data.
+//   - Wires FreshnessBadge so the chrome reflects classifyFreshness('skills').
 
 import type { Metadata } from "next";
-import Link from "next/link";
 
-import { Card, CardBody, CardHeader } from "@/components/ui/Card";
-import { FooterBar } from "@/components/ui/FooterBar";
-import { AgentCommerceActivityPulse } from "@/components/agent-commerce/AgentCommerceActivityPulse";
-import { AgentCommerceCard } from "@/components/agent-commerce/AgentCommerceCard";
-import { AgentCommerceFilterBar } from "@/components/agent-commerce/AgentCommerceFilterBar";
-import { AgentCommerceHero } from "@/components/agent-commerce/AgentCommerceHero";
-import { AgentCommerceMoversBoard } from "@/components/agent-commerce/AgentCommerceMoversBoard";
-import { AgentCommerceTabs } from "@/components/agent-commerce/AgentCommerceTabs";
+import "@/components/agent-commerce/agent-commerce.css";
+
+import { PageHead } from "@/components/ui/PageHead";
+import { SectionHead } from "@/components/ui/SectionHead";
+import { KpiBand } from "@/components/ui/KpiBand";
 import {
-  AgentCommerceTicker,
-  type AgentCommerceTickerItem,
-} from "@/components/agent-commerce/AgentCommerceTicker";
-import { Sparkline } from "@/components/agent-commerce/Sparkline";
+  VerdictRibbon,
+  type VerdictTone,
+} from "@/components/ui/VerdictRibbon";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+import { classifyFreshness } from "@/lib/news/freshness";
+
+import { AgentCommerceTicker } from "@/components/agent-commerce/AgentCommerceTicker";
+import type { AgentCommerceTickerItem } from "@/components/agent-commerce/AgentCommerceTicker";
+import { AgentCommerceFilteredContent } from "@/components/agent-commerce/AgentCommerceFilteredContent";
+import { MoversBoard } from "@/components/agent-commerce/MoversBoard";
+import { ProtocolPulseGrid } from "@/components/agent-commerce/ProtocolPulseGrid";
+import { ScoreDistributionGrid } from "@/components/agent-commerce/ScoreDistributionGrid";
+import { TokenEconomyBoards } from "@/components/agent-commerce/TokenEconomyBoards";
+import { OnchainSettlementsBoard } from "@/components/agent-commerce/OnchainSettlementsBoard";
+import { DuneVolumeBoard } from "@/components/agent-commerce/DuneVolumeBoard";
+
 import {
   getAgentCommerceFile,
   getAgentCommerceItems,
@@ -39,21 +61,7 @@ import {
   getDuneX402Volume,
   refreshDuneX402VolumeFromStore,
 } from "@/lib/dune-x402-volume";
-import {
-  applyFilter,
-  parseCategory,
-  parsePortalReady,
-  parsePricing,
-  parseProtocols,
-  parseSearchQuery,
-  parseTab,
-  TABS,
-  type AgentCommerceFilter,
-} from "@/lib/agent-commerce/extract";
-import type {
-  AgentCommerceItem,
-  AgentCommerceProtocol,
-} from "@/lib/agent-commerce/types";
+import type { AgentCommerceItem } from "@/lib/agent-commerce/types";
 
 export const revalidate = 1200;
 
@@ -79,364 +87,20 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
-interface PageProps {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
-}
-
-function pickFirst(value: string | string[] | undefined): string | undefined {
-  if (Array.isArray(value)) return value[0];
-  return value;
-}
-
-function buildBaseQuery(
-  searchParams: Record<string, string | string[] | undefined>,
-): URLSearchParams {
-  const next = new URLSearchParams();
-  for (const [k, v] of Object.entries(searchParams)) {
-    const first = pickFirst(v);
-    if (typeof first === "string" && first.length > 0) {
-      next.set(k, first);
-    }
-  }
-  return next;
-}
-
 function formatClock(value: string): string {
   const date = new Date(value);
-  return Number.isFinite(date.getTime())
-    ? date.toISOString().slice(11, 19)
-    : "warming";
+  if (!Number.isFinite(date.getTime())) return "—";
+  if (value.startsWith("1970-")) return "—";
+  return date.toISOString().slice(11, 19);
 }
 
-function buildOpportunities(
+function buildTickerItems(
   items: AgentCommerceItem[],
-): { title: string; reason: string }[] {
-  const ops: { title: string; reason: string }[] = [];
-  const x402Count = items.filter((i) => i.badges.x402Enabled).length;
-  const portalCount = items.filter((i) => i.badges.portalReady).length;
-  const billingCount = items.filter(
-    (i) =>
-      i.category === "payments" &&
-      i.kind === "infra" &&
-      i.pricing.type === "subscription",
-  ).length;
-  const inferenceCount = items.filter(
-    (i) => i.category === "inference",
-  ).length;
-  const walletCount = items.filter((i) => i.kind === "wallet").length;
+): AgentCommerceTickerItem[] {
+  const ticker: AgentCommerceTickerItem[] = [];
+  const tokenItems = items.filter((i) => i.live?.tokenSymbol);
 
-  if (x402Count > 0 && portalCount < x402Count / 2) {
-    ops.push({
-      title: "Build x402 directory + Portal manifest crawler",
-      reason: `${x402Count} x402-enabled services tracked, only ${portalCount} expose Portal manifests. The rest are dark to agent discovery.`,
-    });
-  }
-  if (billingCount < 3) {
-    ops.push({
-      title: "Build agent billing SaaS",
-      reason: "Fewer than 3 dedicated agent-billing tools indexed. Stripe-MCP and a handful of x402 SDKs are the only options. Big gap, slim moat.",
-    });
-  }
-  if (inferenceCount > 6 && items.filter((i) => i.protocols.includes("x402")).length < 2) {
-    ops.push({
-      title: "Build x402 inference gateway",
-      reason: `${inferenceCount} inference APIs but only ${items.filter((i) => i.protocols.includes("x402")).length} accept x402. A gateway that adds 402-pricing to any OpenAI-compatible endpoint would be agent-native by default.`,
-    });
-  }
-  if (walletCount > 0) {
-    ops.push({
-      title: "Agent-wallet aggregator dashboard",
-      reason: `${walletCount} agent wallet providers each ship their own SDK and policy DSL. A unified surface (load any wallet, set spend caps in one schema) is missing.`,
-    });
-  }
-  ops.push({
-    title: "Build Agent Commerce analytics for Bloomberg-class buyers",
-    reason: "No DefiLlama-equivalent for x402 settlement volume, MCP install counts, or agent-API per-call prices. This page is the seed.",
-  });
-  return ops;
-}
-
-function MiniBoard({
-  title,
-  items,
-  accent,
-  rightLabel,
-  emptyHint,
-}: {
-  title: string;
-  items: AgentCommerceItem[];
-  accent: string;
-  rightLabel?: string;
-  emptyHint?: string;
-}) {
-  return (
-    <Card className="col-6">
-      <CardHeader showCorner right={<span>{rightLabel ?? `top ${items.length}`}</span>}>
-        {title}
-      </CardHeader>
-      <CardBody>
-        {items.length === 0 ? (
-          <div style={{ padding: "10px 12px", color: "var(--color-text-faint)", fontSize: 12 }}>
-            {emptyHint ?? "No entries match."}
-          </div>
-        ) : (
-          items.map((item, idx) => {
-            const score = item.scores.composite;
-            const tone = score >= 60 ? "#34d399" : score >= 40 ? "#f59e0b" : "var(--color-text-subtle)";
-            // 2026-05-15: removed synthetic seeded sparkline — it suggested
-            // a real time-series that doesn't exist. Pass `[]` so Sparkline
-            // (early-returns on data.length < 2) renders nothing until the
-            // score-history collector lands.
-            const sparkData: number[] = [];
-            return (
-              <Link
-                key={item.id}
-                href={`/agent-commerce/${item.slug}`}
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "20px minmax(0, 1fr) 80px 36px",
-                  gap: 10,
-                  alignItems: "center",
-                  padding: "8px 12px",
-                  borderBottom: "1px solid var(--color-border-subtle)",
-                  textDecoration: "none",
-                  color: "inherit",
-                }}
-              >
-                <span
-                  style={{
-                    fontFamily: "var(--font-mono, ui-monospace)",
-                    fontSize: 10,
-                    color: idx === 0 ? accent : "var(--color-text-faint)",
-                    fontWeight: idx === 0 ? 700 : 400,
-                  }}
-                >
-                  {String(idx + 1).padStart(2, "0")}
-                </span>
-                <span
-                  style={{
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    color: "var(--color-text-default)",
-                    fontSize: 12.5,
-                  }}
-                >
-                  {item.name}
-                </span>
-                <span style={{ color: tone }}>
-                  <Sparkline data={sparkData} color={tone} width={80} height={18} />
-                </span>
-                <span
-                  style={{
-                    color: tone,
-                    fontFamily: "var(--font-mono, ui-monospace)",
-                    fontWeight: 700,
-                    textAlign: "right",
-                  }}
-                >
-                  {score}
-                </span>
-              </Link>
-            );
-          })
-        )}
-      </CardBody>
-    </Card>
-  );
-}
-
-export default async function AgentCommercePage({ searchParams }: PageProps) {
-  await Promise.all([
-    refreshAgentCommerceFromStore(),
-    refreshBaseX402OnchainFromStore(),
-    refreshSolanaX402OnchainFromStore(),
-    refreshDuneX402VolumeFromStore(),
-  ]);
-  const sp = (await searchParams) ?? {};
-  const baseQuery = buildBaseQuery(sp);
-
-  const filter: AgentCommerceFilter = {
-    tab: parseTab(pickFirst(sp.tab)),
-    category: parseCategory(pickFirst(sp.cat)),
-    protocols: parseProtocols(pickFirst(sp.protocol)),
-    pricing: parsePricing(pickFirst(sp.pricing)),
-    portalReady: parsePortalReady(pickFirst(sp.portalready)),
-    query: parseSearchQuery(pickFirst(sp.q)),
-  };
-
-  const file = getAgentCommerceFile();
-  const all = getAgentCommerceItems();
-  const stats = getAgentCommerceStats();
-  const cold = isAgentCommerceCold(file);
-  const computed = formatClock(file.fetchedAt);
-
-  // Per-tab counts for tab strip
-  const tabCounts: Partial<Record<(typeof TABS)[number], number>> = {};
-  for (const tab of TABS) {
-    if (tab === "overview" || tab === "signals" || tab === "opportunities") {
-      tabCounts[tab] = stats.totalItems;
-      continue;
-    }
-    const subset = applyFilter(all, {
-      ...filter,
-      tab,
-      category: null,
-      protocols: new Set<AgentCommerceProtocol>(),
-      pricing: null,
-      portalReady: false,
-      query: "",
-    });
-    tabCounts[tab] = subset.length;
-  }
-
-  const filtered = applyFilter(all, filter);
-  const sorted = filtered
-    .slice()
-    .sort((a, b) => b.scores.composite - a.scores.composite);
-  const grid = sorted.slice(0, 60);
-
-  const totalRendered = sorted.length;
-  const opportunities = filter.tab === "opportunities" ? buildOpportunities(all) : [];
-
-  const protocolBreakdown = Object.entries(stats.byProtocol)
-    .map(([proto, n]) => ({ proto, n }))
-    .sort((a, b) => b.n - a.n)
-    .slice(0, 8);
-
-  const kindBreakdown = Object.entries(stats.byKind)
-    .map(([k, n]) => ({ k, n }))
-    .sort((a, b) => b.n - a.n);
-
-  const categoryBreakdown = Object.entries(stats.byCategory)
-    .map(([k, n]) => ({ k, n }))
-    .sort((a, b) => b.n - a.n);
-
-  const pricingCounts: Record<string, number> = {
-    per_call: 0,
-    subscription: 0,
-    free: 0,
-    unknown: 0,
-  };
-  for (const item of all) {
-    pricingCounts[item.pricing.type] =
-      (pricingCounts[item.pricing.type] ?? 0) + 1;
-  }
-  const pricingRows = Object.entries(pricingCounts)
-    .map(([k, n]) => ({ k, n }))
-    .sort((a, b) => b.n - a.n);
-
-  const scoreBuckets = [
-    { label: "80–100", min: 80, max: 100, tone: "positive", n: 0 },
-    { label: "60–79", min: 60, max: 79, tone: "early", n: 0 },
-    { label: "40–59", min: 40, max: 59, tone: "warning", n: 0 },
-    { label: "20–39", min: 20, max: 39, tone: "external", n: 0 },
-    { label: "0–19", min: 0, max: 19, tone: "neutral", n: 0 },
-  ];
-  for (const item of all) {
-    const s = item.scores.composite;
-    for (const b of scoreBuckets) {
-      if (s >= b.min && s <= b.max) {
-        b.n++;
-        break;
-      }
-    }
-  }
-  const maxBucket = Math.max(...scoreBuckets.map((b) => b.n), 1);
-
-  const flagRows = [
-    { label: "Agent Actionable", n: stats.agentActionableCount },
-    { label: "x402 Enabled", n: stats.x402EnabledCount },
-    { label: "MCP Server", n: stats.mcpServerCount },
-    { label: "Portal Ready", n: stats.portalReadyCount },
-    { label: "AISO ≥80", n: stats.highAisoCount },
-  ];
-
-  const capCounts = new Map<string, number>();
-  for (const item of all) {
-    for (const cap of item.capabilities) {
-      capCounts.set(cap, (capCounts.get(cap) ?? 0) + 1);
-    }
-  }
-  const topCapabilities = Array.from(capCounts.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 32);
-
-  const movers = sorted.slice(0, 12);
-  const topBarMax = Math.max(
-    ...movers.map((m) => m.scores.composite),
-    1,
-  );
-
-  const compactProtocol = (
-    proto: string,
-  ): { color: string; label: string } => {
-    switch (proto) {
-      case "x402":
-        return { color: "#f59e0b", label: "x402" };
-      case "mcp":
-        return { color: "#22d3ee", label: "MCP" };
-      case "a2a":
-        return { color: "#f472b6", label: "A2A" };
-      case "rest":
-      case "graphql":
-      case "grpc":
-      case "http":
-      default:
-        return { color: "var(--color-text-faint)", label: proto.toUpperCase() };
-    }
-  };
-
-  // Realistic accelerating-growth curve to current count. Replace with real
-  // weekly counts once collector tracks firstSeenAt across runs.
-  function growthCurve(target: number, weeks = 12): number[] {
-    const out: number[] = [];
-    for (let i = 0; i < weeks; i++) {
-      const frac = (i + 1) / weeks;
-      const eased = Math.pow(frac, 1.4);
-      out.push(Math.round(target * eased));
-    }
-    return out;
-  }
-
-  function topByKind(kind: AgentCommerceItem["kind"], limit = 5): AgentCommerceItem[] {
-    return all
-      .filter((i) => i.kind === kind)
-      .sort((a, b) => b.scores.composite - a.scores.composite)
-      .slice(0, limit);
-  }
-
-  function topMcpServers(limit = 5): AgentCommerceItem[] {
-    return all
-      .filter((i) => i.badges.mcpServer)
-      .sort((a, b) => b.scores.composite - a.scores.composite)
-      .slice(0, limit);
-  }
-
-  function topX402(limit = 5): AgentCommerceItem[] {
-    return all
-      .filter((i) => i.badges.x402Enabled)
-      .sort((a, b) => b.scores.composite - a.scores.composite)
-      .slice(0, limit);
-  }
-
-  const activitySeries = growthCurve(stats.totalItems);
-  const topWallets = topByKind("wallet");
-  const topApis = topByKind("api");
-  const topMarketplaces = topByKind("marketplace");
-  const topMcp = topMcpServers();
-  const topX402List = topX402();
-
-  // Token-economy boards (CoinGecko). Filter to entities with a tokenSymbol.
-  const tokenItems = all.filter((i) => i.live?.tokenSymbol);
-  const topTokensByMcap = tokenItems
-    .slice()
-    .sort(
-      (a, b) =>
-        (b.live?.marketCapUsd ?? 0) - (a.live?.marketCapUsd ?? 0),
-    )
-    .slice(0, 8);
-  const topTokenGainers = tokenItems
+  const gainers = tokenItems
     .filter((i) => Number.isFinite(i.live?.priceChange24hPct))
     .slice()
     .sort(
@@ -444,18 +108,10 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
         (b.live?.priceChange24hPct ?? 0) -
         (a.live?.priceChange24hPct ?? 0),
     )
-    .slice(0, 8);
-  const tokenMcapTotal = tokenItems.reduce(
-    (a, b) => a + (b.live?.marketCapUsd ?? 0),
-    0,
-  );
-
-  // Live ticker items: top token movers ± freshly-pushed GitHub repos +
-  // newest verified entities. Capped at 24 total (12 unique × 2 looped).
-  const tickerItems: AgentCommerceTickerItem[] = [];
-  for (const item of topTokenGainers.slice(0, 5)) {
+    .slice(0, 5);
+  for (const item of gainers) {
     const change = item.live?.priceChange24hPct ?? 0;
-    tickerItems.push({
+    ticker.push({
       kind: change >= 0 ? "token-up" : "token-down",
       href: `/agent-commerce/${item.slug}`,
       label: `$${item.live?.tokenSymbol ?? ""}`,
@@ -464,7 +120,8 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
       down: change < 0,
     });
   }
-  const tokenLosers = tokenItems
+
+  const losers = tokenItems
     .filter((i) => Number.isFinite(i.live?.priceChange24hPct))
     .slice()
     .sort(
@@ -473,9 +130,9 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
         (b.live?.priceChange24hPct ?? 0),
     )
     .slice(0, 3);
-  for (const item of tokenLosers) {
+  for (const item of losers) {
     const change = item.live?.priceChange24hPct ?? 0;
-    tickerItems.push({
+    ticker.push({
       kind: "token-down",
       href: `/agent-commerce/${item.slug}`,
       label: `$${item.live?.tokenSymbol ?? ""}`,
@@ -484,17 +141,13 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
       down: true,
     });
   }
-  // Defensive: only keep items with a *parseable* ISO pushedAt. Prod has
-  // surfaced rows with malformed/non-string pushedAt values (digest 571787114
-  // observed 2026-05-10) which slip past the existence check and crash the
-  // sort with a NaN comparator. Computing the timestamp once + filtering on
-  // Number.isFinite eliminates that path.
+
   type FreshGithubRow = {
     item: AgentCommerceItem;
     ts: number;
     stars: number;
   };
-  const freshGithub: FreshGithubRow[] = all
+  const freshGithub: FreshGithubRow[] = items
     .map<FreshGithubRow | null>((i) => {
       const pushedAt = i.live?.pushedAt;
       const stars = i.live?.stars;
@@ -508,7 +161,7 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
     .slice(0, 4);
   for (const { item, ts, stars } of freshGithub) {
     const days = Math.max(0, Math.floor((Date.now() - ts) / 86_400_000));
-    tickerItems.push({
+    ticker.push({
       kind: "github-push",
       href: `/agent-commerce/${item.slug}`,
       label: item.name,
@@ -517,27 +170,151 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
     });
   }
 
+  return ticker;
+}
+
+export default async function AgentCommercePage() {
+  await Promise.all([
+    refreshAgentCommerceFromStore(),
+    refreshBaseX402OnchainFromStore(),
+    refreshSolanaX402OnchainFromStore(),
+    refreshDuneX402VolumeFromStore(),
+  ]);
+
+  const file = getAgentCommerceFile();
+  const items = getAgentCommerceItems();
+  const stats = getAgentCommerceStats();
+  const cold = isAgentCommerceCold(file);
+  const computed = formatClock(file.fetchedAt);
+  const tickerItems = buildTickerItems(items);
+
+  const sortedByScore = items
+    .slice()
+    .sort((a, b) => b.scores.composite - a.scores.composite);
+  const movers = sortedByScore.slice(0, 12);
+
+  const base = getBaseX402Onchain();
+  const solana = getSolanaX402Onchain();
+  const dune = getDuneX402Volume();
+
+  // Mirror the FreshnessBadge's verdict on the VerdictRibbon — money tone when
+  // the feed is live, amber when stale/cold. The 'skills' source uses the
+  // 12h slow-cron budget which matches agent-commerce's 12h worker cadence.
+  const verdict = classifyFreshness("skills", file.fetchedAt);
+  const ribbonTone: VerdictTone =
+    verdict.status === "live" ? "money" : "amber";
+
   return (
-    <>
-    <main className="home-surface agent-commerce-page">
-      <AgentCommerceHero
-        computed={computed}
-        windowDays={file.windowDays}
-        stats={stats}
+    <main className="max-w-[1600px] mx-auto px-4 md:px-6 py-4 md:py-6 home-surface agent-commerce-page">
+      <PageHead
+        crumb={
+          <>
+            <b>AGENT COMMERCE</b> · TERMINAL · /AGENT-COMMERCE
+          </>
+        }
+        h1="What agents can transact with."
+        lede="On-chain x402 settlements, agent-callable APIs, MCP servers, wallets and marketplaces — scored by Portal readiness, pricing clarity, AISO visibility, and adoption."
+        clock={
+          <>
+            <span className="big">{computed}</span>
+            <span className="muted">UTC · UPDATED</span>
+            <FreshnessBadge source="skills" lastUpdatedAt={file.fetchedAt} />
+          </>
+        }
+      />
+
+      <KpiBand
+        cells={[
+          {
+            label: "TOTAL",
+            value: stats.totalItems,
+            sub: "entities",
+            pip: "var(--v4-ink-300)",
+          },
+          {
+            label: "x402",
+            value: stats.x402EnabledCount,
+            sub: "enabled",
+            tone: "amber",
+            pip: "var(--v4-amber)",
+          },
+          {
+            label: "PORTAL",
+            value: stats.portalReadyCount,
+            sub: "ready",
+            tone: "money",
+            pip: "var(--v4-money)",
+          },
+          {
+            label: "MCP",
+            value: stats.mcpServerCount,
+            sub: "servers",
+            tone: "acc",
+            pip: "var(--v4-cyan)",
+          },
+          {
+            label: "ACTIONABLE",
+            value: stats.agentActionableCount,
+            sub: "agent-callable",
+            tone: "acc",
+            pip: "var(--v4-violet)",
+          },
+          {
+            label: "AISO ≥80",
+            value: stats.highAisoCount,
+            sub: "highly visible",
+            tone: "amber",
+            pip: "var(--v4-gold)",
+          },
+        ]}
+      />
+
+      <VerdictRibbon
+        tone={ribbonTone}
+        stamp={{
+          eyebrow: "// COMMERCE RADAR",
+          headline: (
+            <span
+              style={{
+                fontFamily:
+                  "var(--font-geist-mono), var(--font-jetbrains-mono), monospace",
+                fontSize: "var(--v4-text-22, 22px)",
+                fontWeight: 600,
+                letterSpacing: "0.04em",
+                color: "var(--v4-ink-100)",
+              }}
+            >
+              {stats.totalItems} entities
+            </span>
+          ),
+          sub: `${file.windowDays}d window · computed ${computed} UTC`,
+        }}
+        text={
+          <>
+            <b>{stats.totalItems} services</b> indexed.{" "}
+            <span style={{ color: "var(--v4-amber)" }}>
+              {stats.x402EnabledCount} x402-enabled
+            </span>
+            ,{" "}
+            <span style={{ color: "var(--v4-money)" }}>
+              {stats.portalReadyCount} Portal Ready
+            </span>
+            ,{" "}
+            <span style={{ color: "var(--v4-cyan)" }}>
+              {stats.mcpServerCount} MCP servers
+            </span>
+            ,{" "}
+            <span style={{ color: "var(--v4-violet)" }}>
+              {stats.agentActionableCount} agent-actionable
+            </span>
+            .
+          </>
+        }
+        actionHref="/feeds/agent-commerce.xml"
+        actionLabel="RSS →"
       />
 
       <AgentCommerceTicker items={tickerItems} />
-
-      <AgentCommerceTabs active={filter.tab} counts={tabCounts} baseQuery={baseQuery} />
-
-      <AgentCommerceFilterBar
-        category={filter.category}
-        protocols={filter.protocols}
-        pricing={filter.pricing}
-        portalReady={filter.portalReady}
-        query={filter.query}
-        baseQuery={baseQuery}
-      />
 
       {cold ? (
         <div className="ac-empty">
@@ -552,1302 +329,103 @@ export default async function AgentCommercePage({ searchParams }: PageProps) {
           </p>
         </div>
       ) : (
-        <>
-          {/* ========== 01+02 — MOVERS BOARD (L) + ACTIVITY PULSE (R) ==========
-            * A8-P4: 2-col body grid. Stacks at <1024px, splits ~65/35 above.
-            * Each column wraps its own .sec-head + content so the grid cell
-            * spans the section title and the section body.
-            */}
-          <div className="ac-body-grid">
-            <div>
-              <AgentCommerceMoversBoard movers={movers} />
-            </div>
-            <div>
-              <AgentCommerceActivityPulse
-                activitySeries={activitySeries}
-                stats={stats}
-              />
-            </div>
-          </div>
-
-          {/* ========== 03 — SCORE DISTRIBUTION ========== */}
-          <div className="sec-head">
-            <span className="sec-num">{"// 03"}</span>
-            <h2 className="sec-title">Score distribution</h2>
-            <span className="sec-meta">
-              avg <b>{stats.averageComposite}</b> · top <b>{stats.topComposite}</b>
-            </span>
-          </div>
-          <div className="grid">
-            <Card className="col-8">
-              <CardHeader showCorner right={<span>{stats.totalItems} indexed</span>}>
-                Top 10 — composite bars
-              </CardHeader>
-              <CardBody>
-                <div className="funding-bars" aria-label="Composite leaderboard">
-                  {sorted.slice(0, 10).map((item, idx) => {
-                    const width = Math.max(
-                      4,
-                      (item.scores.composite / topBarMax) * 100,
-                    );
-                    return (
-                      <Link
-                        href={`/agent-commerce/${item.slug}`}
-                        className="funding-bar"
-                        key={item.id}
-                      >
-                        <span className="idx">{String(idx + 1).padStart(2, "0")}</span>
-                        <span className="track">
-                          <i style={{ width: `${width}%` }} />
-                        </span>
-                        <span className="amt">
-                          {item.scores.composite}
-                          <span style={{ marginLeft: 8, color: "var(--color-text-faint)", fontWeight: 400 }}>
-                            {item.name}
-                          </span>
-                        </span>
-                      </Link>
-                    );
-                  })}
-                </div>
-              </CardBody>
-            </Card>
-            <Card className="col-4">
-              <CardHeader showCorner right={<span>histogram</span>}>
-                Score buckets
-              </CardHeader>
-              <CardBody>
-                {scoreBuckets.map((b) => {
-                  const width = Math.round((b.n / maxBucket) * 100);
-                  return (
-                    <div className="stock-row" key={b.label}>
-                      <span className={`col-pip sd-f${b.tone === "positive" ? "1" : b.tone === "early" ? "2" : b.tone === "warning" ? "3" : b.tone === "external" ? "4" : "5"}`} />
-                      <span className="nm">{b.label}</span>
-                      <span className="px">{b.n}</span>
-                      <span className="ch up">
-                        <span
-                          style={{
-                            display: "inline-block",
-                            width: 60,
-                            height: 4,
-                            background: "var(--color-bg-canvas)",
-                            borderRadius: 2,
-                            position: "relative",
-                            overflow: "hidden",
-                          }}
-                        >
-                          <span
-                            style={{
-                              position: "absolute",
-                              inset: 0,
-                              width: `${width}%`,
-                              background: "var(--color-accent)",
-                            }}
-                          />
-                        </span>
-                      </span>
-                    </div>
-                  );
-                })}
-              </CardBody>
-            </Card>
-          </div>
-
-          {/* ========== 04 — PROTOCOL + KIND MIX ========== */}
-          <div className="sec-head">
-            <span className="sec-num">{"// 04"}</span>
-            <h2 className="sec-title">Protocol &amp; kind mix</h2>
-            <span className="sec-meta">
-              <b>{Object.keys(stats.byProtocol).length}</b> protocols ·{" "}
-              <b>{kindBreakdown.length}</b> kinds
-            </span>
-          </div>
-          <div className="grid">
-            <Card className="col-4">
-              <CardHeader showCorner right={<span>protocols</span>}>
-                Protocol adoption
-              </CardHeader>
-              <CardBody>
-                {protocolBreakdown.map(({ proto, n }) => {
-                  const total = Math.max(stats.totalItems, 1);
-                  const pct = Math.round((n / total) * 100);
-                  const cp = compactProtocol(proto);
-                  return (
-                    <div className="ac-score-row" key={proto}>
-                      <span style={{ color: cp.color, fontWeight: 700 }}>
-                        {cp.label}
-                      </span>
-                      <span className="ac-score-track">
-                        <i
-                          style={{
-                            width: `${pct}%`,
-                            background: cp.color,
-                          }}
-                        />
-                      </span>
-                      <span className="ac-score-num">{n}</span>
-                    </div>
-                  );
-                })}
-              </CardBody>
-            </Card>
-            <Card className="col-4">
-              <CardHeader showCorner right={<span>by kind</span>}>
-                Entity kind
-              </CardHeader>
-              <CardBody>
-                {kindBreakdown.map(({ k, n }) => {
-                  const total = Math.max(stats.totalItems, 1);
-                  const pct = Math.round((n / total) * 100);
-                  return (
-                    <div className="ac-score-row" key={k}>
-                      <span style={{ textTransform: "capitalize" }}>{k}</span>
-                      <span className="ac-score-track">
-                        <i style={{ width: `${pct}%` }} />
-                      </span>
-                      <span className="ac-score-num">{n}</span>
-                    </div>
-                  );
-                })}
-              </CardBody>
-            </Card>
-            <Card className="col-4">
-              <CardHeader showCorner right={<span>by category</span>}>
-                Category mix
-              </CardHeader>
-              <CardBody>
-                {categoryBreakdown.map(({ k, n }) => {
-                  const total = Math.max(stats.totalItems, 1);
-                  const pct = Math.round((n / total) * 100);
-                  return (
-                    <div className="ac-score-row" key={k}>
-                      <span style={{ textTransform: "capitalize" }}>{k}</span>
-                      <span className="ac-score-track">
-                        <i style={{ width: `${pct}%` }} />
-                      </span>
-                      <span className="ac-score-num">{n}</span>
-                    </div>
-                  );
-                })}
-              </CardBody>
-            </Card>
-          </div>
-
-          {/* ========== 05 — PRICING + FLAGS ========== */}
-          <div className="sec-head">
-            <span className="sec-num">{"// 05"}</span>
-            <h2 className="sec-title">Pricing &amp; readiness</h2>
-            <span className="sec-meta">
-              <b>{stats.x402EnabledCount + stats.portalReadyCount}</b> agent-native flags
-            </span>
-          </div>
-          <div className="grid">
-            <Card className="col-6">
-              <CardHeader showCorner right={<span>pricing model</span>}>
-                Pricing distribution
-              </CardHeader>
-              <CardBody>
-                {pricingRows.map(({ k, n }, idx) => {
-                  const total = Math.max(stats.totalItems, 1);
-                  const pct = Math.round((n / total) * 100);
-                  const tone =
-                    k === "free"
-                      ? "#34d399"
-                      : k === "per_call"
-                        ? "#f59e0b"
-                        : k === "subscription"
-                          ? "#a78bfa"
-                          : "var(--color-text-faint)";
-                  return (
-                    <div className="stock-row" key={k}>
-                      <span className={`col-pip sd-f${(idx % 6) + 1}`} />
-                      <span className="nm" style={{ textTransform: "capitalize" }}>
-                        {k.replace("_", "-")}
-                      </span>
-                      <span className="px">{n}</span>
-                      <span className="ch up" style={{ color: tone }}>
-                        {pct}%
-                      </span>
-                    </div>
-                  );
-                })}
-              </CardBody>
-            </Card>
-            <Card className="col-6">
-              <CardHeader showCorner right={<span>readiness</span>}>
-                Status flag adoption
-              </CardHeader>
-              <CardBody>
-                {flagRows.map(({ label, n }) => {
-                  const total = Math.max(stats.totalItems, 1);
-                  const pct = Math.round((n / total) * 100);
-                  return (
-                    <div className="ac-score-row" key={label}>
-                      <span>{label}</span>
-                      <span className="ac-score-track">
-                        <i style={{ width: `${pct}%` }} />
-                      </span>
-                      <span className="ac-score-num">{n}</span>
-                    </div>
-                  );
-                })}
-              </CardBody>
-            </Card>
-          </div>
-
-          {/* ========== 06 — TOKEN ECONOMY (CoinGecko) ========== */}
-          {tokenItems.length > 0 ? (
-            <>
-              <div className="sec-head">
-                <span className="sec-num">{"// 06"}</span>
-                <h2 className="sec-title">Agent token economy</h2>
-                <span className="sec-meta">
-                  <b>{tokenItems.length}</b> tokens · combined mcap{" "}
-                  <b>${(tokenMcapTotal / 1e9).toFixed(2)}B</b>
-                </span>
-              </div>
-              <div className="grid">
-                <Card className="col-6">
-                  <CardHeader showCorner right={<span>by mcap</span>}>
-                    Top agent tokens
-                  </CardHeader>
-                  <CardBody>
-                    {topTokensByMcap.map((item, idx) => {
-                      const mcap = item.live?.marketCapUsd ?? 0;
-                      const change = item.live?.priceChange24hPct ?? 0;
-                      const positive = change >= 0;
-                      return (
-                        <Link
-                          key={item.id}
-                          href={`/agent-commerce/${item.slug}`}
-                          style={{
-                            display: "grid",
-                            gridTemplateColumns:
-                              "20px 70px minmax(0, 1fr) 80px 64px",
-                            alignItems: "center",
-                            gap: 10,
-                            padding: "8px 12px",
-                            borderBottom:
-                              "1px solid var(--color-border-subtle)",
-                            textDecoration: "none",
-                            color: "inherit",
-                            fontFamily: "var(--font-mono, ui-monospace)",
-                            fontSize: 12,
-                          }}
-                        >
-                          <span style={{ color: "var(--color-text-faint)" }}>
-                            {String(idx + 1).padStart(2, "0")}
-                          </span>
-                          <span style={{ color: "#a78bfa", fontWeight: 700 }}>
-                            ${item.live?.tokenSymbol}
-                          </span>
-                          <span
-                            style={{
-                              color: "var(--color-text-default)",
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            {item.name}
-                          </span>
-                          <span style={{ textAlign: "right", color: "#fbbf24" }}>
-                            {mcap >= 1e9
-                              ? `$${(mcap / 1e9).toFixed(2)}B`
-                              : `$${(mcap / 1e6).toFixed(0)}M`}
-                          </span>
-                          <span
-                            style={{
-                              textAlign: "right",
-                              color: positive ? "#34d399" : "#f87171",
-                              fontWeight: 700,
-                            }}
-                          >
-                            {positive ? "+" : ""}
-                            {change.toFixed(1)}%
-                          </span>
-                        </Link>
-                      );
-                    })}
-                  </CardBody>
-                </Card>
-                <Card className="col-6">
-                  <CardHeader showCorner right={<span>24h gainers</span>}>
-                    Top movers
-                  </CardHeader>
-                  <CardBody>
-                    {topTokenGainers.map((item, idx) => {
-                      const change = item.live?.priceChange24hPct ?? 0;
-                      const positive = change >= 0;
-                      return (
-                        <Link
-                          key={item.id}
-                          href={`/agent-commerce/${item.slug}`}
-                          style={{
-                            display: "grid",
-                            gridTemplateColumns:
-                              "20px 70px minmax(0, 1fr) 64px",
-                            alignItems: "center",
-                            gap: 10,
-                            padding: "8px 12px",
-                            borderBottom:
-                              "1px solid var(--color-border-subtle)",
-                            textDecoration: "none",
-                            color: "inherit",
-                            fontFamily: "var(--font-mono, ui-monospace)",
-                            fontSize: 12,
-                          }}
-                        >
-                          <span style={{ color: "var(--color-text-faint)" }}>
-                            {String(idx + 1).padStart(2, "0")}
-                          </span>
-                          <span style={{ color: "#a78bfa", fontWeight: 700 }}>
-                            ${item.live?.tokenSymbol}
-                          </span>
-                          <span
-                            style={{
-                              color: "var(--color-text-default)",
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            {item.name}
-                          </span>
-                          <span
-                            style={{
-                              textAlign: "right",
-                              color: positive ? "#34d399" : "#f87171",
-                              fontWeight: 700,
-                            }}
-                          >
-                            {positive ? "+" : ""}
-                            {change.toFixed(1)}%
-                          </span>
-                        </Link>
-                      );
-                    })}
-                  </CardBody>
-                </Card>
-              </div>
-            </>
-          ) : null}
-
-          {/* ========== CROSS-CHAIN BANNER (sub-section, no number) ========== */}
-          {(() => {
-            const base = getBaseX402Onchain();
-            const sol = getSolanaX402Onchain();
-            const baseTotal = base?.totalSettlements ?? 0;
-            const solTotal = sol?.totalSettlements ?? 0;
-            const total = baseTotal + solTotal;
-            if (total <= 0) return null;
-            const baseFacs = Object.keys(base?.byFacilitator ?? {}).length;
-            const solFacs = Object.keys(sol?.byFacilitator ?? {}).length;
-            const facs = baseFacs + solFacs;
-            const basePct = (baseTotal / total) * 100;
-            const solPct = 100 - basePct;
-            const have: string[] = [];
-            if (baseTotal > 0) have.push("Base");
-            if (solTotal > 0) have.push("Solana");
-            return (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 12,
-                  padding: "10px 14px",
-                  margin: "0 0 12px",
-                  border: "1px solid var(--color-border-subtle)",
-                  borderLeft: "2px solid var(--color-accent)",
-                  background: "var(--color-bg-canvas)",
-                  fontFamily: "var(--font-mono, ui-monospace)",
-                  fontSize: 12,
-                  flexWrap: "wrap",
-                }}
-              >
-                <span style={{ color: "var(--color-text-faint)", letterSpacing: "0.06em", textTransform: "uppercase" }}>
-                  cross-chain x402 ·
-                </span>
-                <span style={{ color: "var(--color-text-default)" }}>
-                  <b>{total.toLocaleString("en-US")}</b> settlements
-                </span>
-                <span style={{ color: "var(--color-text-faint)" }}>·</span>
-                <span style={{ color: "var(--color-text-default)" }}>
-                  <b>{facs}</b> facilitators
-                </span>
-                <span style={{ color: "var(--color-text-faint)" }}>·</span>
-                <span style={{ color: "var(--color-text-faint)" }}>
-                  {have.join(" + ")}
-                </span>
-                {baseTotal > 0 && solTotal > 0 ? (
-                  <span
-                    style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                      gap: 8,
-                      marginLeft: "auto",
-                      minWidth: 220,
-                    }}
-                  >
-                    <span style={{ color: "#3b82f6" }}>Base {basePct.toFixed(0)}%</span>
-                    <span
-                      style={{
-                        position: "relative",
-                        flex: 1,
-                        height: 6,
-                        background: "var(--color-border-subtle)",
-                        borderRadius: 3,
-                        overflow: "hidden",
-                        minWidth: 80,
-                      }}
-                    >
-                      <span style={{ position: "absolute", inset: 0, width: `${basePct}%`, background: "#3b82f6" }} />
-                      <span style={{ position: "absolute", top: 0, bottom: 0, left: `${basePct}%`, width: `${solPct}%`, background: "#a78bfa" }} />
-                    </span>
-                    <span style={{ color: "#a78bfa" }}>Sol {solPct.toFixed(0)}%</span>
-                  </span>
-                ) : null}
-              </div>
-            );
-          })()}
-
-          {/* ========== 07 — ON-CHAIN x402 SETTLEMENTS (Base) ========== */}
-          {(() => {
-            // Source: scripts/fetch-base-x402-onchain.mjs → .data/base-x402-onchain.json
-            // (free Blockscout v2 + Merit-Systems/x402scan address book)
-            // Read via data-store (Redis-first, .data/ file fallback) — refresh
-            // hook is awaited at the top of the page component.
-            const onchain = getBaseX402Onchain();
-            if (!onchain || !onchain.totalSettlements) return null;
-            const total = onchain.totalSettlements;
-            const facs = Object.entries(onchain.byFacilitator ?? {})
-              .map(([name, v]) => ({
-                name,
-                count: v.x402Settlements,
-                share: total > 0 ? (v.x402Settlements / total) * 100 : 0,
-              }))
-              .sort((a, b) => b.count - a.count);
-          const days = Object.entries(onchain.byDay ?? {})
-            .sort(([a], [b]) => (a < b ? -1 : 1))
-            .slice(-21);
-            const maxDay = Math.max(...days.map(([, v]) => v.txs), 1);
-            const facColor: Record<string, string> = {
-              Coinbase: "#3b82f6",
-              Heurist: "var(--color-violet)",
-              CodeNut: "#f59e0b",
-              Thirdweb: "#34d399",
-            };
-            return (
+        <AgentCommerceFilteredContent items={items} stats={stats}>
+          <SectionHead
+            num="// 01"
+            title="Composite movers"
+            meta={
               <>
-                <div className="sec-head">
-                  <span className="sec-num">{"// 07"}</span>
-                  <h2 className="sec-title">On-chain x402 settlements · Base</h2>
-                  <span className="sec-meta">
-                    Base · <b>{total.toLocaleString("en-US")}</b> settlements ·{" "}
-                    <b>{Object.keys(onchain.byFacilitator ?? {}).length}</b>{" "}
-                    facilitators · free via Blockscout
-                  </span>
-                </div>
-                <div className="grid">
-                  <Card className="col-6">
-                    <CardHeader showCorner right={<span>by facilitator</span>}>
-                      Facilitator share
-                    </CardHeader>
-                    <CardBody>
-                      {facs.map((f) => {
-                        const tone = facColor[f.name] ?? "#cbd5e1";
-                        return (
-                          <div
-                            key={f.name}
-                            style={{
-                              display: "grid",
-                              gridTemplateColumns:
-                                "90px minmax(0, 1fr) 60px 50px",
-                              alignItems: "center",
-                              gap: 10,
-                              padding: "8px 12px",
-                              borderBottom:
-                                "1px solid var(--color-border-subtle)",
-                              fontFamily: "var(--font-mono, ui-monospace)",
-                              fontSize: 12,
-                            }}
-                          >
-                            <span style={{ color: tone, fontWeight: 700 }}>
-                              {f.name}
-                            </span>
-                            <span
-                              style={{
-                                position: "relative",
-                                height: 6,
-                                background: "var(--color-bg-canvas)",
-                                borderRadius: 3,
-                                overflow: "hidden",
-                              }}
-                            >
-                              <span
-                                style={{
-                                  position: "absolute",
-                                  inset: 0,
-                                  width: `${f.share}%`,
-                                  background: tone,
-                                }}
-                              />
-                            </span>
-                            <span
-                              style={{
-                                textAlign: "right",
-                                color: "var(--color-text-default)",
-                                fontWeight: 700,
-                              }}
-                            >
-                              {f.count}
-                            </span>
-                            <span
-                              style={{
-                                textAlign: "right",
-                                color: "var(--color-text-faint)",
-                              }}
-                            >
-                              {f.share.toFixed(1)}%
-                            </span>
-                          </div>
-                        );
-                      })}
-                    </CardBody>
-                  </Card>
-                  <Card className="col-6">
-                    <CardHeader
-                      showCorner
-                      right={<span>{days.length}d window</span>}
-                    >
-                      Daily settlements
-                    </CardHeader>
-                    <CardBody>
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "flex-end",
-                          gap: 3,
-                          padding: "16px 14px 8px",
-                          height: 110,
-                        }}
-                      >
-                        {days.map(([day, v]) => {
-                          const h = Math.max(
-                            2,
-                            Math.round((v.txs / maxDay) * 90),
-                          );
-                          return (
-                            <span
-                              key={day}
-                              title={`${day} · ${v.txs} settlements`}
-                              style={{
-                                flex: 1,
-                                height: `${h}px`,
-                                background: "var(--color-accent)",
-                                opacity: 0.85,
-                                borderTop: "1px solid var(--color-accent)",
-                              }}
-                            />
-                          );
-                        })}
-                      </div>
-                      <div
-                        style={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          padding: "0 14px 10px",
-                          fontSize: 10,
-                          color: "var(--color-text-faint)",
-                          fontFamily: "var(--font-mono, ui-monospace)",
-                          letterSpacing: "0.06em",
-                          textTransform: "uppercase",
-                        }}
-                      >
-                        <span>{days[0]?.[0]}</span>
-                        <span>{days[days.length - 1]?.[0]}</span>
-                      </div>
-                    </CardBody>
-                  </Card>
-                </div>
-                {(onchain.samples ?? []).length > 0 ? (
-                  <Card>
-                    <CardHeader
-                      showCorner
-                      right={<span>most recent on-chain settlements</span>}
-                    >
-                      Sample tx hashes
-                    </CardHeader>
-                    <CardBody>
-                      {(onchain.samples ?? []).slice(0, 6).map((s) => (
-                        <a
-                          key={s.txHash}
-                          href={`https://basescan.org/tx/${s.txHash}`}
-                          target="_blank"
-                          rel="noreferrer"
-                          style={{
-                            display: "grid",
-                            gridTemplateColumns: "90px minmax(0, 1fr) 100px",
-                            alignItems: "center",
-                            gap: 12,
-                            padding: "6px 14px",
-                            borderBottom:
-                              "1px solid var(--color-border-subtle)",
-                            color: "inherit",
-                            textDecoration: "none",
-                            fontFamily: "var(--font-mono, ui-monospace)",
-                            fontSize: 11,
-                          }}
-                        >
-                          <span
-                            style={{
-                              color: facColor[s.facilitator] ?? "#cbd5e1",
-                              fontWeight: 700,
-                            }}
-                          >
-                            {s.facilitator}
-                          </span>
-                          <span
-                            style={{
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                              color: "var(--color-text-default)",
-                            }}
-                          >
-                            {s.txHash}
-                          </span>
-                          <span
-                            style={{
-                              textAlign: "right",
-                              color: "var(--color-text-faint)",
-                            }}
-                          >
-                            {new Date(s.timestamp).toISOString().slice(0, 10)}
-                          </span>
-                        </a>
-                      ))}
-                    </CardBody>
-                  </Card>
-                ) : null}
+                <b>{movers.length}</b> · top by score
               </>
-            );
-          })()}
-
-          {/* ========== 08 — ON-CHAIN x402 SETTLEMENTS (Solana) ========== */}
-          {(() => {
-            // Source: scripts/fetch-solana-x402-onchain.mjs → .data/solana-x402-onchain.json
-            // (free Solana RPC + Merit-Systems/x402scan address book)
-            // Read via data-store (Redis-first, .data/ file fallback) — refresh
-            // hook is awaited at the top of the page component.
-            const onchain = getSolanaX402Onchain();
-            if (!onchain || !onchain.totalSettlements) return null;
-            const total = onchain.totalSettlements;
-            const facs = Object.entries(onchain.byFacilitator ?? {})
-              .map(([name, v]) => ({
-                name,
-                count: v.x402Settlements,
-                share: total > 0 ? (v.x402Settlements / total) * 100 : 0,
-              }))
-              .sort((a, b) => b.count - a.count);
-            const days = Object.entries(onchain.byDay ?? {})
-              .sort(([a], [b]) => (a < b ? -1 : 1))
-              .slice(-21);
-            const maxDay = Math.max(...days.map(([, v]) => v.txs), 1);
-            const facColor: Record<string, string> = {
-              CodeNut: "#f59e0b",
-              PayAI: "#22d3ee",
-              Dexter: "var(--color-violet)",
-              Bitrefill: "#fbbf24",
-              RelAI: "#34d399",
-              UltravioletaDAO: "#c084fc",
-              AnySpend: "var(--color-blue)",
-              AurraCloud: "var(--color-pink)",
-              Cascade: "#38bdf8",
-              Corbits: "#fb7185",
-              Daydreams: "#a3e635",
-              OpenFacilitator: "#94a3b8",
-              OpenX402: "#f87171",
-              x402jobs: "#fde047",
-            };
-            return (
-              <>
-                <div className="sec-head">
-                  <span className="sec-num">{"// 08"}</span>
-                  <h2 className="sec-title">On-chain x402 settlements · Solana</h2>
-                  <span className="sec-meta">
-                    Solana · <b>{total.toLocaleString("en-US")}</b> settlements ·{" "}
-                    <b>{Object.keys(onchain.byFacilitator ?? {}).length}</b>{" "}
-                    facilitators · free via mainnet-beta RPC
-                  </span>
-                </div>
-                <div className="grid">
-                  <Card className="col-6">
-                    <CardHeader showCorner right={<span>by facilitator</span>}>
-                      Facilitator share
-                    </CardHeader>
-                    <CardBody>
-                      {facs.map((f) => {
-                        const tone = facColor[f.name] ?? "#cbd5e1";
-                        return (
-                          <div
-                            key={f.name}
-                            style={{
-                              display: "grid",
-                              gridTemplateColumns:
-                                "120px minmax(0, 1fr) 60px 50px",
-                              alignItems: "center",
-                              gap: 10,
-                              padding: "8px 12px",
-                              borderBottom:
-                                "1px solid var(--color-border-subtle)",
-                              fontFamily: "var(--font-mono, ui-monospace)",
-                              fontSize: 12,
-                            }}
-                          >
-                            <span style={{ color: tone, fontWeight: 700 }}>
-                              {f.name}
-                            </span>
-                            <span
-                              style={{
-                                position: "relative",
-                                height: 6,
-                                background: "var(--color-bg-canvas)",
-                                borderRadius: 3,
-                                overflow: "hidden",
-                              }}
-                            >
-                              <span
-                                style={{
-                                  position: "absolute",
-                                  inset: 0,
-                                  width: `${f.share}%`,
-                                  background: tone,
-                                }}
-                              />
-                            </span>
-                            <span
-                              style={{
-                                textAlign: "right",
-                                color: "var(--color-text-default)",
-                                fontWeight: 700,
-                              }}
-                            >
-                              {f.count}
-                            </span>
-                            <span
-                              style={{
-                                textAlign: "right",
-                                color: "var(--color-text-faint)",
-                              }}
-                            >
-                              {f.share.toFixed(1)}%
-                            </span>
-                          </div>
-                        );
-                      })}
-                    </CardBody>
-                  </Card>
-                  <Card className="col-6">
-                    <CardHeader
-                      showCorner
-                      right={<span>{days.length}d window</span>}
-                    >
-                      Daily settlements
-                    </CardHeader>
-                    <CardBody>
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "flex-end",
-                          gap: 3,
-                          padding: "16px 14px 8px",
-                          height: 110,
-                        }}
-                      >
-                        {days.map(([day, v]) => {
-                          const h = Math.max(
-                            2,
-                            Math.round((v.txs / maxDay) * 90),
-                          );
-                          return (
-                            <span
-                              key={day}
-                              title={`${day} · ${v.txs} settlements`}
-                              style={{
-                                flex: 1,
-                                height: `${h}px`,
-                                background: "var(--color-accent)",
-                                opacity: 0.85,
-                                borderTop: "1px solid var(--color-accent)",
-                              }}
-                            />
-                          );
-                        })}
-                      </div>
-                      <div
-                        style={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          padding: "0 14px 10px",
-                          fontSize: 10,
-                          color: "var(--color-text-faint)",
-                          fontFamily: "var(--font-mono, ui-monospace)",
-                          letterSpacing: "0.06em",
-                          textTransform: "uppercase",
-                        }}
-                      >
-                        <span>{days[0]?.[0]}</span>
-                        <span>{days[days.length - 1]?.[0]}</span>
-                      </div>
-                    </CardBody>
-                  </Card>
-                </div>
-                {(onchain.samples ?? []).length > 0 ? (
-                  <Card>
-                    <CardHeader
-                      showCorner
-                      right={<span>most recent on-chain settlements</span>}
-                    >
-                      Sample tx signatures
-                    </CardHeader>
-                    <CardBody>
-                      {(onchain.samples ?? []).slice(0, 6).map((s) => (
-                        <a
-                          key={s.txSig}
-                          href={`https://solscan.io/tx/${s.txSig}`}
-                          target="_blank"
-                          rel="noreferrer"
-                          style={{
-                            display: "grid",
-                            gridTemplateColumns: "120px minmax(0, 1fr) 100px",
-                            alignItems: "center",
-                            gap: 12,
-                            padding: "6px 14px",
-                            borderBottom:
-                              "1px solid var(--color-border-subtle)",
-                            color: "inherit",
-                            textDecoration: "none",
-                            fontFamily: "var(--font-mono, ui-monospace)",
-                            fontSize: 11,
-                          }}
-                        >
-                          <span
-                            style={{
-                              color: facColor[s.facilitator] ?? "#cbd5e1",
-                              fontWeight: 700,
-                            }}
-                          >
-                            {s.facilitator}
-                          </span>
-                          <span
-                            style={{
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                              color: "var(--color-text-default)",
-                            }}
-                          >
-                            {s.txSig}
-                          </span>
-                          <span
-                            style={{
-                              textAlign: "right",
-                              color: "var(--color-text-faint)",
-                            }}
-                          >
-                            {s.blockTime
-                              ? new Date(s.blockTime).toISOString().slice(0, 10)
-                              : "—"}
-                          </span>
-                        </a>
-                      ))}
-                    </CardBody>
-                  </Card>
-                ) : null}
-              </>
-            );
-          })()}
-
-          {/* ========== 09 — HISTORICAL VOLUME (Dune) ========== */}
-          {(() => {
-            // Source: scripts/fetch-dune-x402.mjs → .data/dune-x402-volume.json
-            // Rendered only when the JSON exists. Run the fetcher once a saved
-            // Dune query id is available (paste .dune/x402-volume.sql first).
-            // Read via data-store (Redis-first, .data/ file fallback) — refresh
-            // hook is awaited at the top of the page component.
-            const dune = getDuneX402Volume();
-            if (!dune?.rows?.length) return null;
-            const byDay = new Map<string, number>();
-            const byFac = new Map<string, number>();
-            for (const r of dune.rows) {
-              const v = parseFloat(r.volumeUsdc) || 0;
-              byDay.set(r.day, (byDay.get(r.day) ?? 0) + v);
-              byFac.set(r.facilitator, (byFac.get(r.facilitator) ?? 0) + v);
             }
-            const dayEntries = [...byDay.entries()].sort(([a], [b]) =>
-              a < b ? -1 : 1,
-            );
-            const maxDayVol = Math.max(...dayEntries.map(([, v]) => v), 1);
-            const facEntries = [...byFac.entries()].sort(
-              (a, b) => b[1] - a[1],
-            );
-            const totalVol = facEntries.reduce((acc, [, v]) => acc + v, 0);
-            const facColor: Record<string, string> = {
-              Coinbase: "#3b82f6",
-              Heurist: "var(--color-violet)",
-              CodeNut: "#f59e0b",
-              Thirdweb: "#34d399",
-            };
-            const fmtUsd = (n: number) =>
-              n >= 1_000_000
-                ? `$${(n / 1_000_000).toFixed(1)}M`
-                : n >= 1_000
-                  ? `$${(n / 1_000).toFixed(1)}k`
-                  : `$${n.toFixed(0)}`;
-            return (
+          />
+          <MoversBoard items={movers} />
+
+          <SectionHead
+            num="// 02"
+            title="Protocol pulse"
+            meta={
               <>
-                <div className="sec-head">
-                  <span className="sec-num">{"// 09"}</span>
-                  <h2 className="sec-title">x402 historical volume</h2>
-                  <span className="sec-meta">
-                    Base · <b>{fmtUsd(totalVol)}</b> over{" "}
-                    <b>{dayEntries.length}</b> days · via Dune
-                  </span>
-                </div>
-                <div className="grid">
-                  <Card className="col-8">
-                    <CardHeader
-                      showCorner
-                      right={<span>last day · {dune.lastDay}</span>}
-                    >
-                      Daily USDC volume
-                    </CardHeader>
-                    <CardBody>
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "flex-end",
-                          gap: 1,
-                          padding: "16px 14px 8px",
-                          height: 140,
-                        }}
-                      >
-                        {dayEntries.map(([day, v]) => {
-                          const h = Math.max(
-                            2,
-                            Math.round((v / maxDayVol) * 120),
-                          );
-                          return (
-                            <span
-                              key={day}
-                              title={`${day} · ${fmtUsd(v)}`}
-                              style={{
-                                flex: 1,
-                                height: `${h}px`,
-                                background: "var(--color-accent)",
-                                opacity: 0.85,
-                              }}
-                            />
-                          );
-                        })}
-                      </div>
-                      <div
-                        style={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          padding: "0 14px 10px",
-                          fontSize: 10,
-                          color: "var(--color-text-faint)",
-                          fontFamily: "var(--font-mono, ui-monospace)",
-                          letterSpacing: "0.06em",
-                          textTransform: "uppercase",
-                        }}
-                      >
-                        <span>{dayEntries[0]?.[0]}</span>
-                        <span>{dayEntries[dayEntries.length - 1]?.[0]}</span>
-                      </div>
-                    </CardBody>
-                  </Card>
-                  <Card className="col-4">
-                    <CardHeader showCorner right={<span>USDC total</span>}>
-                      Volume by facilitator
-                    </CardHeader>
-                    <CardBody>
-                      {facEntries.map(([name, v]) => {
-                        const tone = facColor[name] ?? "#cbd5e1";
-                        const share = totalVol > 0 ? (v / totalVol) * 100 : 0;
-                        return (
-                          <div
-                            key={name}
-                            style={{
-                              display: "grid",
-                              gridTemplateColumns:
-                                "90px minmax(0, 1fr) 70px",
-                              alignItems: "center",
-                              gap: 10,
-                              padding: "8px 12px",
-                              borderBottom:
-                                "1px solid var(--color-border-subtle)",
-                              fontFamily: "var(--font-mono, ui-monospace)",
-                              fontSize: 12,
-                            }}
-                          >
-                            <span style={{ color: tone, fontWeight: 700 }}>
-                              {name}
-                            </span>
-                            <span
-                              style={{
-                                position: "relative",
-                                height: 6,
-                                background: "var(--color-bg-canvas)",
-                                borderRadius: 3,
-                                overflow: "hidden",
-                              }}
-                            >
-                              <span
-                                style={{
-                                  position: "absolute",
-                                  inset: 0,
-                                  width: `${share}%`,
-                                  background: tone,
-                                }}
-                              />
-                            </span>
-                            <span
-                              style={{
-                                textAlign: "right",
-                                color: "var(--color-text-default)",
-                                fontWeight: 700,
-                              }}
-                            >
-                              {fmtUsd(v)}
-                            </span>
-                          </div>
-                        );
-                      })}
-                    </CardBody>
-                  </Card>
-                </div>
+                <b>{Object.keys(stats.byProtocol).length}</b> · protocols
+                tracked
               </>
-            );
-          })()}
+            }
+          />
+          <ProtocolPulseGrid stats={stats} />
 
-          {/* ========== 10 — CAPABILITY CLOUD ========== */}
-          {topCapabilities.length > 0 ? (
+          <SectionHead
+            num="// 03"
+            title="Score distribution"
+            meta={
+              <>
+                avg <b>{stats.averageComposite}</b> · top{" "}
+                <b>{stats.topComposite}</b>
+              </>
+            }
+          />
+          <ScoreDistributionGrid
+            items={items}
+            topByScore={sortedByScore}
+            stats={stats}
+          />
+
+          {items.some((i) => i.live?.tokenSymbol) ? (
             <>
-              <div className="sec-head">
-                <span className="sec-num">{"// 10"}</span>
-                <h2 className="sec-title">Capability frequency</h2>
-                <span className="sec-meta">
-                  <b>{capCounts.size}</b> distinct capabilities
-                </span>
-              </div>
-              <Card>
-                <CardBody>
-                  <div className="tag-cloud" style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                    {topCapabilities.map(([cap, n]) => (
-                      <span
-                        key={cap}
-                        className="chip"
-                        style={{
-                          fontSize: 11 + Math.min(6, Math.log2(n + 1)),
-                          opacity: 0.55 + Math.min(0.45, n / 8),
-                        }}
-                      >
-                        {cap}
-                        <em
-                          style={{
-                            fontStyle: "normal",
-                            marginLeft: 4,
-                            color: "var(--color-text-faint)",
-                            fontSize: 10,
-                          }}
-                        >
-                          {n}
-                        </em>
-                      </span>
-                    ))}
-                  </div>
-                </CardBody>
-              </Card>
+              <SectionHead
+                num="// 04"
+                title="Agent token economy"
+                meta={<>CoinGecko · mcap + 24h</>}
+              />
+              <TokenEconomyBoards items={items} />
             </>
           ) : null}
 
-          {/* ========== 11 — OPPORTUNITIES (when on tab) ========== */}
-          {filter.tab === "opportunities" && opportunities.length > 0 ? (
+          {base && base.totalSettlements ? (
             <>
-              <div className="sec-head">
-                <span className="sec-num">{"// 11"}</span>
-                <h2 className="sec-title">Build opportunities</h2>
-                <span className="sec-meta">
-                  <b>{opportunities.length}</b> / generated from gaps
-                </span>
-              </div>
-              <section className="grid">
-                {opportunities.map((op, idx) => (
-                  <Card className="col-6" key={idx}>
-                    <CardHeader
-                      showCorner
-                      right={<span className="sec-num">{`// ${String(idx + 1).padStart(2, "0")}`}</span>}
-                    >
-                      {op.title}
-                    </CardHeader>
-                    <CardBody>
-                      <p
-                        style={{
-                          margin: 0,
-                          color: "var(--color-text-subtle)",
-                          fontSize: 13,
-                          lineHeight: 1.5,
-                        }}
-                      >
-                        {op.reason}
-                      </p>
-                    </CardBody>
-                  </Card>
-                ))}
-              </section>
+              <SectionHead
+                num="// 05"
+                title="On-chain x402 settlements · Base"
+                meta={
+                  <>
+                    <b>{base.totalSettlements.toLocaleString("en-US")}</b> ·
+                    settlements
+                  </>
+                }
+              />
+              <OnchainSettlementsBoard chain="base" data={base} />
             </>
           ) : null}
 
-          {/* ========== 12 — CATEGORY LEADERBOARDS ========== */}
-          <div className="sec-head">
-            <span className="sec-num">{"// 12"}</span>
-            <h2 className="sec-title">Sector leaderboards</h2>
-            <span className="sec-meta">
-              top 5 / sector · sparklines synthetic until history lands
-            </span>
-          </div>
-          <div className="grid">
-            <MiniBoard
-              title="Top wallets"
-              items={topWallets}
-              accent="#a78bfa"
-              emptyHint="No wallets in current data."
-            />
-            <MiniBoard
-              title="Top APIs"
-              items={topApis}
-              accent="#22d3ee"
-              emptyHint="No APIs in current data."
-            />
-          </div>
-          <div className="grid">
-            <MiniBoard
-              title="Top MCP servers"
-              items={topMcp}
-              accent="#22d3ee"
-              rightLabel={`${stats.mcpServerCount} indexed`}
-              emptyHint="No MCP servers detected."
-            />
-            <MiniBoard
-              title="Top x402 services"
-              items={topX402List}
-              accent="#f59e0b"
-              rightLabel={`${stats.x402EnabledCount} enabled`}
-              emptyHint="No x402-enabled services detected."
-            />
-          </div>
-          <div className="grid">
-            <MiniBoard
-              title="Top marketplaces"
-              items={topMarketplaces}
-              accent="#f472b6"
-              emptyHint="No marketplaces in current data."
-            />
-            <Card className="col-6">
-              <CardHeader showCorner right={<span>{filter.tab}</span>}>
-                Filter snapshot
-              </CardHeader>
-              <CardBody>
-                <div
-                  style={{
-                    display: "grid",
-                    gap: 8,
-                    padding: "10px 14px",
-                    fontFamily: "var(--font-mono, ui-monospace)",
-                    fontSize: 11.5,
-                    color: "var(--color-text-subtle)",
-                  }}
-                >
-                  <div>
-                    matching <b style={{ color: "var(--color-text-default)" }}>{totalRendered}</b> of{" "}
-                    {stats.totalItems} entities
-                  </div>
-                  <div>
-                    category:{" "}
-                    <span style={{ color: "var(--color-accent)" }}>
-                      {filter.category ?? "all"}
-                    </span>
-                  </div>
-                  <div>
-                    protocol:{" "}
-                    <span style={{ color: "var(--color-accent)" }}>
-                      {filter.protocols.size === 0
-                        ? "any"
-                        : Array.from(filter.protocols).join(", ")}
-                    </span>
-                  </div>
-                  <div>
-                    pricing:{" "}
-                    <span style={{ color: "var(--color-accent)" }}>
-                      {filter.pricing ?? "any"}
-                    </span>
-                  </div>
-                  <div>
-                    portal-ready filter:{" "}
-                    <span style={{ color: "var(--color-accent)" }}>
-                      {filter.portalReady ? "on" : "off"}
-                    </span>
-                  </div>
-                  {filter.query ? (
-                    <div>
-                      query:{" "}
-                      <span style={{ color: "var(--color-accent)" }}>
-                        “{filter.query}”
-                      </span>
-                    </div>
-                  ) : null}
-                </div>
-              </CardBody>
-            </Card>
-          </div>
-
-          {/* ========== 13 — BROWSE (compact card grid) ========== */}
-          {totalRendered > 0 ? (
+          {solana && solana.totalSettlements ? (
             <>
-              <div className="sec-head">
-                <span className="sec-num">{"// 13"}</span>
-                <h2 className="sec-title">
-                  Browse {filter.tab === "overview" ? "all" : filter.tab}
-                </h2>
-                <span className="sec-meta">
-                  <b>{totalRendered}</b> / matching
-                </span>
-              </div>
-              <div className="ac-grid">
-                {grid.slice(0, 12).map((item) => (
-                  <AgentCommerceCard key={item.id} item={item} />
-                ))}
-              </div>
+              <SectionHead
+                num="// 06"
+                title="On-chain x402 settlements · Solana"
+                meta={
+                  <>
+                    <b>
+                      {solana.totalSettlements.toLocaleString("en-US")}
+                    </b>{" "}
+                    · settlements
+                  </>
+                }
+              />
+              <OnchainSettlementsBoard chain="solana" data={solana} />
             </>
-          ) : (
-            <div className="ac-empty">
-              <h2>No matches for the current filter.</h2>
-              <p>
-                The dashboard above stays global. Loosen the protocol / pricing /
-                portal-ready filters to populate the browse grid.
-              </p>
-            </div>
-          )}
-        </>
+          ) : null}
+
+          {dune?.rows?.length ? (
+            <>
+              <SectionHead
+                num="// 07"
+                title="Dune 24h volume"
+                meta={<>USDC · via Dune</>}
+              />
+              <DuneVolumeBoard data={dune} />
+            </>
+          ) : null}
+        </AgentCommerceFilteredContent>
       )}
     </main>
-    <FooterBar
-      meta={`// AGENT-COMMERCE / m2m-radar / serial ${stats.totalItems}`}
-      actions={`DATA / ${computed} UTC`}
-    />
-    </>
   );
 }

--- a/src/components/agent-commerce/AgentCommerceFilteredContent.tsx
+++ b/src/components/agent-commerce/AgentCommerceFilteredContent.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+// Agent Commerce — client-side filter shell.
+//
+// Cache fix B: the previous server component awaited `searchParams`, which
+// forced /agent-commerce off ISR (full dynamic on every request). This
+// component reads `useSearchParams()` on the client, so the surrounding RSC
+// shell stays statically prerenderable under `revalidate=1200`.
+//
+// The page passes the full corpus + heavy panel children in via props/render
+// props; this component renders the tab strip, filter bar, browse grid, and
+// the active-filter snapshot. Section panels (movers, score distribution,
+// token economy, on-chain, dune) live as JSX children supplied by the page so
+// they remain server-rendered.
+
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+
+import type { ReactNode } from "react";
+
+import { AgentCommerceCard } from "@/components/agent-commerce/AgentCommerceCard";
+import { AgentCommerceFilterBar } from "@/components/agent-commerce/AgentCommerceFilterBar";
+import { AgentCommerceTabs } from "@/components/agent-commerce/AgentCommerceTabs";
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import { SectionHead } from "@/components/ui/SectionHead";
+import {
+  applyFilter,
+  parseCategory,
+  parsePortalReady,
+  parsePricing,
+  parseProtocols,
+  parseSearchQuery,
+  parseTab,
+  TABS,
+  type AgentCommerceFilter,
+} from "@/lib/agent-commerce/extract";
+import type {
+  AgentCommerceItem,
+  AgentCommerceProtocol,
+  AgentCommerceStats,
+} from "@/lib/agent-commerce/types";
+
+interface AgentCommerceFilteredContentProps {
+  items: AgentCommerceItem[];
+  stats: AgentCommerceStats;
+  /** Section panels keyed by section number — rendered above the browse grid. */
+  children: ReactNode;
+}
+
+function buildBaseQuery(sp: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams();
+  for (const [k, v] of sp.entries()) {
+    if (v.length > 0) next.set(k, v);
+  }
+  return next;
+}
+
+export function AgentCommerceFilteredContent({
+  items,
+  stats,
+  children,
+}: AgentCommerceFilteredContentProps) {
+  const sp = useSearchParams();
+
+  const filter: AgentCommerceFilter = useMemo(
+    () => ({
+      tab: parseTab(sp.get("tab")),
+      category: parseCategory(sp.get("cat")),
+      protocols: parseProtocols(sp.get("protocol")),
+      pricing: parsePricing(sp.get("pricing")),
+      portalReady: parsePortalReady(sp.get("portalready")),
+      query: parseSearchQuery(sp.get("q")),
+    }),
+    [sp],
+  );
+
+  const baseQuery = useMemo(
+    () => buildBaseQuery(new URLSearchParams(sp.toString())),
+    [sp],
+  );
+
+  // Per-tab counts for the tab strip — derived client-side because tab counts
+  // change when category/protocol filters mutate the corpus.
+  const tabCounts = useMemo(() => {
+    const counts: Partial<Record<(typeof TABS)[number], number>> = {};
+    for (const tab of TABS) {
+      if (tab === "overview" || tab === "signals" || tab === "opportunities") {
+        counts[tab] = stats.totalItems;
+        continue;
+      }
+      const subset = applyFilter(items, {
+        ...filter,
+        tab,
+        category: null,
+        protocols: new Set<AgentCommerceProtocol>(),
+        pricing: null,
+        portalReady: false,
+        query: "",
+      });
+      counts[tab] = subset.length;
+    }
+    return counts;
+  }, [items, stats.totalItems, filter]);
+
+  const filtered = useMemo(() => applyFilter(items, filter), [items, filter]);
+  const sorted = useMemo(
+    () => filtered.slice().sort((a, b) => b.scores.composite - a.scores.composite),
+    [filtered],
+  );
+  const grid = sorted.slice(0, 60);
+  const totalRendered = sorted.length;
+
+  return (
+    <>
+      <AgentCommerceTabs
+        active={filter.tab}
+        counts={tabCounts}
+        baseQuery={baseQuery}
+      />
+      <AgentCommerceFilterBar
+        category={filter.category}
+        protocols={filter.protocols}
+        pricing={filter.pricing}
+        portalReady={filter.portalReady}
+        query={filter.query}
+        baseQuery={baseQuery}
+      />
+
+      {children}
+
+      <SectionHead
+        num="// 08"
+        title="Filter snapshot"
+        meta={
+          <>
+            <b>{totalRendered}</b> / matching · tab <b>{filter.tab}</b>
+          </>
+        }
+      />
+      <Card>
+        <CardHeader showCorner right={<span>{filter.tab}</span>}>
+          Active filters
+        </CardHeader>
+        <CardBody>
+          <div className="ac-filter-snapshot">
+            <div>
+              matching <b>{totalRendered}</b> of {stats.totalItems} entities
+            </div>
+            <div>
+              category:{" "}
+              <span className="ac-filter-snapshot__val">
+                {filter.category ?? "all"}
+              </span>
+            </div>
+            <div>
+              protocol:{" "}
+              <span className="ac-filter-snapshot__val">
+                {filter.protocols.size === 0
+                  ? "any"
+                  : Array.from(filter.protocols).join(", ")}
+              </span>
+            </div>
+            <div>
+              pricing:{" "}
+              <span className="ac-filter-snapshot__val">
+                {filter.pricing ?? "any"}
+              </span>
+            </div>
+            <div>
+              portal-ready:{" "}
+              <span className="ac-filter-snapshot__val">
+                {filter.portalReady ? "on" : "off"}
+              </span>
+            </div>
+            {filter.query ? (
+              <div>
+                query:{" "}
+                <span className="ac-filter-snapshot__val">
+                  &ldquo;{filter.query}&rdquo;
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </CardBody>
+      </Card>
+
+      {totalRendered > 0 ? (
+        <>
+          <SectionHead
+            num="// 09"
+            title={
+              <>
+                Browse {filter.tab === "overview" ? "all" : filter.tab}
+              </>
+            }
+            meta={
+              <>
+                <b>{totalRendered}</b> / matching
+              </>
+            }
+          />
+          <div className="ac-grid">
+            {grid.slice(0, 12).map((item) => (
+              <AgentCommerceCard key={item.id} item={item} />
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="ac-empty">
+          <h2>No matches for the current filter.</h2>
+          <p>
+            The dashboard above stays global. Loosen the protocol / pricing /
+            portal-ready filters to populate the browse grid.
+          </p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/agent-commerce/DuneVolumeBoard.tsx
+++ b/src/components/agent-commerce/DuneVolumeBoard.tsx
@@ -1,0 +1,110 @@
+// Agent Commerce — Dune historical volume board.
+//
+// Daily USDC volume bars + facilitator share. Returns `null` when the Dune
+// payload is missing or empty so the surrounding section can fall back to a
+// no-data state. All previously-inline colors now resolve via v4 tokens.
+
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+
+import type { DuneX402VolumeFile } from "@/lib/dune-x402-volume";
+
+interface DuneVolumeBoardProps {
+  data: DuneX402VolumeFile | null;
+}
+
+const FACILITATOR_COLORS: Record<string, string> = {
+  Coinbase: "var(--v4-blue)",
+  Heurist: "var(--v4-violet)",
+  CodeNut: "var(--v4-amber)",
+  Thirdweb: "var(--v4-money)",
+};
+
+function fmtUsd(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}k`;
+  return `$${n.toFixed(0)}`;
+}
+
+export function DuneVolumeBoard({ data }: DuneVolumeBoardProps) {
+  if (!data?.rows?.length) return null;
+
+  const byDay = new Map<string, number>();
+  const byFac = new Map<string, number>();
+  for (const r of data.rows) {
+    const v = parseFloat(r.volumeUsdc) || 0;
+    byDay.set(r.day, (byDay.get(r.day) ?? 0) + v);
+    byFac.set(r.facilitator, (byFac.get(r.facilitator) ?? 0) + v);
+  }
+  const dayEntries = [...byDay.entries()].sort(([a], [b]) =>
+    a < b ? -1 : 1,
+  );
+  const maxDayVol = Math.max(...dayEntries.map(([, v]) => v), 1);
+  const facEntries = [...byFac.entries()].sort((a, b) => b[1] - a[1]);
+  const totalVol = facEntries.reduce((acc, [, v]) => acc + v, 0);
+
+  return (
+    <div className="grid">
+      <Card className="col-8">
+        <CardHeader
+          showCorner
+          right={<span>last day · {data.lastDay ?? "—"}</span>}
+        >
+          Daily USDC volume
+        </CardHeader>
+        <CardBody>
+          <div
+            className="ac-dune-bars"
+            role="img"
+            aria-label={`Daily USDC volume over ${dayEntries.length} days`}
+          >
+            {dayEntries.map(([day, v]) => {
+              const h = Math.max(2, Math.round((v / maxDayVol) * 120));
+              return (
+                <span
+                  key={day}
+                  title={`${day} · ${fmtUsd(v)}`}
+                  className="ac-dune-bar"
+                  style={{ height: `${h}px` }}
+                />
+              );
+            })}
+          </div>
+          <div className="ac-dune-bars-axis">
+            <span>{dayEntries[0]?.[0]}</span>
+            <span>{dayEntries[dayEntries.length - 1]?.[0]}</span>
+          </div>
+        </CardBody>
+      </Card>
+      <Card className="col-4">
+        <CardHeader showCorner right={<span>USDC total</span>}>
+          Volume by facilitator
+        </CardHeader>
+        <CardBody>
+          {facEntries.map(([name, v]) => {
+            const tone = FACILITATOR_COLORS[name] ?? "var(--v4-ink-300)";
+            const share = totalVol > 0 ? (v / totalVol) * 100 : 0;
+            return (
+              <div key={name} className="ac-dune-row">
+                <span
+                  className="ac-dune-row__name"
+                  style={{ color: tone }}
+                >
+                  {name}
+                </span>
+                <span className="ac-dune-row__track" aria-hidden>
+                  <i
+                    style={{
+                      width: `${share}%`,
+                      background: tone,
+                    }}
+                  />
+                </span>
+                <span className="ac-dune-row__value">{fmtUsd(v)}</span>
+              </div>
+            );
+          })}
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/agent-commerce/MoversBoard.tsx
+++ b/src/components/agent-commerce/MoversBoard.tsx
@@ -1,0 +1,99 @@
+// Agent Commerce — composite movers board (v4 rebuild).
+//
+// Drops the previous sparkline rail (synthetic until score-history collector
+// lands — operator pulled it). Each row is a v4 mover row with rank, name,
+// protocol/category meta, composite score, and pricing pill. Linked to the
+// per-entity page.
+
+import Link from "next/link";
+
+import type { AgentCommerceItem, AgentCommerceProtocol } from "@/lib/agent-commerce/types";
+
+interface MoversBoardProps {
+  items: AgentCommerceItem[];
+}
+
+const PROTOCOL_LABEL: Record<AgentCommerceProtocol, string> = {
+  x402: "x402",
+  http: "HTTP",
+  mcp: "MCP",
+  a2a: "A2A",
+  rest: "REST",
+  graphql: "GraphQL",
+  grpc: "gRPC",
+};
+
+const PROTOCOL_CLASS: Record<AgentCommerceProtocol, string> = {
+  x402: "ac-mr-proto--x402",
+  http: "ac-mr-proto--http",
+  mcp: "ac-mr-proto--mcp",
+  a2a: "ac-mr-proto--a2a",
+  rest: "ac-mr-proto--http",
+  graphql: "ac-mr-proto--http",
+  grpc: "ac-mr-proto--http",
+};
+
+function scoreToneClass(score: number): string {
+  if (score >= 60) return "ac-mr-score--high";
+  if (score >= 40) return "ac-mr-score--mid";
+  return "ac-mr-score--low";
+}
+
+function pricingLabel(type: string): string {
+  if (type === "unknown") return "—";
+  return type.replace("_", " ");
+}
+
+export function MoversBoard({ items }: MoversBoardProps) {
+  if (items.length === 0) {
+    return (
+      <div className="ac-board-empty">
+        <p>No composite movers yet — collector warming up.</p>
+      </div>
+    );
+  }
+  return (
+    <section className="ac-movers-board" aria-label="Composite movers">
+      {items.map((item, idx) => {
+        const score = item.scores.composite;
+        const toneCls = scoreToneClass(score);
+        return (
+          <Link
+            key={item.id}
+            href={`/agent-commerce/${item.slug}`}
+            className={`ac-mover-row ${idx === 0 ? "is-first" : ""}`}
+          >
+            <span className="ac-mover-row__rank">
+              {String(idx + 1).padStart(2, "0")}
+            </span>
+            <div className="ac-mover-row__body">
+              <div className="ac-mover-row__name">{item.name}</div>
+              <div className="ac-mover-row__meta">
+                <span className="v2-mono ac-mover-row__kind">{item.kind}</span>
+                <span className="ac-mover-row__sep" aria-hidden>
+                  ·
+                </span>
+                <span>{item.category}</span>
+                {item.protocols.slice(0, 3).map((p) => (
+                  <span
+                    key={p}
+                    className={`v2-mono ac-mover-row__proto ${PROTOCOL_CLASS[p]}`}
+                  >
+                    {PROTOCOL_LABEL[p]}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <span className={`ac-mover-row__score ${toneCls}`}>
+              {score}
+              <span className="ac-mover-row__score-lbl">score</span>
+            </span>
+            <span className="ac-mover-row__stage">
+              {pricingLabel(item.pricing.type)}
+            </span>
+          </Link>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/components/agent-commerce/OnchainSettlementsBoard.tsx
+++ b/src/components/agent-commerce/OnchainSettlementsBoard.tsx
@@ -1,0 +1,216 @@
+// Agent Commerce — on-chain x402 settlements board.
+//
+// Single component for both Base + Solana. The `chain` prop selects the
+// facilitator palette, explorer URL prefix, and tx-hash field name. Each
+// chain payload exposes the same byFacilitator / byDay / samples shape so
+// the chrome can stay symmetric.
+
+import type {
+  BaseX402OnchainFile,
+} from "@/lib/base-x402-onchain";
+import type {
+  SolanaX402OnchainFile,
+} from "@/lib/solana-x402-onchain";
+
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+
+export type OnchainChain = "base" | "solana";
+
+interface OnchainSettlementsBoardProps {
+  chain: OnchainChain;
+  data: BaseX402OnchainFile | SolanaX402OnchainFile | null;
+}
+
+// Per-chain facilitator color palette. Keys are facilitator names as they
+// appear in the upstream collector payloads. Unknown facilitators fall back
+// to --v4-ink-300.
+const BASE_FACILITATOR_COLORS: Record<string, string> = {
+  Coinbase: "var(--v4-blue)",
+  Heurist: "var(--v4-violet)",
+  CodeNut: "var(--v4-amber)",
+  Thirdweb: "var(--v4-money)",
+};
+
+const SOLANA_FACILITATOR_COLORS: Record<string, string> = {
+  CodeNut: "var(--v4-amber)",
+  PayAI: "var(--v4-cyan)",
+  Dexter: "var(--v4-violet)",
+  Bitrefill: "var(--v4-gold)",
+  RelAI: "var(--v4-money)",
+  AnySpend: "var(--v4-blue)",
+  AurraCloud: "var(--v4-pink)",
+  OpenFacilitator: "var(--v4-ink-300)",
+};
+
+function facilitatorColor(chain: OnchainChain, name: string): string {
+  const palette =
+    chain === "base" ? BASE_FACILITATOR_COLORS : SOLANA_FACILITATOR_COLORS;
+  return palette[name] ?? "var(--v4-ink-300)";
+}
+
+function explorerUrl(chain: OnchainChain, hash: string): string {
+  return chain === "base"
+    ? `https://basescan.org/tx/${hash}`
+    : `https://solscan.io/tx/${hash}`;
+}
+
+interface SampleRow {
+  facilitator: string;
+  hash: string;
+  date: string;
+}
+
+function normalizeSamples(
+  chain: OnchainChain,
+  data: BaseX402OnchainFile | SolanaX402OnchainFile,
+): SampleRow[] {
+  const samples = data.samples ?? [];
+  return samples.slice(0, 6).map((s) => {
+    if (chain === "base") {
+      const row = s as NonNullable<BaseX402OnchainFile["samples"]>[number];
+      return {
+        facilitator: row.facilitator,
+        hash: row.txHash,
+        date: row.timestamp
+          ? new Date(row.timestamp).toISOString().slice(0, 10)
+          : "—",
+      };
+    }
+    const row = s as NonNullable<SolanaX402OnchainFile["samples"]>[number];
+    return {
+      facilitator: row.facilitator,
+      hash: row.txSig,
+      date: row.blockTime
+        ? new Date(row.blockTime).toISOString().slice(0, 10)
+        : "—",
+    };
+  });
+}
+
+export function OnchainSettlementsBoard({
+  chain,
+  data,
+}: OnchainSettlementsBoardProps) {
+  if (!data || !data.totalSettlements) return null;
+
+  const total = data.totalSettlements;
+  const facilitators = Object.entries(data.byFacilitator ?? {})
+    .map(([name, v]) => ({
+      name,
+      count: v.x402Settlements,
+      share: total > 0 ? (v.x402Settlements / total) * 100 : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const days = Object.entries(data.byDay ?? {})
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .slice(-21);
+  const maxDay = Math.max(...days.map(([, v]) => v.txs), 1);
+  const samples = normalizeSamples(chain, data);
+
+  const chainLabel = chain === "base" ? "Base" : "Solana";
+  const headerRight =
+    chain === "base"
+      ? "free via Blockscout"
+      : "free via mainnet-beta RPC";
+
+  return (
+    <>
+      <div className="grid">
+        <Card className="col-6">
+          <CardHeader showCorner right={<span>by facilitator</span>}>
+            Facilitator share · {chainLabel}
+          </CardHeader>
+          <CardBody>
+            {facilitators.map((f) => {
+              const tone = facilitatorColor(chain, f.name);
+              return (
+                <div key={f.name} className="ac-onchain-row">
+                  <span
+                    className="ac-onchain-row__name"
+                    style={{ color: tone }}
+                  >
+                    {f.name}
+                  </span>
+                  <span className="ac-onchain-row__track" aria-hidden>
+                    <i
+                      style={{
+                        width: `${f.share}%`,
+                        background: tone,
+                      }}
+                    />
+                  </span>
+                  <span className="ac-onchain-row__count">{f.count}</span>
+                  <span className="ac-onchain-row__pct">
+                    {f.share.toFixed(1)}%
+                  </span>
+                </div>
+              );
+            })}
+          </CardBody>
+        </Card>
+        <Card className="col-6">
+          <CardHeader showCorner right={<span>{days.length}d window</span>}>
+            Daily settlements · {chainLabel}
+          </CardHeader>
+          <CardBody>
+            <div
+              className="ac-onchain-bars"
+              role="img"
+              aria-label={`${chainLabel} daily settlements last ${days.length} days`}
+            >
+              {days.map(([day, v]) => {
+                const h = Math.max(2, Math.round((v.txs / maxDay) * 90));
+                return (
+                  <span
+                    key={day}
+                    title={`${day} · ${v.txs} settlements`}
+                    className="ac-onchain-bar"
+                    style={{ height: `${h}px` }}
+                  />
+                );
+              })}
+            </div>
+            <div className="ac-onchain-bars-axis">
+              <span>{days[0]?.[0]}</span>
+              <span className="v2-mono ac-onchain-bars-axis__meta">
+                {headerRight}
+              </span>
+              <span>{days[days.length - 1]?.[0]}</span>
+            </div>
+          </CardBody>
+        </Card>
+      </div>
+      {samples.length > 0 ? (
+        <Card>
+          <CardHeader
+            showCorner
+            right={<span>most recent on-chain settlements</span>}
+          >
+            Sample tx · {chainLabel}
+          </CardHeader>
+          <CardBody>
+            {samples.map((s) => (
+              <a
+                key={s.hash}
+                href={explorerUrl(chain, s.hash)}
+                target="_blank"
+                rel="noreferrer"
+                className="ac-onchain-sample"
+              >
+                <span
+                  className="ac-onchain-sample__facilitator"
+                  style={{ color: facilitatorColor(chain, s.facilitator) }}
+                >
+                  {s.facilitator}
+                </span>
+                <span className="ac-onchain-sample__hash">{s.hash}</span>
+                <span className="ac-onchain-sample__date">{s.date}</span>
+              </a>
+            ))}
+          </CardBody>
+        </Card>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/agent-commerce/ProtocolPulseGrid.tsx
+++ b/src/components/agent-commerce/ProtocolPulseGrid.tsx
@@ -1,0 +1,81 @@
+// Agent Commerce — protocol pulse grid (counts only).
+//
+// Drops the per-protocol synthetic Sparkline that previously sat under each
+// row. The fake time-series suggested historical adoption data that doesn't
+// exist; this v4 rebuild surfaces just the absolute count + share bar so the
+// chrome stays honest until a real per-protocol timeline collector lands.
+
+import type { AgentCommerceStats } from "@/lib/agent-commerce/types";
+
+interface ProtocolPulseGridProps {
+  stats: AgentCommerceStats;
+}
+
+interface PulseRow {
+  label: string;
+  count: number;
+  color: string;
+}
+
+export function ProtocolPulseGrid({ stats }: ProtocolPulseGridProps) {
+  const total = Math.max(stats.totalItems, 1);
+  const rows: PulseRow[] = [
+    { label: "x402", count: stats.x402EnabledCount, color: "var(--v4-amber)" },
+    { label: "MCP", count: stats.mcpServerCount, color: "var(--v4-cyan)" },
+    {
+      label: "Portal",
+      count: stats.portalReadyCount,
+      color: "var(--v4-money)",
+    },
+    {
+      label: "Actionable",
+      count: stats.agentActionableCount,
+      color: "var(--v4-violet)",
+    },
+  ];
+
+  // Protocol counts also include any in stats.byProtocol that aren't already
+  // covered by the flag rows above. We surface up to 4 extras so the grid
+  // matches the original section coverage.
+  const flagLabels = new Set(["x402", "MCP", "Portal", "Actionable"]);
+  const extras: PulseRow[] = Object.entries(stats.byProtocol)
+    .filter(([proto]) => proto !== "x402" && proto !== "mcp")
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4)
+    .map(([proto, n]) => ({
+      label: proto.toUpperCase(),
+      count: n,
+      color: "var(--v4-ink-300)",
+    }))
+    .filter((r) => !flagLabels.has(r.label));
+
+  const allRows = [...rows, ...extras];
+
+  return (
+    <div className="ac-pulse-grid">
+      {allRows.map((row) => {
+        const pct = Math.round((row.count / total) * 100);
+        return (
+          <div key={row.label} className="ac-pulse-row">
+            <span
+              className="v2-mono ac-pulse-row__label"
+              style={{ color: row.color }}
+            >
+              {row.label}
+            </span>
+            <span className="ac-pulse-row__track" aria-hidden>
+              <i
+                style={{
+                  width: `${pct}%`,
+                  background: row.color,
+                }}
+              />
+            </span>
+            <span className="ac-pulse-row__count">{row.count}</span>
+            <span className="ac-pulse-row__pct">{pct}%</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/agent-commerce/ScoreDistributionGrid.tsx
+++ b/src/components/agent-commerce/ScoreDistributionGrid.tsx
@@ -1,0 +1,122 @@
+// Agent Commerce — composite score histogram + top-10 bars.
+//
+// V4 rebuild: drops the hand-rolled inline-styled rows for the histogram and
+// reuses the .funding-bars chrome pattern (same one /funding uses) for the
+// top-10 leaderboard. All colors come from v4 tokens.
+
+import Link from "next/link";
+
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+
+import type { AgentCommerceItem, AgentCommerceStats } from "@/lib/agent-commerce/types";
+
+interface ScoreBucket {
+  label: string;
+  min: number;
+  max: number;
+  color: string;
+  count: number;
+}
+
+function buildBuckets(items: AgentCommerceItem[]): ScoreBucket[] {
+  const buckets: ScoreBucket[] = [
+    { label: "80–100", min: 80, max: 100, color: "var(--v4-money)", count: 0 },
+    { label: "60–79", min: 60, max: 79, color: "var(--v4-blue)", count: 0 },
+    { label: "40–59", min: 40, max: 59, color: "var(--v4-amber)", count: 0 },
+    { label: "20–39", min: 20, max: 39, color: "var(--v4-acc)", count: 0 },
+    { label: "0–19", min: 0, max: 19, color: "var(--v4-ink-400)", count: 0 },
+  ];
+  for (const item of items) {
+    const s = item.scores.composite;
+    for (const b of buckets) {
+      if (s >= b.min && s <= b.max) {
+        b.count++;
+        break;
+      }
+    }
+  }
+  return buckets;
+}
+
+interface ScoreDistributionGridProps {
+  items: AgentCommerceItem[];
+  topByScore: AgentCommerceItem[];
+  stats: AgentCommerceStats;
+}
+
+export function ScoreDistributionGrid({
+  items,
+  topByScore,
+  stats,
+}: ScoreDistributionGridProps) {
+  const buckets = buildBuckets(items);
+  const maxBucket = Math.max(...buckets.map((b) => b.count), 1);
+  const topMax = Math.max(...topByScore.map((i) => i.scores.composite), 1);
+
+  return (
+    <div className="grid">
+      <Card className="col-8">
+        <CardHeader showCorner right={<span>{stats.totalItems} indexed</span>}>
+          Top 10 · composite bars
+        </CardHeader>
+        <CardBody>
+          <div className="funding-bars" aria-label="Composite leaderboard">
+            {topByScore.slice(0, 10).map((item, idx) => {
+              const width = Math.max(
+                4,
+                (item.scores.composite / topMax) * 100,
+              );
+              return (
+                <Link
+                  href={`/agent-commerce/${item.slug}`}
+                  className="funding-bar"
+                  key={item.id}
+                >
+                  <span className="idx">
+                    {String(idx + 1).padStart(2, "0")}
+                  </span>
+                  <span className="track">
+                    <i style={{ width: `${width}%` }} />
+                  </span>
+                  <span className="amt">
+                    {item.scores.composite}
+                    <span className="ac-bar-name">{item.name}</span>
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </CardBody>
+      </Card>
+      <Card className="col-4">
+        <CardHeader showCorner right={<span>histogram</span>}>
+          Score buckets
+        </CardHeader>
+        <CardBody>
+          {buckets.map((b) => {
+            const width = Math.round((b.count / maxBucket) * 100);
+            return (
+              <div className="ac-score-row" key={b.label}>
+                <span
+                  className="ac-score-row__pip"
+                  style={{ background: b.color }}
+                  aria-hidden
+                />
+                <span className="ac-score-row__label">{b.label}</span>
+                <span className="ac-score-row__count">{b.count}</span>
+                <span className="ac-score-row__track" aria-hidden>
+                  <i
+                    style={{
+                      width: `${width}%`,
+                      background: b.color,
+                    }}
+                  />
+                </span>
+              </div>
+            );
+          })}
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/agent-commerce/TokenEconomyBoards.tsx
+++ b/src/components/agent-commerce/TokenEconomyBoards.tsx
@@ -1,0 +1,118 @@
+// Agent Commerce — token-economy boards.
+//
+// CoinGecko-enriched token data: top by mcap + 24h gainers. V4 rebuild —
+// every previously-inline color now lives behind a v4 token (positive/negative
+// rails for direction, violet for the token symbol, amber for mcap, ink-400
+// for rank). Returns `null` when there are no tokens to render so the page
+// doesn't ship an empty section.
+
+import Link from "next/link";
+
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+
+import type { AgentCommerceItem } from "@/lib/agent-commerce/types";
+
+interface TokenEconomyBoardsProps {
+  items: AgentCommerceItem[];
+}
+
+function fmtMcap(value: number): string {
+  if (value >= 1e9) return `$${(value / 1e9).toFixed(2)}B`;
+  return `$${(value / 1e6).toFixed(0)}M`;
+}
+
+function fmtChange(pct: number): string {
+  return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+}
+
+export function TokenEconomyBoards({ items }: TokenEconomyBoardsProps) {
+  const tokenItems = items.filter((i) => i.live?.tokenSymbol);
+  if (tokenItems.length === 0) return null;
+
+  const topByMcap = tokenItems
+    .slice()
+    .sort(
+      (a, b) =>
+        (b.live?.marketCapUsd ?? 0) - (a.live?.marketCapUsd ?? 0),
+    )
+    .slice(0, 8);
+
+  const topGainers = tokenItems
+    .filter((i) => Number.isFinite(i.live?.priceChange24hPct))
+    .slice()
+    .sort(
+      (a, b) =>
+        (b.live?.priceChange24hPct ?? 0) -
+        (a.live?.priceChange24hPct ?? 0),
+    )
+    .slice(0, 8);
+
+  return (
+    <div className="grid">
+      <Card className="col-6">
+        <CardHeader showCorner right={<span>by mcap</span>}>
+          Top agent tokens
+        </CardHeader>
+        <CardBody>
+          {topByMcap.map((item, idx) => {
+            const mcap = item.live?.marketCapUsd ?? 0;
+            const change = item.live?.priceChange24hPct ?? 0;
+            const positive = change >= 0;
+            return (
+              <Link
+                key={item.id}
+                href={`/agent-commerce/${item.slug}`}
+                className="ac-token-row"
+              >
+                <span className="ac-token-row__rank">
+                  {String(idx + 1).padStart(2, "0")}
+                </span>
+                <span className="ac-token-row__symbol">
+                  ${item.live?.tokenSymbol}
+                </span>
+                <span className="ac-token-row__name">{item.name}</span>
+                <span className="ac-token-row__mcap">{fmtMcap(mcap)}</span>
+                <span
+                  className={`ac-token-row__change ${positive ? "is-up" : "is-down"}`}
+                >
+                  {fmtChange(change)}
+                </span>
+              </Link>
+            );
+          })}
+        </CardBody>
+      </Card>
+      <Card className="col-6">
+        <CardHeader showCorner right={<span>24h gainers</span>}>
+          Top movers
+        </CardHeader>
+        <CardBody>
+          {topGainers.map((item, idx) => {
+            const change = item.live?.priceChange24hPct ?? 0;
+            const positive = change >= 0;
+            return (
+              <Link
+                key={item.id}
+                href={`/agent-commerce/${item.slug}`}
+                className="ac-token-row ac-token-row--gainer"
+              >
+                <span className="ac-token-row__rank">
+                  {String(idx + 1).padStart(2, "0")}
+                </span>
+                <span className="ac-token-row__symbol">
+                  ${item.live?.tokenSymbol}
+                </span>
+                <span className="ac-token-row__name">{item.name}</span>
+                <span
+                  className={`ac-token-row__change ${positive ? "is-up" : "is-down"}`}
+                >
+                  {fmtChange(change)}
+                </span>
+              </Link>
+            );
+          })}
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/agent-commerce/agent-commerce.css
+++ b/src/components/agent-commerce/agent-commerce.css
@@ -1240,3 +1240,577 @@
   border-radius: 2px;
   border: 1px solid var(--color-border-subtle);
 }
+
+/* ===========================================================================
+ * V4 rebuild (2026-05-17) — new component chrome.
+ *
+ * Surfaces shipped with the full v4 rebuild of /agent-commerce (PR /
+ * feat(agent-commerce): full v4 rebuild). Replaces inline-styled rows from
+ * the previous 2293-line monolith with tokenised primitives. Mover rows
+ * mirror /funding's MoverRow visual contract; on-chain rows borrow the
+ * .ac-onchain-* contract from the previous render, now token-clean.
+ * ========================================================================= */
+
+/* MoversBoard — leaderboard rows */
+.ac-movers-board {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--v4-line-200);
+  background: var(--v4-bg-050);
+}
+
+.ac-mover-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 88px auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--v4-line-100);
+  color: var(--v4-ink-100);
+  text-decoration: none;
+}
+
+.ac-mover-row:last-child {
+  border-bottom: none;
+}
+
+.ac-mover-row:hover {
+  background: var(--v4-bg-100);
+}
+
+.ac-mover-row.is-first {
+  border-left: 2px solid var(--v4-money);
+  background: var(--v4-money-soft);
+}
+
+.ac-mover-row__rank {
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 11px;
+  color: var(--v4-ink-400);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.ac-mover-row.is-first .ac-mover-row__rank {
+  color: var(--v4-money);
+}
+
+.ac-mover-row__body {
+  min-width: 0;
+}
+
+.ac-mover-row__name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--v4-ink-100);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ac-mover-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--v4-ink-400);
+}
+
+.ac-mover-row__kind {
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  color: var(--v4-ink-300);
+}
+
+.ac-mover-row__sep {
+  color: var(--v4-ink-500);
+}
+
+.ac-mover-row__proto {
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 1px;
+}
+
+.ac-mr-proto--x402 {
+  color: var(--v4-amber);
+  border: 1px solid color-mix(in oklab, var(--v4-amber) 40%, transparent);
+  background: var(--v4-amber-soft);
+}
+
+.ac-mr-proto--mcp {
+  color: var(--v4-cyan);
+}
+
+.ac-mr-proto--a2a {
+  color: var(--v4-pink);
+}
+
+.ac-mr-proto--http {
+  color: var(--v4-ink-400);
+}
+
+.ac-mover-row__score {
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-weight: 700;
+  font-size: 16px;
+  text-align: right;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  line-height: 1.1;
+}
+
+.ac-mover-row__score-lbl {
+  font-size: 8.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--v4-ink-400);
+  font-weight: 600;
+}
+
+.ac-mr-score--high {
+  color: var(--v4-money);
+}
+
+.ac-mr-score--mid {
+  color: var(--v4-amber);
+}
+
+.ac-mr-score--low {
+  color: var(--v4-ink-300);
+}
+
+.ac-mover-row__stage {
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 3px 8px;
+  border: 1px solid var(--v4-line-300);
+  color: var(--v4-ink-200);
+  border-radius: 1px;
+}
+
+.ac-board-empty {
+  padding: 24px 16px;
+  border: 1px solid var(--v4-line-200);
+  background: var(--v4-bg-050);
+  color: var(--v4-ink-300);
+  font-size: 13px;
+}
+
+/* Mobile: drop the score-column width and shrink padding so 375px renders
+ * without horizontal overflow. */
+@media (max-width: 540px) {
+  .ac-mover-row {
+    grid-template-columns: 24px minmax(0, 1fr) 64px;
+    column-gap: 8px;
+    padding: 8px 10px;
+  }
+  .ac-mover-row__stage {
+    display: none;
+  }
+  .ac-mover-row__meta {
+    gap: 4px;
+  }
+}
+
+/* ProtocolPulseGrid */
+.ac-pulse-grid {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--v4-line-200);
+  background: var(--v4-bg-050);
+}
+
+.ac-pulse-row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) 48px 48px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--v4-line-100);
+}
+
+.ac-pulse-row:last-child {
+  border-bottom: none;
+}
+
+.ac-pulse-row__label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.ac-pulse-row__track {
+  position: relative;
+  height: 6px;
+  background: var(--v4-bg-100);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ac-pulse-row__track i {
+  position: absolute;
+  inset: 0;
+}
+
+.ac-pulse-row__count {
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: right;
+  color: var(--v4-ink-100);
+}
+
+.ac-pulse-row__pct {
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 10px;
+  text-align: right;
+  color: var(--v4-ink-400);
+  letter-spacing: 0.06em;
+}
+
+@media (max-width: 540px) {
+  .ac-pulse-row {
+    grid-template-columns: 60px minmax(0, 1fr) 42px;
+    column-gap: 8px;
+  }
+  .ac-pulse-row__pct {
+    display: none;
+  }
+}
+
+/* ScoreDistributionGrid — histogram rows */
+.ac-score-row {
+  display: grid;
+  grid-template-columns: 8px 70px 40px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--v4-line-100);
+}
+
+.ac-score-row:last-child {
+  border-bottom: none;
+}
+
+.ac-score-row__pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 1px;
+}
+
+.ac-score-row__label {
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 11px;
+  color: var(--v4-ink-200);
+}
+
+.ac-score-row__count {
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: right;
+  color: var(--v4-ink-100);
+}
+
+.ac-score-row__track {
+  position: relative;
+  height: 4px;
+  background: var(--v4-bg-100);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.ac-score-row__track i {
+  position: absolute;
+  inset: 0;
+}
+
+.ac-bar-name {
+  margin-left: 8px;
+  color: var(--v4-ink-400);
+  font-weight: 400;
+}
+
+/* TokenEconomyBoards */
+.ac-token-row {
+  display: grid;
+  grid-template-columns: 20px 70px minmax(0, 1fr) 80px 64px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--v4-line-100);
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 12px;
+  text-decoration: none;
+  color: var(--v4-ink-100);
+}
+
+.ac-token-row:hover {
+  background: var(--v4-bg-100);
+}
+
+.ac-token-row--gainer {
+  grid-template-columns: 20px 70px minmax(0, 1fr) 64px;
+}
+
+.ac-token-row__rank {
+  color: var(--v4-ink-400);
+}
+
+.ac-token-row__symbol {
+  color: var(--v4-violet);
+  font-weight: 700;
+}
+
+.ac-token-row__name {
+  color: var(--v4-ink-100);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-sans, system-ui);
+  font-size: 13px;
+}
+
+.ac-token-row__mcap {
+  text-align: right;
+  color: var(--v4-amber);
+}
+
+.ac-token-row__change {
+  text-align: right;
+  font-weight: 700;
+}
+
+.ac-token-row__change.is-up {
+  color: var(--v4-money);
+}
+
+.ac-token-row__change.is-down {
+  color: var(--v4-red);
+}
+
+@media (max-width: 540px) {
+  .ac-token-row {
+    grid-template-columns: 18px 56px minmax(0, 1fr) 56px;
+    column-gap: 6px;
+    padding: 8px 10px;
+  }
+  .ac-token-row__mcap {
+    display: none;
+  }
+}
+
+/* OnchainSettlementsBoard */
+.ac-onchain-row {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) 56px 56px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--v4-line-100);
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 12px;
+}
+
+.ac-onchain-row__name {
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ac-onchain-row__track {
+  position: relative;
+  height: 6px;
+  background: var(--v4-bg-100);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ac-onchain-row__track i {
+  position: absolute;
+  inset: 0;
+}
+
+.ac-onchain-row__count {
+  text-align: right;
+  color: var(--v4-ink-100);
+  font-weight: 700;
+}
+
+.ac-onchain-row__pct {
+  text-align: right;
+  color: var(--v4-ink-400);
+}
+
+.ac-onchain-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  padding: 16px 14px 8px;
+  height: 110px;
+}
+
+.ac-onchain-bar {
+  flex: 1;
+  background: var(--v4-acc);
+  opacity: 0.85;
+  border-top: 1px solid var(--v4-acc);
+}
+
+.ac-onchain-bars-axis {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px 10px;
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.ac-onchain-bars-axis__meta {
+  font-size: 9.5px;
+  color: var(--v4-ink-300);
+}
+
+.ac-onchain-sample {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) 90px;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 14px;
+  border-bottom: 1px solid var(--v4-line-100);
+  color: var(--v4-ink-100);
+  text-decoration: none;
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 11px;
+}
+
+.ac-onchain-sample:hover {
+  background: var(--v4-bg-100);
+}
+
+.ac-onchain-sample__facilitator {
+  font-weight: 700;
+}
+
+.ac-onchain-sample__hash {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--v4-ink-200);
+}
+
+.ac-onchain-sample__date {
+  text-align: right;
+  color: var(--v4-ink-400);
+}
+
+@media (max-width: 540px) {
+  .ac-onchain-row {
+    grid-template-columns: 80px minmax(0, 1fr) 44px;
+    column-gap: 8px;
+  }
+  .ac-onchain-row__pct {
+    display: none;
+  }
+  .ac-onchain-sample {
+    grid-template-columns: 80px minmax(0, 1fr);
+  }
+  .ac-onchain-sample__date {
+    display: none;
+  }
+}
+
+/* DuneVolumeBoard */
+.ac-dune-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  padding: 16px 14px 8px;
+  height: 140px;
+}
+
+.ac-dune-bar {
+  flex: 1;
+  background: var(--v4-acc);
+  opacity: 0.85;
+}
+
+.ac-dune-bars-axis {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 14px 10px;
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 10px;
+  color: var(--v4-ink-400);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.ac-dune-row {
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1fr) 70px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--v4-line-100);
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 12px;
+}
+
+.ac-dune-row__name {
+  font-weight: 700;
+}
+
+.ac-dune-row__track {
+  position: relative;
+  height: 6px;
+  background: var(--v4-bg-100);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ac-dune-row__track i {
+  position: absolute;
+  inset: 0;
+}
+
+.ac-dune-row__value {
+  text-align: right;
+  color: var(--v4-ink-100);
+  font-weight: 700;
+}
+
+@media (max-width: 540px) {
+  .ac-dune-row {
+    grid-template-columns: 76px minmax(0, 1fr) 56px;
+    column-gap: 8px;
+  }
+}
+
+/* Filter snapshot from AgentCommerceFilteredContent */
+.ac-filter-snapshot {
+  display: grid;
+  gap: 8px;
+  padding: 10px 14px;
+  font-family: var(--font-geist-mono), var(--font-jetbrains-mono), monospace;
+  font-size: 11.5px;
+  color: var(--v4-ink-300);
+}
+
+.ac-filter-snapshot__val {
+  color: var(--v4-acc);
+}


### PR DESCRIPTION
## Summary
- Rebuilds the 2293-line /agent-commerce monolith as a v4-native shell matching the /funding pattern: `PageHead` + `KpiBand` + `VerdictRibbon` + `SectionHead` instead of hand-rolled chrome, with `FreshnessBadge` wired to `classifyFreshness('skills')` so the ribbon tone follows the verdict.
- Extracts six new components (`MoversBoard`, `ProtocolPulseGrid`, `ScoreDistributionGrid`, `TokenEconomyBoards`, `OnchainSettlementsBoard` (chain="base"|"solana"), `DuneVolumeBoard`) — all <250 LoC, all v4-token-only, all responsive at 375px. Keeps `AgentCommerceTicker`/`Tabs`/`FilterBar`/`Card`/`Badges` as-is.
- Cache fix B: drops `await searchParams` in the RSC; new `AgentCommerceFilteredContent` (`'use client'`) reads `useSearchParams()` so the page shell stays ISR-cacheable under `revalidate=1200`.
- Deletes the synthetic `growthCurve(Math.pow(frac, 1.4))` headline chart (freshness-honesty violation), `MiniBoard`, the local `Sparkline` consumers, and the bespoke `.page-head`/`.verdict`/`.home-surface` inline blocks.
- Imports the previously-orphaned `agent-commerce.css` from the new `page.tsx` (no AC stylesheet was loading on the live page) and appends v4-token-clean chrome + mobile breakpoints.

## Design-audit metrics
| | before | after |
|---|---|---|
| `page.tsx` LoC | 2293 | 431 |
| inline `style={{}}` blocks | 111 | 5 (inside `VerdictRibbon` headline — same pattern /funding uses) |
| hardcoded hexes | 61 | 0 |
| `--v4-*` token refs | 0 | 12 |
| `await searchParams` | 1 | 0 |

## Test plan
- [x] `npm run typecheck` → clean
- [x] `npm run lint:guards` → 24/24 covered
- [x] `npx eslint` on the 8 touched files → clean
- [ ] Vercel preview renders /agent-commerce at 375px without horizontal overflow on mover/score/token/on-chain rows
- [ ] /agent-commerce filter chips (tab / category / protocol / pricing / portal-ready / q) still update the URL and re-filter the browse grid (now on the client)
- [ ] FreshnessBadge surfaces next to the clock and flips to amber/cold once `NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=false` (default still hides per operator decision)
- [ ] ISR works: deploy URL returns 200 quickly on repeat hits, not a fresh `await searchParams` dynamic render every time

Untouched on purpose: `agent-commerce/[slug]/page.tsx`, `facilitator/[name]/page.tsx` (separate fix PRs), `loading.tsx` / `error.tsx` (already v4), `apps/trendingrepo-worker/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)