### PR TITLE
feat(boundaries): add error.tsx + loading.tsx to 3 missing routes (QoL-2)

### DIFF
--- a/src/app/admin/health/error.tsx
+++ b/src/app/admin/health/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/admin/health/loading.tsx
+++ b/src/app/admin/health/loading.tsx
@@ -1,0 +1,16 @@
+// Route loading skeleton — keeps the layout shell painted while the
+// server component resolves its data fetches.
+
+export default function Loading() {
+  return (
+    <div className="max-w-5xl mx-auto px-4 md:px-6 py-8 md:py-12">
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 bg-[var(--v4-bg-100)] rounded w-1/2" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-full" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-5/6" />
+        <div className="h-32 bg-[var(--v4-bg-050)] rounded w-full" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-4/5" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/keys/error.tsx
+++ b/src/app/admin/keys/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/admin/keys/loading.tsx
+++ b/src/app/admin/keys/loading.tsx
@@ -1,0 +1,16 @@
+// Route loading skeleton — keeps the layout shell painted while the
+// server component resolves its data fetches.
+
+export default function Loading() {
+  return (
+    <div className="max-w-5xl mx-auto px-4 md:px-6 py-8 md:py-12">
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 bg-[var(--v4-bg-100)] rounded w-1/2" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-full" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-5/6" />
+        <div className="h-32 bg-[var(--v4-bg-050)] rounded w-full" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-4/5" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/huggingface/models/error.tsx
+++ b/src/app/huggingface/models/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorPanel } from "@/components/ui/ErrorPanel";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RouteError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const sentry = (window as unknown as { Sentry?: { captureException: (e: Error) => void } }).Sentry;
+      if (sentry?.captureException) sentry.captureException(error);
+    }
+  }, [error]);
+
+  return <ErrorPanel error={error} reset={reset} variant="default" />;
+}

--- a/src/app/huggingface/models/loading.tsx
+++ b/src/app/huggingface/models/loading.tsx
@@ -1,0 +1,16 @@
+// Route loading skeleton — keeps the layout shell painted while the
+// server component resolves its data fetches.
+
+export default function Loading() {
+  return (
+    <div className="max-w-5xl mx-auto px-4 md:px-6 py-8 md:py-12">
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 bg-[var(--v4-bg-100)] rounded w-1/2" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-full" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-5/6" />
+        <div className="h-32 bg-[var(--v4-bg-050)] rounded w-full" />
+        <div className="h-4 bg-[var(--v4-bg-050)] rounded w-4/5" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Plan flagged 10 routes; audit found only 3 actually lacked boundaries — the other 7 already have them from prior session work.

## Routes covered

| Route | Why important |
|---|---|
| `src/app/admin/health` | Operator dashboard — needs visible error state, not blank |
| `src/app/admin/keys` | Pool key dashboard — same |
| `src/app/huggingface/models` | HF model trending detail — public-facing data route |

Each gets `error.tsx` (canonical ErrorPanel + Sentry-capture pattern from /about) and `loading.tsx` (v4-tokened skeleton).

## Out of scope

- Routes the plan flagged but already had boundaries (about, contact, privacy, refer/leaderboard, terms)
- sign-in / sign-up hosted Clerk pages — they live under catch-all `[[...sign-in]]` segments and ClerkAuthForm handles its own error states.

## Verification

- `npm run typecheck` clean
- `npm run lint:guards` clean

Part of Phase 3 (Quality of Life). Second of 2 QoL PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)