### PR TITLE
fix(data): force twitter collector cli exit

### DIFF
--- a/scripts/collect-twitter-signals.ts
+++ b/scripts/collect-twitter-signals.ts
@@ -65,6 +65,7 @@ loadEnvConfig(ROOT);
 
 const USER_AGENT = "TrendingRepo-TwitterCollector/0.1 (+https://trendingrepo.com)";
 const DEFAULT_BASE_URL = "http://localhost:3023";
+const CLI_CLEANUP_TIMEOUT_MS = 5_000;
 
 type CollectorProvider = "nitter" | "fixture" | "web" | "apify";
 type CollectorMode = "direct" | "api";
@@ -1039,14 +1040,33 @@ async function main(): Promise<void> {
   });
 }
 
+async function cleanupForCliExit(): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const cleanup = Promise.allSettled([
+    closeCollectorDataStore(),
+    closeAppDataStore(),
+  ]);
+  const cleanupOutcome = await Promise.race([
+    cleanup.then(() => "closed" as const),
+    new Promise<"timeout">((resolveTimeout) => {
+      timeout = setTimeout(() => resolveTimeout("timeout"), CLI_CLEANUP_TIMEOUT_MS);
+    }),
+  ]);
+
+  if (timeout) clearTimeout(timeout);
+  if (cleanupOutcome === "timeout") {
+    console.warn(
+      `[twitter-collector] cleanup timed out after ${CLI_CLEANUP_TIMEOUT_MS}ms; forcing process exit`,
+    );
+  }
+}
+
 main()
   .catch((error) => {
     console.error(error);
     process.exitCode = 1;
   })
   .finally(async () => {
-    await Promise.allSettled([
-      closeCollectorDataStore(),
-      closeAppDataStore(),
-    ]);
+    await cleanupForCliExit();
+    process.exit(process.exitCode ?? 0);
   });


### PR DESCRIPTION
## Summary
- add bounded datastore cleanup for the Twitter collector CLI
- explicitly exit after collector completion so GitHub Actions does not time out after data is flushed

## Evidence
- run 25995902462 flushed 23 primary posts and updated twitter.json, then hung until the 20m step timeout
- fallback also flushed metadata and then hung until its 15m timeout

## Validation
- npm run test:twitter-collector
- git diff --check
- npm run typecheck
- npm run lint:guards
- npm audit --audit-level=high
- npm run build