### PR TITLE
feat(consent): GDPR cookie consent banner (S3.5.C)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,7 @@ import { SidebarStream } from "@/components/layout/SidebarStream";
 import { SidebarSkeleton } from "@/components/layout/SidebarSkeleton";
 import ClerkRefHandoff from "@/components/auth/ClerkRefHandoff";
 import { WelcomeModalGate } from "@/components/onboarding/WelcomeModalGate";
+import { ConsentBanner } from "@/components/consent/ConsentBanner";
 import { clerkAppearance } from "@/lib/auth/clerk-appearance";
 import { getClerkPublishableKey } from "@/lib/auth/clerk-config";
 import { buildAuthHref } from "@/lib/auth/redirect-url";
@@ -190,6 +191,7 @@ export default async function RootLayout({
         <GlobalShortcutsLazy />
       </IdleMount>
       <ToasterLazy />
+      <ConsentBanner />
     </>
   );
 

--- a/src/components/consent/ConsentBanner.tsx
+++ b/src/components/consent/ConsentBanner.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+// <ConsentBanner /> — S3.5.C GDPR / CCPA cookie consent surface.
+//
+// Bottom-anchored sticky banner shown when `tr_consent` cookie is
+// absent. Two primary actions ("Accept all" / "Necessary only") plus
+// a "Customize" toggle that exposes per-category checkboxes for the
+// 1% of users who want to opt into analytics but not marketing or
+// vice versa.
+//
+// SSR safety: returns null on the server and during the first client
+// render. Only after `useEffect` runs and we've read the cookie do
+// we decide whether to mount the banner. This keeps the server HTML
+// identical to client HTML and avoids hydration warnings.
+//
+// PostHogProvider listens for `trendingrepo:consent-changed` and
+// initialises (or stays dormant) based on the latest decision; this
+// banner does NOT call posthog directly.
+
+import { useEffect, useState } from "react";
+
+import {
+  CONSENT_COOKIE_NAME,
+  readConsent,
+  writeConsent,
+} from "@/lib/consent/cookie";
+
+export function ConsentBanner() {
+  // mounted=true after the first useEffect tick. Until then we render
+  // null so the server-rendered HTML matches the initial client paint.
+  const [mounted, setMounted] = useState(false);
+  const [show, setShow] = useState(false);
+  const [customizing, setCustomizing] = useState(false);
+  const [analytics, setAnalytics] = useState(true);
+  const [marketing, setMarketing] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const decision = readConsent();
+    if (decision === null) {
+      setShow(true);
+    }
+  }, []);
+
+  if (!mounted || !show) return null;
+
+  function persist(decision: { analytics: boolean; marketing: boolean }) {
+    writeConsent(decision);
+    setShow(false);
+  }
+
+  function handleAcceptAll() {
+    persist({ analytics: true, marketing: true });
+  }
+  function handleNecessaryOnly() {
+    persist({ analytics: false, marketing: false });
+  }
+  function handleSaveCustom() {
+    persist({ analytics, marketing });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label="Cookie consent"
+      data-testid={CONSENT_COOKIE_NAME}
+      style={{
+        position: "fixed",
+        bottom: 16,
+        left: 16,
+        right: 16,
+        zIndex: 999,
+        maxWidth: 560,
+        margin: "0 auto",
+        background: "var(--v4-bg-050, #0f1115)",
+        border: "1px solid var(--v4-line-200, #2b2f36)",
+        borderRadius: 6,
+        padding: 16,
+        boxShadow: "0 10px 30px rgba(0,0,0,0.45)",
+        color: "var(--v4-ink-100, #e5e7eb)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        fontFamily: "var(--font-geist-mono), monospace",
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <span
+          style={{
+            fontSize: 10,
+            color: "var(--v4-ink-300, #9aa0a6)",
+            textTransform: "uppercase",
+            letterSpacing: "0.16em",
+          }}
+        >
+          {"// COOKIES"}
+        </span>
+        <span style={{ fontSize: 13, lineHeight: 1.45 }}>
+          We use a minimal set of cookies to make the site work, plus optional
+          analytics and marketing cookies to help us improve. You can change
+          your choice anytime in your browser settings.
+        </span>
+      </div>
+
+      {customizing ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: 12,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked
+              disabled
+              aria-label="Necessary cookies always on"
+            />
+            <span>
+              <b>Necessary</b> — login, session, security (always on)
+            </span>
+          </label>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: 12,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={analytics}
+              onChange={(e) => setAnalytics(e.target.checked)}
+              aria-label="Analytics cookies"
+            />
+            <span>
+              <b>Analytics</b> — anonymised usage events (PostHog)
+            </span>
+          </label>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: 12,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={marketing}
+              onChange={(e) => setMarketing(e.target.checked)}
+              aria-label="Marketing cookies"
+            />
+            <span>
+              <b>Marketing</b> — referrer attribution + remarketing
+            </span>
+          </label>
+        </div>
+      ) : null}
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 8,
+          justifyContent: "flex-end",
+        }}
+      >
+        {!customizing ? (
+          <button
+            type="button"
+            onClick={() => setCustomizing(true)}
+            style={{
+              fontFamily: "inherit",
+              background: "transparent",
+              border: "1px solid var(--v4-line-200, #2b2f36)",
+              color: "var(--v4-ink-200, #c9cdd2)",
+              padding: "6px 12px",
+              borderRadius: 4,
+              fontSize: 11,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              cursor: "pointer",
+            }}
+          >
+            CUSTOMIZE
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={handleNecessaryOnly}
+          style={{
+            fontFamily: "inherit",
+            background: "transparent",
+            border: "1px solid var(--v4-line-200, #2b2f36)",
+            color: "var(--v4-ink-200, #c9cdd2)",
+            padding: "6px 12px",
+            borderRadius: 4,
+            fontSize: 11,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            cursor: "pointer",
+          }}
+        >
+          NECESSARY ONLY
+        </button>
+        {customizing ? (
+          <button
+            type="button"
+            onClick={handleSaveCustom}
+            style={{
+              fontFamily: "inherit",
+              background: "var(--v4-bg-075, #14171c)",
+              border: "1px solid var(--v4-acc, #4cc6ff)",
+              color: "var(--v4-acc, #4cc6ff)",
+              padding: "6px 12px",
+              borderRadius: 4,
+              fontSize: 11,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            SAVE CHOICES
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleAcceptAll}
+            style={{
+              fontFamily: "inherit",
+              background: "var(--v4-bg-075, #14171c)",
+              border: "1px solid var(--v4-acc, #4cc6ff)",
+              color: "var(--v4-acc, #4cc6ff)",
+              padding: "6px 12px",
+              borderRadius: 4,
+              fontSize: 11,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            ACCEPT ALL
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ConsentBanner;

--- a/src/components/providers/PostHogProvider.tsx
+++ b/src/components/providers/PostHogProvider.tsx
@@ -4,6 +4,11 @@ import { useEffect, type ReactNode } from "react";
 import { flushPendingFunnelSteps } from "@/lib/analytics/funnel";
 import type { BrowserPostHogClient } from "@/lib/analytics/posthog-client";
 import { resolvePublicPostHogConfig } from "@/lib/analytics/posthog-config";
+import {
+  CONSENT_CHANGED_EVENT,
+  hasAnalyticsConsent,
+  type ConsentState,
+} from "@/lib/consent/cookie";
 // NOTE: type-only import is erased by SWC; no runtime cost.
 
 export function PostHogProvider({ children }: { children: ReactNode }) {
@@ -15,8 +20,13 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
     });
     if (!key) return;
 
+    // S3.5.C — GDPR / CCPA gate. PostHog never loads until the user has
+    // actively granted analytics consent via the ConsentBanner. The
+    // banner dispatches `trendingrepo:consent-changed` so we can flip
+    // into the live state without a page reload when they accept.
     let cancelled = false;
     let triggered = false;
+    let listeningForConsent = false;
 
     const load = async () => {
       if (cancelled || triggered) return;
@@ -59,22 +69,52 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
       window.dispatchEvent(new Event("trendingrepo:posthog-ready"));
     };
 
-    // Idle trigger
+    // Idle / interaction triggers — guarded by the consent gate inside
+    // `loadIfConsented` so they fire-once but don't actually load
+    // posthog until consent is in place.
     type IdleHandle = number;
     const ric = (window as unknown as {
       requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => IdleHandle;
     }).requestIdleCallback;
     let idleId: IdleHandle | null = null;
-    if (ric) {
-      idleId = ric(() => void load(), { timeout: 3000 });
-    } else {
-      idleId = window.setTimeout(load, 1500) as unknown as IdleHandle;
+
+    const events = ["pointerdown", "keydown", "scroll"] as const;
+    const onInteract = () => void loadIfConsented();
+
+    function loadIfConsented() {
+      if (cancelled || triggered) return;
+      if (!hasAnalyticsConsent()) {
+        // Subscribe (once) to the consent-changed event so we can flip
+        // into the live state as soon as the user accepts.
+        if (!listeningForConsent) {
+          listeningForConsent = true;
+          window.addEventListener(
+            CONSENT_CHANGED_EVENT,
+            onConsentChanged as EventListener,
+            { once: true },
+          );
+        }
+        return;
+      }
+      void load();
     }
 
-    // Interaction trigger
-    const onInteract = () => void load();
-    const events = ["pointerdown", "keydown", "scroll"] as const;
-    events.forEach((e) => window.addEventListener(e, onInteract, { once: true, passive: true }));
+    function onConsentChanged(event: CustomEvent<ConsentState>) {
+      listeningForConsent = false;
+      if (cancelled) return;
+      if (event.detail.analytics) {
+        void load();
+      }
+    }
+
+    if (ric) {
+      idleId = ric(() => loadIfConsented(), { timeout: 3000 });
+    } else {
+      idleId = window.setTimeout(loadIfConsented, 1500) as unknown as IdleHandle;
+    }
+    events.forEach((e) =>
+      window.addEventListener(e, onInteract, { once: true, passive: true }),
+    );
 
     return () => {
       cancelled = true;
@@ -82,6 +122,12 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
       if (cancelIdle && idleId !== null) cancelIdle(idleId);
       else if (idleId !== null) clearTimeout(idleId as unknown as number);
       events.forEach((e) => window.removeEventListener(e, onInteract));
+      if (listeningForConsent) {
+        window.removeEventListener(
+          CONSENT_CHANGED_EVENT,
+          onConsentChanged as EventListener,
+        );
+      }
     };
   }, []);
 

--- a/src/lib/consent/cookie.ts
+++ b/src/lib/consent/cookie.ts
@@ -1,0 +1,97 @@
+// Consent cookie helpers (S3.5.C). Browser-only — server callers should
+// read the `Cookie` header explicitly.
+//
+// The `tr_consent` cookie is a small JSON envelope so we can extend
+// later without renaming or shipping a schema migration. Categories
+// follow the standard IAB / EDPB shape (necessary / analytics /
+// marketing). `necessary` is implicit true everywhere — listed for
+// completeness but the UI doesn't expose a toggle for it because
+// declining "necessary" cookies means the site simply can't function.
+//
+// The cookie value itself is a URL-encoded JSON object; we keep it
+// short enough to fit in any reasonable cookie quota even after
+// repeated re-encodes.
+
+export const CONSENT_COOKIE_NAME = "tr_consent";
+const CONSENT_MAX_AGE_DAYS = 180;
+export const CONSENT_CHANGED_EVENT = "trendingrepo:consent-changed";
+
+export interface ConsentState {
+  necessary: true;
+  analytics: boolean;
+  marketing: boolean;
+  /** Unix epoch ms when the user made the decision. */
+  ts: number;
+}
+
+export const DEFAULT_PRE_DECISION_CONSENT: ConsentState = {
+  necessary: true,
+  analytics: false,
+  marketing: false,
+  ts: 0,
+};
+
+export function readConsent(): ConsentState | null {
+  if (typeof document === "undefined") return null;
+  const raw = document.cookie
+    .split(";")
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${CONSENT_COOKIE_NAME}=`));
+  if (!raw) return null;
+  const value = raw.slice(CONSENT_COOKIE_NAME.length + 1);
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(decodeURIComponent(value)) as Partial<ConsentState>;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return {
+      necessary: true,
+      analytics: Boolean(parsed.analytics),
+      marketing: Boolean(parsed.marketing),
+      ts: typeof parsed.ts === "number" && Number.isFinite(parsed.ts) ? parsed.ts : 0,
+    };
+  } catch {
+    // Malformed cookie — treat as "no decision yet" so the banner
+    // re-prompts. The user can re-grant consent on the next visit.
+    return null;
+  }
+}
+
+export function writeConsent(
+  state: Omit<ConsentState, "necessary" | "ts">,
+): ConsentState {
+  if (typeof document === "undefined") {
+    throw new Error("writeConsent must run in the browser");
+  }
+  const payload: ConsentState = {
+    necessary: true,
+    analytics: state.analytics,
+    marketing: state.marketing,
+    ts: Date.now(),
+  };
+  const encoded = encodeURIComponent(JSON.stringify(payload));
+  const maxAge = CONSENT_MAX_AGE_DAYS * 24 * 60 * 60;
+  const isHttps =
+    typeof window !== "undefined" && window.location.protocol === "https:";
+  const secure = isHttps ? "; Secure" : "";
+  document.cookie = `${CONSENT_COOKIE_NAME}=${encoded}; Max-Age=${maxAge}; Path=/; SameSite=Lax${secure}`;
+  // Broadcast so any listener (PostHogProvider, layout, etc.) can react
+  // without a page reload.
+  try {
+    window.dispatchEvent(
+      new CustomEvent<ConsentState>(CONSENT_CHANGED_EVENT, { detail: payload }),
+    );
+  } catch {
+    // CustomEvent isn't supported on ancient browsers; the page will
+    // still reflect the change on next reload.
+  }
+  return payload;
+}
+
+/**
+ * Convenience — true when the user has actively granted analytics
+ * (i.e. the cookie exists AND `analytics: true`). Returns `false` both
+ * when there is no decision yet AND when the user opted out.
+ */
+export function hasAnalyticsConsent(): boolean {
+  return readConsent()?.analytics === true;
+}


### PR DESCRIPTION
## Summary

GDPR/CCPA cookie consent surface. Bottom-anchored sticky banner shown on first visit with two primary actions (**Accept all** / **Necessary only**) plus a **Customize** toggle for per-category opt-in.

## State

Persisted in the `tr_consent` cookie as a small JSON envelope:

\`\`\`json
{ "necessary": true, "analytics": false, "marketing": false, "ts": 1716000000000 }
\`\`\`

180-day max-age, `SameSite=Lax`, `Secure` when HTTPS.

## PostHog gate (the headline change)

`PostHogProvider` previously auto-initialised on idle/interaction. Now:

- `loadIfConsented()` checks `hasAnalyticsConsent()` before invoking the existing load path
- If consent is missing, the provider subscribes (once) to the `trendingrepo:consent-changed` CustomEvent the banner dispatches on user decision — Accept-all flips to live **without a page reload**
- Cleanup removes the listener if the component unmounts while still waiting

Net effect: zero analytics network calls until consent. Necessary cookies (Clerk session, login flow) are unchanged.

## SSR safety

Banner returns null on the server AND during the first client render (`mounted` gate from useEffect). Server HTML matches initial client HTML — no hydration warnings.

## Files

- `src/lib/consent/cookie.ts` (new, ~100 LoC) — `readConsent`, `writeConsent`, `hasAnalyticsConsent`, event constants
- `src/components/consent/ConsentBanner.tsx` (new, ~260 LoC) — bottom banner UI with Customize expand
- `src/components/providers/PostHogProvider.tsx` — added `loadIfConsented` guard + consent-changed event subscription, prior idle/interaction logic preserved
- `src/app/layout.tsx` — mount `<ConsentBanner />` after `<ToasterLazy />`

## Out of scope (operator follow-ups)

- `/settings/cookies` page to revise consent post-decision (today users can clear the cookie via DevTools to re-prompt)
- Marketing-cookie consumers — none exist yet; the toggle is wired for future use

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint:guards` clean
- [ ] Post-merge:
  - Clear cookies, load `/` — banner appears bottom-center
  - Open DevTools Network → PostHog ingestion endpoint NOT hit
  - Click "Accept all" — banner dismisses, PostHog network calls start within ~1s (event dispatch + load)
  - Reload — banner stays hidden, PostHog initialises on idle
  - Clear `tr_consent` cookie + reload — banner reappears
  - Click "Customize" → uncheck Analytics → "Save choices" — PostHog never initialises

## Risk

Low. Native dialog-less component, no Radix/portals. Backwards-compatible — `hasAnalyticsConsent()` defensively returns false when the cookie can't be parsed, so existing users without the cookie are correctly treated as "no decision yet".

Part of S3.5 (Compliance — marketing-ready milestone). First of 4 PRs in this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)