### PR TITLE
fix(worker): restore health deltas coverage

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/deltas/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/deltas/index.ts
@@ -113,6 +113,52 @@ function flattenToStarsById(payload: TrendingPayload): Map<string, number> {
   return out;
 }
 
+function parseEpochSeconds(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.floor(value > 1_000_000_000_000 ? value / 1000 : value);
+  }
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric)) {
+    return Math.floor(numeric > 1_000_000_000_000 ? numeric / 1000 : numeric);
+  }
+  const parsedMs = Date.parse(trimmed);
+  return Number.isFinite(parsedMs) ? Math.floor(parsedMs / 1000) : null;
+}
+
+export function resolveTrendingSnapshotTs(
+  metaRaw: string | null,
+  currentPayload: TrendingPayload,
+  fallbackNowSeconds: number,
+): number {
+  const candidates: unknown[] = [];
+  if (metaRaw) {
+    const trimmed = metaRaw.trim();
+    if (trimmed) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (parsed && typeof parsed === 'object') {
+          const record = parsed as Record<string, unknown>;
+          candidates.push(record.writtenAt, record.fetchedAt, record.updatedAt, record.ts);
+        } else {
+          candidates.push(parsed);
+        }
+      } catch {
+        candidates.push(trimmed);
+      }
+    }
+  }
+  candidates.push(currentPayload.fetchedAt, fallbackNowSeconds);
+
+  for (const candidate of candidates) {
+    const ts = parseEpochSeconds(candidate);
+    if (ts !== null && Number.isFinite(ts)) return ts;
+  }
+  return fallbackNowSeconds;
+}
+
 async function readJson<T>(
   redis: RedisHandle,
   key: string,
@@ -201,9 +247,7 @@ const fetcher: Fetcher = {
       return done(startedAt, 0, false, errors);
     }
     const currentMetaRaw = await redis.get(TRENDING_META_KEY);
-    const currentTs = currentMetaRaw
-      ? Math.floor(Date.parse(currentMetaRaw) / 1000)
-      : now;
+    const currentTs = resolveTrendingSnapshotTs(currentMetaRaw, currentJson, now);
     const currentStars = flattenToStarsById(currentJson);
     if (currentStars.size === 0) {
       const message = 'current trending has zero joinable rows';

--- a/apps/trendingrepo-worker/src/lib/util/source-watchers.ts
+++ b/apps/trendingrepo-worker/src/lib/util/source-watchers.ts
@@ -166,7 +166,6 @@ export const SUBREDDITS: string[] = [
   'ChatGPTPromptGenius',
   // Extended: Prompts & building
   'PromptEngineering',
-  'AIToolTesting',
   'AIBuilders',
   'AIAssisted',
   // Extended: Learning & research

--- a/apps/trendingrepo-worker/tests/fetchers/deltas/meta-timestamp.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/deltas/meta-timestamp.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTrendingSnapshotTs } from '../../../src/fetchers/deltas/index.js';
+
+describe('deltas timestamp resolver', () => {
+  it('reads writtenAt from JSON data-store metadata', () => {
+    expect(
+      resolveTrendingSnapshotTs(
+        '{"writtenAt":"2026-05-17T11:22:39.301Z","writer":"worker:oss-trending"}',
+        { fetchedAt: '2026-05-17T11:20:00.000Z' },
+        1770000000,
+      ),
+    ).toBe(1779016959);
+  });
+
+  it('keeps compatibility with raw ISO metadata strings', () => {
+    expect(
+      resolveTrendingSnapshotTs(
+        '2026-05-17T11:22:39.301Z',
+        { fetchedAt: '2026-05-17T11:20:00.000Z' },
+        1770000000,
+      ),
+    ).toBe(1779016959);
+  });
+
+  it('falls back to the current payload fetchedAt when metadata is malformed', () => {
+    expect(
+      resolveTrendingSnapshotTs(
+        '{not-json',
+        { fetchedAt: '2026-05-17T11:20:00.000Z' },
+        1770000000,
+      ),
+    ).toBe(1779016800);
+  });
+});

--- a/scripts/_reddit-shared.mjs
+++ b/scripts/_reddit-shared.mjs
@@ -263,7 +263,6 @@ export const SUBREDDITS = [
   "ChatGPTPromptGenius",
   // --- Extended: Prompts & building ---
   "PromptEngineering",
-  "AIToolTesting",
   "AIBuilders",
   "AIAssisted",
   // --- Extended: Learning & research ---


### PR DESCRIPTION
## Summary
- parse Redis trending metadata JSON before writing deltas snapshots, preventing `snapshot:NaN` and restoring history matching
- remove the dead `AIToolTesting` subreddit from both Reddit source registries so one 404 no longer degrades source health
- add focused coverage for metadata timestamp resolution

## Validation
- `npm run typecheck` in `apps/trendingrepo-worker`
- `npx vitest run tests/fetchers/deltas/meta-timestamp.test.ts` in `apps/trendingrepo-worker`
- `node --test scripts\__tests__\reddit-shared.test.mjs`
- `npx eslint apps/trendingrepo-worker/src/fetchers/deltas/index.ts apps/trendingrepo-worker/src/lib/util/source-watchers.ts scripts/_reddit-shared.mjs`
- root `npm run typecheck`
- root `npm audit --audit-level=high`
- worker `npm audit --audit-level=high` (no high/critical findings; existing moderate Vitest/Vite advisory remains out of scope because the fix path is a breaking Vitest upgrade)

## Live proof before PR
- production Clerk sign-in/sign-up loaded live Clerk keys and no longer showed auth unavailable
- `/api/health` strict returned `status=ok` and `sourceStatus=ok`
- deltas coverage recovered from cold `0%` to partial `64.9%`; full real windows will mature as 24h/7d/30d history accrues