### PR TITLE
chore(data): refresh scoring shadow report 2026-05-18T06:03:39Z

### DIFF
--- a/data/scoring-shadow-report.json
+++ b/data/scoring-shadow-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-17T05:40:57.382Z",
+  "generatedAt": "2026-05-18T06:03:38.261Z",
   "reports": [
     {
       "domainKey": "skill",
@@ -8,301 +8,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.578,
+          "momentum": 9.595,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 9.326,
+          "momentum": 9.073,
           "rank": 2
         },
         {
           "id": "manavarya09-design-extract",
           "title": "design-extract",
-          "momentum": 7.868,
+          "momentum": 7.828,
           "rank": 3
+        },
+        {
+          "id": "agents365-ai-drawio-skill",
+          "title": "drawio-skill",
+          "momentum": 7.768,
+          "rank": 4
         },
         {
           "id": "glitternetwork-pinme",
           "title": "pinme",
-          "momentum": 7.81,
-          "rank": 4
+          "momentum": 7.593,
+          "rank": 5
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 7.75,
-          "rank": 5
-        },
-        {
-          "id": "eugeniughelbur-obsidian-second-brain",
-          "title": "obsidian-second-brain",
-          "momentum": 7.38,
+          "momentum": 7.535,
           "rank": 6
         },
         {
           "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
           "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.292,
+          "momentum": 7.356,
           "rank": 7
         },
         {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 6.957,
+          "id": "eugeniughelbur-obsidian-second-brain",
+          "title": "obsidian-second-brain",
+          "momentum": 7.198,
           "rank": 8
-        },
-        {
-          "id": "agents365-ai-drawio-skill",
-          "title": "drawio-skill",
-          "momentum": 6.763,
-          "rank": 9
         },
         {
           "id": "alexgreensh-token-optimizer",
           "title": "token-optimizer",
-          "momentum": 6.612,
+          "momentum": 6.791,
+          "rank": 9
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 6.762,
           "rank": 10
-        },
-        {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 6.416,
-          "rank": 11
-        },
-        {
-          "id": "agricidaniel-claude-blog",
-          "title": "claude-blog",
-          "momentum": 6.346,
-          "rank": 12
-        },
-        {
-          "id": "wuyoscar-gpt-image-2-skill",
-          "title": "gpt_image_2_skill",
-          "momentum": 6.319,
-          "rank": 13
         },
         {
           "id": "denissergeevitch-agents-best-practices",
           "title": "agents-best-practices",
-          "momentum": 6.207,
+          "momentum": 6.26,
+          "rank": 11
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.236,
+          "rank": 12
+        },
+        {
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.234,
+          "rank": 13
+        },
+        {
+          "id": "agricidaniel-claude-blog",
+          "title": "claude-blog",
+          "momentum": 6.171,
           "rank": 14
         },
         {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 6.189,
+          "id": "wuyoscar-gpt-image-2-skill",
+          "title": "gpt_image_2_skill",
+          "momentum": 6.154,
           "rank": 15
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.166,
+          "momentum": 6.093,
           "rank": 16
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 6.02,
+          "rank": 17
         },
         {
           "id": "avdlee-rocketsimapp",
           "title": "RocketSimApp",
-          "momentum": 6.111,
-          "rank": 17
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.092,
+          "momentum": 5.937,
           "rank": 18
         },
         {
           "id": "juneyaooo-gpt-image2-ppt-skills",
           "title": "gpt-image2-ppt-skills",
-          "momentum": 5.995,
+          "momentum": 5.853,
           "rank": 19
+        },
+        {
+          "id": "mrgediao-shuorenhua",
+          "title": "shuorenhua",
+          "momentum": 5.768,
+          "rank": 20
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.876,
-          "rank": 20
+          "momentum": 5.715,
+          "rank": 21
         },
         {
           "id": "bharathkumarsuresh-claude-design-system-hooks",
           "title": "claude-design-system-hooks",
-          "momentum": 5.756,
-          "rank": 21
+          "momentum": 5.596,
+          "rank": 22
         },
         {
           "id": "aspegio-nelson",
           "title": "nelson",
-          "momentum": 5.723,
-          "rank": 22
+          "momentum": 5.56,
+          "rank": 23
         },
         {
           "id": "pegasi-ai-reins",
           "title": "reins",
-          "momentum": 5.596,
-          "rank": 23
-        },
-        {
-          "id": "voidborne-d-humanize-chinese",
-          "title": "humanize-chinese",
-          "momentum": 5.583,
+          "momentum": 5.437,
           "rank": 24
         },
         {
           "id": "mikesheehan54-claude-code-design-ai",
           "title": "Claude-Code-Design-AI",
-          "momentum": 5.503,
+          "momentum": 5.404,
           "rank": 25
         },
         {
           "id": "agents365-ai-video-podcast-maker",
           "title": "video-podcast-maker",
-          "momentum": 5.276,
+          "momentum": 5.145,
           "rank": 26
         },
         {
           "id": "bitwize-music-studio-claude-ai-music-skills",
           "title": "claude-ai-music-skills",
-          "momentum": 5.233,
+          "momentum": 5.104,
           "rank": 27
         },
         {
           "id": "memtensor-skills-vote",
           "title": "skills-vote",
-          "momentum": 5.223,
+          "momentum": 5.075,
           "rank": 28
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.209,
+          "momentum": 5.057,
           "rank": 29
+        },
+        {
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 5.023,
+          "rank": 30
         },
         {
           "id": "vast-ai-vast-cli",
           "title": "vast-cli",
-          "momentum": 5.155,
-          "rank": 30
+          "momentum": 5.008,
+          "rank": 31
+        },
+        {
+          "id": "agents365-ai-paper-fetch",
+          "title": "paper-fetch",
+          "momentum": 4.963,
+          "rank": 32
         },
         {
           "id": "agricidaniel-claude-ads",
           "title": "claude-ads",
-          "momentum": 5.1,
-          "rank": 31
+          "momentum": 4.958,
+          "rank": 33
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 5.065,
-          "rank": 32
+          "momentum": 4.927,
+          "rank": 34
         },
         {
           "id": "keerthanapranesh-claude-code-swarm-toolkit",
           "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.977,
-          "rank": 33
-        },
-        {
-          "id": "likaku-mck-ppt-design-skill",
-          "title": "Mck-ppt-design-skill",
-          "momentum": 4.751,
-          "rank": 34
-        },
-        {
-          "id": "jeecgboot-skills",
-          "title": "skills",
-          "momentum": 4.748,
+          "momentum": 4.841,
           "rank": 35
-        },
-        {
-          "id": "secondsky-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.723,
-          "rank": 36
-        },
-        {
-          "id": "ylsssq926-relic-skill",
-          "title": "relic.skill",
-          "momentum": 4.693,
-          "rank": 37
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.677,
-          "rank": 38
+          "momentum": 4.823,
+          "rank": 36
         },
         {
           "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.652,
+          "momentum": 4.777,
+          "rank": 37
+        },
+        {
+          "id": "jeecgboot-skills",
+          "title": "skills",
+          "momentum": 4.753,
+          "rank": 38
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.664,
           "rank": 39
+        },
+        {
+          "id": "luoling8192-technical-writing",
+          "title": "technical-writing",
+          "momentum": 4.645,
+          "rank": 40
+        },
+        {
+          "id": "likaku-mck-ppt-design-skill",
+          "title": "Mck-ppt-design-skill",
+          "momentum": 4.636,
+          "rank": 41
+        },
+        {
+          "id": "secondsky-claude-skills",
+          "title": "claude-skills",
+          "momentum": 4.595,
+          "rank": 42
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.625,
-          "rank": 40
-        },
-        {
-          "id": "aldefy-compose-skill",
-          "title": "compose-skill",
-          "momentum": 4.485,
-          "rank": 41
-        },
-        {
-          "id": "codeaashu-claude-code",
-          "title": "claude-code",
-          "momentum": 4.446,
-          "rank": 42
-        },
-        {
-          "id": "agricidaniel-claude-shorts",
-          "title": "claude-shorts",
-          "momentum": 4.44,
+          "momentum": 4.56,
           "rank": 43
         },
         {
-          "id": "matlab-agent-skills-playground",
-          "title": "agent-skills-playground",
-          "momentum": 4.417,
+          "id": "ylsssq926-relic-skill",
+          "title": "relic.skill",
+          "momentum": 4.523,
           "rank": 44
         },
         {
-          "id": "ombulabs-claude-code-rails-upgrade-skill",
-          "title": "claude-code_rails-upgrade-skill",
-          "momentum": 4.408,
+          "id": "agents365-ai-excalidraw-skill",
+          "title": "excalidraw-skill",
+          "momentum": 4.495,
           "rank": 45
         },
         {
           "id": "xquik-dev-x-twitter-scraper",
           "title": "x-twitter-scraper",
-          "momentum": 4.363,
+          "momentum": 4.404,
           "rank": 46
         },
         {
           "id": "tonylofgren-aurora-smart-home",
           "title": "aurora-smart-home",
-          "momentum": 4.358,
+          "momentum": 4.374,
           "rank": 47
         },
         {
-          "id": "ximilalaxiang-delive",
-          "title": "DeLive",
-          "momentum": 4.332,
+          "id": "aldefy-compose-skill",
+          "title": "compose-skill",
+          "momentum": 4.359,
           "rank": 48
         },
         {
-          "id": "voidborne-d-master-skill",
-          "title": "master-skill",
-          "momentum": 4.289,
+          "id": "agricidaniel-claude-shorts",
+          "title": "claude-shorts",
+          "momentum": 4.324,
           "rank": 49
         },
         {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.264,
+          "id": "codeaashu-claude-code",
+          "title": "claude-code",
+          "momentum": 4.323,
           "rank": 50
         }
       ],
@@ -310,301 +310,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.578,
+          "momentum": 9.595,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 9.326,
+          "momentum": 9.073,
           "rank": 2
         },
         {
           "id": "manavarya09-design-extract",
           "title": "design-extract",
-          "momentum": 7.868,
+          "momentum": 7.828,
           "rank": 3
+        },
+        {
+          "id": "agents365-ai-drawio-skill",
+          "title": "drawio-skill",
+          "momentum": 7.768,
+          "rank": 4
         },
         {
           "id": "glitternetwork-pinme",
           "title": "pinme",
-          "momentum": 7.81,
-          "rank": 4
+          "momentum": 7.593,
+          "rank": 5
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 7.75,
-          "rank": 5
-        },
-        {
-          "id": "eugeniughelbur-obsidian-second-brain",
-          "title": "obsidian-second-brain",
-          "momentum": 7.38,
+          "momentum": 7.535,
           "rank": 6
         },
         {
           "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
           "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.292,
+          "momentum": 7.356,
           "rank": 7
         },
         {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 6.957,
+          "id": "eugeniughelbur-obsidian-second-brain",
+          "title": "obsidian-second-brain",
+          "momentum": 7.198,
           "rank": 8
-        },
-        {
-          "id": "agents365-ai-drawio-skill",
-          "title": "drawio-skill",
-          "momentum": 6.763,
-          "rank": 9
         },
         {
           "id": "alexgreensh-token-optimizer",
           "title": "token-optimizer",
-          "momentum": 6.612,
+          "momentum": 6.791,
+          "rank": 9
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 6.762,
           "rank": 10
-        },
-        {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 6.416,
-          "rank": 11
-        },
-        {
-          "id": "agricidaniel-claude-blog",
-          "title": "claude-blog",
-          "momentum": 6.346,
-          "rank": 12
-        },
-        {
-          "id": "wuyoscar-gpt-image-2-skill",
-          "title": "gpt_image_2_skill",
-          "momentum": 6.319,
-          "rank": 13
         },
         {
           "id": "denissergeevitch-agents-best-practices",
           "title": "agents-best-practices",
-          "momentum": 6.207,
+          "momentum": 6.26,
+          "rank": 11
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.236,
+          "rank": 12
+        },
+        {
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.234,
+          "rank": 13
+        },
+        {
+          "id": "agricidaniel-claude-blog",
+          "title": "claude-blog",
+          "momentum": 6.171,
           "rank": 14
         },
         {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 6.189,
+          "id": "wuyoscar-gpt-image-2-skill",
+          "title": "gpt_image_2_skill",
+          "momentum": 6.154,
           "rank": 15
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.166,
+          "momentum": 6.093,
           "rank": 16
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 6.02,
+          "rank": 17
         },
         {
           "id": "avdlee-rocketsimapp",
           "title": "RocketSimApp",
-          "momentum": 6.111,
-          "rank": 17
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.092,
+          "momentum": 5.937,
           "rank": 18
         },
         {
           "id": "juneyaooo-gpt-image2-ppt-skills",
           "title": "gpt-image2-ppt-skills",
-          "momentum": 5.995,
+          "momentum": 5.853,
           "rank": 19
+        },
+        {
+          "id": "mrgediao-shuorenhua",
+          "title": "shuorenhua",
+          "momentum": 5.768,
+          "rank": 20
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.876,
-          "rank": 20
+          "momentum": 5.715,
+          "rank": 21
         },
         {
           "id": "bharathkumarsuresh-claude-design-system-hooks",
           "title": "claude-design-system-hooks",
-          "momentum": 5.756,
-          "rank": 21
+          "momentum": 5.596,
+          "rank": 22
         },
         {
           "id": "aspegio-nelson",
           "title": "nelson",
-          "momentum": 5.723,
-          "rank": 22
+          "momentum": 5.56,
+          "rank": 23
         },
         {
           "id": "pegasi-ai-reins",
           "title": "reins",
-          "momentum": 5.596,
-          "rank": 23
-        },
-        {
-          "id": "voidborne-d-humanize-chinese",
-          "title": "humanize-chinese",
-          "momentum": 5.583,
+          "momentum": 5.437,
           "rank": 24
         },
         {
           "id": "mikesheehan54-claude-code-design-ai",
           "title": "Claude-Code-Design-AI",
-          "momentum": 5.503,
+          "momentum": 5.404,
           "rank": 25
         },
         {
           "id": "agents365-ai-video-podcast-maker",
           "title": "video-podcast-maker",
-          "momentum": 5.276,
+          "momentum": 5.145,
           "rank": 26
         },
         {
           "id": "bitwize-music-studio-claude-ai-music-skills",
           "title": "claude-ai-music-skills",
-          "momentum": 5.233,
+          "momentum": 5.104,
           "rank": 27
         },
         {
           "id": "memtensor-skills-vote",
           "title": "skills-vote",
-          "momentum": 5.223,
+          "momentum": 5.075,
           "rank": 28
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.209,
+          "momentum": 5.057,
           "rank": 29
+        },
+        {
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 5.023,
+          "rank": 30
         },
         {
           "id": "vast-ai-vast-cli",
           "title": "vast-cli",
-          "momentum": 5.155,
-          "rank": 30
+          "momentum": 5.008,
+          "rank": 31
+        },
+        {
+          "id": "agents365-ai-paper-fetch",
+          "title": "paper-fetch",
+          "momentum": 4.963,
+          "rank": 32
         },
         {
           "id": "agricidaniel-claude-ads",
           "title": "claude-ads",
-          "momentum": 5.1,
-          "rank": 31
+          "momentum": 4.958,
+          "rank": 33
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 5.065,
-          "rank": 32
+          "momentum": 4.927,
+          "rank": 34
         },
         {
           "id": "keerthanapranesh-claude-code-swarm-toolkit",
           "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.977,
-          "rank": 33
-        },
-        {
-          "id": "likaku-mck-ppt-design-skill",
-          "title": "Mck-ppt-design-skill",
-          "momentum": 4.751,
-          "rank": 34
-        },
-        {
-          "id": "jeecgboot-skills",
-          "title": "skills",
-          "momentum": 4.748,
+          "momentum": 4.841,
           "rank": 35
-        },
-        {
-          "id": "secondsky-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.723,
-          "rank": 36
-        },
-        {
-          "id": "ylsssq926-relic-skill",
-          "title": "relic.skill",
-          "momentum": 4.693,
-          "rank": 37
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.677,
-          "rank": 38
+          "momentum": 4.823,
+          "rank": 36
         },
         {
           "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.652,
+          "momentum": 4.777,
+          "rank": 37
+        },
+        {
+          "id": "jeecgboot-skills",
+          "title": "skills",
+          "momentum": 4.753,
+          "rank": 38
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.664,
           "rank": 39
+        },
+        {
+          "id": "luoling8192-technical-writing",
+          "title": "technical-writing",
+          "momentum": 4.645,
+          "rank": 40
+        },
+        {
+          "id": "likaku-mck-ppt-design-skill",
+          "title": "Mck-ppt-design-skill",
+          "momentum": 4.636,
+          "rank": 41
+        },
+        {
+          "id": "secondsky-claude-skills",
+          "title": "claude-skills",
+          "momentum": 4.595,
+          "rank": 42
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.625,
-          "rank": 40
-        },
-        {
-          "id": "aldefy-compose-skill",
-          "title": "compose-skill",
-          "momentum": 4.485,
-          "rank": 41
-        },
-        {
-          "id": "codeaashu-claude-code",
-          "title": "claude-code",
-          "momentum": 4.446,
-          "rank": 42
-        },
-        {
-          "id": "agricidaniel-claude-shorts",
-          "title": "claude-shorts",
-          "momentum": 4.44,
+          "momentum": 4.56,
           "rank": 43
         },
         {
-          "id": "matlab-agent-skills-playground",
-          "title": "agent-skills-playground",
-          "momentum": 4.417,
+          "id": "ylsssq926-relic-skill",
+          "title": "relic.skill",
+          "momentum": 4.523,
           "rank": 44
         },
         {
-          "id": "ombulabs-claude-code-rails-upgrade-skill",
-          "title": "claude-code_rails-upgrade-skill",
-          "momentum": 4.408,
+          "id": "agents365-ai-excalidraw-skill",
+          "title": "excalidraw-skill",
+          "momentum": 4.495,
           "rank": 45
         },
         {
           "id": "xquik-dev-x-twitter-scraper",
           "title": "x-twitter-scraper",
-          "momentum": 4.363,
+          "momentum": 4.404,
           "rank": 46
         },
         {
           "id": "tonylofgren-aurora-smart-home",
           "title": "aurora-smart-home",
-          "momentum": 4.358,
+          "momentum": 4.374,
           "rank": 47
         },
         {
-          "id": "ximilalaxiang-delive",
-          "title": "DeLive",
-          "momentum": 4.332,
+          "id": "aldefy-compose-skill",
+          "title": "compose-skill",
+          "momentum": 4.359,
           "rank": 48
         },
         {
-          "id": "voidborne-d-master-skill",
-          "title": "master-skill",
-          "momentum": 4.289,
+          "id": "agricidaniel-claude-shorts",
+          "title": "claude-shorts",
+          "momentum": 4.324,
           "rank": 49
         },
         {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.264,
+          "id": "codeaashu-claude-code",
+          "title": "claude-code",
+          "momentum": 4.323,
           "rank": 50
         }
       ],
@@ -613,7 +613,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-17T05:40:55.606Z",
+      "generatedAt": "2026-05-18T06:03:36.687Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     },
@@ -634,188 +634,188 @@
           "rank": 2
         },
         {
-          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
-          "title": "Reddit",
+          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
+          "title": "Gantta",
           "momentum": 0,
           "rank": 3
-        },
-        {
-          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
-          "title": "Exa Search",
-          "momentum": 0,
-          "rank": 4
         },
         {
           "id": "8e2eb2b1-b3fb-4cc5-b3fb-1fa7cb6177fb",
           "title": "Google Sheets",
           "momentum": 0,
+          "rank": 4
+        },
+        {
+          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
+          "title": "Reddit",
+          "momentum": 0,
           "rank": 5
         },
         {
-          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
-          "title": "Gantta",
+          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
+          "title": "Exa Search",
           "momentum": 0,
           "rank": 6
-        },
-        {
-          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
-          "title": "Polymarket",
-          "momentum": 0,
-          "rank": 7
-        },
-        {
-          "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
-          "title": "Linkup",
-          "momentum": 0,
-          "rank": 8
         },
         {
           "id": "267b4011-98f0-4231-a2df-9bb31067c24e",
           "title": "Gmail",
           "momentum": 0,
-          "rank": 9
-        },
-        {
-          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
-          "title": "Swiss Truth MCP",
-          "momentum": 0,
-          "rank": 10
-        },
-        {
-          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
-          "title": "AI Research Assistant",
-          "momentum": 0,
-          "rank": 11
-        },
-        {
-          "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
-          "title": "AgentMail",
-          "momentum": 0,
-          "rank": 12
-        },
-        {
-          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
-          "title": "12306 Ticket Search Server",
-          "momentum": 0,
-          "rank": 13
-        },
-        {
-          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
-          "title": "Flight Search MCP Server",
-          "momentum": 0,
-          "rank": 14
-        },
-        {
-          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
-          "title": "rivalsearch",
-          "momentum": 0,
-          "rank": 15
+          "rank": 7
         },
         {
           "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
           "title": "MCP Server for Singapore Government Open Data",
           "momentum": 0,
-          "rank": 16
+          "rank": 8
         },
         {
-          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
-          "title": "Paper Search",
+          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
+          "title": "rivalsearch",
           "momentum": 0,
-          "rank": 17
+          "rank": 9
         },
         {
-          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
-          "title": "ai-agent-index",
+          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
+          "title": "AI Research Assistant",
           "momentum": 0,
-          "rank": 18
+          "rank": 10
         },
         {
-          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
-          "title": "Blockscout MCP Server",
+          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
+          "title": "Swiss Truth MCP",
           "momentum": 0,
-          "rank": 19
+          "rank": 11
         },
         {
-          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
-          "title": "sbb-mcp",
+          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
+          "title": "12306 Ticket Search Server",
           "momentum": 0,
-          "rank": 20
+          "rank": 12
         },
         {
-          "id": "0401fdd4-89a4-4cb3-b951-3df1975e978b",
-          "title": "DuckDuckGo & Felo AI Search",
+          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
+          "title": "Polymarket",
           "momentum": 0,
-          "rank": 21
+          "rank": 13
         },
         {
           "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
           "title": "Standard Accounting Public MCP",
           "momentum": 0,
-          "rank": 22
+          "rank": 14
         },
         {
-          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
-          "title": "paper-search-mcp-openai-v2",
+          "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
+          "title": "AgentMail",
           "momentum": 0,
-          "rank": 23
+          "rank": 15
         },
         {
-          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
-          "title": "Context Awesome",
+          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
+          "title": "ai-agent-index",
           "momentum": 0,
-          "rank": 24
+          "rank": 16
         },
         {
-          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
-          "title": "KRDS Design System",
+          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
+          "title": "sbb-mcp",
           "momentum": 0,
-          "rank": 25
+          "rank": 17
+        },
+        {
+          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
+          "title": "Flight Search MCP Server",
+          "momentum": 0,
+          "rank": 18
+        },
+        {
+          "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
+          "title": "Linkup",
+          "momentum": 0,
+          "rank": 19
         },
         {
           "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
           "title": "settlegrid-discovery",
           "momentum": 0,
-          "rank": 26
+          "rank": 20
         },
         {
-          "id": "7c0e4ef9-c2e0-4826-a2c9-949ebc5f5b5f",
-          "title": "Ayni",
+          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
+          "title": "KRDS Design System",
           "momentum": 0,
-          "rank": 27
+          "rank": 21
         },
         {
-          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
-          "title": "Mesh MCP",
+          "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
+          "title": "Hugeicons MCP Server",
           "momentum": 0,
-          "rank": 28
+          "rank": 22
         },
         {
-          "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
-          "title": "Context7",
+          "id": "9a58e6b6-6486-47c2-b05d-5362e3b85da7",
+          "title": "AKShare One MCP Server",
           "momentum": 0,
-          "rank": 29
+          "rank": 23
         },
         {
           "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
           "title": "cultural-intelligence",
           "momentum": 0,
-          "rank": 30
-        },
-        {
-          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
-          "title": "Brave Search",
-          "momentum": 0,
-          "rank": 31
+          "rank": 24
         },
         {
           "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
           "title": "Microsoft Learn MCP",
           "momentum": 0,
+          "rank": 25
+        },
+        {
+          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
+          "title": "Context Awesome",
+          "momentum": 0,
+          "rank": 26
+        },
+        {
+          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
+          "title": "Paper Search",
+          "momentum": 0,
+          "rank": 27
+        },
+        {
+          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
+          "title": "Brave Search",
+          "momentum": 0,
+          "rank": 28
+        },
+        {
+          "id": "706d98f8-dc33-453d-9103-d28364976e58",
+          "title": "icons8mcp",
+          "momentum": 0,
+          "rank": 29
+        },
+        {
+          "id": "7c0e4ef9-c2e0-4826-a2c9-949ebc5f5b5f",
+          "title": "Ayni",
+          "momentum": 0,
+          "rank": 30
+        },
+        {
+          "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
+          "title": "Context7",
+          "momentum": 0,
+          "rank": 31
+        },
+        {
+          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
+          "title": "paper-search-mcp-openai-v2",
+          "momentum": 0,
           "rank": 32
         },
         {
-          "id": "33d15eec-1ccf-4070-9323-6ebe58759b50",
-          "title": "Cloud101 Korea",
+          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
+          "title": "Mesh MCP",
           "momentum": 0,
           "rank": 33
         },
@@ -826,50 +826,50 @@
           "rank": 34
         },
         {
-          "id": "dc70d6a2-f904-4a0c-b5b0-d6585e323d65",
-          "title": "ai-marketing-agent",
+          "id": "ba8d79ca-2d8e-40dc-9dbd-df2e1731904b",
+          "title": "Bitpoort",
           "momentum": 0,
           "rank": 35
         },
         {
-          "id": "ba8d79ca-2d8e-40dc-9dbd-df2e1731904b",
-          "title": "Bitpoort",
+          "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
+          "title": "Senzing",
           "momentum": 0,
           "rank": 36
         },
         {
-          "id": "706d98f8-dc33-453d-9103-d28364976e58",
-          "title": "icons8mcp",
+          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
+          "title": "Blockscout MCP Server",
           "momentum": 0,
           "rank": 37
         },
         {
-          "id": "abdea6d2-bc2d-43f3-922a-f836cc91ded5",
-          "title": "strale",
+          "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
+          "title": "Ternary Intelligence Stack",
           "momentum": 0,
           "rank": 38
         },
         {
-          "id": "c379873f-69ec-49ac-9ff3-823925cf6d47",
-          "title": "Weather MCP Server",
+          "id": "33d15eec-1ccf-4070-9323-6ebe58759b50",
+          "title": "Cloud101 Korea",
           "momentum": 0,
           "rank": 39
         },
         {
-          "id": "d6103139-7bb8-4c02-9ea8-645c59f6ca7d",
-          "title": "mcp-music-studio",
+          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
+          "title": "Seoul Essentials",
           "momentum": 0,
           "rank": 40
         },
         {
-          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
-          "title": "Saju Insights",
+          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
+          "title": "srv-d7aoqmh5pdvs7391dcqg",
           "momentum": 0,
           "rank": 41
         },
         {
-          "id": "69f8e0df-fb64-4f79-a684-6cfbdc2ba7ad",
-          "title": "Slack",
+          "id": "1fa33040-57e6-4ab1-9828-329b1204ebc7",
+          "title": "Visualization Charts Server",
           "momentum": 0,
           "rank": 42
         },
@@ -880,44 +880,44 @@
           "rank": 43
         },
         {
-          "id": "eb9488e1-5131-4823-b7a7-101ca4d636e4",
-          "title": "Catalunya 2022",
+          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
+          "title": "MLB Stats Server",
           "momentum": 0,
           "rank": 44
         },
         {
-          "id": "c4cec09e-359e-473c-9427-16aa90cd3fed",
-          "title": "Web Scout",
+          "id": "dc70d6a2-f904-4a0c-b5b0-d6585e323d65",
+          "title": "ai-marketing-agent",
           "momentum": 0,
           "rank": 45
         },
         {
-          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
-          "title": "Seoul Essentials",
+          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
+          "title": "Saju Insights",
           "momentum": 0,
           "rank": 46
-        },
-        {
-          "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
-          "title": "Senzing",
-          "momentum": 0,
-          "rank": 47
         },
         {
           "id": "9df2fd7e-6ff0-46c9-8b1f-17ba466edad1",
           "title": "cryptoiz-mcp",
           "momentum": 0,
+          "rank": 47
+        },
+        {
+          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
+          "title": "Octomil",
+          "momentum": 0,
           "rank": 48
         },
         {
-          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
-          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "id": "de0ed2fa-ad2a-4cca-b45d-16a6ff80bfd7",
+          "title": "Harvard Course Explorer",
           "momentum": 0,
           "rank": 49
         },
         {
-          "id": "1fa33040-57e6-4ab1-9828-329b1204ebc7",
-          "title": "Visualization Charts Server",
+          "id": "d38dd88c-9ced-4ef3-8a56-56ea0ce2ceb4",
+          "title": "cancersupport",
           "momentum": 0,
           "rank": 50
         }
@@ -936,188 +936,188 @@
           "rank": 2
         },
         {
-          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
-          "title": "Reddit",
+          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
+          "title": "Gantta",
           "momentum": 0,
           "rank": 3
-        },
-        {
-          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
-          "title": "Exa Search",
-          "momentum": 0,
-          "rank": 4
         },
         {
           "id": "8e2eb2b1-b3fb-4cc5-b3fb-1fa7cb6177fb",
           "title": "Google Sheets",
           "momentum": 0,
+          "rank": 4
+        },
+        {
+          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
+          "title": "Reddit",
+          "momentum": 0,
           "rank": 5
         },
         {
-          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
-          "title": "Gantta",
+          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
+          "title": "Exa Search",
           "momentum": 0,
           "rank": 6
-        },
-        {
-          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
-          "title": "Polymarket",
-          "momentum": 0,
-          "rank": 7
-        },
-        {
-          "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
-          "title": "Linkup",
-          "momentum": 0,
-          "rank": 8
         },
         {
           "id": "267b4011-98f0-4231-a2df-9bb31067c24e",
           "title": "Gmail",
           "momentum": 0,
-          "rank": 9
-        },
-        {
-          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
-          "title": "Swiss Truth MCP",
-          "momentum": 0,
-          "rank": 10
-        },
-        {
-          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
-          "title": "AI Research Assistant",
-          "momentum": 0,
-          "rank": 11
-        },
-        {
-          "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
-          "title": "AgentMail",
-          "momentum": 0,
-          "rank": 12
-        },
-        {
-          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
-          "title": "12306 Ticket Search Server",
-          "momentum": 0,
-          "rank": 13
-        },
-        {
-          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
-          "title": "Flight Search MCP Server",
-          "momentum": 0,
-          "rank": 14
-        },
-        {
-          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
-          "title": "rivalsearch",
-          "momentum": 0,
-          "rank": 15
+          "rank": 7
         },
         {
           "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
           "title": "MCP Server for Singapore Government Open Data",
           "momentum": 0,
-          "rank": 16
+          "rank": 8
         },
         {
-          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
-          "title": "Paper Search",
+          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
+          "title": "rivalsearch",
           "momentum": 0,
-          "rank": 17
+          "rank": 9
         },
         {
-          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
-          "title": "ai-agent-index",
+          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
+          "title": "AI Research Assistant",
           "momentum": 0,
-          "rank": 18
+          "rank": 10
         },
         {
-          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
-          "title": "Blockscout MCP Server",
+          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
+          "title": "Swiss Truth MCP",
           "momentum": 0,
-          "rank": 19
+          "rank": 11
         },
         {
-          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
-          "title": "sbb-mcp",
+          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
+          "title": "12306 Ticket Search Server",
           "momentum": 0,
-          "rank": 20
+          "rank": 12
         },
         {
-          "id": "0401fdd4-89a4-4cb3-b951-3df1975e978b",
-          "title": "DuckDuckGo & Felo AI Search",
+          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
+          "title": "Polymarket",
           "momentum": 0,
-          "rank": 21
+          "rank": 13
         },
         {
           "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
           "title": "Standard Accounting Public MCP",
           "momentum": 0,
-          "rank": 22
+          "rank": 14
         },
         {
-          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
-          "title": "paper-search-mcp-openai-v2",
+          "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
+          "title": "AgentMail",
           "momentum": 0,
-          "rank": 23
+          "rank": 15
         },
         {
-          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
-          "title": "Context Awesome",
+          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
+          "title": "ai-agent-index",
           "momentum": 0,
-          "rank": 24
+          "rank": 16
         },
         {
-          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
-          "title": "KRDS Design System",
+          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
+          "title": "sbb-mcp",
           "momentum": 0,
-          "rank": 25
+          "rank": 17
+        },
+        {
+          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
+          "title": "Flight Search MCP Server",
+          "momentum": 0,
+          "rank": 18
+        },
+        {
+          "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
+          "title": "Linkup",
+          "momentum": 0,
+          "rank": 19
         },
         {
           "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
           "title": "settlegrid-discovery",
           "momentum": 0,
-          "rank": 26
+          "rank": 20
         },
         {
-          "id": "7c0e4ef9-c2e0-4826-a2c9-949ebc5f5b5f",
-          "title": "Ayni",
+          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
+          "title": "KRDS Design System",
           "momentum": 0,
-          "rank": 27
+          "rank": 21
         },
         {
-          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
-          "title": "Mesh MCP",
+          "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
+          "title": "Hugeicons MCP Server",
           "momentum": 0,
-          "rank": 28
+          "rank": 22
         },
         {
-          "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
-          "title": "Context7",
+          "id": "9a58e6b6-6486-47c2-b05d-5362e3b85da7",
+          "title": "AKShare One MCP Server",
           "momentum": 0,
-          "rank": 29
+          "rank": 23
         },
         {
           "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
           "title": "cultural-intelligence",
           "momentum": 0,
-          "rank": 30
-        },
-        {
-          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
-          "title": "Brave Search",
-          "momentum": 0,
-          "rank": 31
+          "rank": 24
         },
         {
           "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
           "title": "Microsoft Learn MCP",
           "momentum": 0,
+          "rank": 25
+        },
+        {
+          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
+          "title": "Context Awesome",
+          "momentum": 0,
+          "rank": 26
+        },
+        {
+          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
+          "title": "Paper Search",
+          "momentum": 0,
+          "rank": 27
+        },
+        {
+          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
+          "title": "Brave Search",
+          "momentum": 0,
+          "rank": 28
+        },
+        {
+          "id": "706d98f8-dc33-453d-9103-d28364976e58",
+          "title": "icons8mcp",
+          "momentum": 0,
+          "rank": 29
+        },
+        {
+          "id": "7c0e4ef9-c2e0-4826-a2c9-949ebc5f5b5f",
+          "title": "Ayni",
+          "momentum": 0,
+          "rank": 30
+        },
+        {
+          "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
+          "title": "Context7",
+          "momentum": 0,
+          "rank": 31
+        },
+        {
+          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
+          "title": "paper-search-mcp-openai-v2",
+          "momentum": 0,
           "rank": 32
         },
         {
-          "id": "33d15eec-1ccf-4070-9323-6ebe58759b50",
-          "title": "Cloud101 Korea",
+          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
+          "title": "Mesh MCP",
           "momentum": 0,
           "rank": 33
         },
@@ -1128,50 +1128,50 @@
           "rank": 34
         },
         {
-          "id": "dc70d6a2-f904-4a0c-b5b0-d6585e323d65",
-          "title": "ai-marketing-agent",
+          "id": "ba8d79ca-2d8e-40dc-9dbd-df2e1731904b",
+          "title": "Bitpoort",
           "momentum": 0,
           "rank": 35
         },
         {
-          "id": "ba8d79ca-2d8e-40dc-9dbd-df2e1731904b",
-          "title": "Bitpoort",
+          "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
+          "title": "Senzing",
           "momentum": 0,
           "rank": 36
         },
         {
-          "id": "706d98f8-dc33-453d-9103-d28364976e58",
-          "title": "icons8mcp",
+          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
+          "title": "Blockscout MCP Server",
           "momentum": 0,
           "rank": 37
         },
         {
-          "id": "abdea6d2-bc2d-43f3-922a-f836cc91ded5",
-          "title": "strale",
+          "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
+          "title": "Ternary Intelligence Stack",
           "momentum": 0,
           "rank": 38
         },
         {
-          "id": "c379873f-69ec-49ac-9ff3-823925cf6d47",
-          "title": "Weather MCP Server",
+          "id": "33d15eec-1ccf-4070-9323-6ebe58759b50",
+          "title": "Cloud101 Korea",
           "momentum": 0,
           "rank": 39
         },
         {
-          "id": "d6103139-7bb8-4c02-9ea8-645c59f6ca7d",
-          "title": "mcp-music-studio",
+          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
+          "title": "Seoul Essentials",
           "momentum": 0,
           "rank": 40
         },
         {
-          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
-          "title": "Saju Insights",
+          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
+          "title": "srv-d7aoqmh5pdvs7391dcqg",
           "momentum": 0,
           "rank": 41
         },
         {
-          "id": "69f8e0df-fb64-4f79-a684-6cfbdc2ba7ad",
-          "title": "Slack",
+          "id": "1fa33040-57e6-4ab1-9828-329b1204ebc7",
+          "title": "Visualization Charts Server",
           "momentum": 0,
           "rank": 42
         },
@@ -1182,44 +1182,44 @@
           "rank": 43
         },
         {
-          "id": "eb9488e1-5131-4823-b7a7-101ca4d636e4",
-          "title": "Catalunya 2022",
+          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
+          "title": "MLB Stats Server",
           "momentum": 0,
           "rank": 44
         },
         {
-          "id": "c4cec09e-359e-473c-9427-16aa90cd3fed",
-          "title": "Web Scout",
+          "id": "dc70d6a2-f904-4a0c-b5b0-d6585e323d65",
+          "title": "ai-marketing-agent",
           "momentum": 0,
           "rank": 45
         },
         {
-          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
-          "title": "Seoul Essentials",
+          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
+          "title": "Saju Insights",
           "momentum": 0,
           "rank": 46
-        },
-        {
-          "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
-          "title": "Senzing",
-          "momentum": 0,
-          "rank": 47
         },
         {
           "id": "9df2fd7e-6ff0-46c9-8b1f-17ba466edad1",
           "title": "cryptoiz-mcp",
           "momentum": 0,
+          "rank": 47
+        },
+        {
+          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
+          "title": "Octomil",
+          "momentum": 0,
           "rank": 48
         },
         {
-          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
-          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "id": "de0ed2fa-ad2a-4cca-b45d-16a6ff80bfd7",
+          "title": "Harvard Course Explorer",
           "momentum": 0,
           "rank": 49
         },
         {
-          "id": "1fa33040-57e6-4ab1-9828-329b1204ebc7",
-          "title": "Visualization Charts Server",
+          "id": "d38dd88c-9ced-4ef3-8a56-56ea0ce2ceb4",
+          "title": "cancersupport",
           "momentum": 0,
           "rank": 50
         }
@@ -1229,7 +1229,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-17T05:40:56.493Z",
+      "generatedAt": "2026-05-18T06:03:37.454Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     }


### PR DESCRIPTION
Automated data refresh from `Run shadow scoring`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26016418448

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.