### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-17T10:02:03Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,9 +1,25 @@
 {
-  "generatedAt": "2026-05-17T07:46:29.942Z",
+  "generatedAt": "2026-05-17T10:02:03.056Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",
   "overlays": {
+    "Anil-matcha/Open-Generative-AI": {
+      "tier": "verified_trustmrr",
+      "fullName": "Anil-matcha/Open-Generative-AI",
+      "trustmrrSlug": "muapi",
+      "mrrCents": 2329408,
+      "last30DaysCents": 15337323,
+      "totalCents": 58558982,
+      "growthMrr30d": 76.40029184701834,
+      "customers": 0,
+      "activeSubscriptions": 639,
+      "paymentProvider": "stripe",
+      "category": "Artificial Intelligence",
+      "asOf": "2026-04-24T01:59:01.837Z",
+      "matchConfidence": "host",
+      "sourceUrl": "https://trustmrr.com/startup/muapi"
+    },
     "gitroomhq/postiz-app": {
       "tier": "verified_trustmrr",
       "fullName": "gitroomhq/postiz-app",


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/25987775146

Auto-merge enabled — merges once required status checks pass.