### PR TITLE
fix(digest): resolve legacy profile email identities

### DIFF
--- a/src/app/api/cron/digest/weekly/route.ts
+++ b/src/app/api/cron/digest/weekly/route.ts
@@ -18,20 +18,18 @@
 //     call is made even when the provider is configured.
 //
 // User → email mapping:
-//   StarScreener today does NOT persist email addresses. `userId` is
-//   derived from an email HMAC, so the server cannot recover the email
-//   from a rule. Until that changes, operators can provide a JSON map
-//   in `DIGEST_USER_EMAILS_JSON` (format `{ "<userId>": "<email>" }`);
-//   users without an entry are skipped and counted. Once a user→email
-//   table lands, the lookup here should switch to that table and the
-//   env map becomes a test-only override.
+//   Prefer active `profiles.email` rows. The legacy pipeline alert rules
+//   still key by `verifyUserAuth().userId`, so the resolver bridges direct
+//   profile ids, Clerk ids, and signed-session `u_<HMAC(email)>` ids.
+//   `DIGEST_USER_EMAILS_JSON` remains a fallback for local fixtures and any
+//   anonymous/sessionless id that cannot be resolved from profiles.
 //
 // Response shape:
 //   { ok: true, skipped?, attempted, sent, skippedUsers, errors: [...],
 //     durationMs, dryRun }
 
 import { NextRequest, NextResponse } from "next/server";
-import { and, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, isNotNull, isNull } from "drizzle-orm";
 
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
 import { withBodySizeLimit } from "@/lib/api-helpers";
@@ -39,6 +37,7 @@ import {
   buildWeeklyDigests,
   type DigestUserEmailMap,
   loadUserEmailMapFromEnv,
+  mergeProfileEmailsIntoUserEmailMap,
   collectAlertsByUser,
   pickTopBreakouts,
 } from "@/lib/pipeline/alerts/weekly-digest";
@@ -55,13 +54,15 @@ import { mintUnsubToken } from "@/lib/newsletter/tokens";
 import { db } from "@/lib/db/client";
 import { newsletterSubscribers } from "@/lib/db/schema/newsletter";
 import { profiles } from "@/lib/db/schema/profiles";
+import { deriveUserId } from "@/lib/api/session";
 
 /**
- * Resolve userId → email by querying `profiles.email` (the canonical source
- * since Stage 5 / B.1). Falls back to `DIGEST_USER_EMAILS_JSON` for any
- * userIds the DB doesn't yet cover — primarily useful in test/dev where
- * the env override is more convenient than seeding a profile row, and as
- * a temporary safety net for any user whose Clerk webhook hasn't yet
+ * Resolve userId → email by querying `profiles.email` rows (canonical since
+ * Stage 5 / B.1). Deleted profiles are included in the lookup so they can
+ * suppress stale env fallback entries. Falls back to `DIGEST_USER_EMAILS_JSON`
+ * for any userIds the DB doesn't cover — primarily useful in test/dev where
+ * the env override is more convenient than seeding a profile row, and as a
+ * temporary safety net for any user whose Clerk webhook hasn't yet
  * materialised a profile row.
  *
  * DB rows always win when both are present: the DB is the source of truth
@@ -75,21 +76,21 @@ async function resolveUserEmails(
   const ids = Array.from(new Set(userIds));
   if (ids.length === 0) return envMap;
 
-  const merged = new Map(envMap);
   try {
     const rows = await db
       .select({
+        profileId: profiles.id,
         clerkUserId: profiles.clerkUserId,
         email: profiles.email,
+        deletedAt: profiles.deletedAt,
       })
-      .from(profiles)
-      .where(inArray(profiles.clerkUserId, ids));
-    for (const row of rows) {
-      if (!row.email) continue;
-      const trimmed = row.email.trim();
-      if (trimmed.length === 0 || !trimmed.includes("@")) continue;
-      merged.set(row.clerkUserId, trimmed);
-    }
+      .from(profiles);
+    return mergeProfileEmailsIntoUserEmailMap({
+      userIds: ids,
+      fallbackEmails: envMap,
+      profiles: rows,
+      deriveUserIdFromEmail: deriveUserId,
+    });
   } catch (err) {
     // DB read failure must not crash the digest. Fall through to whatever
     // the env map provided (often empty in prod) — the existing
@@ -99,7 +100,7 @@ async function resolveUserEmails(
       err,
     );
   }
-  return merged;
+  return envMap;
 }
 
 export const runtime = "nodejs";

--- a/src/lib/pipeline/__tests__/digest.test.ts
+++ b/src/lib/pipeline/__tests__/digest.test.ts
@@ -34,6 +34,7 @@ import {
   buildWeeklyDigests,
   collectAlertsByUser,
   loadUserEmailMapFromEnv,
+  mergeProfileEmailsIntoUserEmailMap,
 } from "../alerts/weekly-digest";
 import { ConsoleProvider } from "../../email/providers/console";
 import { ResendProvider } from "../../email/providers/resend";
@@ -343,6 +344,95 @@ test("loadUserEmailMapFromEnv: tolerates garbage JSON", () => {
   process.env.DIGEST_USER_EMAILS_JSON = "not-json{";
   assert.equal(loadUserEmailMapFromEnv().size, 0);
   delete process.env.DIGEST_USER_EMAILS_JSON;
+});
+
+test("mergeProfileEmailsIntoUserEmailMap: DB rows win for profile and Clerk ids", () => {
+  const out = mergeProfileEmailsIntoUserEmailMap({
+    userIds: ["profile-a", "clerk-b"],
+    fallbackEmails: new Map([
+      ["profile-a", "stale-profile@example.com"],
+      ["clerk-b", "stale-clerk@example.com"],
+    ]),
+    profiles: [
+      {
+        profileId: "profile-a",
+        clerkUserId: "clerk-a",
+        email: " profile@example.com ",
+        deletedAt: null,
+      },
+      {
+        profileId: "profile-b",
+        clerkUserId: "clerk-b",
+        email: "clerk@example.com",
+        deletedAt: null,
+      },
+    ],
+  });
+
+  assert.equal(out.get("profile-a"), "profile@example.com");
+  assert.equal(out.get("clerk-b"), "clerk@example.com");
+});
+
+test("mergeProfileEmailsIntoUserEmailMap: resolves signed-session email HMAC ids", () => {
+  const out = mergeProfileEmailsIntoUserEmailMap({
+    userIds: ["u_alice_hmac"],
+    fallbackEmails: new Map(),
+    profiles: [
+      {
+        profileId: "profile-a",
+        clerkUserId: "clerk-a",
+        email: "alice@example.com",
+        deletedAt: null,
+      },
+    ],
+    deriveUserIdFromEmail: (email) =>
+      email === "alice@example.com" ? "u_alice_hmac" : "u_other",
+  });
+
+  assert.equal(out.get("u_alice_hmac"), "alice@example.com");
+});
+
+test("mergeProfileEmailsIntoUserEmailMap: suppresses soft-deleted profile identities", () => {
+  const out = mergeProfileEmailsIntoUserEmailMap({
+    userIds: ["profile-deleted", "clerk-deleted", "u_deleted_hmac", "external"],
+    fallbackEmails: new Map([
+      ["profile-deleted", "fallback-profile@example.com"],
+      ["clerk-deleted", "fallback-clerk@example.com"],
+      ["u_deleted_hmac", "fallback-derived@example.com"],
+      ["external", "external@example.com"],
+    ]),
+    profiles: [
+      {
+        profileId: "profile-deleted",
+        clerkUserId: "clerk-deleted",
+        email: "deleted@example.com",
+        deletedAt: new Date("2026-05-18T00:00:00.000Z"),
+      },
+    ],
+    deriveUserIdFromEmail: () => "u_deleted_hmac",
+  });
+
+  assert.equal(out.has("profile-deleted"), false);
+  assert.equal(out.has("clerk-deleted"), false);
+  assert.equal(out.has("u_deleted_hmac"), false);
+  assert.equal(out.get("external"), "external@example.com");
+});
+
+test("mergeProfileEmailsIntoUserEmailMap: ignores invalid profile emails", () => {
+  const out = mergeProfileEmailsIntoUserEmailMap({
+    userIds: ["profile-a"],
+    fallbackEmails: new Map([["profile-a", "fallback@example.com"]]),
+    profiles: [
+      {
+        profileId: "profile-a",
+        clerkUserId: "clerk-a",
+        email: "not-an-email",
+        deletedAt: null,
+      },
+    ],
+  });
+
+  assert.equal(out.get("profile-a"), "fallback@example.com");
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/pipeline/alerts/weekly-digest.ts
+++ b/src/lib/pipeline/alerts/weekly-digest.ts
@@ -8,7 +8,7 @@
 // Contract:
 //   - INPUT: the set of userIds that have rules, the last-7d alert
 //     events grouped by user, the current Repo[] snapshot, and the
-//     operator-provided userId→email map.
+//     resolved userId→email map (profile-backed with env fallback).
 //   - OUTPUT: `DigestInput[]` ready for `renderDigestEmail`, plus the
 //     count of users we had to skip because they had no email on file.
 //
@@ -35,6 +35,26 @@ import type { AlertEvent, AlertEventStore } from "../types";
 
 export type DigestUserEmailMap = ReadonlyMap<string, string>;
 
+export interface DigestProfileEmailRow {
+  profileId: string;
+  clerkUserId: string;
+  email: string | null;
+  /** Non-null means the account was soft-deleted and must not receive mail. */
+  deletedAt?: Date | string | null;
+}
+
+export interface MergeProfileEmailsInput {
+  userIds: Iterable<string>;
+  fallbackEmails: DigestUserEmailMap;
+  profiles: Iterable<DigestProfileEmailRow>;
+  /**
+   * Maps a profile email to the legacy signed-session userId shape
+   * (`u_<hmac>`). Optional because local tests/dev may not configure the
+   * session secret; direct profile/clerk ids still work without it.
+   */
+  deriveUserIdFromEmail?: (email: string) => string;
+}
+
 /**
  * Load `DIGEST_USER_EMAILS_JSON` from the environment. Format:
  *   `{"u_abc":"alice@example.com","u_def":"bob@example.com"}`
@@ -43,9 +63,8 @@ export type DigestUserEmailMap = ReadonlyMap<string, string>;
  * map path is deliberate: with no mapping today the weekly digest can't
  * deliver real emails, so the cron skips every user and logs counts.
  *
- * TODO(auth): replace with a real user table lookup once accounts have
- * email on file. At that point this env map should degrade to a
- * test-only override.
+ * This is now a fallback. The weekly cron merges active `profiles.email`
+ * rows over this map when a profile-backed identity can be matched.
  */
 export function loadUserEmailMapFromEnv(): DigestUserEmailMap {
   const raw = process.env.DIGEST_USER_EMAILS_JSON;
@@ -66,6 +85,57 @@ export function loadUserEmailMapFromEnv(): DigestUserEmailMap {
   } catch {
     return new Map();
   }
+}
+
+/**
+ * Merge profile-backed emails into the digest userId map. The weekly digest
+ * has to bridge two identity eras:
+ *
+ * - legacy pipeline alert rules key by `verifyUserAuth().userId`, commonly
+ *   `u_<HMAC(email)>` for signed browser sessions or arbitrary ids from
+ *   USER_TOKENS_JSON;
+ * - newer account tables key by `profiles.id` / `profiles.clerkUserId`.
+ *
+ * The DB profile email wins when it can be matched to any active digest
+ * userId. Deleted profile identities actively suppress matching env fallback
+ * entries so account deletion cannot leave a digest delivery path behind.
+ * The env map remains a fallback for anonymous/sessionless ids and test
+ * fixtures.
+ */
+export function mergeProfileEmailsIntoUserEmailMap(
+  input: MergeProfileEmailsInput,
+): DigestUserEmailMap {
+  const requested = new Set(input.userIds);
+  const merged = new Map(input.fallbackEmails);
+  if (requested.size === 0) return merged;
+
+  for (const profile of input.profiles) {
+    const email = profile.email?.trim();
+    const candidates = [profile.profileId, profile.clerkUserId];
+    if (email && email.includes("@") && input.deriveUserIdFromEmail) {
+      try {
+        candidates.push(input.deriveUserIdFromEmail(email));
+      } catch {
+        // SESSION_SECRET can be missing in local/dev test contexts. Direct
+        // profile/clerk id matching and env fallback still remain available.
+      }
+    }
+
+    if (profile.deletedAt) {
+      for (const candidate of candidates) {
+        if (requested.has(candidate)) merged.delete(candidate);
+      }
+      continue;
+    }
+
+    if (!email || !email.includes("@")) continue;
+
+    for (const candidate of candidates) {
+      if (requested.has(candidate)) merged.set(candidate, email);
+    }
+  }
+
+  return merged;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #1767. That PR merged before the blocker fix reached main.\n\nWhat changed:\n- resolve weekly digest emails for profiles.id, profiles.clerkUserId, and signed-session u_<HMAC(email)> legacy alert-rule ids\n- include deleted profile rows in the resolver so deleted identities suppress stale DIGEST_USER_EMAILS_JSON fallback entries\n- add focused coverage for DB precedence, signed-session id bridging, deleted-profile suppression, and invalid profile email fallback\n\nLocal validation:\n- npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/pipeline/__tests__/digest.test.ts\n- npm run typecheck\n- npm run lint:guards\n- npm run lint (0 errors, existing warnings)\n- npm audit --audit-level=high (0 vulnerabilities)\n- npm test\n- npm run build