### PR TITLE
feat(seo): 7 OG cards for trending-feed routes (S5.C.3)

### DIFF
--- a/src/app/bluesky/opengraph-image.tsx
+++ b/src/app/bluesky/opengraph-image.tsx
@@ -1,0 +1,25 @@
+// TrendingRepo — /bluesky OG share card (S5.C.3).
+
+import { renderFeedOGImage, FEED_OG_SIZE } from "@/lib/og-feed-card";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const alt = "TrendingRepo — Bluesky signal";
+export const size = FEED_OG_SIZE;
+export const contentType = "image/png";
+
+export default function BlueskyOGImage() {
+  return renderFeedOGImage({
+    alt,
+    eyebrow: "BLUESKY · AT-PROTO",
+    headline: "Repos buzzing on Bluesky",
+    sub: "AT-protocol mentions + reposts, filtered to developer-aligned authors and ranked by 24h velocity.",
+    rows: [
+      { label: "TRACKED AUTHORS", value: "curated" },
+      { label: "VELOCITY WINDOW", value: "24h" },
+      { label: "GH-LINKED ONLY", value: "yes" },
+    ],
+    routePath: "/bluesky",
+    accent: "#0085FF",
+  });
+}

--- a/src/app/consensus/opengraph-image.tsx
+++ b/src/app/consensus/opengraph-image.tsx
@@ -1,0 +1,25 @@
+// TrendingRepo — /consensus OG share card (S5.C.3).
+
+import { renderFeedOGImage, FEED_OG_SIZE } from "@/lib/og-feed-card";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const alt = "TrendingRepo — Consensus analyst";
+export const size = FEED_OG_SIZE;
+export const contentType = "image/png";
+
+export default function ConsensusOGImage() {
+  return renderFeedOGImage({
+    alt,
+    eyebrow: "CONSENSUS · MULTI-MODEL",
+    headline: "Three models. One verdict.",
+    sub: "Top breakout repos analysed by Claude, GPT-4o, and Kimi K2 — independent reads merged into a consensus score with confidence interval.",
+    rows: [
+      { label: "MODELS RUN", value: "3 per repo" },
+      { label: "REFRESH CADENCE", value: "hourly" },
+      { label: "AUDIT TRAIL", value: "open" },
+    ],
+    routePath: "/consensus",
+    accent: "#F472B6",
+  });
+}

--- a/src/app/digest/opengraph-image.tsx
+++ b/src/app/digest/opengraph-image.tsx
@@ -1,0 +1,25 @@
+// TrendingRepo — /digest OG share card (S5.C.3).
+
+import { renderFeedOGImage, FEED_OG_SIZE } from "@/lib/og-feed-card";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const alt = "TrendingRepo — Weekly digest";
+export const size = FEED_OG_SIZE;
+export const contentType = "image/png";
+
+export default function DigestOGImage() {
+  return renderFeedOGImage({
+    alt,
+    eyebrow: "DIGEST · WEEKLY RECAP",
+    headline: "One email. The whole week.",
+    sub: "Personalised digest of every repo that hit your alerts in the past 7 days, plus the platform breakouts you missed.",
+    rows: [
+      { label: "WEEKLY CADENCE", value: "Mondays 08:00" },
+      { label: "DAILY OPTION", value: "available" },
+      { label: "QUIET HOURS", value: "configurable" },
+    ],
+    routePath: "/digest",
+    accent: "#A855F7",
+  });
+}

--- a/src/app/funding/opengraph-image.tsx
+++ b/src/app/funding/opengraph-image.tsx
@@ -1,0 +1,25 @@
+// TrendingRepo — /funding OG share card (S5.C.3).
+
+import { renderFeedOGImage, FEED_OG_SIZE } from "@/lib/og-feed-card";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const alt = "TrendingRepo — OSS funding signals";
+export const size = FEED_OG_SIZE;
+export const contentType = "image/png";
+
+export default function FundingOGImage() {
+  return renderFeedOGImage({
+    alt,
+    eyebrow: "FUNDING · CAPITAL FLOW",
+    headline: "Where the money lands",
+    sub: "Seed, Series A, and grants flowing into open-source repos — sourced from Crunchbase, GitHub Sponsors, and 8 grant programs.",
+    rows: [
+      { label: "SIGNAL SOURCES", value: "10+" },
+      { label: "REFRESH CADENCE", value: "6h" },
+      { label: "GRANT PROGRAMS", value: "tracked" },
+    ],
+    routePath: "/funding",
+    accent: "#10B981",
+  });
+}

--- a/src/app/hackernews/opengraph-image.tsx
+++ b/src/app/hackernews/opengraph-image.tsx
@@ -1,0 +1,25 @@
+// TrendingRepo — /hackernews OG share card (S5.C.3).
+
+import { renderFeedOGImage, FEED_OG_SIZE } from "@/lib/og-feed-card";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const alt = "TrendingRepo — Hacker News signal";
+export const size = FEED_OG_SIZE;
+export const contentType = "image/png";
+
+export default function HackerNewsOGImage() {
+  return renderFeedOGImage({
+    alt,
+    eyebrow: "HACKER NEWS · YC",
+    headline: "Repos breaking on HN",
+    sub: "Hacker News front-page + new submissions, ranked by repo signal strength over the last 24 hours.",
+    rows: [
+      { label: "FRONT-PAGE WINDOW", value: "24h" },
+      { label: "POINT THRESHOLD", value: "≥ 50" },
+      { label: "REPO MENTIONS", value: "tracked" },
+    ],
+    routePath: "/hackernews",
+    accent: "#FF6600",
+  });
+}

--- a/src/app/reddit/opengraph-image.tsx
+++ b/src/app/reddit/opengraph-image.tsx
@@ -1,0 +1,25 @@
+// TrendingRepo — /reddit OG share card (S5.C.3).
+
+import { renderFeedOGImage, FEED_OG_SIZE } from "@/lib/og-feed-card";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const alt = "TrendingRepo — Reddit dev velocity";
+export const size = FEED_OG_SIZE;
+export const contentType = "image/png";
+
+export default function RedditOGImage() {
+  return renderFeedOGImage({
+    alt,
+    eyebrow: "REDDIT · DEV-FORUMS",
+    headline: "Reddit dev velocity",
+    sub: "Sub-by-sub upvote velocity across /r/programming, /r/MachineLearning, /r/rust, /r/golang, and 12 more.",
+    rows: [
+      { label: "TRACKED SUBS", value: "16" },
+      { label: "VELOCITY WINDOW", value: "6h" },
+      { label: "ANTI-BOT FILTER", value: "yes" },
+    ],
+    routePath: "/reddit",
+    accent: "#FF4500",
+  });
+}

--- a/src/app/twitter/opengraph-image.tsx
+++ b/src/app/twitter/opengraph-image.tsx
@@ -1,0 +1,25 @@
+// TrendingRepo — /twitter OG share card (S5.C.3).
+
+import { renderFeedOGImage, FEED_OG_SIZE } from "@/lib/og-feed-card";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const alt = "TrendingRepo — Repos trending on X";
+export const size = FEED_OG_SIZE;
+export const contentType = "image/png";
+
+export default function TwitterOGImage() {
+  return renderFeedOGImage({
+    alt,
+    eyebrow: "X · TWITTER",
+    headline: "Repos trending on X",
+    sub: "Real X/Twitter mentions, ranked by engagement over the last 24 hours.",
+    rows: [
+      { label: "TWEETS · 24h", value: "live" },
+      { label: "TOP KOLs", value: "by engagement" },
+      { label: "MOMENTUM", value: "x-source scored" },
+    ],
+    routePath: "/twitter",
+    accent: "#7AA7FF",
+  });
+}

--- a/src/lib/og-feed-card.tsx
+++ b/src/lib/og-feed-card.tsx
@@ -1,0 +1,174 @@
+// Shared OG card for trending-feed routes (S5.C.3).
+//
+// Each of /twitter, /reddit, /hackernews, /bluesky, /funding, /digest,
+// and /consensus uses this helper to render a brand-consistent share
+// card. The variation between feeds is small enough that the same
+// component handles all of them via a single config object.
+//
+// Layout: 1200×630.
+//   - Eyebrow:  "TRENDINGREPO · <FEED>"
+//   - Headline: feed-specific tagline
+//   - Body:     up to 3 supporting lines (numbers, names, freshness)
+//   - Footer:   route URL + brand wordmark
+
+import { ImageResponse } from "next/og";
+import type { ReactElement } from "react";
+
+import { CardFrame, Wordmark } from "@/lib/og-primitives";
+import { OG_CACHE_HEADERS, OG_COLORS } from "@/lib/seo";
+
+export interface FeedCardConfig {
+  /** Used as the OG image `alt` text — should match the `TrendingRepo — X` pattern. */
+  alt: string;
+  /** Top eyebrow string after the brand mark. */
+  eyebrow: string;
+  /** Hero headline. Kept under ~40 chars to stay one line. */
+  headline: string;
+  /** Sub-headline. */
+  sub: string;
+  /** Up to 3 supporting rows (e.g. "1.2k tweets · 24h"). */
+  rows?: ReadonlyArray<{ label: string; value?: string }>;
+  /** Route path for the footer URL (no trailing slash). */
+  routePath: string;
+  /** Optional accent color override (defaults to brand). */
+  accent?: string;
+}
+
+export const FEED_OG_SIZE = { width: 1200, height: 630 };
+
+export function renderFeedOGImage(config: FeedCardConfig): ImageResponse {
+  const accent = config.accent ?? OG_COLORS.brand;
+
+  return new ImageResponse(
+    (
+      <CardFrame>
+        {/* Eyebrow */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: 2,
+            color: OG_COLORS.textTertiary,
+            textTransform: "uppercase",
+          }}
+        >
+          <span>TrendingRepo</span>
+          <span style={{ color: accent }}>·</span>
+          <span style={{ color: accent }}>{config.eyebrow}</span>
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            display: "flex",
+            marginTop: 32,
+            fontSize: 84,
+            fontWeight: 800,
+            lineHeight: 1,
+            letterSpacing: "-0.02em",
+            color: OG_COLORS.textPrimary,
+          }}
+        >
+          {config.headline}
+        </div>
+
+        {/* Sub */}
+        <div
+          style={{
+            display: "flex",
+            marginTop: 16,
+            fontSize: 28,
+            color: OG_COLORS.textSecondary,
+            maxWidth: 1000,
+            lineHeight: 1.25,
+          }}
+        >
+          {config.sub}
+        </div>
+
+        {/* Optional supporting rows */}
+        {config.rows && config.rows.length > 0 ? (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              marginTop: 40,
+              gap: 12,
+              width: "100%",
+            }}
+          >
+            {config.rows.slice(0, 3).map((row, index) => (
+              <div
+                key={`${row.label}-${index}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "16px 24px",
+                  borderRadius: 12,
+                  backgroundColor: OG_COLORS.bgSecondary,
+                  border: `1px solid ${OG_COLORS.border}`,
+                }}
+              >
+                <span
+                  style={{
+                    display: "flex",
+                    fontSize: 24,
+                    color: OG_COLORS.textPrimary,
+                    fontWeight: 600,
+                  }}
+                >
+                  {row.label}
+                </span>
+                {row.value ? (
+                  <span
+                    style={{
+                      display: "flex",
+                      fontSize: 24,
+                      color: accent,
+                      fontFamily: "monospace",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {row.value}
+                  </span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        {/* Footer */}
+        <div
+          style={{
+            display: "flex",
+            marginTop: "auto",
+            alignItems: "flex-end",
+            justifyContent: "space-between",
+            width: "100%",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              fontSize: 18,
+              fontFamily: "monospace",
+              color: OG_COLORS.textTertiary,
+              letterSpacing: 0.5,
+            }}
+          >
+            trendingrepo.com{config.routePath}
+          </div>
+          <Wordmark />
+        </div>
+      </CardFrame>
+    ),
+    { ...FEED_OG_SIZE, headers: OG_CACHE_HEADERS },
+  );
+}
+
+/** Convenience export so route files don't have to import ReactElement. */
+export type FeedOGImage = ReactElement;


### PR DESCRIPTION
## Summary

Stage 5 / C.3. Closes the OG coverage gap on the seven highest-trafficked trending feeds. Coverage was **13/98** routes; this PR brings it to **20/98** with the routes most likely to be shared in Slack / Discord / X.

## New OG images (1200×630, brand-consistent)

| Route | Accent |
|---|---|
| \`/twitter\` | X blue (#7AA7FF) |
| \`/reddit\` | Reddit orange (#FF4500) |
| \`/hackernews\` | HN orange (#FF6600) |
| \`/bluesky\` | Bluesky blue (#0085FF) |
| \`/funding\` | Money green (#10B981) |
| \`/digest\` | Purple (#A855F7) |
| \`/consensus\` | Pink (#F472B6) |

## Architecture

**Shared helper**: \`src/lib/og-feed-card.tsx\` renders the common layout (1200×630, eyebrow → headline → sub → 3 supporting rows → footer with route URL + brand wordmark).

**Per-route wrapper**: each route file is a thin ~25-line file that supplies feed-specific copy + accent color via a single config object:

\`\`\`tsx
return renderFeedOGImage({
  alt,
  eyebrow: "X · TWITTER",
  headline: "Repos trending on X",
  sub: "Real X/Twitter mentions...",
  rows: [...],
  routePath: "/twitter",
  accent: "#7AA7FF",
});
\`\`\`

This keeps per-route maintenance cost low (a copy change is a 5-line config edit) while ensuring brand consistency across the whole set.

## Currently static

The card content is taglines + feed metadata — no live data fetch. A future PR can extend the helper to optionally accept a \`topItems\` array drawn from each feed's underlying data store, giving the cards live "top 3 right now" rows.

## Verification

- \`npm run typecheck\` clean
- \`npm run lint:guards\` clean

## Test plan (post-deploy)

- [ ] Paste each \`/twitter\`, \`/reddit\`, \`/hackernews\`, \`/bluesky\`, \`/funding\`, \`/digest\`, \`/consensus\` URL into Slack / Discord / X — verify the correct OG card renders with the brand-accent color
- [ ] Use https://www.opengraph.xyz/ to debug any card that fails to render
- [ ] Confirm each route's existing \`metadata.openGraph\` doesn't conflict with the new card (it shouldn't — \`opengraph-image.tsx\` takes precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)