### PR TITLE
feat(billing): portal endpoint + tier display on /you/settings (S5.A.1+A.2)

### DIFF
--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -1,0 +1,148 @@
+// POST /api/billing/portal — create a Stripe Customer Portal session.
+//
+// Auth contract: requires an authenticated caller (verifyUserAuth, same
+// surface as /api/checkout/stripe). Anonymous visitors get 401.
+//
+// Body: none. The route reads the user-tier record to find the Stripe
+// customer id that the webhook handler persisted on the first
+// checkout.session.completed. If the user has never completed checkout
+// (stripeCustomerId is null), we 400 with a friendly hint — the UI
+// should hide the "Manage billing" button in that case anyway.
+//
+// Returns:
+//   200 { ok: true, url: "https://billing.stripe.com/..." }
+//   400 { ok: false, error: "no_subscription" }
+//   401 no session (login required)
+//   503 Stripe not configured
+//   500 unexpected Stripe error
+//
+// Security:
+//   - We pull stripeCustomerId from the SERVER-SIDE tier store keyed by
+//     the auth-derived userId. Never from a body/query value — that would
+//     let anyone open someone else's portal.
+//   - We never echo the Stripe error message to the caller; server log
+//     keeps full detail.
+
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+
+import { userAuthFailureResponse, verifyUserAuth } from "@/lib/api/auth";
+import { getStripeClient, getPortalReturnUrl } from "@/lib/stripe/client";
+import { getUserTierRecord } from "@/lib/pricing/user-tiers";
+
+// lint-allow: no-parsebody - no-body endpoint; verifyUserAuth is the trust boundary.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface PortalOkResponse {
+  ok: true;
+  url: string;
+}
+
+interface PortalErrorResponse {
+  ok: false;
+  error: string;
+  code: string;
+}
+
+function originFromRequest(request: NextRequest): string {
+  const origin = request.headers.get("origin");
+  if (origin && /^https?:\/\//.test(origin)) return origin.replace(/\/$/, "");
+  const publicUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (publicUrl) return publicUrl.replace(/\/$/, "");
+  const host = request.headers.get("host");
+  const proto =
+    request.headers.get("x-forwarded-proto") ??
+    (process.env.NODE_ENV === "production" ? "https" : "http");
+  return host ? `${proto}://${host}` : "http://localhost:3023";
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<PortalOkResponse | PortalErrorResponse>> {
+  // 1. Auth.
+  const auth = verifyUserAuth(request);
+  const deny = userAuthFailureResponse(auth);
+  if (deny) return deny as NextResponse<PortalErrorResponse>;
+  if (auth.kind !== "ok") {
+    return NextResponse.json(
+      { ok: false, error: "login required", code: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+  const { userId } = auth;
+
+  // 2. Look up the Stripe customer for this user. Populated by the
+  //    webhook on checkout.session.completed (see src/lib/stripe/events.ts).
+  const tierRecord = await getUserTierRecord(userId);
+  const stripeCustomerId = tierRecord?.stripeCustomerId ?? null;
+  if (!stripeCustomerId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "no active subscription — complete a checkout first before opening the billing portal",
+        code: "NO_SUBSCRIPTION",
+      },
+      { status: 400 },
+    );
+  }
+
+  // 3. Build the Stripe client (throws if STRIPE_SECRET_KEY unset → 503).
+  let stripe: Stripe;
+  try {
+    stripe = getStripeClient();
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "billing portal not configured (missing STRIPE_SECRET_KEY)",
+        code: "PORTAL_NOT_CONFIGURED",
+      },
+      { status: 503 },
+    );
+  }
+
+  // 4. Create the portal session.
+  const origin = originFromRequest(request);
+  const returnUrl = getPortalReturnUrl(`${origin}/you/settings`);
+
+  try {
+    const session = await stripe.billingPortal.sessions.create({
+      customer: stripeCustomerId,
+      return_url: returnUrl,
+    });
+
+    if (!session.url) {
+      // Should be impossible per Stripe's contract, but guard anyway.
+      console.error("[stripe] billing portal session created without url", {
+        sessionId: session.id,
+      });
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "billing portal session missing redirect url",
+          code: "INTERNAL",
+        },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ ok: true, url: session.url });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[stripe] billingPortal.sessions.create failed", {
+      userId,
+      customerId: stripeCustomerId,
+      error: message,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "billing portal session failed — please retry",
+        code: "STRIPE_ERROR",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/you/settings/SettingsClient.tsx
+++ b/src/app/you/settings/SettingsClient.tsx
@@ -23,6 +23,33 @@ export interface SettingsInitialProfile {
   email: string;
   displayName: string | null;
   avatarUrl: string | null;
+  /** Effective billing tier (post-expiry resolution). */
+  tier: "free" | "pro" | "team" | "enterprise";
+  /** ISO timestamp when the tier expires; null for free / enterprise. */
+  tierExpiresAt: string | null;
+  /**
+   * True when the user has a Stripe customer record (i.e. has completed
+   * at least one checkout). Controls visibility of "Manage billing".
+   */
+  hasStripeCustomer: boolean;
+}
+
+const TIER_LABEL: Record<SettingsInitialProfile["tier"], string> = {
+  free: "Free",
+  pro: "Pro",
+  team: "Team",
+  enterprise: "Enterprise",
+};
+
+function formatRenewalDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }
 
 interface SettingsClientProps {
@@ -37,10 +64,43 @@ export default function SettingsClient({
   );
   const [avatarUrl, setAvatarUrl] = useState(initialProfile.avatarUrl ?? "");
   const [busy, setBusy] = useState(false);
+  const [portalBusy, setPortalBusy] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteConfirmEmail, setDeleteConfirmEmail] = useState("");
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const tierLabel = TIER_LABEL[initialProfile.tier];
+  const renewalDate = formatRenewalDate(initialProfile.tierExpiresAt);
+  const isPaidTier =
+    initialProfile.tier === "pro" || initialProfile.tier === "team";
+
+  async function handleOpenPortal() {
+    setPortalBusy(true);
+    try {
+      const res = await fetch("/api/billing/portal", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+      });
+      const body = (await res
+        .json()
+        .catch(() => null)) as { ok?: boolean; url?: string; error?: string } | null;
+      if (!res.ok || !body?.ok || !body.url) {
+        const reason = body?.error ?? `portal request failed: ${res.status}`;
+        throw new Error(reason);
+      }
+      window.location.assign(body.url);
+    } catch (err) {
+      console.warn("[settings] open portal failed", err);
+      toast.info(
+        err instanceof Error
+          ? err.message
+          : "Couldn't open billing portal. Please try again.",
+      );
+      setPortalBusy(false);
+    }
+  }
 
   async function handleDeleteAccount() {
     setDeleteBusy(true);
@@ -247,6 +307,92 @@ export default function SettingsClient({
               </button>
             </div>
           </form>
+        </section>
+
+        <section
+          className="mt-6 rounded-[2px] p-4 md:p-5"
+          style={{
+            background: "var(--v3-bg-050)",
+            border: "1px solid var(--v3-line-200)",
+          }}
+        >
+          <div
+            className="mb-4 font-mono text-[10px] uppercase tracking-[0.18em]"
+            style={{ color: "var(--v3-ink-300)" }}
+          >
+            {"// BILLING"}
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-0.5">
+              <div className="flex items-baseline gap-2">
+                <span
+                  className="font-mono text-[10px] uppercase tracking-[0.16em]"
+                  style={{ color: "var(--v3-ink-400)" }}
+                >
+                  Current plan
+                </span>
+                <span
+                  className="text-base"
+                  style={{
+                    color: "var(--v3-ink-000)",
+                    fontFamily: "var(--font-geist), Inter, sans-serif",
+                    fontWeight: 510,
+                  }}
+                >
+                  {tierLabel}
+                </span>
+              </div>
+              {isPaidTier && renewalDate ? (
+                <span
+                  className="font-mono text-[11px]"
+                  style={{ color: "var(--v3-ink-300)" }}
+                >
+                  Renews {renewalDate}
+                </span>
+              ) : null}
+              {!isPaidTier ? (
+                <span
+                  className="font-mono text-[11px]"
+                  style={{ color: "var(--v3-ink-300)" }}
+                >
+                  Free tier · 3 alert rules, 5 watched repos.
+                </span>
+              ) : null}
+            </div>
+
+            <div className="flex items-center gap-2">
+              {isPaidTier && initialProfile.hasStripeCustomer ? (
+                <button
+                  type="button"
+                  onClick={() => void handleOpenPortal()}
+                  disabled={portalBusy}
+                  className="inline-flex items-center rounded-[2px] px-3 py-2 font-mono text-[11px] uppercase tracking-[0.16em] transition-colors disabled:opacity-50"
+                  style={{
+                    background: "var(--v3-bg-075)",
+                    border: "1px solid var(--v3-line-200)",
+                    color: "var(--v3-ink-100)",
+                    fontWeight: 500,
+                  }}
+                >
+                  {portalBusy ? "OPENING…" : "MANAGE BILLING"}
+                </button>
+              ) : (
+                <Link
+                  href="/pricing"
+                  className="inline-flex items-center rounded-[2px] px-3 py-2 font-mono text-[11px] uppercase tracking-[0.16em] transition-colors"
+                  style={{
+                    background: "var(--v3-bg-075)",
+                    border: "1px solid var(--v3-acc, var(--v3-line-200))",
+                    color: "var(--v3-acc, var(--v3-ink-100))",
+                    fontWeight: 500,
+                  }}
+                >
+                  UPGRADE TO PRO
+                </Link>
+              )}
+            </div>
+          </div>
         </section>
 
         <section

--- a/src/app/you/settings/page.tsx
+++ b/src/app/you/settings/page.tsx
@@ -3,10 +3,18 @@
 // Server component owns the metadata + initial profile fetch via
 // `requireUser()`. Interactive form lives in `./SettingsClient.tsx`
 // so we can keep the `metadata` export server-side per Next 15.
+//
+// S5.A.2 — tier + Stripe customer reference are looked up here so the
+// client island can render the "Current plan" row + Manage billing /
+// Upgrade buttons without a second client-side fetch. user-tiers.jsonl
+// is keyed by HMAC(SESSION_SECRET, email) per src/lib/api/session.ts —
+// derive the lookup key from the profile email loaded by Clerk.
 
 import type { Metadata } from "next";
 
+import { deriveUserId } from "@/lib/api/session";
 import { requireUser } from "@/lib/auth/server";
+import { getUserTierRecord } from "@/lib/pricing/user-tiers";
 
 import SettingsClient, { type SettingsInitialProfile } from "./SettingsClient";
 
@@ -21,11 +29,37 @@ export const metadata: Metadata = {
 
 export default async function YouSettingsPage() {
   const { profile } = await requireUser();
+
+  // Tier lookup. Best-effort — JSONL read failures degrade to "free"
+  // (the same default `getUserTier` applies for users with no record).
+  const derivedUserId = deriveUserId(profile.email);
+  let tier: "free" | "pro" | "team" | "enterprise" = "free";
+  let tierExpiresAt: string | null = null;
+  let hasStripeCustomer = false;
+  try {
+    const record = await getUserTierRecord(derivedUserId);
+    if (record) {
+      // Honor expiry: an expired Pro record reads as free.
+      const expired =
+        record.expiresAt &&
+        Number.isFinite(Date.parse(record.expiresAt)) &&
+        Date.parse(record.expiresAt) < Date.now();
+      tier = expired ? "free" : record.tier;
+      tierExpiresAt = record.expiresAt;
+      hasStripeCustomer = Boolean(record.stripeCustomerId);
+    }
+  } catch {
+    // Default-deny: leave tier=free, no Manage button. Same as no record.
+  }
+
   const initialProfile: SettingsInitialProfile = {
     handle: profile.handle,
     email: profile.email,
     displayName: profile.displayName,
     avatarUrl: profile.avatarUrl,
+    tier,
+    tierExpiresAt,
+    hasStripeCustomer,
   };
   return <SettingsClient initialProfile={initialProfile} />;
 }


### PR DESCRIPTION
## Summary

Stage 5 / A.1 + A.2 combined. Closes two of the six revenue-loop tracks: a user can see their plan on /you/settings and self-serve manage their subscription via the Stripe Customer Portal.

## A.1 — \`POST /api/billing/portal\`

- Auth via \`verifyUserAuth\` (same surface as \`/api/checkout/stripe\`).
- Reads \`getUserTierRecord(userId).stripeCustomerId\` — populated by the Stripe webhook on the first \`checkout.session.completed\` (see \`src/lib/stripe/events.ts:236\`).
- Returns **400 NO_SUBSCRIPTION** if customer is null (user hasn't completed checkout yet — UI hides the Manage button in that case anyway).
- Returns **503 PORTAL_NOT_CONFIGURED** when \`STRIPE_SECRET_KEY\` is unset (graceful degrade).
- Creates a \`stripe.billingPortal.sessions\` and returns the redirect URL.
- Never leaks Stripe error detail to the caller; server log keeps it.
- \`return_url\` defaults to \`<origin>/you/settings\` (overridable via \`STRIPE_PORTAL_RETURN_URL\`).

## A.2 — Tier display on \`/you/settings\`

- \`page.tsx\` fetches tier via \`getUserTierRecord(deriveUserId(profile.email))\`. \`user-tiers.jsonl\` is keyed by \`HMAC(SESSION_SECRET, email)\` per \`src/lib/api/session.ts:178\` — derive the lookup key the same way the session route does.
- Honors expiry: an expired Pro record reads as free (avoids the "Pro · renews 2025-…past…" gotcha).
- \`SettingsInitialProfile\` extended with \`{ tier, tierExpiresAt, hasStripeCustomer }\`.
- New "// BILLING" section between Profile and Danger Zone:
  - **Paid tier**: "Pro · Renews <date>" + [MANAGE BILLING] button that POSTs \`/api/billing/portal\` and \`window.assign\`s the URL.
  - **Free tier**: "Free tier · 3 alert rules, 5 watched repos" + [UPGRADE TO PRO] link to \`/pricing\`.
- "Manage billing" only renders when both the tier is paid AND the user has a \`stripeCustomerId\` (otherwise we know the portal would 400).

## Why combined PR

A.1 and A.2 ship the same loop — the button without the endpoint is broken, the endpoint without the button is unreachable. Same-PR keeps the diff coherent.

## Verification

\`\`\`bash
npm run typecheck       # clean
npm run lint:guards     # clean
\`\`\`

## Test plan (post-deploy)

- [ ] Free user → \`/you/settings\` shows "Free tier" + "Upgrade to Pro" → click → \`/pricing\`
- [ ] Pro user (test mode) → "Pro · Renews <date>" + "Manage billing"
- [ ] Click "Manage billing" → \`/api/billing/portal\` returns Stripe URL → browser redirects to \`billing.stripe.com\` → after Stripe portal actions, returns to \`/you/settings\`
- [ ] User who never completed checkout sees Free tier + Upgrade link (no broken Manage button)

## Cross-reference

- Operator runbook: \`docs/runbooks/refund-30-day.md\` (merged in #1765) — uses this portal to issue refunds + cancellations
- Stripe live-mode bringup: \`docs/runbooks/stripe-live-mode-bringup.md\` — env vars needed in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)