### PR TITLE
fix(sentry): centralize error capture in ErrorPanel via dynamic import (fix race condition — Codex P2/P3)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -17,15 +17,21 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Sentry capture if available - feature-detect on window so we
-    // don't take a hard dep on @sentry/nextjs from this boundary.
+    // Sentry capture via dynamic import (NOT a window.Sentry probe).
+    // instrumentation-client.ts lazy-loads Sentry via requestIdleCallback
+    // (up to 2500ms), so early-render errors fire BEFORE window.Sentry is
+    // populated. Dynamic import guarantees the SDK is available when the
+    // error fires. Race condition caught by Codex P2/P3 audit.
     if (typeof window !== "undefined") {
-      const sentry = (
-        window as unknown as {
-          Sentry?: { captureException: (e: Error) => void };
-        }
-      ).Sentry;
-      if (sentry?.captureException) sentry.captureException(error);
+      void import("@sentry/nextjs")
+        .then(({ captureException }) => {
+          captureException(error, {
+            tags: { route: window.location.pathname },
+          });
+        })
+        .catch(() => {
+          // Best-effort — UI still renders if Sentry fails to load.
+        });
     }
     console.error("[app/error] unhandled render error", error);
   }, [error]);

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -16,13 +16,21 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
+    // Sentry capture via dynamic import (NOT a window.Sentry probe).
+    // instrumentation-client.ts lazy-loads Sentry via requestIdleCallback
+    // (up to 2500ms), so early-render errors fire BEFORE window.Sentry is
+    // populated. Dynamic import guarantees the SDK is available when the
+    // error fires. Race condition caught by Codex P2/P3 audit.
     if (typeof window !== "undefined") {
-      const sentry = (
-        window as unknown as {
-          Sentry?: { captureException: (e: Error) => void };
-        }
-      ).Sentry;
-      if (sentry?.captureException) sentry.captureException(error);
+      void import("@sentry/nextjs")
+        .then(({ captureException }) => {
+          captureException(error, {
+            tags: { route: window.location.pathname },
+          });
+        })
+        .catch(() => {
+          // Best-effort — UI still renders if Sentry fails to load.
+        });
     }
   }, [error]);
 

--- a/src/components/ui/ErrorPanel.tsx
+++ b/src/components/ui/ErrorPanel.tsx
@@ -21,23 +21,25 @@ interface Props {
 // error.tsx files still call captureException themselves (Sentry deduplicates
 // by fingerprint within a short window, so the double-capture is harmless and
 // lets us centralize incrementally).
+//
+// IMPORTANT: We use a dynamic import here (NOT a `window.Sentry` probe).
+// Codex P2/P3 audit caught a race condition: instrumentation-client.ts lazy-
+// loads Sentry via `requestIdleCallback` with a 2500ms timeout. Early-render
+// errors fire BEFORE `window.Sentry` is populated, so a probe-style check
+// silently no-ops and the error never reaches Sentry. Dynamic import waits
+// for the SDK to be fetched/initialized, so the report always lands.
 function reportToSentryWithRouteTag(error: Error & { digest?: string }): void {
   if (typeof window === "undefined") return;
-  const sentry = (
-    window as unknown as {
-      Sentry?: {
-        captureException: (
-          e: Error,
-          ctx?: { tags?: Record<string, string> },
-        ) => void;
-      };
-    }
-  ).Sentry;
-  if (sentry?.captureException) {
-    sentry.captureException(error, {
-      tags: { route: window.location.pathname },
+  void import("@sentry/nextjs")
+    .then(({ captureException }) => {
+      captureException(error, {
+        tags: { route: window.location.pathname },
+      });
+    })
+    .catch(() => {
+      // If Sentry fails to load (network/CSP/adblock), the error boundary
+      // still renders the UI — capture is best-effort.
     });
-  }
 }
 
 const BTN_PRIMARY =


### PR DESCRIPTION
## Summary
Codex P2/P3 audit caught a race condition introduced by #1599's `window.Sentry` global-probe pattern.

`instrumentation-client.ts:82-99` lazy-loads Sentry via `requestIdleCallback` (up to 2500ms timeout). Early-render errors fire BEFORE `window.Sentry` is populated, so the probe silently no-ops and 70+ route error boundaries fail to report.

This reverts to #1540's dynamic-import pattern, which guarantees the SDK is available when the error fires.

## Files changed (3)
- `src/components/ui/ErrorPanel.tsx` — central capture used by every route error.tsx
- `src/app/error.tsx` — root error boundary
- `src/app/global-error.tsx` — runs when layout itself throws

The 87 route `error.tsx` files are NOT touched. They render `<ErrorPanel>`, so the central capture takes effect. Any redundant per-route captures dedupe by fingerprint within a short window (Sentry default), so the overlap is harmless and lets us centralize incrementally.

## Before → After

**Before** (race condition):
```tsx
const sentry = (window as unknown as { Sentry?: { captureException: ... } }).Sentry;
if (sentry?.captureException) sentry.captureException(error, { tags: { route } });
// → silently no-ops if Sentry hasn't loaded yet
```

**After** (dynamic import, no race):
```tsx
void import("@sentry/nextjs")
  .then(({ captureException }) => {
    captureException(error, { tags: { route: window.location.pathname } });
  })
  .catch(() => {
    // Best-effort — UI still renders if Sentry fails (network/CSP/adblock).
  });
```

## Verification
- [x] `npm run typecheck` — clean
- [x] `npm run lint:guards` — all guards OK (0 missing/orphaned routes, no pool-bypass, img-lazy compliant, keep-last-50 compliant)
- [x] No package-lock.json drift
- [x] No route error.tsx file touched (87 files preserved)

## Test plan
- [ ] Trigger a render error in any route after deploy → verify event lands in Sentry with `route` tag
- [ ] Test on a slow connection (throttled) — Sentry loads after first idle callback, error capture still fires
- [ ] Test with adblock blocking Sentry — UI still renders the ErrorPanel (best-effort catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)