### PR TITLE
feat(onboarding): digest banner on /you/alerts (S3.A)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -172,7 +172,7 @@ export default async function RootLayout({
       <IdleMount>
         <ClerkRefHandoff />
       </IdleMount>
-      {clerkPublishableKey ? <WelcomeModalGate /> : null}
+      <WelcomeModalGate authEnabled={Boolean(clerkPublishableKey)} />
       <Header authEnabled={Boolean(clerkPublishableKey)} />
       <MobileDrawerLazy />
       <AppShell>

--- a/src/app/you/alerts/_components/DigestBanner.tsx
+++ b/src/app/you/alerts/_components/DigestBanner.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+// <DigestBanner /> — S3.A NUX nudge for users with `emailAlertsCadence: "off"`.
+//
+// Renders only when:
+//   1. Resend is configured server-side (`isEmailConfigured()` true)
+//   2. The viewer's current cadence is "off" (i.e. they've never opted in)
+//   3. The local dismissal cookie `sb_digest_dismissed` is absent
+//
+// Picking Daily / Weekly fires a single `PATCH /api/me/profile` call
+// (same endpoint used by `GlobalPreferences`) so the digest behaviour is
+// canonical and there's no second code path to keep in sync. PostHog
+// captures `digest_subscribe` for the dashboard funnel.
+//
+// We deliberately do not echo the freshness-chrome rule: this banner is
+// not a status indicator, it's a prompt. Visual chrome is v3 to match
+// the rest of `/you/alerts`.
+
+import { useState } from "react";
+
+import { toast } from "@/lib/toast";
+import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
+import type { EmailAlertsCadence } from "@/lib/db/schema/profiles";
+
+const COOKIE_NAME = "sb_digest_dismissed";
+const COOKIE_MAX_AGE_DAYS = 30;
+
+function hasDismissalCookie(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.cookie
+    .split(";")
+    .some((entry) => entry.trim().startsWith(`${COOKIE_NAME}=`));
+}
+
+function setDismissalCookie(): void {
+  if (typeof document === "undefined") return;
+  const maxAge = COOKIE_MAX_AGE_DAYS * 24 * 60 * 60;
+  const isHttps =
+    typeof window !== "undefined" && window.location.protocol === "https:";
+  const secure = isHttps ? "; Secure" : "";
+  document.cookie = `${COOKIE_NAME}=1; Max-Age=${maxAge}; Path=/; SameSite=Lax${secure}`;
+}
+
+interface DigestBannerProps {
+  /**
+   * Current cadence from the server. We only render when this is "off"
+   * — anything else means the user already picked a digest setting via
+   * `GlobalPreferences` and the prompt would be noise.
+   */
+  initialCadence: EmailAlertsCadence;
+  /**
+   * Server-side mirror of `isEmailConfigured()`. When false, the banner
+   * is suppressed because the PATCH would succeed but no email would
+   * ever be sent — we'd be lying to the user about delivery.
+   */
+  emailConfigured: boolean;
+}
+
+export function DigestBanner({
+  initialCadence,
+  emailConfigured,
+}: DigestBannerProps) {
+  const [hidden, setHidden] = useState<boolean>(() => {
+    if (!emailConfigured) return true;
+    if (initialCadence !== "off") return true;
+    return hasDismissalCookie();
+  });
+  const [busy, setBusy] = useState<null | EmailAlertsCadence>(null);
+
+  if (hidden) return null;
+
+  async function subscribe(cadence: Extract<EmailAlertsCadence, "daily" | "weekly">) {
+    setBusy(cadence);
+    try {
+      const res = await fetch("/api/me/profile", {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emailAlertsCadence: cadence }),
+      });
+      if (!res.ok) {
+        throw new Error(`profile patch failed: ${res.status}`);
+      }
+      // Fire-and-forget product analytics.
+      try {
+        getLoadedBrowserPostHog()?.capture("digest_subscribe", {
+          cadence,
+          source: "digest_banner",
+          surface: "/you/alerts",
+        });
+      } catch {
+        // analytics must never throw upstream
+      }
+      toast.info(
+        cadence === "daily"
+          ? "Daily digest scheduled — first email at 9am your time."
+          : "Weekly digest scheduled — Sunday 9am your time.",
+      );
+      setHidden(true);
+    } catch (err) {
+      console.warn("[DigestBanner] subscribe failed", err);
+      toast.info(
+        "Couldn't update digest preference. Please try the Global Preferences panel below.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  function dismiss() {
+    setDismissalCookie();
+    setHidden(true);
+  }
+
+  return (
+    <div
+      className="mb-6 rounded-[2px] px-4 py-3"
+      style={{
+        background: "var(--v3-bg-050)",
+        border: "1px solid var(--v3-line-200)",
+      }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div
+            className="font-mono text-[10px] uppercase tracking-[0.18em]"
+            style={{ color: "var(--v3-ink-300)" }}
+          >
+            {"// DIGEST · GET A RECAP"}
+          </div>
+          <div
+            className="mt-1 text-sm leading-snug"
+            style={{ color: "var(--v3-ink-100)" }}
+          >
+            Want a daily or weekly recap of your watchlist events? One email,
+            no extra clicks — change anytime in Global Preferences below.
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void subscribe("daily")}
+            disabled={busy !== null}
+            className="inline-flex items-center rounded-[2px] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:opacity-50"
+            style={{
+              background: "var(--v3-acc-soft, var(--v3-bg-075))",
+              border: "1px solid var(--v3-line-200)",
+              color: "var(--v3-acc, var(--v3-ink-100))",
+              fontWeight: 500,
+            }}
+          >
+            {busy === "daily" ? "…" : "DAILY"}
+          </button>
+          <button
+            type="button"
+            onClick={() => void subscribe("weekly")}
+            disabled={busy !== null}
+            className="inline-flex items-center rounded-[2px] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:opacity-50"
+            style={{
+              background: "var(--v3-acc-soft, var(--v3-bg-075))",
+              border: "1px solid var(--v3-line-200)",
+              color: "var(--v3-acc, var(--v3-ink-100))",
+              fontWeight: 500,
+            }}
+          >
+            {busy === "weekly" ? "…" : "WEEKLY"}
+          </button>
+          <button
+            type="button"
+            onClick={dismiss}
+            disabled={busy !== null}
+            className="inline-flex items-center rounded-[2px] px-2 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors disabled:opacity-50"
+            style={{
+              background: "transparent",
+              border: "1px solid var(--v3-line-200)",
+              color: "var(--v3-ink-300)",
+            }}
+            aria-label="Dismiss digest prompt"
+          >
+            DISMISS
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DigestBanner;

--- a/src/app/you/alerts/page.tsx
+++ b/src/app/you/alerts/page.tsx
@@ -24,6 +24,8 @@ import { requireUser } from "@/lib/auth/server";
 import { AlertRuleList } from "./_components/AlertRuleList";
 import { AddAlertRuleDialog } from "./_components/AddAlertRuleDialog";
 import { GlobalPreferences } from "./_components/GlobalPreferences";
+import { DigestBanner } from "./_components/DigestBanner";
+import { isEmailConfigured } from "@/lib/email/resend-client";
 import type {
   SerializedAlertRule,
   SerializedProfilePrefs,
@@ -125,6 +127,17 @@ export default async function YouAlertsPage() {
             MCP tool too.
           </p>
         </header>
+
+        <DigestBanner
+          initialCadence={
+            prefs.emailAlertsCadence as
+              | "realtime"
+              | "daily"
+              | "weekly"
+              | "off"
+          }
+          emailConfigured={isEmailConfigured()}
+        />
 
         <section className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <div>

--- a/src/components/onboarding/WelcomeModalGate.tsx
+++ b/src/components/onboarding/WelcomeModalGate.tsx
@@ -52,6 +52,19 @@ function setWelcomedCookie(): void {
 }
 
 interface WelcomeModalGateProps {
+  /**
+   * Server-resolved flag mirroring `Boolean(getClerkPublishableKey())`.
+   * Required so Clerk hooks below never execute on environments where
+   * `<ClerkProvider>` did not mount (Vercel Production with only
+   * `pk_test_*` keys; previews with the key disabled). The hook would
+   * otherwise throw "useAuth can only be used within the <ClerkProvider />".
+   *
+   * See `src/lib/__tests__/auth-provider-policy.test.ts` ("only known
+   * callers may import Clerk hooks") — this file is on the allow-list
+   * because it accepts this prop and short-circuits before invoking
+   * `useUser()`.
+   */
+  authEnabled: boolean;
   // Optional override for the displayed name. When null/omitted the
   // gate pulls from Clerk's `useUser()`. Provided as an escape hatch
   // for the server to seed an SSR-friendly value if we ever need it,
@@ -60,8 +73,24 @@ interface WelcomeModalGateProps {
 }
 
 export function WelcomeModalGate({
+  authEnabled,
   displayName: displayNameProp,
-}: WelcomeModalGateProps = {}) {
+}: WelcomeModalGateProps) {
+  if (!authEnabled) return null;
+  return (
+    <WelcomeModalGateInner displayName={displayNameProp} />
+  );
+}
+
+// Inner component isolates the Clerk hook call behind the `authEnabled`
+// gate above. Same render contract as the previous monolithic version —
+// the split is purely so React only invokes `useUser()` when we know
+// ClerkProvider is mounted.
+function WelcomeModalGateInner({
+  displayName: displayNameProp,
+}: {
+  displayName?: string | null;
+}) {
   const { isLoaded, isSignedIn, user } = useUser();
   const [show, setShow] = useState(false);
   // Track whether we've already evaluated the gate condition for this

--- a/src/lib/__tests__/auth-provider-policy.test.ts
+++ b/src/lib/__tests__/auth-provider-policy.test.ts
@@ -114,6 +114,10 @@ test("only known callers may import Clerk hooks (useUser / useAuth)", () => {
     join("src", "components", "layout", "SidebarUserOverlayBridge.tsx"),
     // Auth-form skeleton lives inside a Clerk-rendered tree by construction.
     join("src", "components", "auth", "ClerkAuthForm.tsx"),
+    // Post-signup welcome modal gate (S2.A). Accepts an `authEnabled`
+    // server-resolved prop and short-circuits before invoking useUser()
+    // when ClerkProvider isn't mounted.
+    join("src", "components", "onboarding", "WelcomeModalGate.tsx"),
     // Sign-in / sign-up route surfaces are children of the layout's
     // ClerkProvider and reach Clerk hooks via Clerk's own components.
   ]);


### PR DESCRIPTION
## Summary

NUX prompt for users with `emailAlertsCadence: "off"` (the default for new accounts). Surfaces above the rules list and offers one-click subscribe to a Daily or Weekly digest. Reuses the canonical endpoint (`PATCH /api/me/profile`) so digest behaviour stays single-sourced through `GlobalPreferences` — no second code path.

## Hide conditions (any one suppresses)

1. `isEmailConfigured()` returns false (no Resend key — would lie to users about delivery)
2. Current cadence ≠ `"off"` (user already engaged Global Preferences)
3. Local `sb_digest_dismissed` cookie present (30-day per-device)

## Analytics

PostHog `digest_subscribe` event with `cadence`, `source: "digest_banner"`, `surface: "/you/alerts"` for product analytics dashboard.

## Files

- `src/app/you/alerts/_components/DigestBanner.tsx` (new, ~190 LoC, v3 tokens to match the surrounding chrome)
- `src/app/you/alerts/page.tsx` — mount above the rules section, pass `isEmailConfigured()` + narrowed cadence type

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint:guards` clean
- [ ] Post-merge (gated on Clerk pk_live + Resend env):
  - signed-in user with `emailAlertsCadence: "off"` sees banner
  - clicking DAILY fires PATCH, toast appears, banner hides
  - reload — banner stays hidden (cadence !== "off")
  - dismiss via cookie — reload, banner stays hidden

## Risk

Low. Surgical 2-file change. Server PATCH endpoint already exists and is exercised by `GlobalPreferences`. Banner gracefully no-ops when Resend isn't configured (matches handover §1 directive "degrade gracefully if RESEND_API_KEY unset").

## Operator dependency

To validate end-to-end requires `RESEND_API_KEY` + DNS for the email domain. Currently Clerk also needs `pk_live_*` keys for signed-in users to reach `/you/alerts` at all (separate issue surfaced this session).

Part of S3 (Onboarding Phase 2). Third of ~10-12 PRs. Branched from the CI hotfix branch (#1634) so it inherits the WelcomeModalGate fix and CI should pass once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)