### PR TITLE
fix(worker): allow anonymous mcp side-channel reads

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/mcp-smithery-rank/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/mcp-smithery-rank/index.ts
@@ -1,7 +1,7 @@
 // mcp-smithery-rank fetcher.
 //
 //   API           https://registry.smithery.ai/servers (paginated)
-//   Auth          SMITHERY_API_KEY (Bearer)
+//   Auth          Optional SMITHERY_API_KEY (Bearer)
 //   Rate limit    No published cap; we paginate at pageSize=100, < 100 pages
 //   Cache TTL     None — the aggregate key is overwritten each run
 //   Aggregate key mcp-smithery-rank
@@ -70,22 +70,24 @@ const fetcher: Fetcher = {
       return done(startedAt, 0, false, []);
     }
 
-    const env = loadEnv();
-    if (!env.SMITHERY_API_KEY) {
-      ctx.log.warn('mcp-smithery-rank skipped: SMITHERY_API_KEY not set');
-      const redisPublished = await publishDisabledAggregate();
-      return done(startedAt, 0, redisPublished, []);
-    }
-
     const errors: RunResult['errors'] = [];
-    const headers = { authorization: `Bearer ${env.SMITHERY_API_KEY}` };
+    const env = loadEnv();
+    const headers = env.SMITHERY_API_KEY
+      ? { authorization: `Bearer ${env.SMITHERY_API_KEY}` }
+      : undefined;
+    if (!headers) {
+      ctx.log.warn('SMITHERY_API_KEY not set - using anonymous Smithery registry endpoint');
+    }
 
     const ordered: SmitheryServerEntry[] = [];
     let total = 0;
     try {
       for (let page = 1; page <= MAX_PAGES; page += 1) {
         const url = `${BASE}/servers?page=${page}&pageSize=${PAGE_SIZE}`;
-        const { data } = await ctx.http.json<ListResponse>(url, { headers, timeoutMs: 20_000 });
+        const { data } = await ctx.http.json<ListResponse>(url, {
+          ...(headers ? { headers } : {}),
+          timeoutMs: 20_000,
+        });
         const servers = data.servers ?? [];
         for (const s of servers) ordered.push(s);
         const totalPages = data.pagination?.totalPages ?? 1;
@@ -142,18 +144,6 @@ const fetcher: Fetcher = {
 };
 
 export default fetcher;
-
-async function publishDisabledAggregate(): Promise<boolean> {
-  const payload: SmitheryRankPayload = {
-    fetchedAt: new Date().toISOString(),
-    total: 0,
-    summary: {},
-    status: 'disabled',
-    reason: 'missing_smithery_api_key',
-  };
-  const result = await writeDataStore('mcp-smithery-rank', payload);
-  return result.source === 'redis';
-}
 
 function done(
   startedAt: string,

--- a/apps/trendingrepo-worker/src/fetchers/npm-dependents/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/npm-dependents/index.ts
@@ -1,17 +1,17 @@
 // npm-dependents fetcher.
 //
-//   API           https://libraries.io/api/<platform>/<package>?api_key=...
+//   API           https://libraries.io/api/<platform>/<package>[?api_key=...]
 //                 (the package GET returns `dependent_repos_count` directly,
 //                 saving a paginated dependents call. We verified this against
 //                 a known package — see plan notes.)
-//   Auth          LIBRARIES_IO_API_KEY (libraries.io free tier; 60 req/min)
-//   Rate limit    Free tier ~60 req/min; we sleep 1100ms between calls
+//   Auth          Optional LIBRARIES_IO_API_KEY (libraries.io free tier; 60 req/min)
+//   Rate limit    Free tier / anonymous; we sleep 1100ms between calls
 //   Cache TTL     7 days per-package (mcp-dependents:<pkg>)
 //   Aggregate key mcp-dependents
 //   Cadence       24h (refresh-mcp-dependents.yml)
 //
-// If LIBRARIES_IO_API_KEY is missing the fetcher logs a warning and exits
-// cleanly — the scorer drops the term via existing renormalization.
+// If LIBRARIES_IO_API_KEY is missing the fetcher uses the anonymous package
+// endpoint, which still returns the dependents counts the scorer needs.
 
 import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
 import { writeDataStore, readDataStore } from '../../lib/redis.js';
@@ -65,17 +65,9 @@ const fetcher: Fetcher = {
       return done(startedAt, 0, false, []);
     }
 
-    const apiKey = process.env.LIBRARIES_IO_API_KEY?.trim();
+    const apiKey = process.env.LIBRARIES_IO_API_KEY?.trim() || null;
     if (!apiKey) {
-      ctx.log.warn('LIBRARIES_IO_API_KEY not set - npm-dependents skipped (scorer drops term)');
-      const redisPublished = await publishAggregate('disabled', 'missing_libraries_io_api_key', {
-        roster: 0,
-        npmPackages: 0,
-        ok: 0,
-        failed: 0,
-        cacheHit: 0,
-      });
-      return done(startedAt, 0, redisPublished, []);
+      ctx.log.warn('LIBRARIES_IO_API_KEY not set - using anonymous Libraries.io package endpoint');
     }
 
     const errors: RunResult['errors'] = [];
@@ -214,10 +206,11 @@ function normalizePkg(raw: string): string | null {
   return trimmed.toLowerCase();
 }
 
-async function fetchDependentCount(apiKey: string, pkg: string): Promise<number | null> {
+async function fetchDependentCount(apiKey: string | null, pkg: string): Promise<number | null> {
   // libraries.io path encodes scoped packages as @scope%2Fname.
   const platformPkg = pkg.startsWith('@') ? encodeURIComponent(pkg) : pkg;
-  const url = `https://libraries.io/api/npm/${platformPkg}?api_key=${encodeURIComponent(apiKey)}`;
+  const baseUrl = `https://libraries.io/api/npm/${platformPkg}`;
+  const url = apiKey ? `${baseUrl}?api_key=${encodeURIComponent(apiKey)}` : baseUrl;
   try {
     const data = await fetchJsonWithRetry<LibrariesIoPackage>(url, {
       attempts: 3,

--- a/apps/trendingrepo-worker/tests/fetchers/advisory-sidechannels.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/advisory-sidechannels.test.ts
@@ -3,6 +3,8 @@ import type { FetcherContext, RedisHandle } from '../../src/lib/types.js';
 
 const mockState = vi.hoisted(() => ({
   store: new Map<string, string>(),
+  fetchJsonWithRetry: vi.fn(),
+  sleep: vi.fn(),
 }));
 
 vi.mock('../../src/lib/env.js', () => ({
@@ -56,6 +58,30 @@ vi.mock('../../src/lib/redis.js', () => {
   };
 });
 
+vi.mock('../../src/lib/util/http-helpers.js', () => {
+  class HttpStatusError extends Error {
+    status: number;
+    statusText: string;
+
+    constructor(response: { status: number; statusText: string }, url: string, bodyText = '') {
+      super(
+        `HTTP ${response.status} ${response.statusText}${url ? ` - ${url}` : ''}${
+          bodyText ? ` - ${bodyText}` : ''
+        }`,
+      );
+      this.name = 'HttpStatusError';
+      this.status = response.status;
+      this.statusText = response.statusText;
+    }
+  }
+
+  return {
+    fetchJsonWithRetry: mockState.fetchJsonWithRetry,
+    HttpStatusError,
+    sleep: mockState.sleep,
+  };
+});
+
 const ORIGINAL_ENV = { ...process.env };
 
 function restoreEnv(): void {
@@ -103,40 +129,86 @@ function readPayload<T>(key: string): T {
 afterEach(() => {
   restoreEnv();
   mockState.store.clear();
+  mockState.fetchJsonWithRetry.mockReset();
+  mockState.sleep.mockReset();
   vi.resetModules();
 });
 
 describe('advisory side-channel fetchers', () => {
-  it('npm-dependents publishes a disabled aggregate when Libraries.io key is missing', async () => {
+  it('npm-dependents uses anonymous Libraries.io reads when the key is missing', async () => {
     process.env.NODE_ENV = 'test';
     delete process.env.LIBRARIES_IO_API_KEY;
+    seedPayload('trending-mcp', {
+      items: [
+        {
+          slug: 'context7',
+          raw: { package_name: '@upstash/context7', package_registry: 'npm' },
+        },
+      ],
+    });
+    mockState.fetchJsonWithRetry.mockResolvedValue({
+      dependent_repos_count: 12,
+      dependents_count: 3,
+    });
 
     const { default: fetcher } = await import('../../src/fetchers/npm-dependents/index.js');
     const result = await fetcher.run(makeContext());
 
     expect(result.redisPublished).toBe(true);
-    expect(result.metricsWritten).toBe(0);
+    expect(result.metricsWritten).toBe(1);
+    expect(mockState.fetchJsonWithRetry).toHaveBeenCalledWith(
+      'https://libraries.io/api/npm/%40upstash%2Fcontext7',
+      expect.objectContaining({
+        headers: expect.objectContaining({ accept: 'application/json' }),
+      }),
+    );
     expect(readPayload('mcp-dependents')).toMatchObject({
-      summary: {},
-      counts: { roster: 0, npmPackages: 0, ok: 0, failed: 0, cacheHit: 0 },
-      status: 'disabled',
-      reason: 'missing_libraries_io_api_key',
+      summary: {
+        context7: { count: 15, packageName: '@upstash/context7' },
+      },
+      counts: { roster: 1, npmPackages: 1, ok: 1, failed: 0, cacheHit: 0 },
+      status: 'ok',
     });
   });
 
-  it('mcp-smithery-rank publishes a disabled aggregate when Smithery key is missing', async () => {
+  it('mcp-smithery-rank uses anonymous Smithery reads when the key is missing', async () => {
     process.env.NODE_ENV = 'test';
     delete process.env.SMITHERY_API_KEY;
+    const ctx = makeContext();
+    ctx.http.json = vi.fn(async () => ({
+      data: {
+        servers: [
+          {
+            qualifiedName: '@modelcontextprotocol/server-github',
+            id: 'github',
+            namespace: '@modelcontextprotocol',
+            slug: 'server-github',
+          },
+        ],
+        pagination: { totalPages: 1, totalCount: 1 },
+      },
+      cached: false,
+    }));
 
     const { default: fetcher } = await import('../../src/fetchers/mcp-smithery-rank/index.js');
-    const result = await fetcher.run(makeContext());
+    const result = await fetcher.run(ctx);
 
     expect(result.redisPublished).toBe(true);
+    expect(result.metricsWritten).toBe(2);
+    expect(ctx.http.json).toHaveBeenCalledWith(
+      'https://registry.smithery.ai/servers?page=1&pageSize=100',
+      { timeoutMs: 20_000 },
+    );
     expect(readPayload('mcp-smithery-rank')).toMatchObject({
-      total: 0,
-      summary: {},
-      status: 'disabled',
-      reason: 'missing_smithery_api_key',
+      total: 1,
+      summary: {
+        '@modelcontextprotocol/server-github': {
+          rank: 1,
+          total: 1,
+          qualifiedName: '@modelcontextprotocol/server-github',
+        },
+      },
+      status: 'ok',
     });
   });
 


### PR DESCRIPTION
## Summary
- let mcp-smithery-rank read the public Smithery registry when SMITHERY_API_KEY is absent
- let npm-dependents read anonymous Libraries.io package counts when LIBRARIES_IO_API_KEY is absent
- update side-channel fetcher tests to cover anonymous fallback output

## Validation
- npm --prefix apps\\trendingrepo-worker run test -- tests/fetchers/advisory-sidechannels.test.ts
- npm --prefix apps\\trendingrepo-worker run typecheck
- git diff --check
- npm run lint:guards
- npm run typecheck
- npm audit --audit-level=high