### PR TITLE
fix(ci): restore mcp side-channel producers

### DIFF
--- a/.github/workflows/refresh-mcp-dependents.yml
+++ b/.github/workflows/refresh-mcp-dependents.yml
@@ -1,0 +1,44 @@
+name: Refresh MCP dependents side-channel
+
+# Publishes the Redis-only mcp-dependents aggregate consumed by the MCP
+# scorer. The fetcher caches package-level results for 7d, so a 6h workflow
+# mostly refreshes the aggregate timestamp and picks up new MCP package names.
+on:
+  schedule:
+    - cron: "53 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-dependents-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/trendingrepo-worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: apps/trendingrepo-worker/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish MCP dependents aggregate
+        env:
+          NODE_ENV: production
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          LIBRARIES_IO_API_KEY: ${{ secrets.LIBRARIES_IO_API_KEY }}
+        run: npm run fetcher -- npm-dependents

--- a/.github/workflows/refresh-mcp-smithery-rank.yml
+++ b/.github/workflows/refresh-mcp-smithery-rank.yml
@@ -1,0 +1,44 @@
+name: Refresh MCP Smithery rank side-channel
+
+# Publishes the Redis-only mcp-smithery-rank aggregate consumed by the MCP
+# scorer. Smithery rank is derived from registry list order and is safe to
+# refresh every 6h.
+on:
+  schedule:
+    - cron: "11 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-smithery-rank-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/trendingrepo-worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: apps/trendingrepo-worker/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish MCP Smithery rank aggregate
+        env:
+          NODE_ENV: production
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: npm run fetcher -- mcp-smithery-rank


### PR DESCRIPTION
Restores scheduled/manual worker fetcher workflows for MCP side-channel data that was still showing as non-blocking stale in production freshness.\n\nDetails:\n- Adds Redis-only MCP dependents workflow for the worker npm-dependents fetcher\n- Adds Redis-only Smithery rank workflow for the worker mcp-smithery-rank fetcher\n- Uses Node 22 and worker package cache key\n- Keeps permissions read-only because no repo data commit is needed\n\nValidation:\n- YAML parse OK\n- git diff --check\n- npm --prefix apps/trendingrepo-worker run typecheck\n- npm --prefix apps/trendingrepo-worker run fetcher -- npm-dependents --dry-run\n- npm --prefix apps/trendingrepo-worker run fetcher -- mcp-smithery-rank --dry-run\n- npm run lint:guards\n- npm audit --audit-level=high