### PR TITLE
fix(analytics): align revenue funnel capture

### DIFF
--- a/docs/POSTHOG-FUNNELS.md
+++ b/docs/POSTHOG-FUNNELS.md
@@ -125,6 +125,37 @@ sign-up after the user lands on the auth surface.
 subscription. `sign_up_success` is already covered by the required
 `user.created` subscription.
 
+### `alert-activation` - alerts surface to first rule and digest opt-in
+
+Lives on `/you/alerts` (`src/app/you/alerts/_components`). This funnel starts
+once the user is on the alerts product surface. Upstream account CTA and signup
+events stay in `account-auth`; the welcome modal also emits direct PostHog
+events (`welcome_modal_*`) that are not `funnel_step` events.
+
+| # | Step | Trigger | Notable extra properties |
+| - | ---- | ------- | ------------------------ |
+| 1 | `alert_created` | `AddAlertRuleDialog` receives a successful `POST /api/me/alert-rules` response | `ruleType`, `cadence`, `is_first_rule` |
+| 2 | `digest_subscribed` | `DigestBanner` successfully patches `/api/me/profile` after Daily / Weekly selection | `cadence`, `source` (`digest_banner`) |
+
+Use this flow to measure whether a signed-in user reaches a durable alerting
+setup. `digest_subscribed` is intentionally optional because realtime alerts
+can be useful without email digest opt-in.
+
+### `revenue-loop` - alert paywall to paid checkout
+
+Captures the upgrade path from an alerts quota wall into Stripe Checkout and
+back to the local billing confirmation screen.
+
+| # | Step | Trigger | Notable extra properties |
+| - | ---- | ------- | ------------------------ |
+| 1 | `paywall_shown` | `AddAlertRuleDialog` receives `402 quota_exceeded` from `POST /api/me/alert-rules` | `feature`, `source` (`add_alert_rule_dialog`) |
+| 2 | `checkout_started` | `CheckoutWalkthrough` receives a Stripe Checkout URL from `POST /api/checkout/stripe` | `tier`, `cadence` |
+| 3 | `checkout_completed` | `CheckoutSuccess` confirms the user session resolved to a paid tier after returning from Stripe | `tier` |
+
+`subscription_canceled` is reserved in the typed `FunnelStep` union for the
+Stripe cancellation surface/webhook, but it is not emitted yet. Do not include
+it in dashboard funnels until a call site lands.
+
 ---
 
 ## Adding a new flow

--- a/src/components/pricing/CheckoutSuccess.tsx
+++ b/src/components/pricing/CheckoutSuccess.tsx
@@ -98,7 +98,6 @@ export function CheckoutSuccess({ sessionId }: { sessionId?: string }) {
               step: "checkout_completed",
               flow: "revenue-loop",
               tier: body.tier,
-              session_id: sessionId,
             });
           }
           return;

--- a/src/components/pricing/CheckoutWalkthrough.tsx
+++ b/src/components/pricing/CheckoutWalkthrough.tsx
@@ -117,14 +117,15 @@ export function CheckoutWalkthrough({
       } catch {
         // analytics must never throw upstream
       }
+      const { url } = await startCheckout(tier, cadence);
       // S5.B.5 — checkout_started step in the revenue-loop funnel.
+      // Count only sessions that actually got a Stripe Checkout URL.
       captureFunnelStep({
         step: "checkout_started",
         flow: "revenue-loop",
         tier: tier.key,
         cadence,
       });
-      const { url } = await startCheckout(tier, cadence);
       // Hand off to Stripe. We do NOT call onClose() because the page
       // will fully navigate; if the navigation is somehow blocked the
       // modal stays in its current state for the user to retry.

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -58,6 +58,8 @@ function enqueueFunnelStep(props: FunnelStepProps): void {
  * 5. `submit-repo`       /submit open -> form fill -> submit success
  * 6. `revenue-claim`     repo-detail/direct -> claim revenue form -> submit success
  * 7. `account-auth`      header account CTA -> hosted auth -> webhook success
+ * 8. `alert-activation`  /you/alerts -> alert created -> digest opt-in
+ * 9. `revenue-loop`      paywall -> checkout start -> checkout complete
  */
 export type FunnelFlow =
   | "discover-repo"
@@ -67,9 +69,8 @@ export type FunnelFlow =
   | "submit-repo"
   | "revenue-claim"
   | "account-auth"
-  // S5.B.5 — revenue loop. Five-event funnel:
-  //   signup → welcome_modal_cta_clicked → alert_created
-  //         → checkout_started → checkout_completed
+  // S5.B.5 alert activation and paid conversion. Keep flow semantics
+  // documented in docs/POSTHOG-FUNNELS.md before adding capture calls.
   | "alert-activation"
   | "revenue-loop";
 


### PR DESCRIPTION
Follow-up to #1781.\n\nFixes the review blockers found after #1781 auto-merged:\n- document the new alert-activation and revenue-loop funnel contracts in docs/POSTHOG-FUNNELS.md\n- move checkout_started so it only fires after /api/checkout/stripe returns a Stripe URL\n- keep Stripe session_id out of the generic funnel_step event; the legacy direct checkout_completed event still has it\n- align src/lib/analytics/funnel.ts comments with the actual emitted flows\n\nLocal validation:\n- npm run typecheck\n- npm run lint:guards\n- npm run lint (47 existing warnings, 0 errors)\n- npm run test:hooks -- src/lib/__vitest__/analytics-funnel.test.ts\n- npm audit --audit-level=high\n- git diff --check HEAD~1..HEAD