### PR TITLE
feat(referrals): mount InviteBanner on /you (S3.B)

### DIFF
--- a/src/app/you/YouClient.tsx
+++ b/src/app/you/YouClient.tsx
@@ -40,6 +40,7 @@ import { SectionHead } from "@/components/ui/SectionHead";
 import { KpiBand, type KpiCell } from "@/components/ui/KpiBand";
 import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
 import { buildAuthHref } from "@/lib/auth/redirect-url";
+import { InviteBanner } from "@/components/referrals/InviteBanner";
 
 export interface YouAccountSummary {
   handle: string;
@@ -49,8 +50,16 @@ export interface YouAccountSummary {
 
 export default function YouClient({
   account,
+  inviteBannerDismissedAt,
 }: {
   account: YouAccountSummary | null;
+  /**
+   * ISO timestamp pulled from `profiles.dismissedInviteBannerAt` on the
+   * server. Null when the user has never dismissed (banner shows) or
+   * when there is no account (banner hidden regardless). Undefined when
+   * the caller hasn't migrated yet — same effect as null.
+   */
+  inviteBannerDismissedAt?: string | null;
 }) {
   // Hydration gate — zustand/persist loads from localStorage post-mount,
   // so render a stable placeholder until client state is truly live.
@@ -163,6 +172,9 @@ export default function YouClient({
         kpiBand={<KpiBand cells={kpiCells} />}
         mainPanels={
           <>
+            {account ? (
+              <InviteBanner dismissedAt={inviteBannerDismissedAt} />
+            ) : null}
             <SectionHead
               num="// 01"
               title="Recent activity"

--- a/src/app/you/page.tsx
+++ b/src/app/you/page.tsx
@@ -32,6 +32,17 @@ export default async function YouPage() {
         displayName: user.profile.displayName,
       }
     : null;
+  // S3.B — pull the invite-banner dismissal stamp here so the client
+  // renders deterministically without an extra fetch. Stored as ISO
+  // string to avoid serialising Date objects across the server boundary.
+  const inviteBannerDismissedAt = user?.profile.dismissedInviteBannerAt
+    ? user.profile.dismissedInviteBannerAt.toISOString()
+    : null;
 
-  return <YouClient account={account} />;
+  return (
+    <YouClient
+      account={account}
+      inviteBannerDismissedAt={inviteBannerDismissedAt}
+    />
+  );
 }

--- a/src/components/referrals/InviteBanner.tsx
+++ b/src/components/referrals/InviteBanner.tsx
@@ -2,17 +2,22 @@
 
 // <InviteBanner /> — dismissible "earn early access" CTA (Chunk G).
 //
-// Mounted by other lanes on `/you` and as a one-shot post-watchlist-save
-// nudge. Self-hosted dismissal: PATCH `/api/referrals/me` with
-// `dismissedInviteBannerAt = now()` so the same user doesn't see it on
-// the next page load.
+// Mounted on `/you` (top of mainPanels for signed-in users) and as a
+// one-shot post-watchlist-save nudge. Self-hosted dismissal: PATCH
+// `/api/referrals/me` with `dismissedInviteBannerAt = now()` so the
+// same user doesn't see it on the next page load.
 //
-// Lightweight by design — no Radix, no Framer Motion. v3 design tokens.
+// S3.B (2026-05-17): re-skinned with v4 tokens to match /you and now
+// emits `referral_share_click` (event-name, not funnel-step) when the
+// invite CTA is followed.
+//
+// Lightweight by design — no Radix, no Framer Motion. v4 design tokens.
 
 import Link from "next/link";
 import { useState } from "react";
 
 import { toast } from "@/lib/toast";
+import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
 
 interface InviteBannerProps {
   /**
@@ -70,26 +75,37 @@ export function InviteBanner({
     // Optional inline confirmation when the user clicks the CTA — the
     // /you/refer landing covers the actual flow, this is just a nudge.
     toast.info("Heading to your referral page");
+    // S3.B — fire-and-forget product analytics. PostHog SDK may be
+    // dormant (consent off, no token) — `getLoadedBrowserPostHog`
+    // returns null and the capture quietly skips.
+    try {
+      getLoadedBrowserPostHog()?.capture("referral_share_click", {
+        source: "invite_banner",
+        surface: "/you",
+      });
+    } catch {
+      // Analytics must never throw upstream.
+    }
   }
 
   return (
     <div
-      className="rounded-[2px] px-4 py-3 flex flex-wrap items-center justify-between gap-3"
+      className="rounded-[4px] px-4 py-3 flex flex-wrap items-center justify-between gap-3"
       style={{
-        background: "var(--v3-bg-050)",
-        border: "1px solid var(--v3-acc-dim)",
+        background: "var(--v4-bg-050)",
+        border: "1px solid var(--v4-line-200)",
       }}
     >
       <div className="flex flex-col gap-1 min-w-0">
         <div
           className="font-mono text-[10px] uppercase tracking-[0.18em]"
-          style={{ color: "var(--v3-acc)" }}
+          style={{ color: "var(--v4-acc)" }}
         >
           {"// EARN EARLY ACCESS"}
         </div>
         <div
           className="text-sm leading-snug"
-          style={{ color: "var(--v3-ink-100)" }}
+          style={{ color: "var(--v4-ink-100)" }}
         >
           Invite a friend to TrendingRepo. Badges + early access — no cash, no spam.
         </div>
@@ -98,11 +114,11 @@ export function InviteBanner({
         <Link
           href="/you/refer"
           onClick={copyAndCelebrate}
-          className="inline-flex items-center rounded-[2px] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors"
+          className="inline-flex items-center rounded-[3px] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors"
           style={{
-            background: "var(--v3-acc-soft)",
-            border: "1px solid var(--v3-acc-dim)",
-            color: "var(--v3-acc)",
+            background: "var(--v4-bg-075)",
+            border: "1px solid var(--v4-line-200)",
+            color: "var(--v4-acc)",
             fontWeight: 500,
           }}
         >
@@ -112,11 +128,11 @@ export function InviteBanner({
           type="button"
           onClick={() => void dismiss()}
           disabled={busy}
-          className="inline-flex items-center rounded-[2px] px-2 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:opacity-50"
+          className="inline-flex items-center rounded-[3px] px-2 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:opacity-50"
           style={{
             background: "transparent",
-            border: "1px solid var(--v3-line-200)",
-            color: "var(--v3-ink-300)",
+            border: "1px solid var(--v4-line-200)",
+            color: "var(--v4-ink-300)",
           }}
           aria-label="Dismiss invite banner"
         >


### PR DESCRIPTION
## Summary

The `InviteBanner` component shipped with the /you/refer infra (Chunk G) but was never actually mounted anywhere — the file comment said "Mounted by other lanes on /you" yet no lane wired it up. This PR closes that loop.

- Banner now appears at the top of `/you` mainPanels for signed-in users
- Hidden when `profile.dismissedInviteBannerAt` is set (existing dismiss flow via `PATCH /api/referrals/me` is unchanged)
- Re-skinned with v4 design tokens (`--v4-bg-050`, `--v4-line-200`, `--v4-acc`) to match the surrounding /you panels — was v3 from the original Chunk G draft
- CTA click emits a fire-and-forget PostHog event `referral_share_click` with `source: "invite_banner"` and `surface: "/you"` for product analytics

## Files

- `src/components/referrals/InviteBanner.tsx` — v3→v4 token swap, PostHog capture in `copyAndCelebrate`, doc comment refreshed for the new mount site
- `src/app/you/page.tsx` — pull `dismissedInviteBannerAt` from `getOptionalUser()` profile, pass as ISO string to client
- `src/app/you/YouClient.tsx` — accept `inviteBannerDismissedAt` prop, mount `<InviteBanner>` as first mainPanels child only when `account !== null`

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint:guards` clean
- [ ] Post-merge: load `/you` signed-in, verify banner appears, click "Invite friends", verify navigation + PostHog event
- [ ] Click dismiss, reload, verify banner stays hidden (existing flow unchanged)

## Risk

Low. SSR/CSR safe — banner mounts only after `getOptionalUser()` resolves and account is present. PostHog capture is fire-and-forget; SDK may be dormant (consent off / no token) in which case `getLoadedBrowserPostHog()` returns null and the call quietly skips.

Part of S3 (Onboarding Phase 2) per the approved plan. Second of ~10-12 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)