### PR TITLE
fix(ci): restore ai rss freshness producer

### DIFF
--- a/.github/workflows/scrape-ai-rss.yml
+++ b/.github/workflows/scrape-ai-rss.yml
@@ -1,0 +1,65 @@
+name: Refresh AI RSS signals
+
+# Claude/OpenAI news freshness is part of the production health budget. The
+# old single-source workflows were retired, so this combined producer restores
+# the data path with a staggered 6h cadence and one protected-main data PR.
+on:
+  schedule:
+    - cron: "31 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ai-rss-refresh
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh Claude news
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+        run: npm run scrape:claude-rss
+
+      - name: Refresh OpenAI news
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
+        run: npm run scrape:openai-rss
+
+      - name: Compute commit timestamp
+        id: ts
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit if changed
+        timeout-minutes: 5
+        uses: ./.github/actions/git-commit-data
+        with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+          actor-email: "bot@trendingrepo.com"
+          message: "chore(data): refresh ai rss signals ${{ steps.ts.outputs.value }}"
+          paths: |
+            data/claude-rss.json
+            data/_meta/claude-rss.json
+            data/openai-rss.json
+            data/_meta/openai-rss.json


### PR DESCRIPTION
Restores a scheduled/manual Claude + OpenAI RSS freshness producer after the old single-source workflows were retired. Uses Node 22, pinned actions, and the protected-main data PR action for the four RSS data/meta outputs.\n\nValidation:\n- YAML parse OK\n- git diff --check\n- npm run lint:guards\n- npm run typecheck\n- npm audit --audit-level=high\n- npm run build