### PR TITLE
fix(api): tighten soft health deadline

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -56,7 +56,7 @@ const RANKINGS_STALE_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 const COVERAGE_WARN_PCT = 50;
 // Soft health is polled by uptime checks; return cached truth quickly instead
 // of letting a slow Redis/data-store refresh become the outage signal.
-const SOFT_REFRESH_DEADLINE_MS = 500;
+const SOFT_REFRESH_DEADLINE_MS = 150;
 
 type HealthStatus = "ok" | "stale" | "error";
 


### PR DESCRIPTION
## Summary
- tighten the soft `/api/health?soft=1` refresh deadline from 500ms to 150ms

## Why
The first production perf hit after the 500ms fix improved but still missed the 600ms uptime-probe TTFB budget at 1057ms. Warm manual soft health was 334ms, so this keeps soft probes from waiting through a cold lambda plus a full refresh timeout. Hard and detailed health still use the full refresh path.

## Validation
- `npx eslint src/app/api/health/route.ts`
- `npm run typecheck`