### PR TITLE
fix(actions): drop inline gh pr merge --auto from git-commit-data (Twitter root cause)

### DIFF
--- a/.github/actions/git-commit-data/action.yml
+++ b/.github/actions/git-commit-data/action.yml
@@ -1,10 +1,9 @@
-name: Commit data files via PR + auto-merge
+name: Commit data files via PR (async auto-merge via label)
 description: |
   Stage an explicit allowlist of paths, short-circuit if there is no diff,
-  commit on a unique data-bot branch, push that branch, open a PR against
-  main, and enable auto-merge (squash + delete-branch). The PR merges
-  automatically once the required "Typecheck, guards, tests, build, e2e"
-  status check passes.
+  commit on a unique data-bot branch, push that branch, and open a PR
+  against main with the `auto-merge` label so `auto-merge-bot.yml`
+  enables auto-merge asynchronously.
 
   Why this exists (AGN-858 / AGN-861): main is a protected branch — direct
   `git push origin main` from a workflow returns GH006. The previous
@@ -12,6 +11,17 @@ description: |
   on every attempt because the protection rule, not transient ref drift,
   was the blocker. Switching to PR + auto-merge respects the protection
   rule without requiring operator-side rule edits.
+
+  Hardening (2026-05-18, twitter-cancellation root cause): the action
+  USED to call `gh pr merge --auto` inline after `gh pr create`. That
+  call hung indefinitely when concurrent data PRs queued up — see
+  docs/forensic/twitter-cancellation-2026-05-17.md — which let the
+  90-minute job timeout fire on collectors that had already finished in
+  90 seconds. Fix: drop the inline `gh pr merge --auto` and rely on the
+  label-driven `auto-merge-bot.yml` workflow (triggered by
+  `pull_request_target` on label / open / sync) to enable auto-merge
+  out-of-band. Data branches still merge once required checks pass,
+  but the data-collection workflow exits cleanly within seconds.
 
   Path allowlist is required (CLAUDE.md anti-pattern: never `git add -A`).
   Calling workflows must declare:
@@ -42,9 +52,14 @@ inputs:
     required: false
     default: "data"
   pr-label:
-    description: Label applied to the auto-generated PR (must already exist on the repo, or be empty).
+    description: |
+      Comma-separated labels applied to the auto-generated PR. The
+      `auto-merge` label is what `auto-merge-bot.yml` keys on — drop it
+      only when you want the PR to sit open for manual review (e.g. a
+      one-off backfill that needs human eyes). The `automation` label
+      is purely descriptive for the activity feed.
     required: false
-    default: "automation"
+    default: "automation,auto-merge"
   ignore-missing:
     description: |
       When "true", missing paths in the allowlist are silently skipped
@@ -164,7 +179,7 @@ runs:
         # out of the activity feed but operators can click through to the
         # run for full logs.
         RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
-        PR_BODY=$(printf 'Automated data refresh from `%s`.\n\n- Files changed: %s\n- Run: %s\n\nAuto-merge enabled — merges once required status checks pass.\n' \
+        PR_BODY=$(printf 'Automated data refresh from `%s`.\n\n- Files changed: %s\n- Run: %s\n\nThe `auto-merge` label is set; `auto-merge-bot.yml` enables\nauto-merge asynchronously, which avoids the `gh pr merge --auto`\nhang surface that timed out Twitter collectors at 90 min (see\n`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once\nrequired status checks pass.\n' \
           "$WORKFLOW_NAME" "$FILES_CHANGED" "$RUN_URL")
 
         PR_CREATE_ARGS=(
@@ -184,18 +199,18 @@ runs:
         # point, so the data is durable — surface the failure as a
         # warning and let the operator open the PR manually rather than
         # failing the whole job (AGN-803 follow-up to AGN-858/861).
+        #
+        # Note (2026-05-18): we DELIBERATELY do NOT call `gh pr merge
+        # --auto` here. That call queues on required status checks and
+        # blocks the runner for up to the job timeout when many data
+        # PRs are open, which is what was killing collect-twitter.yml.
+        # The `auto-merge` label applied above triggers
+        # `auto-merge-bot.yml` (pull_request_target: labeled) which
+        # enables auto-merge in a separate, short-lived workflow — same
+        # end state, no blocking on this runner.
         if PR_URL=$(gh pr create "${PR_CREATE_ARGS[@]}" 2>&1); then
           echo "opened PR: $PR_URL"
-          # Enable auto-merge (squash, delete branch on merge). The PR
-          # will sit until the required "Typecheck, guards, tests,
-          # build, e2e" status check reports success, then merge
-          # automatically. If auto-merge isn't enabled at the repo
-          # level, this errors out and the PR stays open for human
-          # merge — surface that as a warning rather than failing the
-          # data-collection job.
-          if ! gh pr merge --auto --squash --delete-branch "$PR_URL"; then
-            echo "::warning::gh pr merge --auto failed for ${PR_URL} — PR is open but not set to auto-merge. Operator must enable repo-level auto-merge or merge manually."
-          fi
+          echo "auto-merge label applied — auto-merge-bot.yml will enable async."
         else
           echo "::warning::gh pr create failed for ${BRANCH}: ${PR_URL}. Data branch is pushed but no PR was opened. Operator must enable Settings → Actions → General → Workflow permissions → 'Allow GitHub Actions to create and approve pull requests', or open the PR manually from ${BRANCH}."
           PR_URL=""


### PR DESCRIPTION
## Summary

Root-cause fix for the Twitter cancellation pattern documented in \`docs/forensic/twitter-cancellation-2026-05-17.md\`. Yesterday's forensic doc identified that the actual collector finishes in **87 seconds** but the workflow hangs another **~88 minutes** until the 90-min timeout fires. The hang is here.

## Root cause

The composite action calls \`gh pr merge --auto --squash --delete-branch <PR_URL>\` synchronously, immediately after \`gh pr create\`. That call blocks on the required-status-checks queue. With 17 data-refresh workflows funnelling through this action, the queue saturates and the inline call sits until the workflow times out. All 17 workflows inherit the hang.

## Fix

Switch to label-driven async auto-merge:

- \`pr-label\` default flipped from \`"automation"\` to \`"automation,auto-merge"\`
- \`.github/workflows/auto-merge-bot.yml\` already listens for \`pull_request_target.labeled\` events with the \`auto-merge\` label and enables auto-merge in its own short-lived runner — **zero blocking** on the data collector
- Inline \`gh pr merge --auto\` block removed
- PR body updated to reference the forensic doc

## End-to-end behaviour after this change

1. Collector writes data
2. Action commits + pushes a unique branch
3. Action opens a PR with labels: \`automation\`, \`auto-merge\`
4. \`auto-merge-bot.yml\` fires on the labeled event, enables auto-merge
5. Required CI runs → PR merges automatically → branch deleted (squash)
6. **Collector workflow exits cleanly within seconds**, not 90 minutes later

## Blast radius

All 17 data-refresh workflows that call \`./.github/actions/git-commit-data\` inherit the fix without per-workflow changes:

- \`collect-twitter.yml\` (the original symptom)
- \`collect-funding.yml\`, \`scrape-trending.yml\`, \`cron-reddit-daily.yml\`
- \`cron-agent-commerce.yml\`, \`cron-freshness-check.yml\`, \`ping-mcp-liveness.yml\`
- \`promote-unknown-mentions.yml\`, \`refresh-reddit-baselines.yml\`
- \`run-shadow-scoring.yml\`, \`scrape-awesome-skills.yml\`
- \`scrape-huggingface.yml\` (+ -spaces / -datasets)
- \`sync-trustmrr.yml\`, \`sweep-cross-source-mentions.yml\`, \`sweep-staleness.yml\`
- \`check-profile-completion.yml\`

## Verification (post-merge)

\`\`\`bash
# Manual dispatch
gh workflow run collect-twitter.yml --ref main --field limit=10 --field mode=direct --field dry_run=false

# Watch
gh run view <RUN_ID> --log

# Verify:
# 1. Collector run completes in under 5 min (was timing out at 90)
# 2. Resulting PR has labels: automation, auto-merge
# 3. auto-merge-bot.yml shows a run that enabled auto-merge
# 4. PR auto-merges once required checks pass
\`\`\`

## Risk

Low. The async auto-merge path was already wired (auto-merge-bot.yml has been present and listening for some time); this change just stops the data-collection runner from doing the same job synchronously. Worst case if auto-merge-bot fails: PRs stay open with the auto-merge label and an operator clicks the merge button — same end state, just human-paced. No data loss possible since the data branch is already pushed when this step exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)