### PR TITLE
chore(data): refresh mcp liveness 2026-05-18T04:59:46Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-17T19:55:31.526Z",
+  "fetchedAt": "2026-05-18T04:59:42.077Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -1737,6 +1737,46 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "proplineapi/propline": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "shomechakraborty/scientific tools mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "thinkcol/lenx mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "influqa/cryptoagentmail": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "doorman11991/budget-aware-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "artkeyai/bhived": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "blackwell-systems/knowing": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "timwal78/mcp-paywall": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "coding-dev-tools/click-to-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "guimaster97/markdown web scraper api": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "mountainmystic/hederatoolbox": {
       "isStdio": true,
       "livenessInferred": true
@@ -1802,86 +1842,6 @@
       "livenessInferred": true
     },
     "outlook": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "raz-labs/interactive mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sajal2692/weaviate mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "maidtoshelly/uluvoimcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rodgomesc/terminal hook": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kmexnx/invoice mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "klausandrade/codewatch-memory": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jkang8/mcp-obsidian": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vapvarun/wp astro mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "agentics-ai/code mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "opendining/ableton live mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "zhound420/d365 finance & operations mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "qinsehm1128/mcp-ty": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jameswilliamwisdom/x402 mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "danielefavi/code review mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "demixid/mcp local codebase search": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rskmanz/routine-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "paulbennet/afk mode": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "seang1121/sports betting mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dalisys/n8n community nodes mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "weinerac/quest apartment hotels mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -2706,6 +2666,10 @@
       "livenessInferred": true
     },
     "babuvenky76/wealth management mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "weinerac/quest apartment hotels mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3998,6 +3962,42 @@
       "livenessInferred": true
     },
     "markswendsen-code/petsmart mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "intelagentstudios/intelagent mcp template": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mcp-telegram/mcp-telegram": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "newageflyfish-max/volthq-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/fluxmcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kud/trakt mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mikan-atomoki/text-to-model": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "moneyflowz367/affilync mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "masonbesmer/discord mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cleburn/aegis mcp server": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26014411052

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.