### PR TITLE
fix(ci): restore social news freshness producers

### DIFF
--- a/.github/workflows/scrape-bluesky.yml
+++ b/.github/workflows/scrape-bluesky.yml
@@ -1,0 +1,61 @@
+name: Refresh Bluesky signals
+
+# Bluesky is part of the fast-source /api/health budget. Keep it on an
+# hourly cadence so the 4h health threshold survives normal runner delays.
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bluesky-refresh
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh Bluesky mentions and trending
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
+        run: npm run scrape:bsky
+
+      - name: Compute commit timestamp
+        id: ts
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit if changed
+        timeout-minutes: 5
+        uses: ./.github/actions/git-commit-data
+        with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+          actor-email: "bot@trendingrepo.com"
+          message: "chore(data): refresh bluesky signals ${{ steps.ts.outputs.value }}"
+          paths: |
+            data/bluesky-mentions.json
+            data/bluesky-trending.json
+            data/_meta/bluesky.json
+            data/unknown-mentions.jsonl

--- a/.github/workflows/scrape-devto.yml
+++ b/.github/workflows/scrape-devto.yml
@@ -1,0 +1,61 @@
+name: Refresh dev.to signals
+
+# dev.to is lower cadence than the fast social sources, but it still feeds
+# consensus/news surfaces and should not depend on page-triggered recovery.
+on:
+  schedule:
+    - cron: "3 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: devto-refresh
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh dev.to mentions and trending
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
+          DEVTO_API_KEYS: ${{ secrets.DEVTO_API_KEYS }}
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
+        run: npm run scrape:devto
+
+      - name: Compute commit timestamp
+        id: ts
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit if changed
+        timeout-minutes: 5
+        uses: ./.github/actions/git-commit-data
+        with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+          actor-email: "bot@trendingrepo.com"
+          message: "chore(data): refresh dev.to signals ${{ steps.ts.outputs.value }}"
+          paths: |
+            data/devto-mentions.json
+            data/devto-trending.json
+            data/_meta/devto.json
+            data/unknown-mentions.jsonl

--- a/.github/workflows/scrape-lobsters.yml
+++ b/.github/workflows/scrape-lobsters.yml
@@ -1,0 +1,57 @@
+name: Refresh Lobsters signals
+
+# Lobsters is a small public source. Hourly polling is enough to keep the
+# fast-source health budget green without hammering upstream.
+on:
+  schedule:
+    - cron: "37 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: lobsters-refresh
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh Lobsters mentions and trending
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+        run: npm run scrape:lobsters
+
+      - name: Compute commit timestamp
+        id: ts
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit if changed
+        timeout-minutes: 5
+        uses: ./.github/actions/git-commit-data
+        with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+          actor-email: "bot@trendingrepo.com"
+          message: "chore(data): refresh lobsters signals ${{ steps.ts.outputs.value }}"
+          paths: |
+            data/lobsters-mentions.json
+            data/lobsters-trending.json
+            data/_meta/lobsters.json
+            data/unknown-mentions.jsonl

--- a/.github/workflows/scrape-producthunt.yml
+++ b/.github/workflows/scrape-producthunt.yml
@@ -1,0 +1,61 @@
+name: Refresh ProductHunt launches
+
+# Product Hunt moves through the day as votes/comments settle. Four daily
+# snapshots keep launch data current without burning API budget overnight.
+on:
+  schedule:
+    - cron: "8 11,15,19,23 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: producthunt-refresh
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Refresh ProductHunt launches
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          PRODUCTHUNT_TOKEN: ${{ secrets.PRODUCTHUNT_TOKEN }}
+          PRODUCTHUNT_TOKENS: ${{ secrets.PRODUCTHUNT_TOKENS }}
+          GITHUB_TOKEN: ${{ github.token }}
+          TOOLBOX_INGEST_URL: ${{ secrets.TOOLBOX_INGEST_URL }}
+          TOOLBOX_INGEST_HMAC_SECRET: ${{ secrets.TOOLBOX_INGEST_HMAC_SECRET }}
+        run: npm run scrape:ph
+
+      - name: Compute commit timestamp
+        id: ts
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit if changed
+        timeout-minutes: 5
+        uses: ./.github/actions/git-commit-data
+        with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+          actor-email: "bot@trendingrepo.com"
+          message: "chore(data): refresh ProductHunt launches ${{ steps.ts.outputs.value }}"
+          paths: |
+            data/producthunt-launches.json
+            data/_meta/producthunt.json
+            data/unknown-mentions.jsonl


### PR DESCRIPTION
Restores scheduled/manual producers for Bluesky, Lobsters, dev.to, and ProductHunt after the old single-source workflows were retired. These sources feed health, consensus, news, and cross-source mention surfaces and should not depend on page-triggered recovery.\n\nDetails:\n- Pinned checkout/setup-node actions\n- Node 22 to match package engines\n- Redis metadata writes enabled for every restored producer\n- Protected-main data PR action with exact path allowlists\n\nValidation:\n- YAML parse OK for all four workflows\n- git diff --check\n- npm run lint:guards\n- npm run typecheck\n- npm audit --audit-level=high