### PR TITLE
fix(worker): mark empty mcp dependents aggregate

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/npm-dependents/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/npm-dependents/index.ts
@@ -100,6 +100,17 @@ const fetcher: Fetcher = {
       seenPkgs.add(pkg);
     }
     ctx.log.info({ roster: items.length, npmPackages: seenPkgs.size }, 'npm-dependents targets resolved');
+    if (seenPkgs.size === 0) {
+      ctx.log.warn({ roster: items.length }, 'npm-dependents found no npm package coordinates');
+      const redisPublished = await publishAggregate('empty', 'no_npm_packages', {
+        roster: items.length,
+        npmPackages: 0,
+        ok: 0,
+        failed: 0,
+        cacheHit: 0,
+      });
+      return done(startedAt, items.length, redisPublished, []);
+    }
 
     const pkgResults = new Map<string, number>();
     let ok = 0;

--- a/apps/trendingrepo-worker/tests/fetchers/advisory-sidechannels.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/advisory-sidechannels.test.ts
@@ -173,6 +173,34 @@ describe('advisory side-channel fetchers', () => {
     });
   });
 
+  it('npm-dependents publishes an empty aggregate when the roster has no npm package coordinates', async () => {
+    process.env.NODE_ENV = 'test';
+    delete process.env.LIBRARIES_IO_API_KEY;
+    seedPayload('trending-mcp', {
+      items: [
+        {
+          slug: 'smithery-only',
+          url: 'https://smithery.invalid/example',
+          raw: { sources: ['smithery'] },
+        },
+      ],
+    });
+
+    const { default: fetcher } = await import('../../src/fetchers/npm-dependents/index.js');
+    const result = await fetcher.run(makeContext());
+
+    expect(result.redisPublished).toBe(true);
+    expect(result.itemsSeen).toBe(1);
+    expect(result.metricsWritten).toBe(0);
+    expect(mockState.fetchJsonWithRetry).not.toHaveBeenCalled();
+    expect(readPayload('mcp-dependents')).toMatchObject({
+      summary: {},
+      counts: { roster: 1, npmPackages: 0, ok: 0, failed: 0, cacheHit: 0 },
+      status: 'empty',
+      reason: 'no_npm_packages',
+    });
+  });
+
   it('mcp-smithery-rank uses anonymous Smithery reads when the key is missing', async () => {
     process.env.NODE_ENV = 'test';
     delete process.env.SMITHERY_API_KEY;


### PR DESCRIPTION
## Summary
- publish mcp-dependents as empty/no_npm_packages when the live MCP roster has no npm package coordinates
- avoid a misleading empty ok aggregate when no Libraries.io calls can be made
- add a regression test for Smithery/Glama-only MCP rosters

## Validation
- npm --prefix apps\\trendingrepo-worker run test -- tests/fetchers/advisory-sidechannels.test.ts
- npm --prefix apps\\trendingrepo-worker run typecheck
- git diff --check
- npm run lint:guards
- npm run typecheck
- npm audit --audit-level=high