### PR TITLE
fix(worker): read published mcp package fields

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/npm-dependents/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/npm-dependents/index.ts
@@ -39,6 +39,8 @@ interface RosterMcpItem {
   slug?: string;
   id?: string;
   url?: string;
+  package_name?: string | null;
+  package_registry?: string | null;
   raw?: Record<string, unknown> & { package_name?: string; package_registry?: string };
 }
 
@@ -182,6 +184,12 @@ async function publishAggregate(
 }
 
 function extractNpmPackage(it: RosterMcpItem): string | null {
+  const topLevel = typeof it.package_name === 'string' ? it.package_name : null;
+  const topLevelRegistry = typeof it.package_registry === 'string' ? it.package_registry.toLowerCase() : null;
+  if (topLevel && (topLevelRegistry === 'npm' || topLevelRegistry === null)) {
+    return normalizePkg(topLevel);
+  }
+
   const raw = (it.raw ?? {}) as Record<string, unknown>;
   const direct = typeof raw.package_name === 'string' ? raw.package_name : null;
   const registry = typeof raw.package_registry === 'string' ? raw.package_registry : null;

--- a/apps/trendingrepo-worker/tests/fetchers/advisory-sidechannels.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/advisory-sidechannels.test.ts
@@ -142,7 +142,9 @@ describe('advisory side-channel fetchers', () => {
       items: [
         {
           slug: 'context7',
-          raw: { package_name: '@upstash/context7', package_registry: 'npm' },
+          package_name: '@upstash/context7',
+          package_registry: 'npm',
+          raw: { sources: ['official'] },
         },
       ],
     });


### PR DESCRIPTION
## Summary
- teach npm-dependents to read package_name/package_registry from the published trending-mcp item shape
- keep raw nested package fallback for older payloads
- update the side-channel test to cover the current published payload contract

## Validation
- npm --prefix apps\\trendingrepo-worker run test -- tests/fetchers/advisory-sidechannels.test.ts
- npm --prefix apps\\trendingrepo-worker run typecheck
- git diff --check
- npm run lint:guards
- npm run typecheck
- npm audit --audit-level=high