### PR TITLE
chore(workflows): remove last live APIFY_API_TOKEN reference (policy alignment)

### DIFF
--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -61,18 +61,15 @@ jobs:
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
         run: npm --prefix apps/trendingrepo-worker run fetcher -- crunchbase
-      # 2026-05-17: DISABLED — APIFY policy off (see docs/POLICY-NO-APIFY.md).
-      # The x-funding fetcher in apps/trendingrepo-worker uses Apify to scrape
-      # X/Twitter funding mentions. Step is gated `if: false` so the schedule
-      # keeps running for the RSS + Crunchbase + SEC paths (all free) while
-      # the Apify-only step is skipped. Restore by changing `if:` back to the
-      # dry-run guard ONLY after operator sign-off on the Apify budget.
-      - if: false
-        name: Refresh X funding side-channel (DISABLED — Apify off)
-        env:
-          REDIS_URL: ${{ secrets.REDIS_URL }}
-          APIFY_API_TOKEN: ${{ secrets.APIFY_API_TOKEN }}
-        run: npm --prefix apps/trendingrepo-worker run fetcher -- x-funding
+      # 2026-05-18: REMOVED — APIFY policy permanently off (see
+      # docs/POLICY-NO-APIFY.md). The x-funding fetcher in
+      # apps/trendingrepo-worker used Apify to scrape X/Twitter funding
+      # mentions. The step was previously gated `if: false`; the dead
+      # secret reference (APIFY_API_TOKEN) was the last live tie between
+      # this workflow and the disabled vendor.
+      #
+      # Restore-path if Apify is ever re-approved: revert this commit AND
+      # confirm the operator-budget decision in docs/POLICY-NO-APIFY.md.
       - if: github.event.inputs.dry_run != 'true'
         name: Commit if changed
         # Step-level timeout — git-commit-data invokes `gh pr merge --auto`

--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -85,10 +85,12 @@ jobs:
           # `apidojo/tweet-scraper` actor returned 0 posts on every query for
           # the prior ~2 weeks (last run with non-empty payload was
           # 2026-04-23). 2026-05-17: APIFY operator policy off (see
-          # docs/POLICY-NO-APIFY.md) — `nitter` is now the permanent default
-          # and the APIFY_API_TOKEN env below is intentionally a no-op
-          # (stripped). Re-enabling Apify requires reverting this commit AND
-          # operator sign-off.
+          # docs/POLICY-NO-APIFY.md) — `nitter` is now the permanent default.
+          # 2026-05-18: APIFY_API_TOKEN env reference removed from this
+          # workflow entirely (was already stripped from the env block; the
+          # stale "env below" comment now accurately describes "no env").
+          # Re-enabling Apify requires reverting these commits AND operator
+          # sign-off.
           TWITTER_COLLECTOR_PROVIDER: ${{ vars.TWITTER_COLLECTOR_PROVIDER || 'nitter' }}
           # "direct" writes to .data/twitter-*.jsonl locally (so we can commit
           # them back to main). "api" would POST to Vercel's ingest endpoint,
@@ -113,9 +115,11 @@ jobs:
           TWITTER_COLLECTOR_REPOS: ${{ github.event.inputs.repos || '' }}
           TWITTER_COLLECTOR_BASE_URL: ${{ vars.TRENDINGREPO_URL || vars.STARSCREENER_URL || 'https://trendingrepo.com' }}
           INTERNAL_AGENT_TOKEN: ${{ secrets.INTERNAL_AGENT_TOKEN }}
-          # 2026-05-17: APIFY_API_TOKEN + APIFY_TWITTER_ACTOR intentionally
-          # NOT passed (operator policy off — docs/POLICY-NO-APIFY.md). The
-          # collector now relies on nitter primary + cookies-web fallback.
+          # APIFY_API_TOKEN + APIFY_TWITTER_ACTOR are NOT passed (operator
+          # policy permanently off as of 2026-05-17 — see
+          # docs/POLICY-NO-APIFY.md). Collector relies on nitter primary +
+          # cookies-web fallback. 2026-05-18 cleanup: this comment is the
+          # only remaining trace; no env declarations to remove.
           TWITTER_WEB_ACCOUNTS_JSON: ${{ secrets.TWITTER_WEB_ACCOUNTS_JSON }}
           TWITTER_GRAPHQL_SEARCH_QUERY_ID: ${{ vars.TWITTER_GRAPHQL_SEARCH_QUERY_ID }}
           # TWITTER_WEB_DEBUG: "1"  # uncomment when diagnosing empty responses


### PR DESCRIPTION
Aligns workflow surface with `docs/POLICY-NO-APIFY.md`. The `if: false` dead step in `collect-funding.yml` still passed `APIFY_API_TOKEN` to a never-running fetcher — the last live tie between any workflow and the disabled vendor. Remove the entire step + refresh stale comments in `collect-twitter.yml` that referenced an env var that had already been stripped.

After this PR: zero live `APIFY_*` env declarations across `.github/workflows/`; only doc comments remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)