### PR TITLE
chore(data): refresh lobsters signals 2026-05-18T05:50:31Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T01:30:53.963Z",
+  "ts": "2026-05-18T05:50:31.676Z",
   "count": 1,
-  "durationMs": 4009,
+  "durationMs": 3882,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T01:30:49.967Z",
+  "fetchedAt": "2026-05-18T05:50:27.809Z",
   "windowDays": 7,
-  "scannedStories": 78,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -197,14 +197,14 @@
     },
     "sander110419/lightroom-cc-on-linux": {
       "count7d": 1,
-      "scoreSum7d": 19,
+      "scoreSum7d": 21,
       "topStory": {
         "shortId": "l34yuj",
         "title": "Claude Code managed to get Adobe Lightroom working on Linux",
-        "score": 19,
+        "score": 21,
         "url": "https://github.com/sander110419/lightroom-cc-on-linux",
         "commentsUrl": "https://lobste.rs/s/l34yuj/claude_code_managed_get_adobe_lightroom",
-        "hoursSincePosted": 12.543333333333333
+        "hoursSincePosted": 16.870555555555555
       },
       "stories": [
         {
@@ -213,11 +213,11 @@
           "url": "https://github.com/sander110419/lightroom-cc-on-linux",
           "commentsUrl": "https://lobste.rs/s/l34yuj/claude_code_managed_get_adobe_lightroom",
           "by": "",
-          "score": 19,
-          "commentCount": 3,
+          "score": 21,
+          "commentCount": 4,
           "createdUtc": 1779022693,
-          "ageHours": 12.543333333333333,
-          "trendingScore": 0.3425765753742244,
+          "ageHours": 16.870555555555555,
+          "trendingScore": 0.25617825646357734,
           "tags": [
             "linux",
             "vibecoding"
@@ -449,7 +449,7 @@
     {
       "fullName": "sander110419/lightroom-cc-on-linux",
       "count7d": 1,
-      "scoreSum7d": 19
+      "scoreSum7d": 21
     },
     {
       "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T01:30:49.967Z",
+  "fetchedAt": "2026-05-18T05:50:27.809Z",
   "windowHours": 72,
-  "scannedTotal": 78,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -346,6 +346,25 @@
       "trendingScore": 1.1700683971771915,
       "tags": [
         "linux"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "ynxkj6",
+      "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
+      "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
+      "commentsUrl": "https://lobste.rs/s/ynxkj6/researcher_says_microsoft_secretly",
+      "by": "",
+      "score": 12,
+      "commentCount": 0,
+      "createdUtc": 1779073563,
+      "ageHours": 2.74,
+      "trendingScore": 1.1628233219610766,
+      "tags": [
+        "programming",
+        "security",
+        "windows"
       ],
       "description": "",
       "linkedRepos": []
@@ -878,24 +897,6 @@
         "javascript",
         "satire",
         "testing"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "grynsa",
-      "title": "The old world of tech is dying and the new cannot be born",
-      "url": "https://www.baldurbjarnason.com/2026/the-old-world-of-tech-is-dying/",
-      "commentsUrl": "https://lobste.rs/s/grynsa/old_world_tech_is_dying_new_cannot_be_born",
-      "by": "",
-      "score": 6,
-      "commentCount": 1,
-      "createdUtc": 1778843931,
-      "ageHours": 1.9575,
-      "trendingScore": 0.7621138691105094,
-      "tags": [
-        "culture",
-        "practices"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -188921,3 +188921,8 @@
 {"source":"twitter","fullName":"mattpocock/skills","observedAt":"2026-05-18T05:12:55.510Z"}
 {"source":"twitter","fullName":"playcanvas/supers","observedAt":"2026-05-18T05:12:55.510Z"}
 {"source":"twitter","fullName":"apernet/hysteria","observedAt":"2026-05-18T05:12:55.510Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-18T05:50:30.191Z"}
+{"source":"lobsters","fullName":"greenm01/triad","observedAt":"2026-05-18T05:50:30.191Z"}
+{"source":"lobsters","fullName":"sbz/keygen","observedAt":"2026-05-18T05:50:30.191Z"}
+{"source":"lobsters","fullName":"orinimron123/cve-2026-40369-exploit","observedAt":"2026-05-18T05:50:30.191Z"}
+{"source":"lobsters","fullName":"ortegaalfredo/vulns-ai","observedAt":"2026-05-18T05:50:30.191Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26015989078

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.