### PR TITLE
chore(ci): pre-push hook running auth-provider-policy sentinel

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# .githooks/pre-push — defence-in-depth gate for the auth-provider-policy
+# regression sentinel (see src/lib/__tests__/auth-provider-policy.test.ts).
+#
+# Why this hook exists (2026-05-18 hardening, after WelcomeModalGate
+# regression took main red for ~2 hours on 2026-05-17):
+#
+#   The test is REQUIRED in CI but only catches violations once a PR is
+#   open. The full `npm test` suite runs ~5 minutes, so contributors
+#   often skip it locally. A violation can therefore land on a PR,
+#   trigger a 5-minute CI run, fail, get hotfixed, get pushed again —
+#   easily 30 minutes of cycle time for what is fundamentally a
+#   one-line allow-list omission.
+#
+#   This hook runs JUST the auth-provider-policy test on `git push`.
+#   The test is pure file I/O over the src/ tree (no DB, no network),
+#   completes in under 1 second on a warm cache, and rejects the push
+#   if the policy is violated.
+#
+# Activation (one-time, per local checkout):
+#   npm run hooks:install
+#
+# Bypass (rare, only for emergency main-only ops pushes):
+#   git push --no-verify
+#
+# This hook NEVER runs in CI — Vercel and GitHub Actions checkouts do
+# not execute git hooks. It is purely a local-laptop guardrail.
+
+set -euo pipefail
+
+# Skip if we're inside a CI environment that somehow ran git push
+# (defensive — Vercel + Actions don't set core.hooksPath to .githooks,
+# but a contributor running CI locally via `act` might).
+if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  exit 0
+fi
+
+# Quick sanity check that node + the project root are reachable.
+if ! command -v node >/dev/null 2>&1; then
+  echo "[pre-push] node not on PATH — skipping policy check"
+  echo "[pre-push] (this is a soft-skip; CI will catch any regression)"
+  exit 0
+fi
+
+TEST_FILE="src/lib/__tests__/auth-provider-policy.test.ts"
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "[pre-push] $TEST_FILE missing — skipping policy check"
+  exit 0
+fi
+
+echo "[pre-push] running auth-provider-policy regression sentinel..."
+
+# Run JUST the policy test. node --test on a single .ts file relies on
+# Node's experimental TS support OR tsx — try tsx first because it's
+# already a dependency for the existing npm test pipeline.
+if command -v npx >/dev/null 2>&1; then
+  if npx --no-install tsx --test "$TEST_FILE" >/dev/null 2>&1; then
+    echo "[pre-push] auth-provider-policy: OK"
+    exit 0
+  fi
+fi
+
+# Re-run with output visible so the contributor sees what failed.
+echo "[pre-push] policy test failed. Re-running with full output:"
+npx --no-install tsx --test "$TEST_FILE"
+echo
+echo "[pre-push] push BLOCKED. Fix the violation above or add the file"
+echo "[pre-push] to the ALLOW_LIST in $TEST_FILE."
+echo "[pre-push] Emergency bypass: git push --no-verify"
+exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,14 @@ Thanks for your interest. This guide gets you from clone to a merged PR.
 git clone https://github.com/0motionguy/starscreener.git
 cd starscreener
 npm install
+npm run hooks:install        # arm the local pre-push policy gate (one-time)
 cp .env.example .env.local   # then fill in the required values
 npm run dev                  # starts at http://localhost:3023
 ```
+
+### Pre-push policy gate
+
+`npm run hooks:install` points `core.hooksPath` at `.githooks/`. The committed `.githooks/pre-push` runs **only** the auth-provider-policy regression sentinel (`src/lib/__tests__/auth-provider-policy.test.ts`) — under one second — and refuses to push if any client component imports a Clerk hook without the sanctioned `authEnabled` gate. CI catches the same violation but only after a five-minute round trip; the hook catches it before the push leaves your laptop. Emergency bypass: `git push --no-verify`.
 
 ## Where things live
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lint:img-lazy": "node scripts/check-img-lazy.mjs",
     "lint:keep-last-50": "node scripts/check-collector-keep-last-50.mjs",
     "lint:routes-config": "node scripts/check-routes-config.mjs",
+    "hooks:install": "node scripts/install-githooks.mjs",
     "verify:pool-throughput": "node scripts/verify-pool-throughput.mjs",
     "verify:sentry-wiring": "node scripts/verify-sentry-wiring.mjs",
     "lint:guards": "npm run lint:tokens && npm run lint:err-message && npm run lint:zod-routes && npm run lint:runtime && npm run lint:api-cache && npm run lint:err-envelope && npm run lint:v3-budget && npm run lint:bypass && npm run lint:img-lazy && npm run lint:keep-last-50 && npm run lint:routes-config",

--- a/scripts/install-githooks.mjs
+++ b/scripts/install-githooks.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// scripts/install-githooks.mjs
+//
+// One-time setup: point `core.hooksPath` at `.githooks/` so the
+// committed pre-push hook fires on `git push`. Run via:
+//     npm run hooks:install
+//
+// We deliberately avoid `husky` to keep dev-dep weight down — the
+// hook script is tiny, lives in version control, and self-skips in CI
+// environments. See `.githooks/pre-push` header comment for why this
+// gate exists in the first place.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+function run(cmd, args) {
+  return execFileSync(cmd, args, { encoding: "utf-8" }).trim();
+}
+
+try {
+  const root = run("git", ["rev-parse", "--show-toplevel"]);
+  const hooksDir = join(root, ".githooks");
+  if (!existsSync(hooksDir)) {
+    console.error(`[hooks:install] ${hooksDir} not found — wrong cwd?`);
+    process.exit(1);
+  }
+  run("git", ["config", "core.hooksPath", ".githooks"]);
+  console.log("[hooks:install] core.hooksPath -> .githooks");
+  console.log("[hooks:install] pre-push: auth-provider-policy sentinel armed");
+  console.log("[hooks:install] bypass with: git push --no-verify");
+} catch (err) {
+  console.error("[hooks:install] failed:", err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Closes the local-gate gap surfaced in the 2026-05-18 CI defence-in-depth audit. The auth-provider-policy regression sentinel is REQUIRED in CI but only catches violations after a PR opens and the full ~5-minute test job completes. A contributor who pushes a \`useUser\`-without-\`authEnabled\`-prop client component therefore burns a full CI cycle on what is fundamentally a one-line allow-list omission. On 2026-05-17 this cost ~2 hours of red main while #1634 hotfixed WelcomeModalGate.

## Fix

Fast LOCAL gate that runs ONLY the policy test on \`git push\` (<1s, no DB, no network). The hook is committed under \`.githooks/\` instead of being installed via husky to keep dev-dep weight at zero — one \`npm run hooks:install\` configures \`core.hooksPath\` and the hook is armed.

## Hook lifecycle

- Self-skips in CI environments (\`CI\`/\`GITHUB_ACTIONS\` env)
- Soft-skips if \`node\` or the test file is missing
- Otherwise runs \`npx tsx --test src/lib/__tests__/auth-provider-policy.test.ts\`
- On failure: re-runs with verbose output and exits 1
- Emergency bypass: \`git push --no-verify\`

## Files

- \`.githooks/pre-push\` (new) — the hook itself
- \`scripts/install-githooks.mjs\` (new) — one-time \`core.hooksPath\` setup
- \`package.json\` — new \`hooks:install\` script
- \`CONTRIBUTING.md\` — onboarding step explaining the gate

## Test plan

- [x] \`npm run hooks:install\` succeeded
- [x] \`bash .githooks/pre-push\` returned \"auth-provider-policy: OK\"
- [ ] Operator runs \`npm run hooks:install\` once per local checkout
- [ ] Future regression of WelcomeModalGate-style violation should now fail at \`git push\`, not on PR CI 5 minutes later

## Why no husky

Husky 9 is fine but it adds a dev-dep, a postinstall side-effect, and a \`.husky/\` directory with shim scripts. None of that is necessary when we only need one hook running one test. A 70-line shell script + a 35-line installer is smaller and easier to audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)