### PR TITLE
fix(ci): lint guard now detects 'use client' even with leading comments (Codex P2)

### DIFF
--- a/scripts/lint-no-secret-env-in-client.mjs
+++ b/scripts/lint-no-secret-env-in-client.mjs
@@ -28,11 +28,15 @@ function walk(dir) {
     }
     if (!/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(entry)) continue;
     const body = readFileSync(full, "utf8");
-    // Quick skip: file must have "use client" directive on its first
-    // non-blank line (Next.js requirement). We accept either quote style.
+    // Quick skip: file must have "use client" directive as its first
+    // non-comment content (Next.js allows leading single-line + block
+    // comments before the directive). We accept either quote style.
+    const stripped = body
+      .replace(/^\s+/, "") // leading whitespace
+      .replace(/^(\/\/[^\n]*\n|\/\*[\s\S]*?\*\/\s*)+/, ""); // leading comments (single + block)
     if (
-      !/^[\s\n]*"use client"/.test(body) &&
-      !/^[\s\n]*'use client'/.test(body)
+      !stripped.startsWith('"use client"') &&
+      !stripped.startsWith("'use client'")
     )
       continue;
     const matches = body.matchAll(/process\.env\.([A-Z_][A-Z0-9_]*)/g);


### PR DESCRIPTION
## Summary
- Codex audit P2: `scripts/lint-no-secret-env-in-client.mjs:31` only detected `"use client"` as the FIRST non-blank content. Files with leading single-line or block comments before the directive were silently skipped, leaving a hole in the secret-env guard.
- Fix: strip leading whitespace + JS comments before testing for the `"use client"` directive. Quote-style detection (single vs double) is preserved.
- No active leak was found on main, but the guard now correctly catches the comment-prefixed pattern.

## Diff (load-bearing)
```diff
-    // Quick skip: file must have "use client" directive on its first
-    // non-blank line (Next.js requirement). We accept either quote style.
+    // Quick skip: file must have "use client" directive as its first
+    // non-comment content (Next.js allows leading single-line + block
+    // comments before the directive). We accept either quote style.
+    const stripped = body
+      .replace(/^\s+/, "") // leading whitespace
+      .replace(/^(\/\/[^\n]*\n|\/\*[\s\S]*?\*\/\s*)+/, ""); // leading comments
     if (
-      !/^[\s\n]*"use client"/.test(body) &&
-      !/^[\s\n]*'use client'/.test(body)
+      !stripped.startsWith('"use client"') &&
+      !stripped.startsWith("'use client'")
     )
       continue;
```

## Test plan
- [x] Created fixture `src/app/__test_fixture_lint__/page.tsx` with leading `/** copyright */ // comment` then `"use client"` then `process.env.SOME_SECRET_KEY`
- [x] Confirmed OLD regex would silently skip the fixture (`oldPasses === false` on the leading-comment file)
- [x] Confirmed NEW logic flags the fixture: `Found 1 client-side reads of non-public env vars: ... process.env.SOME_SECRET_KEY` (exit 1)
- [x] Confirmed `NEXT_PUBLIC_*` and `NODE_ENV` reads in the same fixture were correctly NOT flagged
- [x] Removed fixture, re-ran on main: `OK - no secret env reads in client files.` (exit 0)
- [x] Only `scripts/lint-no-secret-env-in-client.mjs` modified (no test fixtures checked in — the workflow at `.github/workflows/lint-no-secret-env-in-client.yml` references the script directly, no fixtures needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)