### PR TITLE
chore(data): refresh ai rss signals 2026-05-18T04:50:19Z

### DIFF
--- a/data/_meta/claude-rss.json
+++ b/data/_meta/claude-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "claude-rss",
   "reason": "ok",
-  "ts": "2026-05-17T19:44:19.074Z",
+  "ts": "2026-05-18T04:50:16.787Z",
   "count": 1,
-  "durationMs": 4316,
+  "durationMs": 5926,
   "extra": {}
 }

--- a/data/_meta/openai-rss.json
+++ b/data/_meta/openai-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "openai-rss",
   "reason": "ok",
-  "ts": "2026-05-17T19:44:22.322Z",
+  "ts": "2026-05-18T04:50:19.772Z",
   "count": 1,
-  "durationMs": 3091,
+  "durationMs": 2836,
   "extra": {}
 }

--- a/data/claude-rss.json
+++ b/data/claude-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-17T19:44:14.763Z",
+  "fetchedAt": "2026-05-18T04:50:10.866Z",
   "source": "claude",
   "feedUrl": "https://www.anthropic.com/news",
   "error": null,

--- a/data/openai-rss.json
+++ b/data/openai-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-17T19:44:19.235Z",
+  "fetchedAt": "2026-05-18T04:50:16.940Z",
   "source": "openai",
   "feedUrl": "https://openai.com/news/rss.xml",
   "error": null,


### PR DESCRIPTION
Automated data refresh from `Refresh AI RSS signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26014139931

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.