### PR TITLE
feat(billing): paywall toast + Welcome-to-Pro success surface (S5.A.5+A.6)

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -10,6 +10,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { CheckoutSuccess } from "@/components/pricing/CheckoutSuccess";
 import { PricingCard } from "@/components/pricing/PricingCard";
 import { PricingFAQ } from "@/components/pricing/PricingFAQ";
 import { TierComparison } from "@/components/pricing/TierComparison";
@@ -47,12 +48,21 @@ export const metadata: Metadata = {
 export const revalidate = 3600;
 
 interface PricingPageProps {
-  searchParams?: Promise<{ cadence?: string | string[] }>;
+  searchParams?: Promise<{
+    cadence?: string | string[];
+    checkout?: string | string[];
+    session_id?: string | string[];
+  }>;
 }
 
 function resolveCadence(raw: string | string[] | undefined): BillingCadence {
   const value = Array.isArray(raw) ? raw[0] : raw;
   return value === "yearly" ? "yearly" : "monthly";
+}
+
+function firstParam(raw: string | string[] | undefined): string | undefined {
+  if (!raw) return undefined;
+  return Array.isArray(raw) ? raw[0] : raw;
 }
 
 // -----------------------------------------------------------------------------
@@ -96,12 +106,21 @@ export default async function PricingPage({ searchParams }: PricingPageProps) {
 
   const nextCadence: BillingCadence = cadence === "yearly" ? "monthly" : "yearly";
 
+  // S5.A.6 — post-Stripe-checkout success surface. Stripe redirects to
+  // /pricing?checkout=success&session_id=cs_test_... after a successful
+  // session. The CheckoutSuccess island polls /api/auth/session for the
+  // tier flip and surfaces a "Welcome to Pro" confirmation.
+  const checkoutSuccess = firstParam(params?.checkout) === "success";
+  const sessionId = firstParam(params?.session_id);
+
   return (
     <main className="min-h-screen bg-bg-primary text-text-primary font-mono">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: jsonLd }}
       />
+
+      {checkoutSuccess ? <CheckoutSuccess sessionId={sessionId} /> : null}
 
       <div className="max-w-[1400px] mx-auto px-4 md:px-6 py-8 md:py-12">
         {/* Hero */}

--- a/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
+++ b/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
@@ -312,6 +312,26 @@ export function AddAlertRuleDialog({
         | ApiErr;
       if (!res.ok || data.ok === false) {
         const err = data as ApiErr;
+        // S5.A.3: 402 quota_exceeded is a paywall trigger. Surface the
+        // upgrade CTA via Sonner action button rather than the standard
+        // error toast so the user sees the path forward in one click.
+        if (res.status === 402 && err.error === "quota_exceeded") {
+          const upgradeUrl =
+            typeof (err as ApiErr & { upgradeUrl?: string }).upgradeUrl === "string"
+              ? (err as ApiErr & { upgradeUrl?: string }).upgradeUrl!
+              : "/pricing";
+          toast.info(err.message ?? "You've hit your plan's limit.", {
+            duration: 10000,
+            action: {
+              label: "Upgrade",
+              onClick: () => {
+                window.location.href = upgradeUrl;
+              },
+            },
+          });
+          setSubmitting(false);
+          return;
+        }
         if (err.error === "rule_cap_exceeded") {
           throw new AdminRecoverableError("You have hit the 25-rule limit. Delete one first.");
         }

--- a/src/components/pricing/CheckoutSuccess.tsx
+++ b/src/components/pricing/CheckoutSuccess.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+// <CheckoutSuccess /> — S5.A.6 post-checkout success surface.
+//
+// Mounted from /pricing/page.tsx when ?checkout=success is in the URL.
+// Polls /api/auth/session every 1.5s for up to 30s waiting for the user's
+// tier to flip from "free" → "pro" / "team". Stripe's webhook usually
+// delivers within 1-2s, so the wait is normally invisible.
+//
+// On flip: terminal-aesthetic confirmation + "Create next alert" +
+// "Manage billing" buttons. No confetti — matches the rest of the
+// product's restrained chrome.
+//
+// On timeout (30s without flip): "Payment recorded — your tier will
+// activate shortly. Refresh if it doesn't appear in 1 minute." This
+// covers the very unlikely race where the webhook is delayed (Stripe
+// SLA is best-effort, not real-time).
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+
+import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
+
+interface SessionProbeResponse {
+  ok: boolean;
+  tier?: string;
+  tierExpiresAt?: string | null;
+}
+
+type FlipState =
+  | { kind: "waiting"; pollsAttempted: number }
+  | { kind: "flipped"; tier: "pro" | "team"; expiresAt: string | null }
+  | { kind: "timeout" };
+
+const POLL_INTERVAL_MS = 1500;
+const POLL_MAX_ATTEMPTS = 20; // 20 * 1.5s = 30s ceiling.
+
+function isPaidTier(tier: string | undefined): tier is "pro" | "team" {
+  return tier === "pro" || tier === "team";
+}
+
+function formatRenewalDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function CheckoutSuccess({ sessionId }: { sessionId?: string }) {
+  const [state, setState] = useState<FlipState>({
+    kind: "waiting",
+    pollsAttempted: 0,
+  });
+  // Track whether we've already fired the funnel event so a re-render
+  // doesn't double-capture.
+  const fundedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let attempt = 0;
+
+    async function poll() {
+      if (cancelled) return;
+      attempt += 1;
+      try {
+        const res = await fetch("/api/auth/session", {
+          credentials: "include",
+          cache: "no-store",
+        });
+        const body = (await res.json().catch(() => null)) as
+          | SessionProbeResponse
+          | null;
+        if (cancelled) return;
+        if (body?.ok && isPaidTier(body.tier)) {
+          setState({
+            kind: "flipped",
+            tier: body.tier,
+            expiresAt: body.tierExpiresAt ?? null,
+          });
+          // Fire funnel event ONCE.
+          if (!fundedRef.current) {
+            fundedRef.current = true;
+            try {
+              getLoadedBrowserPostHog()?.capture("checkout_completed", {
+                tier: body.tier,
+                session_id: sessionId,
+              });
+            } catch {
+              // analytics must never throw
+            }
+          }
+          return;
+        }
+        if (attempt >= POLL_MAX_ATTEMPTS) {
+          setState({ kind: "timeout" });
+          return;
+        }
+        setState({ kind: "waiting", pollsAttempted: attempt });
+        setTimeout(poll, POLL_INTERVAL_MS);
+      } catch {
+        // Network failure — back off and retry once. If we hit the
+        // attempt ceiling, downgrade to timeout.
+        if (attempt >= POLL_MAX_ATTEMPTS) {
+          setState({ kind: "timeout" });
+          return;
+        }
+        setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    }
+
+    // Start polling immediately.
+    poll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      style={{
+        maxWidth: 720,
+        margin: "32px auto",
+        padding: "20px 24px",
+        border: "1px solid var(--v2-line-200, var(--v3-line-200))",
+        background: "var(--v2-bg-050, var(--v3-bg-050))",
+        borderRadius: 4,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--font-geist-mono), monospace",
+          fontSize: 10,
+          letterSpacing: "0.18em",
+          textTransform: "uppercase",
+          color: "var(--v2-ink-400, var(--v3-ink-400))",
+        }}
+      >
+        {"// CHECKOUT · COMPLETE"}
+      </span>
+
+      {state.kind === "flipped" ? (
+        <>
+          <h2
+            style={{
+              fontFamily: "var(--font-geist), Inter, sans-serif",
+              fontSize: 28,
+              fontWeight: 510,
+              letterSpacing: "-0.018em",
+              lineHeight: 1.1,
+              margin: 0,
+              color: "var(--v2-ink-000, var(--v3-ink-000))",
+            }}
+          >
+            You&apos;re on {state.tier === "pro" ? "Pro" : "Team"}.
+          </h2>
+          <p
+            style={{
+              fontSize: 14,
+              color: "var(--v2-ink-200, var(--v3-ink-200))",
+              margin: 0,
+            }}
+          >
+            {state.expiresAt && formatRenewalDate(state.expiresAt)
+              ? `Renews ${formatRenewalDate(state.expiresAt)}.`
+              : "Subscription active."}{" "}
+            Your new quota lights up on the next page load.
+          </p>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 10,
+              paddingTop: 4,
+            }}
+          >
+            <Link
+              href="/you/alerts"
+              className="v2-btn v2-btn-primary"
+              style={{ minHeight: 38 }}
+            >
+              CREATE YOUR NEXT ALERT →
+            </Link>
+            <Link
+              href="/you/settings"
+              className="v2-btn v2-btn-ghost"
+              style={{ minHeight: 38 }}
+            >
+              MANAGE BILLING
+            </Link>
+          </div>
+        </>
+      ) : state.kind === "timeout" ? (
+        <>
+          <h2
+            style={{
+              fontFamily: "var(--font-geist), Inter, sans-serif",
+              fontSize: 24,
+              fontWeight: 510,
+              letterSpacing: "-0.018em",
+              lineHeight: 1.1,
+              margin: 0,
+              color: "var(--v2-ink-000, var(--v3-ink-000))",
+            }}
+          >
+            Payment recorded.
+          </h2>
+          <p
+            style={{
+              fontSize: 14,
+              color: "var(--v2-ink-200, var(--v3-ink-200))",
+              margin: 0,
+            }}
+          >
+            Your tier will activate shortly. If it hasn&apos;t appeared in 60
+            seconds, refresh the page or check{" "}
+            <Link
+              href="/you/settings"
+              style={{ color: "var(--v2-acc, var(--v3-acc))" }}
+            >
+              /you/settings
+            </Link>
+            . If the issue persists, reply to your Stripe receipt and
+            we&apos;ll fix it manually.
+          </p>
+        </>
+      ) : (
+        <>
+          <h2
+            style={{
+              fontFamily: "var(--font-geist), Inter, sans-serif",
+              fontSize: 24,
+              fontWeight: 510,
+              letterSpacing: "-0.018em",
+              lineHeight: 1.1,
+              margin: 0,
+              color: "var(--v2-ink-000, var(--v3-ink-000))",
+            }}
+          >
+            Activating your subscription…
+          </h2>
+          <p
+            style={{
+              fontSize: 14,
+              color: "var(--v2-ink-200, var(--v3-ink-200))",
+              margin: 0,
+            }}
+          >
+            Confirming with Stripe (attempt {state.pollsAttempted + 1} of{" "}
+            {POLL_MAX_ATTEMPTS}). This usually takes 1-2 seconds.
+          </p>
+        </>
+      )}
+    </section>
+  );
+}
+
+export default CheckoutSuccess;

--- a/src/components/pricing/CheckoutWalkthrough.tsx
+++ b/src/components/pricing/CheckoutWalkthrough.tsx
@@ -250,12 +250,27 @@ export function CheckoutWalkthrough({
                 margin: 0,
               }}
             >
-              Cancel anytime — no commitment
+              30-day money-back guarantee
             </h2>
             <p style={{ fontSize: 13, color: "var(--v2-ink-200)", margin: 0 }}>
-              You can cancel from your Stripe dashboard or by replying to any
-              billing email. We keep your watchlist + alert rules even if you
-              downgrade back to Free.
+              If TrendingRepo doesn&apos;t earn its keep in the first 30 days,
+              reply to any billing email and we&apos;ll refund the full charge —
+              no questions, no exit interview.
+            </p>
+            <p style={{ fontSize: 13, color: "var(--v2-ink-200)", margin: 0 }}>
+              You can cancel anytime from{" "}
+              <code
+                style={{
+                  fontFamily: "var(--font-geist-mono), monospace",
+                  fontSize: 12,
+                  color: "var(--v2-ink-100)",
+                }}
+              >
+                /you/settings
+              </code>{" "}
+              (Stripe-hosted portal — your card never touches our servers). We
+              keep your watchlist and alert rules even if you downgrade back to
+              Free.
             </p>
             <p
               style={{
@@ -266,8 +281,7 @@ export function CheckoutWalkthrough({
                 borderTop: "1px solid var(--v2-line-100)",
               }}
             >
-              Next step opens a hosted Stripe Checkout in this tab. Your card
-              never touches our servers.
+              Next step opens a hosted Stripe Checkout in this tab.
             </p>
           </section>
         )}


### PR DESCRIPTION
## Summary

Stage 5 / A.5 + A.6 combined. Closes the visible paywall loop: a 402 quota response from #1775 surfaces a one-click "Upgrade" CTA, and the Stripe checkout redirect lands on a credible "You're on Pro" page that polls \`/api/auth/session\` for the tier flip.

## A.5 — Paywall handler in AddAlertRuleDialog

When POST \`/api/me/alert-rules\` returns **402 quota_exceeded** (new envelope from #1775), surface a Sonner toast with:

- Server-provided message ("You've reached your plan's alert rule limit (3). Upgrade for more.")
- **[Upgrade]** action button → navigates to \`/pricing\` (or \`upgradeUrl\` from the response)
- 10-second duration so the user has time to click

Pre-existing 429 \`rule_cap_exceeded\` handler kept for back-compat during the deploy window.

## A.5 — CheckoutWalkthrough step-2 copy update

Step 2 headline: **"Cancel anytime — no commitment"** → **"30-day money-back guarantee"**. Body backed by the operator runbook \`docs/runbooks/refund-30-day.md\` (merged in #1765):

- Reply to any billing email within 30 days for a full refund, no exit interview
- Cancel from \`/you/settings\` (Stripe-hosted portal)
- Watchlist + alert rules preserved on downgrade

This is the safety net that justifies the "instant paywall, no trial" decision from the Stage 5 plan.

## A.6 — \`<CheckoutSuccess />\` client island

New file: \`src/components/pricing/CheckoutSuccess.tsx\` (267 lines). Mounted from \`/pricing/page.tsx\` when \`?checkout=success\` is present.

Polls \`/api/auth/session\` every 1.5s up to 30s. State machine:

| State | UI |
|---|---|
| \`waiting\` | "Activating your subscription… (attempt N of 20)" |
| \`flipped\` | "You're on Pro. Renews <date>" + [Create next alert] + [Manage billing] |
| \`timeout\` | "Payment recorded. Your tier will activate shortly. Refresh in 60s or check /you/settings." |

Fires PostHog \`checkout_completed\` event once (ref-tracked) when the flip is detected. Handles the Stripe webhook delay race: redirect can hit \`/pricing\` before the webhook lands — polling closes the window without surfacing a broken "free tier" state.

No confetti — restrained chrome matches the rest of the product.

## Deferred follow-up

\`customer_email\` pre-fill in \`/api/checkout/stripe\` was scoped for this PR but skipped: the route uses \`verifyUserAuth\` (HMAC-of-email userId) but \`profiles.email\` is keyed by \`clerkUserId\`, so the lookup is non-trivial without mixing auth schemes. Existing behavior (Stripe collects email at checkout) works for the first-dollar loop. Follow-up PR can add the pre-fill by also calling \`currentUser()\` from \`@clerk/nextjs/server\`.

## Verification

- \`npm run typecheck\` clean
- \`npm run lint:guards\` clean

## End-to-end test plan (post-merge with Stripe test mode)

1. **Free user creates 4th alert rule** → 402 → toast: "You've reached your plan's alert rule limit (3). Upgrade for more." with [Upgrade] button
2. **Click [Upgrade]** → \`/pricing\`
3. **Click Pro card** → CheckoutWalkthrough opens; step 2 shows **"30-day money-back guarantee"**
4. **Complete Stripe test card 4242…** → redirected to \`/pricing?checkout=success&session_id=cs_test_...\`
5. **CheckoutSuccess polls \`/api/auth/session\`** → flips to "You're on Pro" within 1-3 seconds
6. **Click [Create your next alert]** → \`/you/alerts\` now allows rule #4

## Cross-reference

- **A.3** 402 quota envelope → #1775 (just merged)
- **A.1+A.2** /you/settings tier display + billing portal → #1773 (just merged)
- **D.3** refund runbook backing the money-back copy → #1765 (merged)
- **B.1** \`profiles.email\` swap for digest → #1767 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)