### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-18T04:48:24Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,9 +1,25 @@
 {
-  "generatedAt": "2026-05-18T00:15:31.416Z",
+  "generatedAt": "2026-05-18T04:48:23.540Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",
   "overlays": {
+    "0xMassi/webclaw": {
+      "tier": "verified_trustmrr",
+      "fullName": "0xMassi/webclaw",
+      "trustmrrSlug": "webclaw",
+      "mrrCents": 9900,
+      "last30DaysCents": 4950,
+      "totalCents": 4950,
+      "growthMrr30d": null,
+      "customers": 0,
+      "activeSubscriptions": 1,
+      "paymentProvider": "stripe",
+      "category": "Developer Tools",
+      "asOf": "2026-04-24T01:59:01.837Z",
+      "matchConfidence": "exact",
+      "sourceUrl": "https://trustmrr.com/startup/webclaw"
+    },
     "Anil-matcha/Open-Generative-AI": {
       "tier": "verified_trustmrr",
       "fullName": "Anil-matcha/Open-Generative-AI",


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26014091578

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.