### PR TITLE
feat(submit-funnel): submit_validated + submit_error steps (S3.D)

### DIFF
--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -87,14 +87,16 @@ Lives on `/submit` (`src/components/submissions/DropRepoPage.tsx`).
 | - | ---- | ------- | ------------------------ |
 | 1 | `submit_open` | DropRepoPage mount | — |
 | 2 | `submit_fill` | First non-empty change to the repo input on the current mount | — |
-| 3 | `submit_success` | API responded `ok: true` | `kind` (`created` \| `duplicate` \| `already_tracked`) |
+| 3 | `submit_validated` | `handleSubmit` invocation, before the POST is sent | `hasCategory` (boolean), `hasShareUrl` (boolean) |
+| 4 | `submit_success` | API responded `ok: true` | `kind` (`created` \| `duplicate` \| `already_tracked`) |
+| 5 | `submit_error` | `handleSubmit` fetch threw or API responded `ok: false` | `reason` (first 80 chars of error message) |
 
 `submit_fill` fires **once per mount** — clearing the form after a
 successful "created" submission also resets the latch so a follow-up
-submission is captured cleanly. There's no explicit `submit_failure`
-event today: validation failures keep the operator on the form, which
-the dashboard can spot as `submit_fill` without a downstream
-`submit_success`.
+submission is captured cleanly. `submit_validated` fires every submit
+attempt; the gap between it and `submit_success` measures backend
+rejection rate, while `submit_error` carries the truncated reason for
+the dashboard to group by (network vs. duplicate vs. throttle, etc.).
 
 ### `revenue-claim` - repo to revenue claim form to moderation queue
 

--- a/src/components/submissions/DropRepoPage.tsx
+++ b/src/components/submissions/DropRepoPage.tsx
@@ -145,6 +145,16 @@ export function DropRepoPage() {
     setError(null);
     setResult(null);
 
+    // AGN-848 — funnel step "submit_validated". Fires once per submit
+    // attempt, distinguishing form-fill from form-send. Flat props let
+    // the dashboard split on category presence + share URL completeness.
+    captureFunnelStep({
+      step: "submit_validated",
+      flow: "submit-repo",
+      hasCategory: category !== null,
+      hasShareUrl: shareUrl.trim().length > 0,
+    });
+
     try {
       const res = await fetch("/api/repo-submissions", {
         method: "POST",
@@ -193,6 +203,17 @@ export function DropRepoPage() {
         setFillFired(false);
       }
     } catch (err) {
+      const reason = (err instanceof Error ? err.message : String(err)).slice(
+        0,
+        80,
+      );
+      // AGN-848 — funnel step "submit_error". Tag with truncated reason
+      // so the dashboard can group failures without leaking long stacks.
+      captureFunnelStep({
+        step: "submit_error",
+        flow: "submit-repo",
+        reason,
+      });
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setSubmitting(false);

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -89,7 +89,9 @@ export type FunnelStep =
   // submit
   | "submit_open"
   | "submit_fill"
+  | "submit_validated"
   | "submit_success"
+  | "submit_error"
   // revenue claim
   | "revenue_claim_open"
   | "revenue_claim_submit_success"


### PR DESCRIPTION
## Summary

Closes the funnel measurement gap in `docs/POSTHOG-FUNNELS.md` — the dashboard previously had no way to distinguish form-fill from form-send, and no way to attribute API rejections. Adds two new `funnel_step` literals.

- `submit_validated` — fires once per submit attempt with flat props (`hasCategory`, `hasShareUrl`) before the POST is sent. Measures form-completion intent.
- `submit_error` — fires on fetch throw or API `ok: false` with a truncated `reason` (first 80 chars). Groups failures without leaking long stacks.

Existing `submit_open` / `submit_fill` / `submit_success` are unchanged — no duplicate events.

## Files

- `src/lib/analytics/funnel.ts` — extend `FunnelStep` union (+2 literals)
- `src/components/submissions/DropRepoPage.tsx` — capture both new steps in `handleSubmit`
- `docs/POSTHOG-FUNNELS.md` — table updated to 5 rows with property columns + body copy revised

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint:guards` clean
- [x] `npx vitest run src/lib/__vitest__/analytics-funnel.test.ts` passes
- [ ] Post-merge: verify PostHog dashboard receives `submit_validated` + `submit_error` events on the next prod submission flow

## Risk

Near-zero — analytics-only, fire-and-forget. PostHog funnel definitions may need an additive update (no breaking changes).

Part of S3 (Onboarding Phase 2) per the approved plan `~/.claude/plans/word-for-this-one-reflective-pine.md`. First of ~10-12 PRs in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)