### PR TITLE
fix(ci): WelcomeModalGate authEnabled prop unblocks main CI

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -172,7 +172,7 @@ export default async function RootLayout({
       <IdleMount>
         <ClerkRefHandoff />
       </IdleMount>
-      {clerkPublishableKey ? <WelcomeModalGate /> : null}
+      <WelcomeModalGate authEnabled={Boolean(clerkPublishableKey)} />
       <Header authEnabled={Boolean(clerkPublishableKey)} />
       <MobileDrawerLazy />
       <AppShell>

--- a/src/components/onboarding/WelcomeModalGate.tsx
+++ b/src/components/onboarding/WelcomeModalGate.tsx
@@ -52,6 +52,19 @@ function setWelcomedCookie(): void {
 }
 
 interface WelcomeModalGateProps {
+  /**
+   * Server-resolved flag mirroring `Boolean(getClerkPublishableKey())`.
+   * Required so Clerk hooks below never execute on environments where
+   * `<ClerkProvider>` did not mount (Vercel Production with only
+   * `pk_test_*` keys; previews with the key disabled). The hook would
+   * otherwise throw "useAuth can only be used within the <ClerkProvider />".
+   *
+   * See `src/lib/__tests__/auth-provider-policy.test.ts` ("only known
+   * callers may import Clerk hooks") — this file is on the allow-list
+   * because it accepts this prop and short-circuits before invoking
+   * `useUser()`.
+   */
+  authEnabled: boolean;
   // Optional override for the displayed name. When null/omitted the
   // gate pulls from Clerk's `useUser()`. Provided as an escape hatch
   // for the server to seed an SSR-friendly value if we ever need it,
@@ -60,8 +73,24 @@ interface WelcomeModalGateProps {
 }
 
 export function WelcomeModalGate({
+  authEnabled,
   displayName: displayNameProp,
-}: WelcomeModalGateProps = {}) {
+}: WelcomeModalGateProps) {
+  if (!authEnabled) return null;
+  return (
+    <WelcomeModalGateInner displayName={displayNameProp} />
+  );
+}
+
+// Inner component isolates the Clerk hook call behind the `authEnabled`
+// gate above. Same render contract as the previous monolithic version —
+// the split is purely so React only invokes `useUser()` when we know
+// ClerkProvider is mounted.
+function WelcomeModalGateInner({
+  displayName: displayNameProp,
+}: {
+  displayName?: string | null;
+}) {
   const { isLoaded, isSignedIn, user } = useUser();
   const [show, setShow] = useState(false);
   // Track whether we've already evaluated the gate condition for this

--- a/src/lib/__tests__/auth-provider-policy.test.ts
+++ b/src/lib/__tests__/auth-provider-policy.test.ts
@@ -114,6 +114,10 @@ test("only known callers may import Clerk hooks (useUser / useAuth)", () => {
     join("src", "components", "layout", "SidebarUserOverlayBridge.tsx"),
     // Auth-form skeleton lives inside a Clerk-rendered tree by construction.
     join("src", "components", "auth", "ClerkAuthForm.tsx"),
+    // Post-signup welcome modal gate (S2.A). Accepts an `authEnabled`
+    // server-resolved prop and short-circuits before invoking useUser()
+    // when ClerkProvider isn't mounted.
+    join("src", "components", "onboarding", "WelcomeModalGate.tsx"),
     // Sign-in / sign-up route surfaces are children of the layout's
     // ClerkProvider and reach Clerk hooks via Clerk's own components.
   ]);


### PR DESCRIPTION
## Summary

**Main has been red since 2026-05-17T09:57Z.** The `auth-provider-policy.test.ts` regression sentinel — built after the 2026-05-15 prod crash — flags `WelcomeModalGate.tsx` (shipped in #1624) as an unsanctioned consumer of Clerk hooks. The conditional mount in `layout.tsx` (`{clerkPublishableKey ? <WelcomeModalGate /> : null}`) avoided the prod crash but the component itself wasn't defensive — the test enforces that defensive pattern explicitly.

This brings WelcomeModalGate into compliance with the established pattern (mirrors `SidebarUserOverlayBridge` + `HeaderAccountLoaded`):

- WelcomeModalGate now takes a required `authEnabled: boolean` prop
- Early-returns `null` when `authEnabled` is false, **before** the inner component invokes `useUser()`
- Inner component split isolates the Clerk hook behind the gate
- `layout.tsx`: `{clerkPublishableKey ? <WelcomeModalGate /> : null}` → `<WelcomeModalGate authEnabled={Boolean(clerkPublishableKey)} />`
- ALLOW_LIST gets the new entry with a reference comment

## Files

- `src/components/onboarding/WelcomeModalGate.tsx` — accepts prop, splits inner component
- `src/app/layout.tsx` — pass `authEnabled` (server-resolved)
- `src/lib/__tests__/auth-provider-policy.test.ts` — ALLOW_LIST extended

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint:guards` clean
- [x] `node --test src/lib/__tests__/auth-provider-policy.test.ts` — all 6 subtests pass

## Risk

Surgical. Production behavior unchanged — same component, same conditional mount, same hooks. Test now passes, CI on main unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)