### PR TITLE
feat(onboarding): post-signup welcome modal (one-time, cookie-gated)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,7 @@ import { Header } from "@/components/layout/Header";
 import { SidebarStream } from "@/components/layout/SidebarStream";
 import { SidebarSkeleton } from "@/components/layout/SidebarSkeleton";
 import ClerkRefHandoff from "@/components/auth/ClerkRefHandoff";
+import { WelcomeModalGate } from "@/components/onboarding/WelcomeModalGate";
 import { clerkAppearance } from "@/lib/auth/clerk-appearance";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import { buildAuthHref } from "@/lib/auth/redirect-url";
@@ -171,6 +172,7 @@ export default async function RootLayout({
       <IdleMount>
         <ClerkRefHandoff />
       </IdleMount>
+      {clerkPublishableKey ? <WelcomeModalGate /> : null}
       <Header authEnabled={Boolean(clerkPublishableKey)} />
       <MobileDrawerLazy />
       <AppShell>

--- a/src/components/onboarding/WelcomeModal.tsx
+++ b/src/components/onboarding/WelcomeModal.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+// Post-signup welcome modal. One-time, cookie-gated. Surfaces after a
+// new user lands back on `/` (or anywhere) after the Clerk hosted sign-up
+// flow completes. Two CTAs:
+//   1. Primary  — links to /you/alerts (the activation step)
+//   2. Secondary — dismiss + look around
+//
+// The modal is intentionally non-blocking: ESC and outside-click both
+// dismiss. We don't gate any feature behind it; this is a nudge, not a
+// gate. Engagement is measured via PostHog events:
+//   - welcome_modal_shown        (fired when modal first paints)
+//   - welcome_modal_dismissed    (any close path: ESC, backdrop, secondary CTA)
+//   - welcome_modal_cta_clicked  (primary CTA — links to /you/alerts)
+//
+// Visual conventions: native <dialog> + showModal() to inherit the
+// browser's a11y plumbing (focus trap, backdrop, ESC). Same primitive as
+// ConfirmDialog.tsx so we stay consistent. V4 tokens via inline styles
+// since dialog elements live outside Tailwind's normal cascading scope
+// in some configs.
+
+import Link from "next/link";
+import { useCallback, useEffect, useRef } from "react";
+
+import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
+
+interface WelcomeModalProps {
+  displayName: string | null;
+  show: boolean;
+  onDismiss: () => void;
+}
+
+function captureEvent(
+  event:
+    | "welcome_modal_shown"
+    | "welcome_modal_dismissed"
+    | "welcome_modal_cta_clicked",
+  properties?: Record<string, unknown>,
+): void {
+  try {
+    const posthog = getLoadedBrowserPostHog();
+    if (posthog) {
+      posthog.capture(event, properties ?? {});
+    }
+  } catch {
+    // Analytics must never throw upstream.
+  }
+}
+
+export function WelcomeModal({
+  displayName,
+  show,
+  onDismiss,
+}: WelcomeModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const ctaRef = useRef<HTMLAnchorElement>(null);
+  // Fire `welcome_modal_shown` exactly once per mount-and-show cycle.
+  // useRef instead of state so the event fires before the next paint.
+  const shownFired = useRef(false);
+
+  // Open / close the underlying <dialog> in lockstep with the `show` prop.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (show && !dialog.open) {
+      dialog.showModal();
+      if (!shownFired.current) {
+        captureEvent("welcome_modal_shown", {
+          has_display_name: displayName !== null,
+        });
+        shownFired.current = true;
+      }
+      // Focus the primary CTA so keyboard users can hit Enter to act.
+      // requestAnimationFrame ensures the dialog has actually opened.
+      requestAnimationFrame(() => {
+        ctaRef.current?.focus();
+      });
+    } else if (!show && dialog.open) {
+      dialog.close();
+    }
+  }, [show, displayName]);
+
+  // Native <dialog> emits "cancel" on ESC. Surface to caller as dismiss.
+  const handleCancel = useCallback(
+    (event: React.SyntheticEvent<HTMLDialogElement>) => {
+      event.preventDefault();
+      captureEvent("welcome_modal_dismissed", { reason: "escape" });
+      onDismiss();
+    },
+    [onDismiss],
+  );
+
+  // Backdrop click → dismiss.
+  const handleBackdropClick = useCallback(
+    (event: React.MouseEvent<HTMLDialogElement>) => {
+      if (event.target === dialogRef.current) {
+        captureEvent("welcome_modal_dismissed", { reason: "backdrop" });
+        onDismiss();
+      }
+    },
+    [onDismiss],
+  );
+
+  const handleSecondaryClick = useCallback(() => {
+    captureEvent("welcome_modal_dismissed", { reason: "secondary_cta" });
+    onDismiss();
+  }, [onDismiss]);
+
+  const handlePrimaryClick = useCallback(() => {
+    captureEvent("welcome_modal_cta_clicked", {
+      destination: "/you/alerts",
+    });
+    // Note: we do NOT call onDismiss() here. The Link navigates away;
+    // the cookie is set by the gate when it sees the modal close on
+    // unmount. (Gate sets the cookie when `show` flips false OR on any
+    // dismiss handler — see WelcomeModalGate.)
+    onDismiss();
+  }, [onDismiss]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onCancel={handleCancel}
+      onClick={handleBackdropClick}
+      aria-labelledby="welcome-modal-title"
+      aria-describedby="welcome-modal-description"
+      style={{
+        background: "var(--v4-bg-025)",
+        color: "var(--v4-ink-100)",
+        border: "1px solid var(--v4-line-200)",
+        borderRadius: "4px",
+        padding: 0,
+        margin: "auto",
+        maxWidth: "min(92vw, 30rem)",
+        boxShadow: "0 24px 60px -12px rgba(0, 0, 0, 0.6)",
+      }}
+      className="welcome-modal"
+    >
+      <div style={{ padding: "1.25rem 1.5rem 1.5rem" }}>
+        {/* WELCOME pill — mono accent at top of card */}
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.375rem",
+            padding: "0.25rem 0.5rem",
+            background: "var(--v4-acc-soft)",
+            color: "var(--v4-acc)",
+            border: "1px solid var(--v4-acc)",
+            borderRadius: "2px",
+            fontFamily: "var(--v4-mono)",
+            fontSize: "var(--v4-text-10)",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: "6px",
+              height: "6px",
+              background: "var(--v4-acc)",
+              borderRadius: "50%",
+              boxShadow: "0 0 6px var(--v4-acc-glow)",
+            }}
+          />
+          Welcome
+        </div>
+
+        <h2
+          id="welcome-modal-title"
+          style={{
+            marginTop: "0.875rem",
+            fontFamily: "var(--v4-sans)",
+            fontSize: "var(--v4-text-22)",
+            fontWeight: 600,
+            lineHeight: 1.25,
+            letterSpacing: "-0.01em",
+            color: "var(--v4-ink-000)",
+          }}
+        >
+          Welcome, {displayName ?? "there"}!
+        </h2>
+
+        <p
+          id="welcome-modal-description"
+          style={{
+            marginTop: "0.625rem",
+            fontFamily: "var(--v4-sans)",
+            fontSize: "var(--v4-text-14)",
+            lineHeight: 1.5,
+            color: "var(--v4-ink-200)",
+          }}
+        >
+          Set up your first alert in 2 minutes — that&apos;s how you&apos;ll
+          catch breakouts before they&apos;re cold.
+        </p>
+
+        <div
+          style={{
+            marginTop: "1.5rem",
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "flex-end",
+            gap: "0.5rem",
+          }}
+        >
+          <button
+            type="button"
+            onClick={handleSecondaryClick}
+            style={{
+              padding: "0.5rem 0.875rem",
+              background: "transparent",
+              border: "1px solid var(--v4-line-300)",
+              color: "var(--v4-ink-200)",
+              fontFamily: "var(--v4-mono)",
+              fontSize: "var(--v4-text-11)",
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              borderRadius: "3px",
+              cursor: "pointer",
+            }}
+          >
+            Look around first
+          </button>
+          <Link
+            ref={ctaRef}
+            href="/you/alerts"
+            onClick={handlePrimaryClick}
+            style={{
+              padding: "0.5rem 0.875rem",
+              background: "var(--v4-acc)",
+              border: "1px solid var(--v4-acc)",
+              color: "var(--v4-bg-000)",
+              fontFamily: "var(--v4-mono)",
+              fontSize: "var(--v4-text-11)",
+              fontWeight: 700,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              borderRadius: "3px",
+              textDecoration: "none",
+              cursor: "pointer",
+            }}
+          >
+            Create my first alert
+          </Link>
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
+export default WelcomeModal;

--- a/src/components/onboarding/WelcomeModalGate.tsx
+++ b/src/components/onboarding/WelcomeModalGate.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+// Cookie-gated mounting point for the post-signup welcome modal.
+//
+// Lifecycle:
+//   1. Mounted from the root layout (always-on, like ClerkRefHandoff).
+//   2. On mount, read the `sb_welcomed` cookie. If present → never show.
+//   3. Subscribe to Clerk's `useUser()`. When the user is loaded and signed
+//      in AND the cookie is absent, set `show=true` once.
+//   4. Any dismiss path writes the `sb_welcomed=1` cookie (90 day expiry,
+//      path=/, lax, secure-in-prod) so the modal never appears again on
+//      this device.
+//
+// The cookie strategy is per-device (not per-user). A user who signs in
+// from a different browser will see the modal again — acceptable for v1.
+// If we ever need per-user tracking, swap to a `profiles.onboarded_at`
+// timestamp; the component contract stays the same.
+//
+// Why client-side instead of server-rendering with cookies(): Clerk's
+// session cookie is the source of truth for "signed in", and that's
+// only reliably reachable client-side without forcing the entire root
+// layout to be dynamic. <ClerkRefHandoff /> already established this
+// pattern.
+
+import { useUser } from "@clerk/nextjs";
+import { useCallback, useEffect, useState } from "react";
+
+import { WelcomeModal } from "./WelcomeModal";
+
+const COOKIE_NAME = "sb_welcomed";
+const COOKIE_MAX_AGE_DAYS = 90;
+
+function hasWelcomedCookie(): boolean {
+  if (typeof document === "undefined") return false;
+  // Cheap substring scan — avoids parsing every cookie pair just to
+  // check existence of one key.
+  return document.cookie
+    .split(";")
+    .some((entry) => entry.trim().startsWith(`${COOKIE_NAME}=`));
+}
+
+function setWelcomedCookie(): void {
+  if (typeof document === "undefined") return;
+  const maxAgeSeconds = COOKIE_MAX_AGE_DAYS * 24 * 60 * 60;
+  // Secure flag only in production — locally we serve over http://.
+  // window.location.protocol is the most reliable signal because
+  // NODE_ENV isn't available client-side in standalone builds.
+  const isHttps =
+    typeof window !== "undefined" && window.location.protocol === "https:";
+  const secureFragment = isHttps ? "; Secure" : "";
+  document.cookie = `${COOKIE_NAME}=1; Max-Age=${maxAgeSeconds}; Path=/; SameSite=Lax${secureFragment}`;
+}
+
+interface WelcomeModalGateProps {
+  // Optional override for the displayed name. When null/omitted the
+  // gate pulls from Clerk's `useUser()`. Provided as an escape hatch
+  // for the server to seed an SSR-friendly value if we ever need it,
+  // but for now the gate is fully client-driven.
+  displayName?: string | null;
+}
+
+export function WelcomeModalGate({
+  displayName: displayNameProp,
+}: WelcomeModalGateProps = {}) {
+  const { isLoaded, isSignedIn, user } = useUser();
+  const [show, setShow] = useState(false);
+  // Track whether we've already evaluated the gate condition for this
+  // session. Without this guard, a user dismissing the modal would re-
+  // trigger `setShow(true)` on the next render before the cookie write
+  // had a chance to propagate.
+  const [evaluated, setEvaluated] = useState(false);
+
+  useEffect(() => {
+    if (!isLoaded || evaluated) return;
+    if (isSignedIn && !hasWelcomedCookie()) {
+      setShow(true);
+    }
+    setEvaluated(true);
+  }, [isLoaded, isSignedIn, evaluated]);
+
+  const handleDismiss = useCallback(() => {
+    setWelcomedCookie();
+    setShow(false);
+  }, []);
+
+  if (!show) return null;
+
+  // Pull display name from Clerk if not provided. Mirrors the precedence
+  // used in HeaderAccountLoaded.tsx so the modal greets the user with
+  // the same string they see on their profile chip.
+  const resolvedDisplayName =
+    displayNameProp ??
+    user?.firstName ??
+    user?.fullName ??
+    user?.username ??
+    null;
+
+  return (
+    <WelcomeModal
+      displayName={resolvedDisplayName}
+      show={show}
+      onDismiss={handleDismiss}
+    />
+  );
+}
+
+export default WelcomeModalGate;


### PR DESCRIPTION
## Summary

Adds a one-time post-signup welcome modal. New users land back on `/` after Clerk sign-up and see a friendly nudge to set up their first alert.

- Two CTAs: primary "Create my first alert" → `/you/alerts`, secondary "Look around first" → dismiss.
- Cookie-gated (per-device): `sb_welcomed=1`, 90-day expiry, Path=/, SameSite=Lax, Secure-in-prod.
- Built on the native `<dialog>` primitive (matches `ConfirmDialog.tsx` convention). Non-blocking: ESC + outside-click both dismiss.
- V4 design tokens throughout (`--v4-bg-025`, `--v4-ink-000`, `--v4-acc`, `--v4-mono`, etc.). Mono accent on the WELCOME pill.

## Schema decision

**Option A (cookie)** — chosen for v1. No DB migration needed, sufficient for per-device tracking. If we later want per-user state (so a user who signs in on a different browser doesn't see it again), add `profiles.onboarded_at` and swap the cookie check for a server-side prop — the component contract stays the same.

## Analytics

Direct `posthog.capture()` calls (not via `funnel_step` — these aren't part of an existing funnel flow):
- `welcome_modal_shown` — fired on first paint, with `has_display_name` boolean
- `welcome_modal_dismissed` — fired on any close path with `reason: "escape" | "backdrop" | "secondary_cta"`
- `welcome_modal_cta_clicked` — fired on primary CTA, with `destination: "/you/alerts"`

## Files

- `src/components/onboarding/WelcomeModal.tsx` — presentation component (native `<dialog>`, V4 tokens, analytics).
- `src/components/onboarding/WelcomeModalGate.tsx` — client gate: reads `sb_welcomed` cookie, subscribes to Clerk `useUser()`, sets cookie on dismiss.
- `src/app/layout.tsx` — surgical insertion of `<WelcomeModalGate />` next to `<ClerkRefHandoff />` (gated on `clerkPublishableKey` so the `useUser()` hook never throws when Clerk is unconfigured).

## Test plan

- [ ] Sign up with a fresh account → modal appears on `/` with display name
- [ ] Click "Create my first alert" → routes to `/you/alerts`, cookie is set
- [ ] Refresh `/` → modal does NOT reappear (cookie present)
- [ ] In a fresh incognito session, signed-in user → modal appears, ESC dismisses, cookie set
- [ ] In incognito, signed-in user → modal appears, click backdrop → cookie set, no modal on reload
- [ ] Anonymous user → modal never appears (Clerk `isSignedIn` is false)
- [ ] Cookie expires after 90 days → modal would reappear (manual: clear cookie + reload)
- [ ] Lighthouse: no impact on first paint (gate is mounted but renders `null` until cookie evaluation + Clerk ready)

## Verification

- `npm run typecheck` — clean
- `npm run lint:guards` — clean (0 missing budgets, 0 orphaned config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)