### PR TITLE
fix(freshness): replace hardcoded LIVE labels with FreshnessBadge (QoL-1)

### DIFF
--- a/src/app/alerts/new/NewAlertClient.tsx
+++ b/src/app/alerts/new/NewAlertClient.tsx
@@ -593,7 +593,7 @@ export default function NewAlertClient() {
         }
         rightRail={
           <>
-            <SectionHead num="// 02" title="Preview" meta="LIVE" />
+            <SectionHead num="// 02" title="Preview" />
             <p
               style={{
                 fontFamily: "var(--font-geist-mono), monospace",

--- a/src/app/consensus/page.tsx
+++ b/src/app/consensus/page.tsx
@@ -23,7 +23,6 @@ import { PageHead } from "@/components/ui/PageHead";
 import { SectionHead } from "@/components/ui/SectionHead";
 import { KpiBand } from "@/components/ui/KpiBand";
 import { VerdictRibbon } from "@/components/ui/VerdictRibbon";
-import { LiveDot } from "@/components/ui/LiveDot";
 import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
 
 export const runtime = "nodejs";
@@ -261,7 +260,6 @@ export default async function ConsensusPage() {
           <>
             <span className="big">{computedClock}</span>
             <span className="muted">UTC · COMPUTED</span>
-            <LiveDot label="FEED LIVE" />
             <FreshnessBadge source="mcp" lastUpdatedAt={computedAt || null} />
             <Link href="/api/scoring/consensus?limit=100" className="json-link">
               JSON →
@@ -342,7 +340,7 @@ export default async function ConsensusPage() {
             <span className="key">{"// MATRIX · X · OURS RANK → · Y · EXTERNAL RANK ↓"}</span>
             <span style={{ color: "var(--v4-ink-400)" }}>· COLOR · VERDICT BAND</span>
             <span className="right">
-              <LiveDot label="LIVE" />
+              <FreshnessBadge source="mcp" lastUpdatedAt={computedAt || null} />
             </span>
           </div>
           <div className="matrix-legend">


### PR DESCRIPTION
Memory-rule violation cleanup. Three sites had `<LiveDot label="LIVE" />` / `meta="LIVE"` strings that lied about data freshness or duplicated existing badges.

## Sites cleaned

| Site | Before | After |
|---|---|---|
| consensus hero clock | `<LiveDot label="FEED LIVE" />` next to a real `<FreshnessBadge>` | redundant LiveDot dropped |
| consensus matrix panel head | `<LiveDot label="LIVE" />` (hardcoded) | `<FreshnessBadge source="mcp" lastUpdatedAt={computedAt} />` |
| /alerts/new Preview head | `meta="LIVE"` (form-state preview, not a data freshness signal) | meta dropped |

## Out of scope

- `reddit/page.tsx` + `research/page.tsx` use conditional `cold ? "COLD" : "LIVE"` strings tied to real cold-cache state — not memory-rule violations.
- `design-lab/primitives/page.tsx` LiveDot is part of the primitive showcase by design.
- `console.log` calls in lib/* originally flagged in the plan are **structured-JSON observability events** with `scope:` fields (resend-client, github-compare, source-health-tracker). Wrapping them in NODE_ENV would break production log aggregation; left untouched.

## Verification

- `npm run typecheck` clean
- `npm run lint:guards` clean

Part of Phase 3 (Quality of Life) per approved plan. First of 2 QoL PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)