### PR TITLE
fix(ci): commit twitter checkpoint through data PR

### DIFF
--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -271,13 +271,15 @@ jobs:
         if: |
           success() &&
           (steps.collect_primary.outcome == 'success' || steps.web_fallback.outcome == 'success')
-        run: |
-          if [ -n "$(git status --porcelain data/.twitter-signal-count)" ]; then
-            git add data/.twitter-signal-count
-            git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" \
-              commit -m "ci(twitter): update signal-count checkpoint"
-            git push
-          fi
+        timeout-minutes: 5
+        env:
+          HUSKY: "0"
+        uses: ./.github/actions/git-commit-data
+        with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+          message: "ci(twitter): update signal-count checkpoint"
+          paths: |
+            data/.twitter-signal-count
 
       - name: Fail if all Twitter collectors failed
         if: |


### PR DESCRIPTION
## Summary
- stop the Twitter workflow from pushing data/.twitter-signal-count directly to protected main
- route the checkpoint update through the existing git-commit-data PR action with DATA_BOT_TOKEN

## Evidence
- run 25997036892 proved the collector lifecycle fix: collect finished, fallback skipped, consensus ran, and the data PR step opened #1681
- the run failed only when the checkpoint step tried to push directly to protected main

## Validation
- YAML parse for .github/workflows/collect-twitter.yml
- git diff --check
- npm run lint:guards