### PR TITLE
fix(onboarding): WelcomeModal backdrop + stale comment (S2.F polish)

### DIFF
--- a/src/components/onboarding/WelcomeModal.tsx
+++ b/src/components/onboarding/WelcomeModal.tsx
@@ -110,11 +110,7 @@ export function WelcomeModal({
     captureEvent("welcome_modal_cta_clicked", {
       destination: "/you/alerts",
     });
-    // Note: we do NOT call onDismiss() here. The Link navigates away;
-    // the cookie is set by the gate when it sees the modal close on
-    // unmount. (Gate sets the cookie when `show` flips false OR on any
-    // dismiss handler — see WelcomeModalGate.)
-    onDismiss();
+    onDismiss(); // Closes modal + sets cookie via WelcomeModalGate.
   }, [onDismiss]);
 
   return (
@@ -134,7 +130,7 @@ export function WelcomeModal({
         maxWidth: "min(92vw, 30rem)",
         boxShadow: "0 24px 60px -12px rgba(0, 0, 0, 0.6)",
       }}
-      className="welcome-modal"
+      className="welcome-modal backdrop:bg-black/60 backdrop:backdrop-blur-sm"
     >
       <div style={{ padding: "1.25rem 1.5rem 1.5rem" }}>
         {/* WELCOME pill — mono accent at top of card */}


### PR DESCRIPTION
## Summary

design-auditor on S2.F (post-Stage-2 merge) flagged 2 micro-issues:

1. **WelcomeModal lacked \`::backdrop\` styling** — was opening against the browser's default backdrop (transparent / light rgba) instead of the dimmed + blurred surface used by every other modal in the app (\`ConfirmDialog\`, \`AddAlertRuleDialog\`). Added Tailwind \`backdrop:bg-black/60 backdrop:backdrop-blur-sm\` classes matching the existing convention.

2. **Stale comment + redundant \`onDismiss()\` call** in \`handlePrimaryClick\` — comment claimed we don't call \`onDismiss()\` but the function did call it. Removed the misleading comment, kept the call (which correctly closes the modal + sets the cookie via \`WelcomeModalGate\`).

## Files modified

- \`src/components/onboarding/WelcomeModal.tsx\` (+2 / -6)

## Verification

- \`npm run typecheck\` clean
- No behavior change on working paths; only the backdrop is now visible + the code comment matches the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)