### PR TITLE
feat(ux): 17 loading.tsx skeletons for admin + /you/* + form routes (S5.C.4)

### DIFF
--- a/src/app/admin/ideas-queue/loading.tsx
+++ b/src/app/admin/ideas-queue/loading.tsx
@@ -1,0 +1,33 @@
+// Admin queue skeleton — matches the rendered table chrome so the
+// hand-off into real content has no layout shift.
+
+export default function AdminIdeasQueueLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-14 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-10 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/ideas-queue/loading.tsx
+++ b/src/app/admin/ideas-queue/loading.tsx
@@ -6,7 +6,7 @@ export default function AdminIdeasQueueLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-64 rounded-[2px]"
+          className="h-7 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="grid grid-cols-2 gap-2 md:grid-cols-4">

--- a/src/app/admin/login/loading.tsx
+++ b/src/app/admin/login/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminLoginLoading() {
     <div className="mx-auto max-w-md px-4 py-12 md:py-20">
       <div className="animate-pulse space-y-3">
         <div
-          className="h-7 w-48 rounded-[2px]"
+          className="h-7 w-full max-w-48 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div
@@ -15,7 +15,7 @@ export default function AdminLoginLoading() {
           style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
         />
         <div
-          className="h-10 w-32 rounded-[2px]"
+          className="h-10 w-full max-w-32 rounded-[2px]"
           style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
         />
       </div>

--- a/src/app/admin/login/loading.tsx
+++ b/src/app/admin/login/loading.tsx
@@ -1,0 +1,24 @@
+export default function AdminLoginLoading() {
+  return (
+    <div className="mx-auto max-w-md px-4 py-12 md:py-20">
+      <div className="animate-pulse space-y-3">
+        <div
+          className="h-7 w-48 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div
+          className="h-12 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-12 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-10 w-32 rounded-[2px]"
+          style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/pool-aggregate/loading.tsx
+++ b/src/app/admin/pool-aggregate/loading.tsx
@@ -1,0 +1,21 @@
+export default function AdminPoolAggregateLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-72 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-20 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/pool-aggregate/loading.tsx
+++ b/src/app/admin/pool-aggregate/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminPoolAggregateLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-72 rounded-[2px]"
+          className="h-7 w-full max-w-72 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="grid grid-cols-2 gap-2 md:grid-cols-3">

--- a/src/app/admin/pool/loading.tsx
+++ b/src/app/admin/pool/loading.tsx
@@ -1,0 +1,25 @@
+export default function AdminPoolLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-14 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+        <div
+          className="h-72 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/pool/loading.tsx
+++ b/src/app/admin/pool/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminPoolLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-64 rounded-[2px]"
+          className="h-7 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="grid grid-cols-2 gap-2 md:grid-cols-4">

--- a/src/app/admin/referrals/loading.tsx
+++ b/src/app/admin/referrals/loading.tsx
@@ -1,0 +1,21 @@
+export default function AdminReferralsLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-12 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/referrals/loading.tsx
+++ b/src/app/admin/referrals/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminReferralsLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-64 rounded-[2px]"
+          className="h-7 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="space-y-2">

--- a/src/app/admin/revenue-queue/loading.tsx
+++ b/src/app/admin/revenue-queue/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminRevenueQueueLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-64 rounded-[2px]"
+          className="h-7 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="grid grid-cols-2 gap-2 md:grid-cols-4">

--- a/src/app/admin/revenue-queue/loading.tsx
+++ b/src/app/admin/revenue-queue/loading.tsx
@@ -1,0 +1,30 @@
+export default function AdminRevenueQueueLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-14 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-14 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/scoring-shadow/loading.tsx
+++ b/src/app/admin/scoring-shadow/loading.tsx
@@ -1,0 +1,25 @@
+export default function AdminScoringShadowLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-72 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div
+          className="h-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-10 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/scoring-shadow/loading.tsx
+++ b/src/app/admin/scoring-shadow/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminScoringShadowLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-72 rounded-[2px]"
+          className="h-7 w-full max-w-72 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div

--- a/src/app/admin/scrapes/loading.tsx
+++ b/src/app/admin/scrapes/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminScrapesLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-64 rounded-[2px]"
+          className="h-7 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="space-y-2">

--- a/src/app/admin/scrapes/loading.tsx
+++ b/src/app/admin/scrapes/loading.tsx
@@ -1,0 +1,21 @@
+export default function AdminScrapesLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="space-y-2">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-12 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/staleness/loading.tsx
+++ b/src/app/admin/staleness/loading.tsx
@@ -1,0 +1,21 @@
+export default function AdminStalenessLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-20 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/staleness/loading.tsx
+++ b/src/app/admin/staleness/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminStalenessLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-64 rounded-[2px]"
+          className="h-7 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="grid grid-cols-2 gap-2 md:grid-cols-3">

--- a/src/app/admin/sweep-cost/loading.tsx
+++ b/src/app/admin/sweep-cost/loading.tsx
@@ -1,0 +1,25 @@
+export default function AdminSweepCostLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div
+          className="h-32 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-10 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/sweep-cost/loading.tsx
+++ b/src/app/admin/sweep-cost/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminSweepCostLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-64 rounded-[2px]"
+          className="h-7 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div

--- a/src/app/admin/unknown-mentions/loading.tsx
+++ b/src/app/admin/unknown-mentions/loading.tsx
@@ -1,0 +1,21 @@
+export default function AdminUnknownMentionsLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-7 w-72 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div className="space-y-2">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-12 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/unknown-mentions/loading.tsx
+++ b/src/app/admin/unknown-mentions/loading.tsx
@@ -3,7 +3,7 @@ export default function AdminUnknownMentionsLoading() {
     <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-7 w-72 rounded-[2px]"
+          className="h-7 w-full max-w-72 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div className="space-y-2">

--- a/src/app/agent-commerce/facilitator/loading.tsx
+++ b/src/app/agent-commerce/facilitator/loading.tsx
@@ -4,11 +4,11 @@ export default function AgentCommerceFacilitatorLoading() {
       <div className="animate-pulse space-y-5">
         <div className="space-y-2">
           <div
-            className="h-9 w-80 rounded-[2px]"
+            className="h-9 w-full max-w-80 rounded-[2px]"
             style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
           />
           <div
-            className="h-4 w-96 rounded-[2px]"
+            className="h-4 w-full max-w-96 rounded-[2px]"
             style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
           />
         </div>

--- a/src/app/agent-commerce/facilitator/loading.tsx
+++ b/src/app/agent-commerce/facilitator/loading.tsx
@@ -1,0 +1,27 @@
+export default function AgentCommerceFacilitatorLoading() {
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-4 md:px-6 md:py-6">
+      <div className="animate-pulse space-y-5">
+        <div className="space-y-2">
+          <div
+            className="h-9 w-80 rounded-[2px]"
+            style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+          />
+          <div
+            className="h-4 w-96 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+          />
+        </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-40 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/alerts/new/loading.tsx
+++ b/src/app/alerts/new/loading.tsx
@@ -3,7 +3,7 @@ export default function AlertsNewLoading() {
     <div className="mx-auto max-w-[760px] px-4 py-6 md:px-6 md:py-8">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-9 w-64 rounded-[2px]"
+          className="h-9 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div
@@ -19,7 +19,7 @@ export default function AlertsNewLoading() {
           style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
         />
         <div
-          className="h-10 w-32 rounded-[2px]"
+          className="h-10 w-full max-w-32 rounded-[2px]"
           style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
         />
       </div>

--- a/src/app/alerts/new/loading.tsx
+++ b/src/app/alerts/new/loading.tsx
@@ -1,0 +1,28 @@
+export default function AlertsNewLoading() {
+  return (
+    <div className="mx-auto max-w-[760px] px-4 py-6 md:px-6 md:py-8">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-9 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div
+          className="h-12 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-12 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-32 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-10 w-32 rounded-[2px]"
+          style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/submit/revenue/loading.tsx
+++ b/src/app/submit/revenue/loading.tsx
@@ -3,11 +3,11 @@ export default function SubmitRevenueLoading() {
     <div className="mx-auto max-w-[760px] px-4 py-6 md:px-6 md:py-8">
       <div className="animate-pulse space-y-4">
         <div
-          className="h-9 w-64 rounded-[2px]"
+          className="h-9 w-full max-w-64 rounded-[2px]"
           style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
         />
         <div
-          className="h-4 w-96 rounded-[2px]"
+          className="h-4 w-full max-w-96 rounded-[2px]"
           style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
         />
         <div
@@ -23,7 +23,7 @@ export default function SubmitRevenueLoading() {
           style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
         />
         <div
-          className="h-10 w-32 rounded-[2px]"
+          className="h-10 w-full max-w-32 rounded-[2px]"
           style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
         />
       </div>

--- a/src/app/submit/revenue/loading.tsx
+++ b/src/app/submit/revenue/loading.tsx
@@ -1,0 +1,32 @@
+export default function SubmitRevenueLoading() {
+  return (
+    <div className="mx-auto max-w-[760px] px-4 py-6 md:px-6 md:py-8">
+      <div className="animate-pulse space-y-4">
+        <div
+          className="h-9 w-64 rounded-[2px]"
+          style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+        />
+        <div
+          className="h-4 w-96 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-12 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-12 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-24 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-10 w-32 rounded-[2px]"
+          style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/you/alerts/loading.tsx
+++ b/src/app/you/alerts/loading.tsx
@@ -8,22 +8,22 @@ export default function YouAlertsLoading() {
         {/* Header */}
         <div className="space-y-2">
           <div
-            className="h-3 w-32 rounded-[2px]"
+            className="h-3 w-full max-w-32 rounded-[2px]"
             style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
           />
           <div
-            className="h-9 w-72 rounded-[2px]"
+            className="h-9 w-full max-w-72 rounded-[2px]"
             style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
           />
           <div
-            className="h-4 w-96 rounded-[2px]"
+            className="h-4 w-full max-w-96 rounded-[2px]"
             style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
           />
         </div>
 
         {/* Add-rule CTA */}
         <div
-          className="h-12 w-48 rounded-[2px]"
+          className="h-12 w-full max-w-48 rounded-[2px]"
           style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
         />
 

--- a/src/app/you/alerts/loading.tsx
+++ b/src/app/you/alerts/loading.tsx
@@ -1,0 +1,43 @@
+// /you/alerts — alert rule list skeleton. Mirrors the page chrome so the
+// hand-off into real content has no layout shift.
+
+export default function YouAlertsLoading() {
+  return (
+    <div className="mx-auto max-w-[1200px] px-4 py-6 md:px-6 md:py-8">
+      <div className="animate-pulse space-y-5">
+        {/* Header */}
+        <div className="space-y-2">
+          <div
+            className="h-3 w-32 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+          />
+          <div
+            className="h-9 w-72 rounded-[2px]"
+            style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+          />
+          <div
+            className="h-4 w-96 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+          />
+        </div>
+
+        {/* Add-rule CTA */}
+        <div
+          className="h-12 w-48 rounded-[2px]"
+          style={{ background: "var(--v3-bg-075, var(--v4-bg-075))" }}
+        />
+
+        {/* Rule rows */}
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-20 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/you/refer/loading.tsx
+++ b/src/app/you/refer/loading.tsx
@@ -4,11 +4,11 @@ export default function YouReferLoading() {
       <div className="animate-pulse space-y-5">
         <div className="space-y-2">
           <div
-            className="h-9 w-72 rounded-[2px]"
+            className="h-9 w-full max-w-72 rounded-[2px]"
             style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
           />
           <div
-            className="h-4 w-96 rounded-[2px]"
+            className="h-4 w-full max-w-96 rounded-[2px]"
             style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
           />
         </div>

--- a/src/app/you/refer/loading.tsx
+++ b/src/app/you/refer/loading.tsx
@@ -1,0 +1,31 @@
+export default function YouReferLoading() {
+  return (
+    <div className="mx-auto max-w-[800px] px-4 py-6 md:px-6 md:py-8">
+      <div className="animate-pulse space-y-5">
+        <div className="space-y-2">
+          <div
+            className="h-9 w-72 rounded-[2px]"
+            style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+          />
+          <div
+            className="h-4 w-96 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+          />
+        </div>
+        <div
+          className="h-32 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-24 rounded-[2px]"
+              style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/you/settings/loading.tsx
+++ b/src/app/you/settings/loading.tsx
@@ -4,15 +4,15 @@ export default function YouSettingsLoading() {
       <div className="animate-pulse space-y-5">
         <div className="space-y-2">
           <div
-            className="h-3 w-32 rounded-[2px]"
+            className="h-3 w-full max-w-32 rounded-[2px]"
             style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
           />
           <div
-            className="h-9 w-64 rounded-[2px]"
+            className="h-9 w-full max-w-64 rounded-[2px]"
             style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
           />
           <div
-            className="h-4 w-80 rounded-[2px]"
+            className="h-4 w-full max-w-80 rounded-[2px]"
             style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
           />
         </div>

--- a/src/app/you/settings/loading.tsx
+++ b/src/app/you/settings/loading.tsx
@@ -1,0 +1,34 @@
+export default function YouSettingsLoading() {
+  return (
+    <div className="mx-auto max-w-[760px] px-4 py-6 md:px-6 md:py-8">
+      <div className="animate-pulse space-y-5">
+        <div className="space-y-2">
+          <div
+            className="h-3 w-32 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+          />
+          <div
+            className="h-9 w-64 rounded-[2px]"
+            style={{ background: "var(--v3-bg-100, var(--v4-bg-100))" }}
+          />
+          <div
+            className="h-4 w-80 rounded-[2px]"
+            style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+          />
+        </div>
+        <div
+          className="h-56 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-24 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+        <div
+          className="h-40 rounded-[2px]"
+          style={{ background: "var(--v3-bg-050, var(--v4-bg-050))" }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Stage 5 / C.4. Closes the remaining \`loading.tsx\` gap. Coverage was 81/98; this PR brings it to **98/98** across all top-level app routes.

## Breakdown

| Section | Routes |
|---|---|
| Admin sub-routes (11) | \`ideas-queue\`, \`login\`, \`pool\`, \`pool-aggregate\`, \`referrals\`, \`revenue-queue\`, \`scoring-shadow\`, \`scrapes\`, \`staleness\`, \`sweep-cost\`, \`unknown-mentions\` |
| You-pages (3) | \`/you/alerts\`, \`/you/refer\`, \`/you/settings\` |
| Form routes (3) | \`/alerts/new\`, \`/agent-commerce/facilitator\`, \`/submit/revenue\` |

## Pattern

Each skeleton:
- Mirrors the real page's outer chrome (header → KPI strip → table/form blocks)
- Uses Tailwind \`animate-pulse\`
- Inline-styled with V3/V4 CSS-var fallbacks (\`var(--v3-bg-050, var(--v4-bg-050))\`) so both theme namespaces work
- Server component (no \`"use client"\`) — pure presentational

## Verification

- \`npm run typecheck\` clean
- \`npm run lint:guards\` clean

## Test plan

- [x] All 17 files have a default export
- [x] No client-side JS bundled (pure server components)
- [x] CSS variables resolve in both V3 and V4 theme namespaces
- [ ] Post-deploy: visit each route with a slow connection; verify the skeleton renders before content lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)