### PR TITLE
feat(onboarding): alerts polish — empty state + tooltips + presets + first-alert toast (S2.BCDE)

### DIFF
--- a/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
+++ b/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
@@ -21,6 +21,7 @@ import { LoaderCircle, Plus, X } from "lucide-react";
 import { AdminRecoverableError, TransientHttpError } from "@/lib/errors";
 import { cn } from "@/lib/utils";
 import {
+  toast,
   toastAlertCreated,
   toastAlertError,
   toastWebhookSecretCopied,
@@ -35,6 +36,14 @@ import type {
   SerializedAlertRule,
 } from "./types";
 import type { AlertRuleType, AlertCadence } from "@/lib/db/schema/alerts";
+import { AlertPresets, type PresetSetters } from "./AlertPresets";
+import { FieldTooltip } from "./FieldTooltip";
+
+// Custom event used by sibling empty-state components to open the
+// create-rule dialog without holding a ref into this component.
+// Exported for tests / other islands; consumers fire:
+//   window.dispatchEvent(new CustomEvent(ALERTS_OPEN_CREATE_EVENT))
+export const ALERTS_OPEN_CREATE_EVENT = "alerts:open-create-dialog";
 
 interface AddAlertRuleDialogProps {
   existingRuleCount: number;
@@ -161,6 +170,21 @@ export function AddAlertRuleDialog({
       dialog.close();
     }
   }, [open]);
+
+  // External open trigger — sibling components (e.g. the EmptyState CTA in
+  // AlertRuleList) dispatch ALERTS_OPEN_CREATE_EVENT to open the dialog
+  // without holding a ref into this island.
+  useEffect(() => {
+    const onOpen = () => {
+      if (existingRuleCount >= 25) {
+        toastAlertError("You have hit the 25-rule limit. Delete one first.");
+        return;
+      }
+      setOpen(true);
+    };
+    window.addEventListener(ALERTS_OPEN_CREATE_EVENT, onOpen);
+    return () => window.removeEventListener(ALERTS_OPEN_CREATE_EVENT, onOpen);
+  }, [existingRuleCount]);
 
   // ESC + backdrop click → close, but only when not submitting AND not
   // sitting on the secret-reveal screen (we want the user to actively
@@ -293,7 +317,26 @@ export function AddAlertRuleDialog({
         }
         throw new TransientHttpError(err.message || err.error || `HTTP ${res.status}`, res.status);
       }
-      toastAlertCreated();
+      // S2.E — first-alert success toast. If this was the user's first
+      // rule (count snapshot taken when the page rendered), use the
+      // richer onboarding-style toast with a link back to /watchlist.
+      // Otherwise, keep the terse confirmation.
+      if (existingRuleCount === 0) {
+        toast.success(
+          "Alert created! First report in ~1h. Until then, explore your watchlist.",
+          {
+            duration: 8000,
+            action: {
+              label: "Watchlist",
+              onClick: () => {
+                window.location.href = "/watchlist";
+              },
+            },
+          },
+        );
+      } else {
+        toastAlertCreated();
+      }
       // If a webhook URL was set, the server returned the plaintext secret
       // exactly once. Switch to the reveal phase and force the user to copy
       // it before continuing.
@@ -393,13 +436,47 @@ export function AddAlertRuleDialog({
               </button>
             </header>
 
+            {/* Quick-start templates — S2.D */}
+            <AlertPresets
+              snapshot={{
+                ruleType,
+                cadence,
+                rankScope,
+                rankMaxRank,
+                rankDirection,
+                mentionMultiplier,
+                mentionWindow,
+              }}
+              setters={
+                {
+                  setName,
+                  setRuleType,
+                  setCadence,
+                  setBreakoutFullName,
+                  setBreakoutMinScore,
+                  setRankScope,
+                  setRankMaxRank,
+                  setRankDirection,
+                  setReleaseFullName,
+                  setReleaseIncludePre,
+                  setMentionFullName,
+                  setMentionMultiplier,
+                  setMentionWindow,
+                } satisfies PresetSetters
+              }
+            />
+
             {/* Step 1 — type picker */}
             <fieldset className="mb-4">
               <legend
-                className="mb-2 font-mono text-[10px] uppercase tracking-[0.16em]"
+                className="mb-2 inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.16em]"
                 style={{ color: "var(--v3-ink-400)" }}
               >
                 {"// 01 · TYPE"}
+                <FieldTooltip
+                  label="Rule type"
+                  content="Pick what you want notified about. 'Breakout' fires on rank change. 'Daily digest' summarizes 24h activity. 'New release' fires on new GitHub releases."
+                />
               </legend>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {RULE_TYPE_OPTIONS.map((opt) => (
@@ -532,10 +609,14 @@ export function AddAlertRuleDialog({
               </legend>
 
               <div
-                className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em]"
+                className="mb-2 inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em]"
                 style={{ color: "var(--v3-ink-300)" }}
               >
                 Cadence
+                <FieldTooltip
+                  label="Cadence"
+                  content="How often we check this rule. 1h = realtime, 24h = daily digest."
+                />
               </div>
               <div className="mb-3 flex flex-wrap gap-2">
                 {(["realtime", "daily", "weekly"] as AlertCadence[]).map(
@@ -573,10 +654,14 @@ export function AddAlertRuleDialog({
               </div>
 
               <label
-                className="block font-mono text-[10px] uppercase tracking-[0.14em]"
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em]"
                 style={{ color: "var(--v3-ink-300)" }}
               >
                 Webhook URL (optional, https only)
+                <FieldTooltip
+                  label="Webhook"
+                  content="Send notifications to a URL. Slack/Discord/your-API. Must be HTTPS."
+                />
               </label>
               <input
                 type="url"
@@ -607,6 +692,10 @@ export function AddAlertRuleDialog({
                   onChange={(e) => setUseQuietHours(e.target.checked)}
                 />
                 Per-rule quiet hours (overrides profile default)
+                <FieldTooltip
+                  label="Quiet hours"
+                  content="Suppress notifications during these hours. Useful for sleep / focus."
+                />
               </label>
               {useQuietHours ? (
                 <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">

--- a/src/app/you/alerts/_components/AlertPresets.tsx
+++ b/src/app/you/alerts/_components/AlertPresets.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+// AlertPresets — quick-start templates for the alert-rule create dialog.
+//
+// Each preset is a single-click way to populate the most common rule
+// shapes a watcher will set up:
+//
+//   - Breakout (any repo)
+//   - Daily digest (rank threshold drops in top-100)
+//   - New release (specific repo)
+//   - Mention spike (any repo, 3x baseline / 24h)
+//
+// Each preset's `applyTo(setters)` writes onto the form state held in
+// AddAlertRuleDialog. We pass the setters individually (not a single
+// state object) so this stays compatible with the dialog's existing
+// useState shape without needing a reducer refactor.
+//
+// Visual: row of cards above the form fields. Active preset highlighted
+// when the current form state matches it.
+
+import { Activity, BellRing, GitBranch, TrendingUp } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import type { AlertRuleType, AlertCadence } from "@/lib/db/schema/alerts";
+
+// The subset of dialog setters each preset can write to.
+// Kept as a flat record (not the form-state object) so AddAlertRuleDialog
+// doesn't need to change its useState topology.
+export interface PresetSetters {
+  setName: (v: string) => void;
+  setRuleType: (v: AlertRuleType) => void;
+  setCadence: (v: AlertCadence) => void;
+  setBreakoutFullName: (v: string) => void;
+  setBreakoutMinScore: (v: string) => void;
+  setRankScope: (v: "global" | "category") => void;
+  setRankMaxRank: (v: string) => void;
+  setRankDirection: (v: "into" | "outof") => void;
+  setReleaseFullName: (v: string) => void;
+  setReleaseIncludePre: (v: boolean) => void;
+  setMentionFullName: (v: string) => void;
+  setMentionMultiplier: (v: string) => void;
+  setMentionWindow: (v: "24h" | "7d") => void;
+}
+
+export interface AlertPreset {
+  id: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  // Color tokens lifted from the four signal categories used elsewhere
+  // (matches AddAlertRuleDialog's RULE_TYPE_OPTIONS palette).
+  accentVar: string;
+  // Identity probe — used to highlight the active card when current form
+  // state matches this preset.
+  matches: (form: PresetSnapshot) => boolean;
+  applyTo: (s: PresetSetters) => void;
+}
+
+// Form-state snapshot the picker uses for `matches`. Mirrors only the
+// fields presets care about — full snapshot would be noisy.
+export interface PresetSnapshot {
+  ruleType: AlertRuleType;
+  cadence: AlertCadence;
+  rankScope: "global" | "category";
+  rankMaxRank: string;
+  rankDirection: "into" | "outof";
+  mentionMultiplier: string;
+  mentionWindow: "24h" | "7d";
+}
+
+export const ALERT_PRESETS: AlertPreset[] = [
+  {
+    id: "breakout-any",
+    label: "Breakout",
+    description: "Cross-source spike on any watched repo.",
+    icon: TrendingUp,
+    accentVar: "--v3-acc",
+    matches: (f) => f.ruleType === "breakout" && f.cadence === "realtime",
+    applyTo: (s) => {
+      s.setName("Breakouts on my watchlist");
+      s.setRuleType("breakout");
+      s.setCadence("realtime");
+      s.setBreakoutFullName("");
+      s.setBreakoutMinScore("0.6");
+    },
+  },
+  {
+    id: "daily-digest",
+    label: "Daily digest",
+    description: "Daily summary of top-100 movers.",
+    icon: BellRing,
+    accentVar: "--v3-sig-amber",
+    matches: (f) =>
+      f.ruleType === "rank_threshold" &&
+      f.cadence === "daily" &&
+      f.rankScope === "global" &&
+      f.rankMaxRank === "100" &&
+      f.rankDirection === "into",
+    applyTo: (s) => {
+      s.setName("Daily top-100 movers");
+      s.setRuleType("rank_threshold");
+      s.setCadence("daily");
+      s.setRankScope("global");
+      s.setRankMaxRank("100");
+      s.setRankDirection("into");
+    },
+  },
+  {
+    id: "new-release",
+    label: "New release",
+    description: "Notify when a specific repo ships a release.",
+    icon: GitBranch,
+    accentVar: "--v3-sig-green",
+    matches: (f) => f.ruleType === "release" && f.cadence === "realtime",
+    applyTo: (s) => {
+      s.setName("New release");
+      s.setRuleType("release");
+      s.setCadence("realtime");
+      s.setReleaseFullName("vercel/next.js");
+      s.setReleaseIncludePre(false);
+    },
+  },
+  {
+    id: "mention-spike",
+    label: "Mention spike",
+    description: "3x baseline mentions over 24 hours.",
+    icon: Activity,
+    accentVar: "--v3-sig-red",
+    matches: (f) =>
+      f.ruleType === "mention_spike" &&
+      f.mentionMultiplier === "3" &&
+      f.mentionWindow === "24h",
+    applyTo: (s) => {
+      s.setName("Mention spike (3x / 24h)");
+      s.setRuleType("mention_spike");
+      s.setCadence("realtime");
+      s.setMentionFullName("");
+      s.setMentionMultiplier("3");
+      s.setMentionWindow("24h");
+    },
+  },
+];
+
+interface AlertPresetsProps {
+  snapshot: PresetSnapshot;
+  setters: PresetSetters;
+}
+
+export function AlertPresets({ snapshot, setters }: AlertPresetsProps) {
+  return (
+    <div className="mb-4">
+      <p
+        className="mb-2 font-mono text-[10px] uppercase tracking-[0.16em]"
+        style={{ color: "var(--v3-ink-400)" }}
+      >
+        {"// QUICK-START TEMPLATES"}
+      </p>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {ALERT_PRESETS.map((preset) => {
+          const Icon = preset.icon;
+          const active = preset.matches(snapshot);
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => preset.applyTo(setters)}
+              className="group rounded-[2px] border p-2.5 text-left transition-colors focus:outline-none focus-visible:ring-1"
+              style={
+                active
+                  ? {
+                      borderColor: `var(${preset.accentVar})`,
+                      background: `color-mix(in srgb, var(${preset.accentVar}) 12%, transparent)`,
+                    }
+                  : {
+                      borderColor: "var(--v3-line-200)",
+                      background: "var(--v3-bg-050)",
+                    }
+              }
+              aria-pressed={active}
+              aria-label={`Use preset: ${preset.label}`}
+            >
+              <div className="flex items-center gap-1.5">
+                <Icon
+                  className="size-3.5"
+                  style={{
+                    color: active
+                      ? `var(${preset.accentVar})`
+                      : "var(--v3-ink-300)",
+                  }}
+                  aria-hidden
+                />
+                <span
+                  className="font-mono text-[10px] uppercase tracking-[0.14em]"
+                  style={{
+                    color: active
+                      ? `var(${preset.accentVar})`
+                      : "var(--v3-ink-200)",
+                    fontWeight: 500,
+                  }}
+                >
+                  {preset.label}
+                </span>
+              </div>
+              <p
+                className="mt-1 text-[11px] leading-snug"
+                style={{ color: "var(--v3-ink-300)" }}
+              >
+                {preset.description}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default AlertPresets;

--- a/src/app/you/alerts/_components/AlertRuleList.tsx
+++ b/src/app/you/alerts/_components/AlertRuleList.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { TransientHttpError } from "@/lib/errors";
 import {
   toastAlertDeleted,
@@ -35,6 +36,7 @@ import {
 } from "@/lib/toast";
 
 import type { ApiErr, ApiOk, SerializedAlertRule } from "./types";
+import { ALERTS_OPEN_CREATE_EVENT } from "./AddAlertRuleDialog";
 
 // 4 distinct colors per ALERT_RULE_TYPES — matches the picker in
 // AddAlertRuleDialog so users see the same color end-to-end.
@@ -218,26 +220,28 @@ export function AlertRuleList({ initialRules }: AlertRuleListProps) {
 
   if (rules.length === 0) {
     return (
-      <div
-        className="rounded-[2px] px-4 py-8 text-center"
-        style={{
-          border: "1px dashed var(--v3-line-200)",
-          background: "var(--v3-bg-025)",
-        }}
-      >
-        <p
-          className="font-mono text-[11px] uppercase tracking-[0.16em]"
-          style={{ color: "var(--v3-ink-300)" }}
-        >
-          {"// NO ALERT RULES YET"}
-        </p>
-        <p
-          className="mt-2 text-sm"
-          style={{ color: "var(--v3-ink-300)" }}
-        >
-          Add one to get notified about your watched repos.
-        </p>
-      </div>
+      <EmptyState
+        variant="no-data"
+        title="No alerts yet"
+        description="Watch for breakout rank changes, daily digests, or new releases. Set your first rule in 30 seconds."
+        cta={
+          <button
+            type="button"
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent(ALERTS_OPEN_CREATE_EVENT))
+            }
+            className="inline-flex items-center gap-1.5 rounded-[2px] border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.16em] transition-colors"
+            style={{
+              background: "var(--v3-acc-soft)",
+              border: "1px solid var(--v3-acc-dim)",
+              color: "var(--v3-acc)",
+              fontWeight: 500,
+            }}
+          >
+            Create your first alert
+          </button>
+        }
+      />
     );
   }
 

--- a/src/app/you/alerts/_components/FieldTooltip.tsx
+++ b/src/app/you/alerts/_components/FieldTooltip.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// FieldTooltip — accessible inline help tooltip for form-field labels.
+//
+// Why custom (not Radix): the repo has no @radix-ui/react-tooltip dep, and
+// the alert-rules dialog already avoids Radix in favor of native <dialog>
+// (see ConfirmDialog / AddAlertRuleDialog). Pulling Radix in just for a
+// hover bubble would burn 30+ kB and break that convention.
+//
+// Behavior:
+//   - Trigger is a <button type="button"> wrapping an Info icon. Buttons get
+//     keyboard focus for free; users can tab to the icon and the bubble
+//     appears on `:focus-visible`. Hover with a mouse also reveals it.
+//   - Bubble is rendered absolutely-positioned. `role="tooltip"` + an
+//     `aria-describedby` link back from the trigger gives screen readers
+//     the description on focus.
+//   - No portal needed — the bubble lives next to the icon, and the parent
+//     <fieldset> doesn't clip overflow.
+
+import { useId } from "react";
+import { Info } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface FieldTooltipProps {
+  /** Human label of the field this tooltip describes (a11y context only). */
+  label: string;
+  /** Description copy shown on hover/focus. */
+  content: string;
+  /** Optional override for the tooltip placement. Defaults to "right". */
+  side?: "right" | "left" | "top";
+  className?: string;
+}
+
+export function FieldTooltip({
+  label,
+  content,
+  side = "right",
+  className,
+}: FieldTooltipProps) {
+  const id = useId();
+  const tooltipId = `${id}-tip`;
+
+  const sidePositionClass =
+    side === "left"
+      ? "right-full top-1/2 -translate-y-1/2 mr-2"
+      : side === "top"
+        ? "bottom-full left-1/2 -translate-x-1/2 mb-2"
+        : "left-full top-1/2 -translate-y-1/2 ml-2";
+
+  return (
+    <span className={cn("relative inline-flex group", className)}>
+      <button
+        type="button"
+        // Native title gives a baseline fallback (e.g. when the popup is
+        // hidden by an OS-level forced-colors override).
+        title={`${label}: ${content}`}
+        aria-describedby={tooltipId}
+        aria-label={`More info about ${label}`}
+        className={cn(
+          "inline-flex items-center justify-center rounded-[2px] p-0.5",
+          "cursor-help focus:outline-none focus-visible:ring-1",
+          "focus-visible:ring-[var(--v3-acc)]",
+        )}
+      >
+        <Info
+          className="h-3.5 w-3.5 opacity-70 transition-opacity group-hover:opacity-100"
+          style={{ color: "var(--v3-ink-300)" }}
+          aria-hidden
+        />
+      </button>
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className={cn(
+          // Hidden by default; revealed on hover of the wrapper OR focus of
+          // the trigger button. Pointer-events-none keeps it from blocking
+          // clicks on neighbouring fields.
+          "pointer-events-none absolute z-50 w-64 rounded-[2px] border px-2.5 py-1.5",
+          "font-mono text-[11px] leading-snug",
+          "opacity-0 transition-opacity duration-150",
+          "group-hover:opacity-100 group-focus-within:opacity-100",
+          sidePositionClass,
+        )}
+        style={{
+          background: "var(--v3-bg-100)",
+          borderColor: "var(--v3-line-200)",
+          color: "var(--v3-ink-200)",
+          boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+        }}
+      >
+        {content}
+      </span>
+    </span>
+  );
+}
+
+export default FieldTooltip;


### PR DESCRIPTION
## Summary

Four small UX polish items for `/you/alerts`, combined to avoid conflicts with parallel agent work.

- **S2.B** Empty state hint on `/you/alerts` when the user has zero rules.
- **S2.C** Inline tooltips on the create-alert form fields (Rule type / Cadence / Webhook / Quiet hours).
- **S2.D** Quick-start preset templates above the form (Breakout / Daily digest / New release / Mention spike).
- **S2.E** Richer first-alert success toast with a CTA back to `/watchlist`.

## What changed

**Added**
- `src/app/you/alerts/_components/FieldTooltip.tsx` — CSS-only, keyboard-accessible tooltip (`role="tooltip"` + `aria-describedby`, focus-visible + hover triggers). No radix dependency — matches the dialog's native-element convention.
- `src/app/you/alerts/_components/AlertPresets.tsx` — 4 preset cards. Each preset's `applyTo(setters)` writes to the dialog's existing useState setters; no reducer refactor needed.

**Modified**
- `src/app/you/alerts/_components/AlertRuleList.tsx` — empty state now uses `<EmptyState variant="no-data">` with a primary CTA that dispatches `ALERTS_OPEN_CREATE_EVENT` to open the existing dialog.
- `src/app/you/alerts/_components/AddAlertRuleDialog.tsx` — listens for `ALERTS_OPEN_CREATE_EVENT`; renders `<AlertPresets>` above the type picker; adds tooltips on Rule type / Cadence / Webhook URL / Quiet hours; first-alert toast (rich + `/watchlist` action) when `existingRuleCount === 0` at submit time.

## Decisions

- No DOM ref drilling between siblings — used a window `CustomEvent` to open the dialog from the empty-state CTA. Less invasive than lifting state into the page.
- The `0 of 25` counter was already muted; leaving it as-is.
- Tooltip rendered inline (no portal) — neither the `<fieldset>` nor parent `<dialog>` clips overflow.

## API surface untouched

No changes under `src/app/api/me/alert-rules/*` or the Zod schemas — all four items are pure UI.

## Verification

- `npm run typecheck` — clean (no diagnostics).
- `npm run lint:guards` — clean (img-lazy / keep-last-50 / routes-config all OK).

## Test plan

- [ ] Visit `/you/alerts` with zero rules → expect `<EmptyState>` with "Create your first alert" CTA. Click it → dialog opens.
- [ ] In the dialog, click each preset → corresponding form fields populate; the active preset card highlights.
- [ ] Tab through the form → each tooltip reveals on focus (not just hover).
- [ ] Submit a rule when the user previously had zero → expect the rich toast "Alert created! First report in ~1h…" with a Watchlist action.
- [ ] Submit a rule when the user already had ≥1 → expect the existing terse "Alert rule created" toast.