### PR TITLE
feat(analytics): funnel events for alert activation + revenue loop (S5.B.5)

### DIFF
--- a/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
+++ b/src/app/you/alerts/_components/AddAlertRuleDialog.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { LoaderCircle, Plus, X } from "lucide-react";
 
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 import { AdminRecoverableError, TransientHttpError } from "@/lib/errors";
 import { cn } from "@/lib/utils";
 import {
@@ -320,6 +321,16 @@ export function AddAlertRuleDialog({
             typeof (err as ApiErr & { upgradeUrl?: string }).upgradeUrl === "string"
               ? (err as ApiErr & { upgradeUrl?: string }).upgradeUrl!
               : "/pricing";
+          // S5.B.5 — paywall_shown step in the revenue-loop funnel.
+          captureFunnelStep({
+            step: "paywall_shown",
+            flow: "revenue-loop",
+            feature:
+              typeof (err as ApiErr & { feature?: string }).feature === "string"
+                ? (err as ApiErr & { feature?: string }).feature
+                : undefined,
+            source: "add_alert_rule_dialog",
+          });
           toast.info(err.message ?? "You've hit your plan's limit.", {
             duration: 10000,
             action: {
@@ -341,6 +352,14 @@ export function AddAlertRuleDialog({
       // rule (count snapshot taken when the page rendered), use the
       // richer onboarding-style toast with a link back to /watchlist.
       // Otherwise, keep the terse confirmation.
+      // S5.B.5 — alert_created step in the alert-activation funnel.
+      captureFunnelStep({
+        step: "alert_created",
+        flow: "alert-activation",
+        ruleType,
+        cadence,
+        is_first_rule: existingRuleCount === 0,
+      });
       if (existingRuleCount === 0) {
         toast.success(
           "Alert created! First report in ~1h. Until then, explore your watchlist.",

--- a/src/app/you/alerts/_components/DigestBanner.tsx
+++ b/src/app/you/alerts/_components/DigestBanner.tsx
@@ -19,6 +19,7 @@
 import { useState } from "react";
 
 import { toast } from "@/lib/toast";
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
 import type { EmailAlertsCadence } from "@/lib/db/schema/profiles";
 
@@ -81,7 +82,7 @@ export function DigestBanner({
       if (!res.ok) {
         throw new Error(`profile patch failed: ${res.status}`);
       }
-      // Fire-and-forget product analytics.
+      // Fire-and-forget product analytics + canonical funnel step.
       try {
         getLoadedBrowserPostHog()?.capture("digest_subscribe", {
           cadence,
@@ -91,6 +92,13 @@ export function DigestBanner({
       } catch {
         // analytics must never throw upstream
       }
+      // S5.B.5 — digest_subscribed step in the alert-activation funnel.
+      captureFunnelStep({
+        step: "digest_subscribed",
+        flow: "alert-activation",
+        cadence,
+        source: "digest_banner",
+      });
       toast.info(
         cadence === "daily"
           ? "Daily digest scheduled — first email at 9am your time."

--- a/src/components/pricing/CheckoutSuccess.tsx
+++ b/src/components/pricing/CheckoutSuccess.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
 
 interface SessionProbeResponse {
@@ -92,6 +93,13 @@ export function CheckoutSuccess({ sessionId }: { sessionId?: string }) {
             } catch {
               // analytics must never throw
             }
+            // S5.B.5 — checkout_completed step in the revenue-loop funnel.
+            captureFunnelStep({
+              step: "checkout_completed",
+              flow: "revenue-loop",
+              tier: body.tier,
+              session_id: sessionId,
+            });
           }
           return;
         }

--- a/src/components/pricing/CheckoutWalkthrough.tsx
+++ b/src/components/pricing/CheckoutWalkthrough.tsx
@@ -21,6 +21,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { captureFunnelStep } from "@/lib/analytics/funnel";
 import type { BillingCadence, TierDefinition } from "@/lib/pricing/tiers";
 import { getLoadedBrowserPostHog } from "@/lib/analytics/posthog-client";
 
@@ -116,6 +117,13 @@ export function CheckoutWalkthrough({
       } catch {
         // analytics must never throw upstream
       }
+      // S5.B.5 — checkout_started step in the revenue-loop funnel.
+      captureFunnelStep({
+        step: "checkout_started",
+        flow: "revenue-loop",
+        tier: tier.key,
+        cadence,
+      });
       const { url } = await startCheckout(tier, cadence);
       // Hand off to Stripe. We do NOT call onClose() because the page
       // will fully navigate; if the navigation is somehow blocked the

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -66,7 +66,12 @@ export type FunnelFlow =
   | "compare-add"
   | "submit-repo"
   | "revenue-claim"
-  | "account-auth";
+  | "account-auth"
+  // S5.B.5 — revenue loop. Five-event funnel:
+  //   signup → welcome_modal_cta_clicked → alert_created
+  //         → checkout_started → checkout_completed
+  | "alert-activation"
+  | "revenue-loop";
 
 /**
  * Canonical step identifiers. Listed centrally so any regression in
@@ -100,7 +105,15 @@ export type FunnelStep =
   | "sign_in_view"
   | "sign_up_view"
   | "sign_in_success"
-  | "sign_up_success";
+  | "sign_up_success"
+  // S5.B.5 alert activation
+  | "alert_created"
+  | "digest_subscribed"
+  // S5.B.5 revenue loop
+  | "paywall_shown"
+  | "checkout_started"
+  | "checkout_completed"
+  | "subscription_canceled";
 
 interface FunnelStepProps {
   step: FunnelStep;


### PR DESCRIPTION
## Summary

Stage 5 / B.5. Adds six new funnel-step identifiers and wires them into the canonical user paths so PostHog can render two end-to-end funnels:

| Funnel | Steps |
|---|---|
| \`alert-activation\` | signup → welcome_modal_cta_clicked → \`alert_created\` → \`digest_subscribed\` |
| \`revenue-loop\` | \`paywall_shown\` → \`checkout_started\` → \`checkout_completed\` → \`subscription_canceled\` |

## New step identifiers

- \`alert_created\` — after POST \`/api/me/alert-rules\` succeeds
- \`digest_subscribed\` — after PATCH \`/api/me/profile\` cadence!=off succeeds
- \`paywall_shown\` — when a 402 \`quota_exceeded\` surfaces the upsell toast
- \`checkout_started\` — when CheckoutWalkthrough "continue" is clicked
- \`checkout_completed\` — when CheckoutSuccess polls and detects the tier flip
- \`subscription_canceled\` — reserved for a future webhook-triggered event

## Call sites wired

| File | Step | When |
|---|---|---|
| \`AddAlertRuleDialog.tsx\` | \`alert_created\` | After successful POST; properties: ruleType, cadence, is_first_rule |
| \`AddAlertRuleDialog.tsx\` | \`paywall_shown\` | When 402 quota_exceeded comes back; properties: feature key |
| \`DigestBanner.tsx\` | \`digest_subscribed\` | After successful PATCH; properties: cadence, source |
| \`CheckoutWalkthrough.tsx\` | \`checkout_started\` | When user clicks Continue on step 2 |
| \`CheckoutSuccess.tsx\` | \`checkout_completed\` | When polling detects the tier flip (ref-tracked, fires exactly once) |

## Existing posthog.capture calls kept

\`posthog.capture("digest_subscribe", ...)\` and \`posthog.capture("checkout_completed", ...)\` direct calls remain — they're product-analytics events with their own dashboards. The funnel-step variants are the canonical typed events that feed PostHog's funnel visualisation.

## Verification

- \`npm run typecheck\` clean
- \`npm run lint:guards\` clean

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint:guards\` clean
- [x] All 6 new step identifiers compile under the strict FunnelStep union
- [x] 2 new flow identifiers compile under FunnelFlow union
- [ ] **Post-deploy**: walk the full flow (signup → alert → 402 → upgrade → checkout → success) and verify all 5 funnel events fire in PostHog
- [ ] **PostHog dashboard**: build the \`alert-activation\` and \`revenue-loop\` funnels using the new step IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)