### PR TITLE
fix(ci): isolate twitter checkpoint data branch

### DIFF
--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -278,6 +278,7 @@ jobs:
         with:
           gh-token: ${{ secrets.DATA_BOT_TOKEN }}
           message: "ci(twitter): update signal-count checkpoint"
+          branch-prefix: data-checkpoint
           paths: |
             data/.twitter-signal-count
 


### PR DESCRIPTION
## Summary
- give the Twitter checkpoint PR action its own data-checkpoint branch prefix
- prevent collision with the main Twitter data PR branch generated earlier in the same workflow run

## Evidence
- run 25997289453 completed collect/consensus/data PR work but checkpoint push failed with stale info against data/collect-twitter-signals-25997289453-1

## Validation
- YAML parse for .github/workflows/collect-twitter.yml
- git diff --check
- npm run lint:guards