### PR TITLE
[codex] schedule webhook dead-letter digest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,23 @@ SENTRY_PROJECT=trendingrepo
 # exhaustion) can post a best-effort JSON alert here.
 # OPS_ALERT_WEBHOOK=https://hooks.slack.com/services/...
 
+# Direct Slack ops notifications used by cron digests and customer webhook
+# dead-letter summaries. DEFAULT is fallback, OPS is internal, CUSTOMER_OPS is
+# for customer-impacting delivery failures, SIGNALS is optional source noise.
+# SLACK_WEBHOOK_DEFAULT=
+# SLACK_WEBHOOK_OPS=
+# SLACK_WEBHOOK_CUSTOMER_OPS=
+# SLACK_WEBHOOK_SIGNALS=
+# SLACK_WEBHOOK_CRITICAL=
+# SLACK_ONCALL_USER_IDS=U12345678,U23456789
+# SLACK_QUIET_HOURS_RANGE=22:00-07:00
+# SLACK_QUIET_HOURS_TZ=Europe/Berlin
+# SLACK_RATE_LIMIT_PER_SOURCE=20
+# SLACK_RATE_LIMIT_WINDOW_SECONDS=600
+
+# Optional Healthchecks.io ping URL for the webhook dead-letter digest route.
+# HEALTHCHECK_WEBHOOKS_DEAD_LETTER_DIGEST=https://hc-ping.com/<uuid>
+
 # -- Optional: Google PageSpeed Insights -------------------------------------
 # Google PageSpeed Insights API key for `npm run lighthouse:routes:prod`.
 # Get one at https://developers.google.com/speed/docs/insights/v5/get-started

--- a/.github/workflows/cron-webhooks-dead-letter-digest.yml
+++ b/.github/workflows/cron-webhooks-dead-letter-digest.yml
@@ -1,0 +1,52 @@
+name: Cron - webhooks dead-letter digest
+
+# Daily ops digest for end-user webhook deliveries that exhausted retry budget.
+# Required repo config:
+#   secrets.CRON_SECRET    - must match server CRON_SECRET env
+#   vars.TRENDINGREPO_URL - optional; defaults to prod URL
+
+on:
+  schedule:
+    - cron: "9 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cron-webhooks-dead-letter-digest
+  cancel-in-progress: false
+
+env:
+  BASE_URL: ${{ vars.TRENDINGREPO_URL || vars.STARSCREENER_URL || 'https://trendingrepo.com' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: GET /api/cron/webhooks/dead-letter-digest
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET is unset - refusing to fire unauthenticated"
+            exit 1
+          fi
+
+          code=$(curl -sS -o /tmp/dead-letter-digest-out -w "%{http_code}" \
+            "$BASE_URL/api/cron/webhooks/dead-letter-digest" \
+            -H "Authorization: Bearer $CRON_SECRET")
+
+          echo "DEAD LETTER DIGEST HTTP $code"
+          if command -v jq >/dev/null 2>&1 && jq . /tmp/dead-letter-digest-out >/dev/null 2>&1; then
+            jq . /tmp/dead-letter-digest-out | head -c 2000
+          else
+            head -c 2000 /tmp/dead-letter-digest-out
+          fi
+          echo
+
+          if [ "$code" != "200" ]; then
+            echo "::error::cron/webhooks/dead-letter-digest call failed ($code)"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ The pipeline's recurring work (ingest, persist, cleanup, rebuild, predictions, A
 | `0,30 * * * *`   | `/api/cron/aiso-drain`           | Drain AISO rescan queue (every 30 min)      |
 | `5,35 * * * *`   | `/api/cron/webhooks/scan`        | Enqueue breakout + funding webhook deliveries |
 | `10,40 * * * *`  | `/api/cron/webhooks/flush`       | Drain Slack / Discord webhook queue         |
+| `9 9 * * *`      | `/api/cron/webhooks/dead-letter-digest` | Summarize failed customer webhook deliveries |
 | `*/15 * * * *`   | `/api/health`                    | Unauthed freshness / status probe           |
 
 ### Primary: GitHub Actions
@@ -389,6 +390,7 @@ Deliver breakout, funding, and (phase-2) revenue events to Slack or Discord as s
 
 1. `data/webhook-targets.json` holds a list of operator-configured targets. The scan cron (`/api/cron/webhooks/scan`, every 30 min at :05 / :35) reads the latest derived repos + funding feed and enqueues a row per matching target into `.data/webhook-queue.jsonl`. Enqueue is idempotent — the same (event, subject, target) tuple never duplicates.
 2. The flush cron (`/api/cron/webhooks/flush`, every 30 min at :10 / :40) drains the queue. 5s timeout per POST, 3s gap between POSTs to avoid rate limits. Non-2xx responses bump `attempts`; rows that hit 5 attempts move to `.data/webhook-dead-letter.jsonl` so the queue can drain forward.
+3. The dead-letter digest cron (`/api/cron/webhooks/dead-letter-digest`, daily at 09:09 UTC) reads the dead-letter JSONL file, aggregates recent rows by target/event, and posts a customer-ops Slack summary without exposing webhook URLs.
 
 **Add a Slack target:**
 

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -8,8 +8,8 @@ status: living
 
 Last derived from filesystem on 2026-05-05. Direct re-derivation:
 
-- Workflows: `Glob .github/workflows/*.yml` (count = 72)
-- Cron API routes: `Glob src/app/api/cron/**/route.ts` (count = 14)
+- Workflows: `Glob .github/workflows/*.yml` (count = 63)
+- Cron API routes: `Glob src/app/api/cron/**/route.ts` (count = 15)
 - Worker fetchers: `apps/trendingrepo-worker/src/registry.ts` (44 active in `FETCHERS[]`, all imported and exported; 4 stub directories — `huggingface`, `github`, `mcp-so`, `mcp-servers-repo` — kept on disk as documentation of intent (NOT imported, NOT in `FETCHERS[]`, NOT scheduled — see banner comment at `registry.ts:23-27`). They previously emitted "not yet implemented" Sentry warnings every cron tick; PR #93 unwired them but left the directories so a future port can re-add to the array. 3 implementations exist on disk and have full code + tests but are not yet wired: `ai-blogs`, `arxiv`, `github-events` (see banner comment at the top of each `index.ts` for the promotion path). `agent-commerce/` is data-only.)
 - Env vars: `.env.example` + `src/lib/env.ts` + `process.env.*` greps in `scripts/` and `apps/trendingrepo-worker/src/`
 
@@ -19,7 +19,7 @@ commit.
 
 ---
 
-## 1. GH Actions (.github/workflows/*.yml) - 72 files
+## 1. GH Actions (.github/workflows/*.yml) - 63 files
 
 Source: `Grep -E "^name:|cron:" .github/workflows/<file>.yml`. Only
 `schedule.cron` triggers + the workflow's primary `run:` line are shown.
@@ -49,6 +49,7 @@ Workflows with multiple cron entries list each.
 | cron-pipeline-rebuild.yml | Cron - pipeline rebuild | `0 5 * * 0` (Sun 05:00) | weekly mention store rebuild |
 | cron-twitter-outbound.yml | Cron - Twitter outbound | `0 14 * * *` and `0 16 * * 5` | POST `/api/cron/twitter-daily` (daily) or `/api/cron/twitter-weekly-recap` (Fri) |
 | cron-warmup.yml | Warm Vercel routes (25 public routes) | `*/5 8-21 * * *` | matrix probe via `node scripts/probe-route.mjs`, summarized into `cron-warmup-summary` artifact (30d retention). Captures status, TTFB, transfer size, `cache-control`, `x-vercel-cache`, `x-vercel-id`, `age`. Restored 2026-05-08 from `a4ea0628`. |
+| cron-webhooks-dead-letter-digest.yml | Cron - webhooks dead-letter digest | `9 9 * * *` | GET `/api/cron/webhooks/dead-letter-digest` and Slack-notify recent customer webhook delivery dead letters |
 | cron-webhooks-flush.yml | Cron - webhooks flush + scan | `5,35 * * * *` | POST `/api/cron/webhooks/scan` then `/api/cron/webhooks/flush` |
 | docs-freshness.yml | docs-freshness | `0 13 * * 1` (Mon 13:00) + PR | `node scripts/check-docs-freshness.mjs` |
 | enrich-arxiv.yml | Enrich arXiv signals | `13 */12 * * *` | `node scripts/enrich-arxiv.mjs` |
@@ -111,11 +112,11 @@ Workflows with multiple cron entries list each.
 
 Unclassified: none. Every workflow has a parsed `name:` and trigger.
 
-Total cron-driven workflows: 62. Push/PR-only or dispatch-only: 10.
+Total cron-driven workflows: 63. Push/PR-only or dispatch-only: 10.
 
 ---
 
-## 2. Cron API routes (src/app/api/cron/*/route.ts) - 14 routes
+## 2. Cron API routes (src/app/api/cron/*/route.ts) - 15 routes
 
 Source: `Glob src/app/api/cron/**/route.ts`. Caller workflow derived from
 `grep -r "/api/cron/<path>" .github/workflows/`.
@@ -132,6 +133,7 @@ Source: `Glob src/app/api/cron/**/route.ts`. Caller workflow derived from
 | `/api/cron/twitter-daily` | cron-twitter-outbound.yml (`0 14 * * *`) | Bearer `CRON_SECRET` | Daily outbound Twitter thread |
 | `/api/cron/twitter-weekly-recap` | cron-twitter-outbound.yml (`0 16 * * 5`) | Bearer `CRON_SECRET` | Friday weekly recap thread |
 | `/api/cron/webhooks/flush` | cron-webhooks-flush.yml (`5,35 * * * *`) | Bearer `CRON_SECRET` | Drains webhook queue |
+| `/api/cron/webhooks/dead-letter-digest` | cron-webhooks-dead-letter-digest.yml (`9 9 * * *`) | Bearer `CRON_SECRET` | Summarizes recent customer webhook delivery dead letters |
 | `/api/cron/webhooks/scan` | cron-webhooks-flush.yml (`5,35 * * * *`, runs before flush) | Bearer `CRON_SECRET` | Enqueues breakouts + funding rows |
 
 Auth pattern: every route uses `verifyCronAuth` (or equivalent) reading

--- a/docs/SITE-WIREMAP.md
+++ b/docs/SITE-WIREMAP.md
@@ -194,6 +194,7 @@ HF route note: the sidebar intentionally has one Hugging Face row (`/huggingface
 | cron-digest-weekly | Mon 8am | weekly digest | `/digest`, `/digest/[date]`, email digest via Resend |
 | cron-twitter-outbound | daily `0 14 * * *` | twitter-outbound-runs.jsonl | (worker side, replies / outbound reach) |
 | cron-webhooks-flush | every 30 min | webhook delivery | (server-side only) |
+| cron-webhooks-dead-letter-digest | daily `9 9 * * *` | webhook dead-letter digest | Slack ops notification only |
 | cron-aiso-drain | every 30 min | alert events delivery | `/alerts` events |
 | cron-mcp-usage-rotate | monthly day 1 | mcp-usage rolling window rotate | `/model-usage` |
 | ping-mcp-liveness | every 6h | mcp-liveness | `/mcp` liveness pill |

--- a/docs/handoffs/SESSION-KICKOFF-2026-05-19.md
+++ b/docs/handoffs/SESSION-KICKOFF-2026-05-19.md
@@ -8,6 +8,15 @@ Two prior sessions (2026-05-17 + 2026-05-18) shipped **17 PRs + 5 hardening PRs 
 
 **Stage 4 is what's left.** It is split across 5 implementation tracks (A–E), 6 operator items (which only the human can unblock), and ~12 stale bot data PRs to flush. Most of Stage 4 is small, surgical, and parallelisable.
 
+## 0.1 Execution addendum (2026-05-18 03:53 UTC)
+
+This kickoff was executed once after PR #1747 merged. Do not repeat the already-completed checks below.
+
+- **S4.A is DONE.** `collect-twitter.yml` run `26011938587` completed successfully from `2026-05-18T03:29:53Z` to `2026-05-18T03:32:11Z` (<3 min). It produced and auto-merged #1748 and #1749; `origin/main` then advanced again with #1750 to `7f7ab234a`.
+- **S4.D is still open.** The 12 pre-#1743 data PRs remain open with only the `automation` label: #1627, #1639, #1657, #1670, #1704, #1714, #1717, #1723, #1726, #1730, #1732, #1738.
+- **Additional ops hardening landed in the follow-up branch.** The branch adds a customer webhook dead-letter digest cron (`GET /api/cron/webhooks/dead-letter-digest` + GitHub Actions schedule), Slack customer-ops notifications, a reusable Healthchecks wrapper, dead-letter timestamps, tests, docs, and a `perf:bundle` fix for standalone Next manifests.
+- **Still remaining from the original code tracks:** S4.B account purge cron, S4.C full Lighthouse/PSI workflow wiring, and S4.E security-helper unit tests.
+
 ## 1. Paste-ready role prompt
 
 Copy everything in the fenced block below into the kickoff message of the fresh session.

--- a/scripts/perf-bundle.mjs
+++ b/scripts/perf-bundle.mjs
@@ -11,6 +11,8 @@
 // Defaults:
 //   routes config: perf/routes.json
 //   .next/app-build-manifest.json must exist (run `next build` first).
+//   For standalone builds, Next may leave the top-level manifest empty and
+//   write the app page chunk map to .next/standalone/.next instead.
 //
 // Exit codes:
 //   0  no violations
@@ -39,12 +41,20 @@ const strict = Boolean(args.strict);
 const topN = Number.parseInt(args.top ?? "10", 10);
 
 const NEXT_DIR = resolve(".next");
-const APP_MANIFEST = join(NEXT_DIR, "app-build-manifest.json");
-const BUILD_MANIFEST = join(NEXT_DIR, "build-manifest.json");
+const MANIFEST_CANDIDATES = [
+  {
+    app: join(NEXT_DIR, "app-build-manifest.json"),
+    build: join(NEXT_DIR, "build-manifest.json"),
+  },
+  {
+    app: join(NEXT_DIR, "standalone", ".next", "app-build-manifest.json"),
+    build: join(NEXT_DIR, "standalone", ".next", "build-manifest.json"),
+  },
+];
 
-if (!existsSync(APP_MANIFEST)) {
+if (!MANIFEST_CANDIDATES.some((candidate) => existsSync(candidate.app))) {
   console.error(
-    `error: ${APP_MANIFEST} not found. Run \`npm run build\` first.`,
+    `error: ${MANIFEST_CANDIDATES[0].app} not found. Run \`npm run build\` first.`,
   );
   process.exit(2);
 }
@@ -102,10 +112,42 @@ const FORBIDDEN = [
   },
 ];
 
-const appManifest = JSON.parse(readFileSync(APP_MANIFEST, "utf8"));
-const buildManifest = existsSync(BUILD_MANIFEST)
-  ? JSON.parse(readFileSync(BUILD_MANIFEST, "utf8"))
-  : null;
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function readManifestPair() {
+  const existing = [];
+  for (const candidate of MANIFEST_CANDIDATES) {
+    if (!existsSync(candidate.app)) continue;
+    const app = readJson(candidate.app);
+    const pages = app.pages ?? {};
+    existing.push({ ...candidate, appManifest: app });
+    if (Object.keys(pages).some((key) => key.endsWith("/page"))) {
+      return {
+        appManifest: app,
+        buildManifest: existsSync(candidate.build) ? readJson(candidate.build) : null,
+        appManifestPath: candidate.app,
+        buildManifestPath: existsSync(candidate.build) ? candidate.build : null,
+      };
+    }
+  }
+
+  const fallback = existing[0];
+  return {
+    appManifest: fallback.appManifest,
+    buildManifest: existsSync(fallback.build) ? readJson(fallback.build) : null,
+    appManifestPath: fallback.app,
+    buildManifestPath: existsSync(fallback.build) ? fallback.build : null,
+  };
+}
+
+const {
+  appManifest,
+  buildManifest,
+  appManifestPath,
+  buildManifestPath,
+} = readManifestPair();
 
 // Chunk → size cache (raw bytes from disk)
 const chunkSizeCache = new Map();
@@ -288,6 +330,8 @@ const largestChunks = [...allChunkSizes.entries()]
 
 const summary = {
   runAt: new Date().toISOString(),
+  appManifestPath,
+  buildManifestPath,
   routes: routeTotals.length,
   skippedRoutes,
   violations: violations.length,

--- a/src/app/api/cron/webhooks/dead-letter-digest/route.ts
+++ b/src/app/api/cron/webhooks/dead-letter-digest/route.ts
@@ -1,0 +1,224 @@
+// GET /api/cron/webhooks/dead-letter-digest
+//
+// Daily digest for end-user webhook deliveries that exhausted the retry
+// budget and moved to webhook-dead-letter.jsonl.
+
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "node:fs";
+
+import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
+import { serverError } from "@/lib/api/error-response";
+import { withHealthcheck } from "@/lib/healthcheck";
+import { notify, type NotifyResult } from "@/lib/notify";
+import { deadLetterLocation } from "@/lib/webhooks/publish";
+import type {
+  WebhookDelivery,
+  WebhookEvent,
+  WebhookProvider,
+} from "@/lib/webhooks/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const LOOKBACK_HOURS = 24;
+const MAX_SAMPLES = 5;
+const CACHE_HEADERS = {
+  "Cache-Control": "no-store",
+} as const;
+
+type DeadLetterRow = WebhookDelivery & {
+  finalizedAt?: string;
+};
+
+interface DigestResult {
+  recent: number;
+  total: number;
+  byEvent: Partial<Record<WebhookEvent, number>>;
+  byTarget: Record<string, number>;
+  samples: Array<{
+    event: WebhookEvent;
+    target: string;
+    attempts: number;
+    lastError: string | null;
+  }>;
+}
+
+interface DigestResponse extends DigestResult {
+  ok: true;
+  notify?: NotifyResult;
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+function isWebhookProvider(value: unknown): value is WebhookProvider {
+  return value === "slack" || value === "discord";
+}
+
+function isWebhookEvent(value: unknown): value is WebhookEvent {
+  return value === "breakout" || value === "funding" || value === "revenue";
+}
+
+function parseDeadLetterRow(value: unknown): DeadLetterRow | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Partial<DeadLetterRow>;
+  if (typeof row.id !== "string") return null;
+  if (typeof row.dedupKey !== "string") return null;
+  if (typeof row.targetId !== "string") return null;
+  if (!isWebhookProvider(row.provider)) return null;
+  if (!isWebhookEvent(row.event)) return null;
+  if (typeof row.createdAt !== "string") return null;
+  if (typeof row.attempts !== "number" || !Number.isFinite(row.attempts)) return null;
+  return row as DeadLetterRow;
+}
+
+async function readDeadLetterRows(): Promise<DeadLetterRow[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(deadLetterLocation(), "utf8");
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    throw err;
+  }
+
+  const rows: DeadLetterRow[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const row = parseDeadLetterRow(JSON.parse(line));
+      if (row) rows.push(row);
+    } catch {
+      console.warn("[webhooks:dead-letter-digest] skipping malformed dead-letter line");
+    }
+  }
+  return rows;
+}
+
+function timestampMs(row: DeadLetterRow): number | null {
+  const raw = row.deadLetteredAt ?? row.finalizedAt ?? row.createdAt;
+  const ts = Date.parse(raw);
+  return Number.isFinite(ts) ? ts : null;
+}
+
+function targetKey(row: DeadLetterRow): string {
+  return `${row.provider}:${row.targetId}`;
+}
+
+function buildDigest(rows: DeadLetterRow[], now = Date.now()): DigestResult {
+  const cutoff = now - LOOKBACK_HOURS * 60 * 60 * 1000;
+  const recentRows = rows.filter((row) => {
+    const ts = timestampMs(row);
+    return ts !== null && ts >= cutoff;
+  });
+
+  const byEvent: Partial<Record<WebhookEvent, number>> = {};
+  const byTarget: Record<string, number> = {};
+  for (const row of recentRows) {
+    byEvent[row.event] = (byEvent[row.event] ?? 0) + 1;
+    const key = targetKey(row);
+    byTarget[key] = (byTarget[key] ?? 0) + 1;
+  }
+
+  const samples = recentRows.slice(0, MAX_SAMPLES).map((row) => ({
+    event: row.event,
+    target: targetKey(row),
+    attempts: row.attempts,
+    lastError: row.lastError ? row.lastError.slice(0, 120) : null,
+  }));
+
+  return {
+    recent: recentRows.length,
+    total: rows.length,
+    byEvent,
+    byTarget,
+    samples,
+  };
+}
+
+function formatCountLines(counts: Record<string, number>): string {
+  const lines = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([name, count]) => `* \`${name}\`: ${count}`);
+  return lines.length > 0 ? lines.join("\n") : "* none";
+}
+
+function formatSampleLines(samples: DigestResult["samples"]): string {
+  if (samples.length === 0) return "* none";
+  return samples
+    .map((sample) => {
+      const err = sample.lastError ? ` - ${sample.lastError}` : "";
+      return `* \`${sample.event}\` -> \`${sample.target}\` (${sample.attempts} attempts)${err}`;
+    })
+    .join("\n");
+}
+
+async function handle(request: NextRequest): Promise<NextResponse> {
+  const deny = authFailureResponse(verifyCronAuth(request));
+  if (deny) return deny;
+
+  const oversize = withBodySizeLimit(request);
+  if (oversize) return oversize;
+
+  try {
+    const rows = await readDeadLetterRows();
+    const digest = buildDigest(rows);
+    let notifyResult: NotifyResult | undefined;
+
+    if (digest.recent > 0) {
+      notifyResult = await notify({
+        severity: "ops",
+        audience: "customer",
+        source: "webhook.dead-letter.digest",
+        title: `${digest.recent} end-user webhook delivery failures (24h)`,
+        message: [
+          `*${digest.recent}* end-user webhook deliveries failed in the last 24h.`,
+          `Total dead-letter rows: *${digest.total}*.`,
+          "",
+          "*By target:*",
+          formatCountLines(digest.byTarget),
+          "",
+          "*By event:*",
+          formatCountLines(digest.byEvent as Record<string, number>),
+          "",
+          `*Sample failures (${digest.samples.length}):*`,
+          formatSampleLines(digest.samples),
+          "",
+          "_Source: webhook-dead-letter.jsonl. Target IDs are shown; webhook URLs are intentionally omitted._",
+        ].join("\n"),
+        context: {
+          recentCount: digest.recent,
+          totalRows: digest.total,
+          byTarget: digest.byTarget,
+          byEvent: digest.byEvent,
+          sampleCount: digest.samples.length,
+        },
+        idempotencyKey: `dead-letter-digest:${new Date().toISOString().slice(0, 10)}`,
+      });
+    }
+
+    const body: DigestResponse = {
+      ok: true,
+      ...digest,
+      ...(notifyResult ? { notify: notifyResult } : {}),
+    };
+    return NextResponse.json(body, { headers: CACHE_HEADERS });
+  } catch (err) {
+    return serverError(err, {
+      scope: "[api:cron:webhooks:dead-letter-digest]",
+      publicMessage: "dead letter digest failed",
+      code: "DEAD_LETTER_DIGEST_FAILED",
+    });
+  }
+}
+
+const handler = withHealthcheck("webhooks-dead-letter-digest", handle);
+
+export const GET = handler;

--- a/src/lib/__tests__/cron-route-typed-error-contract.test.ts
+++ b/src/lib/__tests__/cron-route-typed-error-contract.test.ts
@@ -24,6 +24,7 @@ const ROUTES: CronRouteCase[] = [
   { name: "news-auto-recover", path: "/api/cron/news-auto-recover", method: "POST", modulePath: "@/app/api/cron/news-auto-recover/route" },
   { name: "twitter-daily", path: "/api/cron/twitter-daily", method: "POST", modulePath: "@/app/api/cron/twitter-daily/route" },
   { name: "twitter-weekly-recap", path: "/api/cron/twitter-weekly-recap", method: "POST", modulePath: "@/app/api/cron/twitter-weekly-recap/route" },
+  { name: "webhooks-dead-letter-digest", path: "/api/cron/webhooks/dead-letter-digest", method: "GET", modulePath: "@/app/api/cron/webhooks/dead-letter-digest/route" },
   { name: "webhooks-flush", path: "/api/cron/webhooks/flush", method: "POST", modulePath: "@/app/api/cron/webhooks/flush/route" },
   { name: "webhooks-scan", path: "/api/cron/webhooks/scan", method: "POST", modulePath: "@/app/api/cron/webhooks/scan/route" },
 ];

--- a/src/lib/__tests__/healthcheck.test.ts
+++ b/src/lib/__tests__/healthcheck.test.ts
@@ -1,0 +1,104 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { withHealthcheck } from "@/lib/healthcheck";
+
+const ORIGINAL_ENV = {
+  CRON_SECRET: process.env.CRON_SECRET,
+  HEALTHCHECK_WEBHOOKS_TEST: process.env.HEALTHCHECK_WEBHOOKS_TEST,
+};
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function restoreEnv(): void {
+  for (const key of Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  globalThis.fetch = ORIGINAL_FETCH;
+}
+
+function request(auth = "Bearer cron-secret"): Request {
+  return new Request("https://trendingrepo.com/api/cron/webhooks/test", {
+    headers: { authorization: auth },
+  });
+}
+
+test.beforeEach(() => {
+  restoreEnv();
+  process.env.CRON_SECRET = "cron-secret";
+  process.env.HEALTHCHECK_WEBHOOKS_TEST = "https://hc-ping.com/check-id";
+});
+
+test.after(() => {
+  restoreEnv();
+});
+
+test("withHealthcheck pings start and success for authorized successful runs", async () => {
+  const calls: Array<{ url: string; body: string }> = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), body: String(init?.body ?? "") });
+    return new Response("ok", { status: 200 });
+  };
+
+  const handler = withHealthcheck("webhooks-test", async () => Response.json({ ok: true }));
+  const res = await handler(request());
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(calls, [
+    { url: "https://hc-ping.com/check-id/start", body: "" },
+    { url: "https://hc-ping.com/check-id", body: "Route webhooks-test returned 200" },
+  ]);
+});
+
+test("withHealthcheck pings failure for authorized non-ok responses", async () => {
+  const calls: Array<{ url: string; body: string }> = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), body: String(init?.body ?? "") });
+    return new Response("ok", { status: 200 });
+  };
+
+  const handler = withHealthcheck("webhooks-test", async () => new Response("no", { status: 500 }));
+  const res = await handler(request());
+
+  assert.equal(res.status, 500);
+  assert.deepEqual(calls, [
+    { url: "https://hc-ping.com/check-id/start", body: "" },
+    { url: "https://hc-ping.com/check-id/fail", body: "Route webhooks-test returned 500" },
+  ]);
+});
+
+test("withHealthcheck skips pings for unauthorized cron probes", async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response("ok", { status: 200 });
+  };
+
+  const handler = withHealthcheck("webhooks-test", async () => new Response("no", { status: 401 }));
+  const res = await handler(request("Bearer wrong-secret"));
+
+  assert.equal(res.status, 401);
+  assert.equal(calls, 0);
+});
+
+test("withHealthcheck reports thrown handler failures without swallowing the error", async () => {
+  const calls: Array<{ url: string; body: string }> = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), body: String(init?.body ?? "") });
+    return new Response("ok", { status: 200 });
+  };
+
+  const handler = withHealthcheck("webhooks-test", async () => {
+    throw new Error("boom");
+  });
+
+  await assert.rejects(() => handler(request()), /boom/);
+  assert.deepEqual(calls, [
+    { url: "https://hc-ping.com/check-id/start", body: "" },
+    { url: "https://hc-ping.com/check-id/fail", body: "boom" },
+  ]);
+});

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1,0 +1,159 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  __resetNotifyStateForTests,
+  notify,
+} from "@/lib/notify";
+
+const ORIGINAL_ENV = {
+  SLACK_WEBHOOK_DEFAULT: process.env.SLACK_WEBHOOK_DEFAULT,
+  SLACK_WEBHOOK_OPS: process.env.SLACK_WEBHOOK_OPS,
+  SLACK_WEBHOOK_CUSTOMER_OPS: process.env.SLACK_WEBHOOK_CUSTOMER_OPS,
+  SLACK_WEBHOOK_SIGNALS: process.env.SLACK_WEBHOOK_SIGNALS,
+  SLACK_WEBHOOK_CRITICAL: process.env.SLACK_WEBHOOK_CRITICAL,
+  SLACK_RATE_LIMIT_PER_SOURCE: process.env.SLACK_RATE_LIMIT_PER_SOURCE,
+  SLACK_RATE_LIMIT_WINDOW_SECONDS: process.env.SLACK_RATE_LIMIT_WINDOW_SECONDS,
+  SLACK_QUIET_HOURS_RANGE: process.env.SLACK_QUIET_HOURS_RANGE,
+};
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function resetEnv(): void {
+  for (const key of Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  globalThis.fetch = ORIGINAL_FETCH;
+  __resetNotifyStateForTests();
+}
+
+test.beforeEach(() => {
+  resetEnv();
+});
+
+test.after(() => {
+  resetEnv();
+});
+
+test("notify returns no_webhook_configured when no Slack webhook env is set", async () => {
+  delete process.env.SLACK_WEBHOOK_DEFAULT;
+  delete process.env.SLACK_WEBHOOK_OPS;
+
+  const result = await notify({
+    severity: "ops",
+    source: "test.notify.no-webhook",
+    title: "No webhook",
+    message: "Nothing should be posted",
+  });
+
+  assert.deepEqual(result, {
+    delivered: false,
+    reason: "no_webhook_configured",
+  });
+});
+
+test("notify posts to customer ops webhook and masks secret-looking context", async () => {
+  process.env.SLACK_WEBHOOK_CUSTOMER_OPS = "https://hooks.slack.com/services/customer";
+  process.env.SLACK_WEBHOOK_DEFAULT = "https://hooks.slack.com/services/default";
+
+  let postedUrl = "";
+  let postedBody = "";
+  globalThis.fetch = async (url, init) => {
+    postedUrl = String(url);
+    postedBody = String(init?.body ?? "");
+    return new Response("ok", { status: 200 });
+  };
+
+  const result = await notify({
+    severity: "ops",
+    audience: "customer",
+    source: "test.notify.customer",
+    title: "Customer event",
+    message: "A customer-facing ops event fired",
+    context: {
+      maskedValue: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1234",
+      nested: { callback: "https://hooks.slack.com/services/T000/B000/SECRET" },
+    },
+  });
+
+  assert.deepEqual(result, { delivered: true, reason: null });
+  assert.equal(postedUrl, "https://hooks.slack.com/services/customer");
+  assert.match(postedBody, /aaaa.*1234/);
+  assert.doesNotMatch(postedBody, /aaaaaaaaaaaaaaaaaaaaaaaa/);
+  assert.doesNotMatch(postedBody, /T000\/B000\/SECRET/);
+});
+
+test("notify dedupes repeated idempotency keys before posting", async () => {
+  process.env.SLACK_WEBHOOK_OPS = "https://hooks.slack.com/services/ops";
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response("ok", { status: 200 });
+  };
+
+  const args = {
+    severity: "ops" as const,
+    source: "test.notify.dedupe",
+    title: "Deduped",
+    message: "Only posts once",
+    idempotencyKey: "dedupe-key",
+  };
+
+  assert.deepEqual(await notify(args), { delivered: true, reason: null });
+  assert.deepEqual(await notify(args), {
+    delivered: false,
+    reason: "deduped",
+  });
+  assert.equal(calls, 1);
+});
+
+test("notify applies per-source ops rate limiting", async () => {
+  process.env.SLACK_WEBHOOK_OPS = "https://hooks.slack.com/services/ops";
+  process.env.SLACK_RATE_LIMIT_PER_SOURCE = "1";
+  process.env.SLACK_RATE_LIMIT_WINDOW_SECONDS = "600";
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response("ok", { status: 200 });
+  };
+
+  const first = await notify({
+    severity: "ops",
+    source: "test.notify.rate",
+    title: "First",
+    message: "Allowed",
+  });
+  const second = await notify({
+    severity: "ops",
+    source: "test.notify.rate",
+    title: "Second",
+    message: "Blocked",
+  });
+
+  assert.deepEqual(first, { delivered: true, reason: null });
+  assert.deepEqual(second, { delivered: false, reason: "rate_limited" });
+  assert.equal(calls, 1);
+});
+
+test("notify reports abort errors as post_timeout", async () => {
+  process.env.SLACK_WEBHOOK_OPS = "https://hooks.slack.com/services/ops";
+  globalThis.fetch = async () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    throw err;
+  };
+
+  const result = await notify({
+    severity: "ops",
+    source: "test.notify.timeout",
+    title: "Timeout",
+    message: "Fetch aborted",
+  });
+
+  assert.deepEqual(result, { delivered: false, reason: "post_timeout" });
+});

--- a/src/lib/healthcheck.ts
+++ b/src/lib/healthcheck.ts
@@ -1,0 +1,76 @@
+/**
+ * Healthchecks.io cron wrapper for trendingrepo Vercel routes.
+ * Mirrors AISO `lib/healthcheck.ts`. See that file for full doc.
+ *
+ * Env: HEALTHCHECK_<UPPER_SNAKE_ROUTE_NAME>=https://hc-ping.com/<uuid>
+ *
+ * Usage:
+ *   import { withHealthcheck } from "@/lib/healthcheck";
+ *
+ *   export const GET = withHealthcheck("aiso-drain", async (req) => {
+ *     ...
+ *     return Response.json({ ok: true });
+ *   });
+ *
+ * Defense-in-depth: skips Healthchecks pings when the request fails cron
+ * auth (CRON_SECRET bearer header). This way bots probing the cron URLs
+ * can't burn Healthchecks "down" alerts by hitting /start without ever
+ * succeeding — only authorized cron runs count.
+ */
+
+const PING_TIMEOUT_MS = 2_000;
+
+function envKey(routeName: string): string {
+  return "HEALTHCHECK_" + routeName.toUpperCase().replace(/[-/]/g, "_");
+}
+
+function isUnauthorizedCronProbe(req: Request): boolean {
+  const expected = process.env.CRON_SECRET?.trim();
+  if (!expected) return false;
+  return req.headers.get("authorization") !== `Bearer ${expected}`;
+}
+
+async function ping(url: string, suffix: "" | "/start" | "/fail", body?: string): Promise<void> {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), PING_TIMEOUT_MS);
+  try {
+    await fetch(`${url.replace(/\/$/, "")}${suffix}`, {
+      method: body ? "POST" : "GET",
+      body,
+      signal: ctl.signal,
+    });
+  } catch {
+    // Ping failures must never break the cron handler.
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export function withHealthcheck<Req extends Request, R extends Response>(
+  routeName: string,
+  handler: (request: Req) => R | Promise<R>,
+): (request: Req) => Promise<R> {
+  return async (request: Req): Promise<R> => {
+    const url = process.env[envKey(routeName)]?.trim();
+    const skipPing = isUnauthorizedCronProbe(request);
+    if (url && !skipPing) {
+      await ping(url, "/start");
+    }
+    try {
+      const res = await handler(request);
+      if (url && !skipPing) {
+        if (res.ok) {
+          await ping(url, "", `Route ${routeName} returned ${res.status}`);
+        } else {
+          await ping(url, "/fail", `Route ${routeName} returned ${res.status}`);
+        }
+      }
+      return res;
+    } catch (err) {
+      if (url && !skipPing) {
+        await ping(url, "/fail", err instanceof Error ? err.message : String(err));
+      }
+      throw err;
+    }
+  };
+}

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,349 @@
+/**
+ * trendingrepo Slack ops notify - direct webhook POST.
+ * Standalone copy of @toolbox/notify@0.1.0 (AISO has the same copy).
+ * Sync changes manually if upstream pattern evolves.
+ *
+ * This is NOT the end-user webhook system (src/lib/webhooks/) - that's
+ * for breakout/funding events to user-configured webhooks. THIS module
+ * is for OPS alerts (cron failures, EngineErrors, signups).
+ *
+ * Env (Vercel project settings - Sensitive):
+ *   SLACK_WEBHOOK_CRITICAL / SLACK_WEBHOOK_OPS / SLACK_WEBHOOK_DEFAULT
+ *   SLACK_WEBHOOK_CUSTOMER_OPS / SLACK_WEBHOOK_SIGNALS
+ *   SLACK_QUIET_HOURS_RANGE / SLACK_QUIET_HOURS_TZ
+ *   SLACK_RATE_LIMIT_PER_SOURCE / SLACK_RATE_LIMIT_WINDOW_SECONDS
+ */
+
+export type Severity = "critical" | "ops" | "signals";
+
+export type Audience = "internal" | "customer";
+
+export interface NotifyArgs {
+  severity: Severity;
+  source: string;
+  title: string;
+  message: string;
+  context?: Record<string, unknown>;
+  idempotencyKey?: string;
+  /**
+   * Customer vs internal audience routing. Defaults to "internal".
+   * Customer messages route to SLACK_WEBHOOK_CUSTOMER_OPS (with OPS/DEFAULT fallback).
+   */
+  audience?: Audience;
+}
+
+export interface NotifyResult {
+  delivered: boolean;
+  reason:
+    | null
+    | "no_webhook_configured"
+    | "deduped"
+    | "rate_limited"
+    | "quiet_hours"
+    | "post_failed"
+    | "post_timeout"
+    | "post_threw";
+}
+
+const TOKEN_PREFIX_PATTERNS = [
+  /^sk[_-]/i,
+  /^pk[_-]/i,
+  /^rk[_-]/i,
+  /^whsec[_-]/i,
+  /^ghp_/,
+  /^github_pat_/,
+  /^ghs_/,
+  /^gho_/,
+  /^xox[abpsr]-/,
+  /^xapp-/,
+  /^AKIA/,
+  /^ASIA/,
+  /^SG\./,
+  /^AIza/,
+  /^eyJ/,
+  /^Bearer\s/i,
+  /^Basic\s/i,
+  /^sntrys_/,
+  /^sntryu_/,
+  /^anthropic-api-key-/i,
+  /^pcsk_/i,
+  /^privy_/i,
+  /^npm_/,
+  /^supabase_/i,
+  /^tbk_/,
+];
+const WEBHOOK_URL_PATTERNS = [
+  /^https?:\/\/hooks\.slack\.com\/services\//i,
+  /^https?:\/\/discord(?:app)?\.com\/api\/webhooks\//i,
+];
+const TOKEN_CHARSET = /^[A-Za-z0-9_\-./+=]+$/;
+
+function looksLikeToken(s: string): boolean {
+  if (s.length < 20) return false;
+  for (const re of WEBHOOK_URL_PATTERNS) if (re.test(s)) return true;
+  for (const re of TOKEN_PREFIX_PATTERNS) if (re.test(s)) return true;
+  if (s.length >= 32 && TOKEN_CHARSET.test(s) && !s.includes(" ")) return true;
+  return false;
+}
+
+function maskString(s: string): string {
+  if (!looksLikeToken(s)) return s;
+  if (s.length <= 8) return "********";
+  return `${s.slice(0, 4)}…${s.slice(-4)}`;
+}
+
+function maskSecrets<T>(value: T): T {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return maskString(value) as unknown as T;
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map((v) => maskSecrets(v)) as unknown as T;
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = maskSecrets(v);
+    return out as unknown as T;
+  }
+  return value;
+}
+
+function isQuietHours(now: Date = new Date()): boolean {
+  const rangeStr = process.env.SLACK_QUIET_HOURS_RANGE?.trim();
+  if (!rangeStr) return false;
+  const m = rangeStr.match(/^(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/);
+  if (!m) return false;
+  const [, sh, sm, eh, em] = m;
+  const tz = process.env.SLACK_QUIET_HOURS_TZ?.trim() || "Europe/Berlin";
+  let hour = -1;
+  let minute = -1;
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).formatToParts(now);
+    for (const p of parts) {
+      if (p.type === "hour") hour = Number(p.value);
+      if (p.type === "minute") minute = Number(p.value);
+    }
+  } catch {
+    return false;
+  }
+  if (hour < 0 || minute < 0) return false;
+  if (hour === 24) hour = 0;
+  const nowMins = hour * 60 + minute;
+  const startMins = Number(sh) * 60 + Number(sm);
+  const endMins = Number(eh) * 60 + Number(em);
+  if (startMins === endMins) return false;
+  if (startMins < endMins) return nowMins >= startMins && nowMins < endMins;
+  return nowMins >= startMins || nowMins < endMins;
+}
+
+const inProcessDedup = new Map<string, number>();
+const DEDUP_TTL_MS = 5 * 60 * 1000;
+function checkDedup(key: string): boolean {
+  const now = Date.now();
+  for (const [k, expiry] of inProcessDedup.entries()) {
+    if (expiry < now) inProcessDedup.delete(k);
+  }
+  if (inProcessDedup.has(key)) return true;
+  inProcessDedup.set(key, now + DEDUP_TTL_MS);
+  return false;
+}
+
+const rateCount = new Map<string, { count: number; resetAt: number }>();
+
+function rateLimitPerSource(): number {
+  return Number(process.env.SLACK_RATE_LIMIT_PER_SOURCE) || 20;
+}
+
+function rateLimitWindowMs(): number {
+  return (Number(process.env.SLACK_RATE_LIMIT_WINDOW_SECONDS) || 600) * 1000;
+}
+
+function checkRateLimit(source: string): boolean {
+  const now = Date.now();
+  const limit = rateLimitPerSource();
+  const entry = rateCount.get(source);
+  if (!entry || entry.resetAt < now) {
+    rateCount.set(source, { count: 1, resetAt: now + rateLimitWindowMs() });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > limit;
+}
+
+const SEVERITY_EMOJI: Record<Severity, string> = { critical: "🚨", ops: "ℹ️", signals: "📡" };
+const SEVERITY_COLOR: Record<Severity, string> = { critical: "#dc3545", ops: "#0d6efd", signals: "#6c757d" };
+
+const SOURCE_EMOJI: Array<[RegExp, string]> = [
+  [/^github\./, "🐙"],
+  [/^clerk\./, "👤"],
+  [/sign-?up/i, "🎉"],
+  [/sign-?in/i, "👤"],
+  [/^reddit\./, "🤖"],
+  [/^twitter\./, "🐦"],
+  [/^bluesky\./, "🦋"],
+  [/^hackernews\./, "📰"],
+  [/^producthunt\./, "🚀"],
+  [/^huggingface\./, "🤗"],
+  [/^npm\./, "📦"],
+  [/^arxiv\./, "📄"],
+  [/^devto\./, "👩‍💻"],
+  [/^lobsters\./, "🦞"],
+  [/cron/i, "⏰"],
+  [/digest/i, "📊"],
+  [/scan/i, "🔭"],
+  [/dispatch/i, "📤"],
+  [/recover/i, "🔁"],
+  [/flush/i, "🚰"],
+  [/quarantine/i, "⚠️"],
+  [/fatal/i, "💀"],
+];
+
+function pickEmoji(args: NotifyArgs): string {
+  for (const [re, e] of SOURCE_EMOJI) if (re.test(args.source)) return e;
+  return SEVERITY_EMOJI[args.severity];
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 3) + "…";
+}
+
+function buildPayload(args: NotifyArgs): {
+  text: string;
+  attachments: Array<{ color: string; blocks: unknown[] }>;
+} {
+  const emoji = pickEmoji(args);
+  const env = process.env.VERCEL_ENV || process.env.NODE_ENV || "unknown";
+  const headerText = truncate(`${emoji} ${args.title}`, 150);
+  const blocks: unknown[] = [
+    { type: "header", text: { type: "plain_text", text: headerText, emoji: true } },
+    { type: "section", text: { type: "mrkdwn", text: truncate(args.message, 2900) } },
+  ];
+  if (args.context && Object.keys(args.context).length > 0) {
+    const masked = maskSecrets(args.context);
+    const json = JSON.stringify(masked, null, 2);
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: "```" + truncate(json, 1800) + "```" },
+    });
+  }
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: `_${new Date().toISOString()} · \`${args.source}\` · env:\`${env}\` · severity:\`${args.severity}\` · *trendingrepo*_`,
+      },
+    ],
+  });
+  return {
+    text: headerText,
+    attachments: [{ color: SEVERITY_COLOR[args.severity], blocks }],
+  };
+}
+
+function resolveWebhookUrl(severity: Severity, audience: Audience): string | null {
+  if (audience === "customer") {
+    return (
+      process.env.SLACK_WEBHOOK_CUSTOMER_OPS?.trim() ||
+      process.env.SLACK_WEBHOOK_OPS?.trim() ||
+      process.env.SLACK_WEBHOOK_DEFAULT?.trim() ||
+      null
+    );
+  }
+  if (severity === "critical") {
+    return (
+      process.env.SLACK_WEBHOOK_CRITICAL?.trim() ||
+      process.env.SLACK_WEBHOOK_DEFAULT?.trim() ||
+      null
+    );
+  }
+  if (severity === "signals") {
+    return (
+      process.env.SLACK_WEBHOOK_SIGNALS?.trim() ||
+      process.env.SLACK_WEBHOOK_OPS?.trim() ||
+      process.env.SLACK_WEBHOOK_DEFAULT?.trim() ||
+      null
+    );
+  }
+  return (
+    process.env.SLACK_WEBHOOK_OPS?.trim() ||
+    process.env.SLACK_WEBHOOK_DEFAULT?.trim() ||
+    null
+  );
+}
+
+function onCallMention(): string {
+  const raw = process.env.SLACK_ONCALL_USER_IDS?.trim();
+  if (!raw) return "";
+  const ids = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => /^U[A-Z0-9]{6,}$/.test(s));
+  if (ids.length === 0) return "";
+  if (ids.length === 1) return `<@${ids[0]}>`;
+  const d = new Date();
+  const target = new Date(d.valueOf());
+  const dayNr = (target.getUTCDay() + 6) % 7;
+  target.setUTCDate(target.getUTCDate() - dayNr + 3);
+  const firstThursday = target.valueOf();
+  target.setUTCMonth(0, 1);
+  if (target.getUTCDay() !== 4) {
+    target.setUTCMonth(0, 1 + ((4 - target.getUTCDay()) + 7) % 7);
+  }
+  const week = 1 + Math.ceil((firstThursday - target.valueOf()) / 604800000);
+  return `<@${ids[week % ids.length]}>`;
+}
+
+export async function notify(args: NotifyArgs): Promise<NotifyResult> {
+  if (args.severity !== "critical" && isQuietHours()) {
+    return { delivered: false, reason: "quiet_hours" };
+  }
+  const audience: Audience = args.audience ?? "internal";
+  const url = resolveWebhookUrl(args.severity, audience);
+  if (!url) return { delivered: false, reason: "no_webhook_configured" };
+  if (args.idempotencyKey && checkDedup(args.idempotencyKey)) {
+    return { delivered: false, reason: "deduped" };
+  }
+  if (args.severity !== "critical" && checkRateLimit(args.source)) {
+    return { delivered: false, reason: "rate_limited" };
+  }
+  if (args.severity === "critical") {
+    const mention = onCallMention();
+    if (mention) args = { ...args, message: `${mention} ${args.message}` };
+  }
+  const payload = buildPayload(args);
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), 3_000);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: ctl.signal,
+    });
+    if (!res.ok) {
+      console.warn("[notify] post_failed", { status: res.status, source: args.source });
+      return { delivered: false, reason: "post_failed" };
+    }
+    return { delivered: true, reason: null };
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === "AbortError";
+    console.warn("[notify] " + (aborted ? "timeout" : "threw"), {
+      source: args.source,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      delivered: false,
+      reason: aborted ? "post_timeout" : "post_threw",
+    };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export function __resetNotifyStateForTests(): void {
+  inProcessDedup.clear();
+  rateCount.clear();
+}

--- a/src/lib/pipeline/__tests__/webhooks-dead-letter-digest.test.ts
+++ b/src/lib/pipeline/__tests__/webhooks-dead-letter-digest.test.ts
@@ -1,0 +1,188 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+import { deadLetterLocation } from "@/lib/webhooks/publish";
+import {
+  __resetNotifyStateForTests,
+  type NotifyResult,
+} from "@/lib/notify";
+
+const TMP_DATA_DIR = mkdtempSync(path.join(os.tmpdir(), "ss-webhook-digest-"));
+const ORIGINAL_ENV = {
+  NODE_ENV: process.env.NODE_ENV,
+  CRON_SECRET: process.env.CRON_SECRET,
+  TRENDINGREPO_DATA_DIR: process.env.TRENDINGREPO_DATA_DIR,
+  STARSCREENER_DATA_DIR: process.env.STARSCREENER_DATA_DIR,
+  SLACK_WEBHOOK_CUSTOMER_OPS: process.env.SLACK_WEBHOOK_CUSTOMER_OPS,
+  SLACK_WEBHOOK_OPS: process.env.SLACK_WEBHOOK_OPS,
+  SLACK_WEBHOOK_DEFAULT: process.env.SLACK_WEBHOOK_DEFAULT,
+};
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function restoreEnv(): void {
+  for (const key of Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>) {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      (process.env as Record<string, string | undefined>)[key] = value;
+    }
+  }
+  globalThis.fetch = ORIGINAL_FETCH;
+  __resetNotifyStateForTests();
+}
+
+function configureTestEnv(): void {
+  restoreEnv();
+  (process.env as Record<string, string>).NODE_ENV = "production";
+  process.env.CRON_SECRET = "cron-test-secret";
+  process.env.TRENDINGREPO_DATA_DIR = TMP_DATA_DIR;
+  delete process.env.STARSCREENER_DATA_DIR;
+}
+
+function authorizedRequest(): NextRequest {
+  return new NextRequest("https://trendingrepo.com/api/cron/webhooks/dead-letter-digest", {
+    method: "GET",
+    headers: { authorization: "Bearer cron-test-secret" },
+  });
+}
+
+async function invokeDigest(): Promise<{
+  status: number;
+  body: Record<string, unknown> & { notify?: NotifyResult };
+}> {
+  const { GET } = await import("@/app/api/cron/webhooks/dead-letter-digest/route");
+  const res = await GET(authorizedRequest());
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+test.beforeEach(() => {
+  rmSync(TMP_DATA_DIR, { recursive: true, force: true });
+  configureTestEnv();
+});
+
+test.after(() => {
+  rmSync(TMP_DATA_DIR, { recursive: true, force: true });
+  restoreEnv();
+});
+
+test("dead-letter digest uses data-dir aware path and treats missing file as empty", async () => {
+  const { status, body } = await invokeDigest();
+
+  assert.equal(status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.recent, 0);
+  assert.equal(body.total, 0);
+  assert.equal(deadLetterLocation(), path.join(TMP_DATA_DIR, "webhook-dead-letter.jsonl"));
+});
+
+test("dead-letter digest aggregates real WebhookDelivery rows and skips malformed lines", async () => {
+  process.env.SLACK_WEBHOOK_CUSTOMER_OPS = "https://hooks.slack.com/services/customer";
+  let postedBody = "";
+  globalThis.fetch = async (_url, init) => {
+    postedBody = String(init?.body ?? "");
+    return new Response("ok", { status: 200 });
+  };
+
+  const now = new Date().toISOString();
+  const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+  const rows = [
+    {
+      id: "breakout:vercel/next.js:slack-main",
+      dedupKey: "breakout:vercel/next.js:slack-main",
+      targetId: "slack-main",
+      provider: "slack",
+      event: "breakout",
+      payload: { fullName: "vercel/next.js" },
+      createdAt: now,
+      attempts: 5,
+      lastError: "HTTP 500",
+      deadLetter: true,
+    },
+    "{malformed",
+    {
+      id: "funding:round-1:discord-main",
+      dedupKey: "funding:round-1:discord-main",
+      targetId: "discord-main",
+      provider: "discord",
+      event: "funding",
+      payload: { id: "round-1", headline: "Seed" },
+      createdAt: now,
+      attempts: 6,
+      lastError: "timeout",
+      deadLetter: true,
+    },
+    {
+      id: "breakout:old:slack-main",
+      dedupKey: "breakout:old:slack-main",
+      targetId: "slack-main",
+      provider: "slack",
+      event: "breakout",
+      payload: { fullName: "old/repo" },
+      createdAt: old,
+      attempts: 5,
+      lastError: "old",
+      deadLetter: true,
+    },
+  ];
+  mkdirSync(TMP_DATA_DIR, { recursive: true });
+  writeFileSync(
+    deadLetterLocation(),
+    rows.map((row) => (typeof row === "string" ? row : JSON.stringify(row))).join("\n") + "\n",
+    "utf8",
+  );
+
+  const { status, body } = await invokeDigest();
+
+  assert.equal(status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.recent, 2);
+  assert.equal(body.total, 3);
+  assert.deepEqual(body.byEvent, { breakout: 1, funding: 1 });
+  assert.deepEqual(body.byTarget, {
+    "slack:slack-main": 1,
+    "discord:discord-main": 1,
+  });
+  assert.deepEqual(body.notify, { delivered: true, reason: null });
+  assert.match(postedBody, /2 end-user webhook delivery failures/);
+  assert.match(postedBody, /slack-main/);
+  assert.match(postedBody, /discord-main/);
+  assert.doesNotMatch(postedBody, /hooks\.slack\.com/);
+});
+
+test("dead-letter digest awaits notify and returns delivery failure reason", async () => {
+  process.env.SLACK_WEBHOOK_CUSTOMER_OPS = "https://hooks.slack.com/services/customer";
+  globalThis.fetch = async () => new Response("nope", { status: 500 });
+
+  mkdirSync(TMP_DATA_DIR, { recursive: true });
+  writeFileSync(
+    deadLetterLocation(),
+    JSON.stringify({
+      id: "breakout:vercel/next.js:slack-main",
+      dedupKey: "breakout:vercel/next.js:slack-main",
+      targetId: "slack-main",
+      provider: "slack",
+      event: "breakout",
+      payload: { fullName: "vercel/next.js" },
+      createdAt: new Date().toISOString(),
+      attempts: 5,
+      lastError: "HTTP 500",
+      deadLetter: true,
+    }) + "\n",
+    "utf8",
+  );
+
+  const { status, body } = await invokeDigest();
+
+  assert.equal(status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.recent, 1);
+  assert.deepEqual(body.notify, {
+    delivered: false,
+    reason: "post_failed",
+  });
+});

--- a/src/lib/webhooks/publish.ts
+++ b/src/lib/webhooks/publish.ts
@@ -283,7 +283,11 @@ export async function appendDeadLetter(
 ): Promise<void> {
   const p = deadLetterLocation();
   await fs.mkdir(path.dirname(p), { recursive: true });
-  await fs.appendFile(p, JSON.stringify({ ...row, deadLetter: true }) + "\n", "utf8");
+  await fs.appendFile(
+    p,
+    JSON.stringify({ ...row, deadLetter: true, deadLetteredAt: nowIso() }) + "\n",
+    "utf8",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/webhooks/types.ts
+++ b/src/lib/webhooks/types.ts
@@ -69,6 +69,8 @@ export interface WebhookDelivery {
   deliveredAt?: string;
   /** Marker — only set when the row has been moved to dead-letter. */
   deadLetter?: boolean;
+  /** Timestamp set when the drain moves the row into the dead-letter file. */
+  deadLetteredAt?: string;
 }
 
 /** Minimal repo shape the breakout formatter needs. Keeps the import narrow. */


### PR DESCRIPTION
## Summary

- Adds a daily customer webhook dead-letter digest cron and authenticated `GET /api/cron/webhooks/dead-letter-digest` route.
- Adds Slack customer-ops notification support, a reusable Healthchecks wrapper, dead-letter timestamps, route/docs/env wiring, and focused tests.
- Fixes `perf:bundle` for Next standalone builds where the top-level app manifest is empty, and updates the Stage 4 kickoff addendum with the executed Twitter verification.

## Validation

- `npx tsc --noEmit --pretty false`
- `npm run lint:guards`
- `npm run perf:bundle` (26 page routes, 0 violations)
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/healthcheck.test.ts src/lib/__tests__/notify.test.ts src/lib/pipeline/__tests__/webhooks-dead-letter-digest.test.ts src/lib/__tests__/cron-route-typed-error-contract.test.ts src/lib/pipeline/__tests__/webhooks.test.ts` (55 pass)
- `npm test` (1282 pass)
- `npm run build` (passes; existing warnings remain for unused `Link`, deprecated `STARSCREENER_*` env aliases, Redis fallback, and missing PostHog env)
- pre-push hook: `auth-provider-policy` OK

## Remaining Stage 4 Work

- S4.B account purge cron
- S4.C full Lighthouse/PSI workflow wiring
- S4.D stale pre-#1743 data PR sweep
- S4.E security-helper unit tests