### PR TITLE
docs(runbooks): operator runbooks for Stage 5 launch (S5.D.3)

### DIFF
--- a/docs/runbooks/clerk-pk-live-bringup.md
+++ b/docs/runbooks/clerk-pk-live-bringup.md
@@ -1,0 +1,170 @@
+# Runbook — Clerk live-key bringup
+
+**When to use:** one-time, to flip TrendingRepo's Clerk integration from test keys (`pk_test_*` / `sk_test_*`) to live keys (`pk_live_*` / `sk_live_*`). Without this, the production `/sign-in` page shows "Auth unavailable" and no real signups are possible.
+
+**Pre-reqs:**
+
+- Clerk dashboard account exists, app provisioned, custom domain mapped (`auth.trendingrepo.com`).
+- Vercel CLI authed (`vercel whoami` succeeds).
+- All Stage 5 PRs merged. Doing it before would ship signup capability without a working revenue loop above it.
+
+**Estimated time:** 15–20 minutes including verification.
+
+## 1. Verify Clerk app is configured for production
+
+In the Clerk dashboard:
+
+1. Top-left dropdown → ensure you're on the **TrendingRepo (production)** instance (not the development one).
+2. **Settings** → **API Keys**:
+   - **Publishable key** — starts `pk_live_`
+   - **Secret key** — starts `sk_live_`
+3. **Settings** → **Domains**:
+   - Custom domain: `auth.trendingrepo.com` (or whatever is configured)
+   - Verify DNS records are propagated and Clerk shows ✅
+4. **Webhooks** → confirm there's an endpoint at `https://trendingrepo.com/api/webhooks/clerk` with event types `user.created` + `user.updated` enabled, signing secret matches what's in `CLERK_WEBHOOK_SECRET` env.
+
+If any of these aren't set up: Clerk's own docs at <https://clerk.com/docs/deployments/overview> walk through DNS + domain verification. That's outside this runbook's scope — return here once Clerk's dashboard shows the production instance fully configured.
+
+## 2. Set Vercel env vars
+
+```bash
+vercel env add CLERK_PUBLISHABLE_KEY production
+# Paste: pk_live_...
+
+vercel env add CLERK_SECRET_KEY production
+# Paste: sk_live_...
+
+# If the webhook secret changed (it does when you re-create the endpoint):
+vercel env rm CLERK_WEBHOOK_SECRET production
+vercel env add CLERK_WEBHOOK_SECRET production
+# Paste: whsec_... (from Clerk dashboard → Webhooks → click endpoint → reveal signing secret)
+```
+
+The code also reads `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (mirror of the secret-side `CLERK_PUBLISHABLE_KEY`) for the client-side bundle:
+
+```bash
+vercel env add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY production
+# Paste: same pk_live_... as above
+```
+
+Verify the four are set:
+
+```bash
+vercel env ls | grep CLERK_
+# Expect 4 lines, all "production" environment.
+```
+
+## 3. Redeploy
+
+```bash
+vercel --prod --yes
+# Note the deployment URL
+```
+
+The env vars are baked in at deploy time. Without a redeploy, the new keys are dormant.
+
+## 4. Verify
+
+### 4a. Page-level smoke
+
+```bash
+# Sign-in page should render the Clerk widget without "auth unavailable" banner
+curl -sI https://trendingrepo.com/sign-in
+# Expect: 200 (or 307/308 redirect to /sign-in/ — both fine)
+
+# Open in a browser:
+# https://trendingrepo.com/sign-in
+# Expect: Clerk's hosted sign-in widget renders, with the TrendingRepo branding (if you uploaded a logo in Clerk).
+# Expect: NO "Auth unavailable" / "Configuration error" message.
+```
+
+### 4b. End-to-end signup test
+
+1. Use an email you control but haven't signed up with before (e.g., `yourname+e2e-2026-05-19@gmail.com`)
+2. Visit `https://trendingrepo.com/sign-up`
+3. Complete Clerk's signup flow (email verification step included)
+4. Land back on `/you`
+5. Verify in Clerk dashboard → **Users** that the user appears with status `Active`
+6. Verify in TrendingRepo: the user has a row in `profiles` (you can check via a one-off admin endpoint or by hitting `/you/settings` and seeing the email — it should be the one you just signed up with)
+
+### 4c. Welcome modal
+
+The welcome modal (S2 / `WelcomeModal.tsx`) should appear on the first visit to `/` after signup. Cookie-gated (`sb_welcomed`, 90-day expiry).
+
+### 4d. Webhook delivery
+
+Clerk dashboard → **Webhooks** → click your endpoint → **Recent deliveries**. Each signup fires a `user.created` event. The endpoint should respond with 200 within 1s. If it 4xx's:
+
+- 400 = signing secret mismatch — re-check step 2
+- 401 = endpoint URL wrong — re-check Clerk dashboard's URL
+- 5xx = handler crashed — `vercel logs --since 5m | grep "clerk webhook"`
+
+## 5. Verify the post-signup email triggers (B.2 once merged)
+
+If the Stage 5 B.2 PR is merged (day-1 welcome email), the Clerk `user.created` webhook should also enqueue an email. Verify:
+
+```bash
+# From the operator side:
+# Wait ~5 min after the test signup, then check Resend dashboard for a sent email to <e2e-email>.
+# Subject: "You're in. Catch breakouts before they're cold."
+```
+
+If the email didn't send, check:
+- `vercel logs --since 10m | grep welcome-email`
+- Resend dashboard → API logs
+
+## 6. Update operator log
+
+```bash
+echo "$(date -u +%FT%TZ): Clerk live keys enabled; e2e signup test passed; user $E2E_USER provisioned." >> docs/OPERATOR.md
+git add docs/OPERATOR.md
+git commit -m "docs(operator): clerk live key bringup complete"
+git push
+```
+
+## Rollback
+
+If something breaks (signup flow regresses, users can't log in):
+
+```bash
+# Restore test keys (signups still possible but only with Clerk test instance)
+vercel env rm CLERK_PUBLISHABLE_KEY production
+vercel env add CLERK_PUBLISHABLE_KEY production
+# Paste: pk_test_...
+
+vercel env rm CLERK_SECRET_KEY production
+vercel env add CLERK_SECRET_KEY production
+# Paste: sk_test_...
+
+vercel env rm NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY production
+vercel env add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY production
+# Paste: pk_test_...
+
+vercel --prod --yes
+```
+
+This will reverse-revert the change. Real-money signups will stop, but the app stays online.
+
+If the issue is webhook-only (signups work, profile rows don't get created), check the webhook secret rather than rolling back keys.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| "Auth unavailable" banner persists after redeploy | Env vars set on wrong environment (Preview not Production) | `vercel env ls` — verify each row says `production` |
+| Sign-in widget renders but signup fails with "Verification email not sent" | Clerk's email provider not configured for prod (or DNS for `auth.trendingrepo.com` not propagated) | Clerk dashboard → **Settings** → **Email Provider**. Default uses Clerk's mail; for higher deliverability, configure Resend/SendGrid here. |
+| User signs up but `profiles` row never appears | Clerk webhook 4xx'ing (check Clerk dashboard) | Re-check `CLERK_WEBHOOK_SECRET` in Vercel matches the signing secret shown in Clerk |
+| Profile row created but `email` field is empty | Clerk webhook payload format changed | `vercel logs` for the webhook handler; check `src/app/api/webhooks/clerk/route.ts` for how it parses `user.created` |
+| `/you` page redirects to sign-in even after successful signup | Cookie/session mismatch | Open browser devtools → Application → Cookies; verify Clerk session cookie is set on `.trendingrepo.com`. Common cause: Clerk app's "Frontend API URL" doesn't match the deployed origin. |
+
+## What this runbook does NOT cover
+
+- Configuring OAuth providers (Google, GitHub) in Clerk — separate dashboard task, not blocking sign-up
+- Custom branding inside Clerk's hosted widget — purely aesthetic, do after revenue starts
+- MFA enforcement — Clerk supports it; defaults are fine for v1
+- Sub-orgs / multi-tenant — TrendingRepo isn't multi-tenant; ignore Clerk's organization features
+
+## Cross-reference
+
+- [Stripe live-mode bringup](./stripe-live-mode-bringup.md) — sister bringup; checkout requires signup to actually work
+- [Refund runbook](./refund-30-day.md) — when a real user wants their money back, you'll need this too

--- a/docs/runbooks/refund-30-day.md
+++ b/docs/runbooks/refund-30-day.md
@@ -1,0 +1,120 @@
+# Runbook — 30-day money-back refund
+
+**When to use:** a customer requests a refund within 30 days of paying for Pro/Team. The product's checkout copy promises this, surfaced at:
+
+- `src/components/pricing/CheckoutWalkthrough.tsx` step-2 ("30-day money-back guarantee")
+- `/pricing` FAQ
+
+**Who runs this:** operator. Not automated. Should take < 5 minutes per refund.
+
+## Decision tree
+
+| Days since charge | Refund? | Action |
+|---|---|---|
+| 0–30 | **Yes**, full refund | Process per steps below |
+| 31+ | **No** (policy) | Reply with the canned email at bottom; if exception is warranted (rare), document the reason in the Stripe note. |
+
+## Steps
+
+### 1. Find the charge
+
+```
+https://dashboard.stripe.com/payments?status[]=successful&query=<customer-email-or-id>
+```
+
+The customer's email is on the Stripe customer record. If they only gave you a userId, look it up via:
+
+```bash
+# From the trendingrepo repo
+grep '"<userId>"' .data/user-tiers.jsonl | head -1
+# Field: stripeCustomerId — paste into Stripe dashboard search
+```
+
+### 2. Verify subscription state
+
+In Stripe dashboard → Customers → Subscriptions tab. Status should be `active` or `past_due`. If `canceled` already, the customer's tier is already free — refund is the only remaining action.
+
+### 3. Issue the refund
+
+In the customer's most-recent successful payment:
+
+- Click **"Refund"** → **"Full refund"** → reason: **"Customer requested"**
+- Stripe refunds to the original payment method. ETA per dashboard.
+
+### 4. Cancel the subscription (if not already)
+
+If subscription is still `active` or `past_due`:
+
+- Subscriptions tab → click the subscription → **"Cancel subscription"** → **"Cancel immediately"** (not "at period end" — they paid for this period and we just refunded it, so end access immediately)
+- Confirm.
+
+Stripe will emit `customer.subscription.deleted` → our webhook hits `handleSubscriptionDeleted` → `setUserTier(userId, "free", null, …)` → user is downgraded automatically. Verify in `.data/user-tiers.jsonl`:
+
+```bash
+grep '"<userId>"' .data/user-tiers.jsonl | tail -1
+# Should show: "tier":"free","expiresAt":null
+```
+
+If the tier did NOT downgrade within 2 minutes (webhook delay or signature mismatch in test mode), edit `.data/user-tiers.jsonl` manually:
+
+```jsonl
+{"userId":"<userId>","tier":"free","expiresAt":null,"stripeCustomerId":"cus_…","stripeSubscriptionId":"sub_…","createdAt":"<orig>","updatedAt":"<now-iso>"}
+```
+
+Append the corrected row to the bottom of the file. The store dedupes by userId on next read, so the latest row wins. Commit + push so prod picks it up.
+
+### 5. Email the customer
+
+Send (from `hello@trendingrepo.com`):
+
+```
+Subject: Refund processed — TrendingRepo
+
+Hi <name>,
+
+Your refund of $<amount> has been processed and should appear on your card within 5–10 business days, depending on your bank.
+
+Your Pro features have been removed; your alerts and watchlists are kept intact so you can re-subscribe later without losing setup.
+
+If this was a billing issue rather than a product issue, let us know what we got wrong — we'd love to keep you.
+
+— TrendingRepo team
+```
+
+### 6. (Optional) Log the reason
+
+If the customer gave a reason in their request, add it to a brief CSV at `docs/forensic/refund-log.csv`:
+
+```csv
+date,userId,amount_usd,reason,product_lesson
+2026-06-12,user_abc,19.00,too-expensive,upgrade-friction-anchor-too-high
+```
+
+This becomes the input for monthly product reviews — patterns here tell us what to fix.
+
+## After-31-day refusal email
+
+```
+Subject: About your TrendingRepo refund request
+
+Hi <name>,
+
+Our money-back guarantee window is 30 days from the original charge; your subscription is past that window. I can still cancel your renewal so you won't be charged again — just confirm.
+
+If there's a specific reason you're stepping away that wasn't covered by the 30-day window, let me know directly — exceptions exist for genuine product failure.
+
+— TrendingRepo team
+```
+
+## Edge cases
+
+- **Refund a charge after subscription already self-canceled** → still possible. Same Stripe steps; the user-tier record is already free, so no manual edit needed.
+- **Partial refund (e.g., they used Pro for 15 days, want pro-rated)** → discouraged. The 30-day promise is full-refund-or-keep. If business reason justifies it, issue a partial refund in Stripe (the "Refund" dialog allows partial amounts), then manually edit `.data/user-tiers.jsonl` to set `expiresAt` to the appropriate prorated date (instead of `null`).
+- **Card declined during refund** → contact the customer to update their card; some banks reject refunds to closed/expired cards. Stripe will surface this in the dashboard.
+- **Multiple subscriptions** (e.g., Pro + later upgraded to Team) → refund whichever charge the customer is unhappy with. Stripe's audit log tracks proration. Cancel any remaining active subscription per step 4.
+
+## What NOT to do
+
+- **Never refund a chargeback** — disputes have their own dispute-evidence flow. Refunding a disputed charge can cost the chargeback fee + the refunded amount (double hit).
+- **Never refund without canceling the subscription** — Stripe will re-bill them next cycle, and they'll be entitled to a second refund.
+- **Never edit `.data/user-tiers.jsonl` to delete a row** — append-only. Add a new row with the corrected state; the store dedupes by userId on read.

--- a/docs/runbooks/stripe-live-mode-bringup.md
+++ b/docs/runbooks/stripe-live-mode-bringup.md
@@ -1,0 +1,170 @@
+# Runbook — Stripe live-mode bringup
+
+**When to use:** one-time, to flip TrendingRepo from Stripe test mode (`sk_test_*`) to live mode (`sk_live_*`). After this runs cleanly, real money can flow.
+
+**Pre-reqs:**
+
+- Stripe account exists, business profile completed, bank account verified.
+- Vercel CLI authed (`vercel whoami` succeeds).
+- `gh` CLI authed.
+- This runbook should run **after** Stage 5 PRs are merged. Doing it earlier ships an empty pricing surface to real users.
+
+**Estimated time:** 30–45 minutes including verification.
+
+## 1. Create products in Stripe live mode
+
+In Stripe dashboard, toggle to **live mode** (top-left switch). Then **Products** → **Add product** for each of:
+
+| Name | Description | Statement descriptor |
+|---|---|---|
+| TrendingRepo Pro (monthly) | Pro plan — monthly billing | `TRENDINGREPO PRO` |
+| TrendingRepo Pro (yearly) | Pro plan — annual billing (2 months free) | `TRENDINGREPO PRO` |
+| TrendingRepo Team (monthly) | Team plan — per-seat monthly | `TRENDINGREPO TEAM` |
+| TrendingRepo Team (yearly) | Team plan — per-seat annual | `TRENDINGREPO TEAM` |
+
+For each: pricing model = **Recurring**, billing period = monthly/yearly, currency = USD, amount per the tier table in `src/lib/pricing/tiers.ts` (Pro $19/mo, Pro $190/yr, Team $49/seat/mo, Team $490/seat/yr). After creating, copy the **price ID** (starts `price_`).
+
+## 2. Set Vercel env vars
+
+Run these from the repo root (one block — paste, then enter the value for each prompt):
+
+```bash
+vercel env add STRIPE_SECRET_KEY production
+# Paste: sk_live_...
+
+vercel env add STRIPE_PRO_MONTHLY_PRICE_ID production
+# Paste: price_... (from step 1)
+
+vercel env add STRIPE_PRO_YEARLY_PRICE_ID production
+# Paste: price_...
+
+vercel env add STRIPE_TEAM_MONTHLY_PRICE_ID production
+# Paste: price_...
+
+vercel env add STRIPE_TEAM_YEARLY_PRICE_ID production
+# Paste: price_...
+```
+
+Do NOT add to `preview` env — preview deploys must continue to use `sk_test_*` so Stage 5 work doesn't accidentally charge real cards. Verify:
+
+```bash
+vercel env ls | grep STRIPE_
+# Each should show "production" in the Environment column. None in "Preview" or "Development".
+```
+
+## 3. Register the production webhook endpoint
+
+In Stripe live mode dashboard → **Developers** → **Webhooks** → **Add endpoint**.
+
+- **Endpoint URL:** `https://trendingrepo.com/api/webhooks/stripe`
+- **Description:** `TrendingRepo prod` (visible only in Stripe dashboard)
+- **API version:** match what `getStripeClient()` pins (currently `2025-02-24.acacia`)
+- **Events to send** — exactly these 4 (NOT "all events" — that floods our webhook handler with no-ops):
+  - `checkout.session.completed`
+  - `customer.subscription.updated`
+  - `customer.subscription.deleted`
+  - `invoice.payment_failed`
+
+Click **Add endpoint**. Stripe shows a **Signing secret** starting with `whsec_`. Copy it.
+
+```bash
+vercel env add STRIPE_WEBHOOK_SECRET production
+# Paste: whsec_...
+```
+
+## 4. Enable Stripe Tax (EU + UK + global compliance)
+
+EU customers will fail to check out without proper VAT handling. UK requires VAT MOSS. US has state-by-state nexus once you cross thresholds (~$100k/yr).
+
+- Stripe live mode → **Tax** → **Settings**
+- **Default tax behavior:** Inclusive (recommended — price shown on /pricing is the total the customer pays; Stripe handles VAT extraction)
+- **Origin address:** your registered business address
+- **Tax codes:** for digital subscriptions, use `txcd_10103001` (SaaS — pre-written and configurable software)
+- Click **Enable Stripe Tax**
+
+In Stripe dashboard → **Products** → each price → toggle **"Tax behavior: Inclusive"**. Save.
+
+When checking out, Stripe will auto-detect the customer's country, calculate the local VAT/sales tax from the inclusive price, and remit it to the right tax authority (Stripe Tax handles this for ~50 jurisdictions; you receive a quarterly Stripe Tax report).
+
+For **B2B reverse-charge** (EU companies entering a VAT ID get tax-zeroed and self-report), no extra config — Stripe Tax does this automatically when `customer_tax_id` is collected. Checkout sessions auto-collect tax IDs once Stripe Tax is on.
+
+## 5. Confirm receipt emails
+
+Stripe dashboard → **Settings** → **Emails** (live mode):
+
+- **Successful payments:** ✅ ON
+- **Failed payments:** ✅ ON
+- **Refunds:** ✅ ON
+
+Receipt template is automatic; if you want a custom logo/footer, **Settings** → **Branding** → upload the TrendingRepo logo + brand color.
+
+## 6. Smoke test on production
+
+```bash
+# Verify the env is loaded
+curl -sI https://trendingrepo.com/api/webhooks/stripe
+# Expect: HTTP/2 405 (GET not allowed; POST only) — confirms the route is mounted with the new secret.
+
+# Smoke the pricing page
+curl -sI https://trendingrepo.com/pricing
+# Expect: 200
+
+# Smoke checkout endpoint (should require auth)
+curl -sI -X POST https://trendingrepo.com/api/checkout/stripe -H 'Content-Type: application/json' -d '{"tier":"pro","cadence":"monthly"}'
+# Expect: 401 (login required) — confirms the route is responding
+```
+
+If you have access to a test account, do a real `$0.50` test charge through `/pricing`:
+
+1. Sign in
+2. Click upgrade
+3. Use a **real card with a small amount** (Stripe doesn't allow live test cards — you'll actually pay $0.50 if you set the price that low temporarily)
+4. Verify webhook fires (Stripe dashboard → Webhooks → Recent deliveries — should show a `checkout.session.completed` with 200 response from your endpoint within 2s)
+5. Verify `.data/user-tiers.jsonl` on prod (via a Vercel deploy log or a one-off admin endpoint) shows the test user upgraded
+6. Refund the charge via the [refund-30-day runbook](./refund-30-day.md)
+7. Verify the user is downgraded back to free
+
+If smoke fails: check `vercel logs --since 5m | grep stripe` for handler errors. The signature verification path logs `[stripe] webhook signature verification failed` if `STRIPE_WEBHOOK_SECRET` is wrong.
+
+## 7. Update internal docs
+
+After live mode is confirmed working:
+
+```bash
+# Note in the operator log
+echo "$(date -u +%FT%TZ): Stripe live mode enabled; webhook registered; first charge verified." >> docs/OPERATOR.md
+git add docs/OPERATOR.md
+git commit -m "docs(operator): stripe live mode bringup complete"
+git push
+```
+
+## Rollback
+
+If something breaks (revenue lost > customer trust):
+
+```bash
+# Restore test mode env (so the app stops accepting live cards)
+vercel env rm STRIPE_SECRET_KEY production
+vercel env add STRIPE_SECRET_KEY production
+# Paste: sk_test_...
+
+# Redeploy
+vercel --prod
+```
+
+The pricing page will then return 503 from `/api/checkout/stripe` for paid tiers, since `STRIPE_PRO_MONTHLY_PRICE_ID` etc. were live-mode IDs not in test mode. The CheckoutWalkthrough surfaces this gracefully (inline error, modal stays open).
+
+Optionally also disable the webhook endpoint in the Stripe live mode dashboard so any in-flight events stop hitting our prod URL.
+
+## What this runbook does NOT cover
+
+- Marketing copy on `/pricing` — that's a product decision, not an operator one
+- Stripe Connect (we're not a platform; users don't onboard sub-merchants)
+- 1099-K reporting — applies to platforms, not direct SaaS sales
+- Bank account verification — already a Stripe account pre-req
+- Adyen / Braintree / Paddle migration — single-provider for now
+
+## Cross-reference
+
+- [Refund runbook](./refund-30-day.md) — process individual refunds
+- [Clerk live keys runbook](./clerk-pk-live-bringup.md) — sister bringup; auth must be live for checkout to actually be reachable by real users


### PR DESCRIPTION
## Summary

Three operator runbooks covering the operator-blocked items the next launch wave depends on. Part of S5.D.3 in the Stage 5 plan (\`C:\Users\mirko\.claude\plans\plan-out-super-laser-serialized-cupcake.md\`).

- **\`docs/runbooks/refund-30-day.md\`** — process individual refunds within the 30-day money-back window. Stripe dashboard steps, user-tiers state surgery, edge cases (partial refunds, chargebacks, multi-subscription), canned customer emails for refund-issued + after-31-day refusal.
- **\`docs/runbooks/stripe-live-mode-bringup.md\`** — one-time flip from \`sk_test_*\` to \`sk_live_*\`. Product creation in Stripe live mode, env var rollout via \`vercel env add\`, webhook registration limited to the 4 events the handler actually processes, Stripe Tax enable for EU/UK compliance, receipt confirmation, smoke gates, rollback path.
- **\`docs/runbooks/clerk-pk-live-bringup.md\`** — Clerk \`pk_test_*\` → \`pk_live_*\` flip. Env wiring (4 vars), end-to-end signup verification, common failure modes table, rollback to test keys.

## Why these matter

The Stage 5 code-side work ships everything needed for revenue collection. These runbooks ensure the operator can flip the keys and **process the first refund** without having to ask the CTO every step.

Tied to Stage 5 /GOAL "First Dollar": once code lands + operator runs these, the loop closes.

## Test plan

- [x] All three runbooks render in GitHub Markdown preview
- [x] Cross-references between runbooks resolve (refund ↔ stripe ↔ clerk)
- [x] Stripe live-mode steps match the actual env var names in \`src/lib/stripe/client.ts\`
- [x] Clerk env var names match the actual reads in \`src/lib/auth/clerk-config.ts\` / \`@clerk/nextjs\`
- [x] Webhook events listed in stripe-live-mode-bringup.md match the 4 handlers in \`src/lib/stripe/events.ts\` (\`checkout.session.completed\`, \`customer.subscription.updated\`, \`customer.subscription.deleted\`, \`invoice.payment_failed\`)
- [x] Refund runbook's \`.data/user-tiers.jsonl\` surgery steps match the store's append-only + dedupe-on-read contract

No code changes. Pure docs PR. Should auto-merge once CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)