### PR TITLE
feat(onboarding): day-1 welcome email via Clerk webhook (S5.B.2)

### DIFF
--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -23,6 +23,8 @@ import { profiles } from "@/lib/db/schema/profiles";
 import { referralCodes, referrals } from "@/lib/db/schema/referrals";
 import { reserveHandleFromClerk } from "@/lib/auth/handle";
 import { posthogCapture } from "@/lib/analytics/posthog";
+import { getEmailProvider, resolveEmailFrom } from "@/lib/email/send";
+import { renderWelcomeEmail } from "@/lib/email/templates/welcome";
 import { deriveCode } from "@/lib/referrals/code";
 import { verifyRefCookie } from "@/lib/referrals/cookie";
 import {
@@ -213,6 +215,33 @@ async function handleUserCreated(
     });
   } catch (err) {
     console.warn("[clerk-webhook] referral attribution failed", data.id, err);
+  }
+
+  // ---------------------------------------------------------------------
+  // S5.B.2 — fire-and-forget welcome email. Best-effort: never throw
+  // out of this block, because Resend failure must not block account
+  // creation either. No code-side dedup — onConflictDoUpdate above means
+  // a retried user.created webhook re-renders + re-sends the welcome;
+  // operator-side Resend dedup or a future profiles.welcomeEmailSentAt
+  // column would tighten this, but a duplicate welcome is a minor UX
+  // issue (one email, same content) rather than a security/data issue.
+  // ---------------------------------------------------------------------
+  try {
+    const provider = getEmailProvider();
+    const rendered = renderWelcomeEmail({
+      handle: insertedProfile.handle,
+      profileId: insertedProfile.id,
+      firstName: data.first_name,
+    });
+    await provider.send({
+      to: email,
+      from: resolveEmailFrom(),
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+    });
+  } catch (err) {
+    console.warn("[clerk-webhook] welcome email send failed", data.id, err);
   }
 
   posthogCapture("funnel_step", {

--- a/src/lib/email/templates/welcome.ts
+++ b/src/lib/email/templates/welcome.ts
@@ -1,0 +1,180 @@
+// Day-1 welcome email template (S5.B.2).
+//
+// Pure: takes a flat data object, returns { subject, html, text }.
+// No Resend SDK touch — the Clerk webhook handler calls `sendEmail()`
+// from `@/lib/email/send` with this output.
+//
+// Goal: turn a fresh Clerk signup into an activated user. The CTA links
+// straight to /you/alerts?preset=breakout so the first click lands on a
+// pre-populated alert form (one save → first alert wired).
+//
+// Footer mirrors the existing transactional emails (referral-milestone,
+// user-alert): monospace meta, dim foreground, HMAC-signed unsubscribe
+// link that toggles `email_system=false` without requiring auth (the
+// HMAC binds the link to one profile).
+
+import { createHmac } from "node:crypto";
+
+const SITE = "https://trendingrepo.com";
+
+export interface WelcomeEmailInput {
+  /** Recipient handle (used in the salutation + reference id). */
+  handle: string;
+  /** UUID of the recipient's `profiles.id` row — bound into the unsub HMAC. */
+  profileId: string;
+  /** Optional first name for personalised salutation; falls back to "there". */
+  firstName?: string | null;
+}
+
+export interface WelcomeEmailOutput {
+  subject: string;
+  html: string;
+  text: string;
+  referenceId: string;
+}
+
+function unsubscribeUrl(profileId: string): string {
+  const secret = process.env.EMAIL_UNSUBSCRIBE_SECRET ?? "";
+  if (!secret) {
+    // No secret configured (dev / test) — degrade to the settings link so
+    // the user can self-unsub via the UI instead of a signed query string.
+    return `${SITE}/you/settings`;
+  }
+  const sig = createHmac("sha256", secret)
+    .update(`unsub:system:${profileId}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `${SITE}/api/email/unsubscribe?p=${encodeURIComponent(profileId)}&kind=system&sig=${sig}`;
+}
+
+export function renderWelcomeEmail(
+  input: WelcomeEmailInput,
+): WelcomeEmailOutput {
+  const greeting = input.firstName?.trim() || "there";
+  const unsubHref = unsubscribeUrl(input.profileId);
+  const ctaHref = `${SITE}/you/alerts?preset=breakout`;
+
+  const subject = "You're in. Catch breakouts before they're cold.";
+
+  const text = [
+    `Hey ${greeting},`,
+    "",
+    "Welcome to TrendingRepo. You're set up — alerts, watchlist, the works.",
+    "",
+    "The fastest way to get value: spin up your first alert. We've pre-",
+    "filled a Breakout rule that fires when a repo hits multiple cross-",
+    "source channels in 24 hours. Two clicks and you're done:",
+    "",
+    `  ${ctaHref}`,
+    "",
+    "What else lives behind your account:",
+    "",
+    "  - Watchlist — pin repos to track their momentum across sources",
+    "  - Compare — stack up to 5 repos side-by-side",
+    "  - Digest  — daily or weekly recap email (you can flip this on at",
+    "             /you/alerts → Global preferences)",
+    "  - Refer   — invite a friend, earn badges (operator at 5, founder at 25)",
+    "",
+    "Questions? Reply to this email and a human will read it.",
+    "",
+    "— TrendingRepo team",
+    "",
+    "---",
+    "TrendingRepo · trendingrepo.com",
+    `Unsubscribe from system emails: ${unsubHref}`,
+  ].join("\n");
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>${escapeHtml(subject)}</title>
+  </head>
+  <body style="margin:0;padding:0;background:#0b0b0d;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e8e8ea;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;background:#0b0b0d;">
+      <tr>
+        <td align="center" style="padding:32px 16px;">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;background:#161618;border:1px solid #2a2a2e;border-radius:6px;">
+            <tr>
+              <td style="padding:28px 32px 8px;">
+                <span style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;letter-spacing:0.18em;text-transform:uppercase;color:#8b8b91;">// 00 WELCOME</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 32px 8px;">
+                <h1 style="font-size:28px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin:0;color:#fafafa;">
+                  You're in. Catch breakouts before they're cold.
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 8px;">
+                <p style="font-size:15px;line-height:1.55;color:#cccce0;margin:0;">
+                  Hey ${escapeHtml(greeting)},
+                </p>
+                <p style="font-size:15px;line-height:1.55;color:#cccce0;margin:12px 0 0;">
+                  Welcome to TrendingRepo. You're set up — alerts, watchlist, the works.
+                </p>
+                <p style="font-size:15px;line-height:1.55;color:#cccce0;margin:12px 0 0;">
+                  The fastest way to get value: spin up your first alert. We've pre-filled a <b>Breakout</b> rule that fires when a repo hits multiple cross-source channels in 24 hours. Two clicks and you're done.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td align="center" style="padding:24px 32px 8px;">
+                <a href="${ctaHref}" style="display:inline-block;background:#fafafa;color:#0b0b0d;padding:12px 22px;border-radius:4px;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;letter-spacing:0.16em;text-transform:uppercase;font-weight:600;text-decoration:none;">CREATE YOUR FIRST ALERT →</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 8px;">
+                <p style="font-size:13px;line-height:1.55;color:#9595a3;margin:0;">What else lives behind your account:</p>
+                <ul style="font-size:13px;line-height:1.55;color:#cccce0;margin:8px 0 0;padding-left:18px;">
+                  <li><b>Watchlist</b> — pin repos to track their momentum across sources</li>
+                  <li><b>Compare</b> — stack up to 5 repos side-by-side</li>
+                  <li><b>Digest</b> — daily or weekly recap email (flip on at /you/alerts)</li>
+                  <li><b>Refer</b> — invite a friend, earn badges (operator at 5, founder at 25)</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 24px;">
+                <p style="font-size:13px;line-height:1.55;color:#9595a3;margin:0;">
+                  Questions? Reply to this email — a human will read it.
+                </p>
+                <p style="font-size:13px;line-height:1.55;color:#9595a3;margin:8px 0 0;">
+                  — TrendingRepo team
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:14px 32px;border-top:1px solid #2a2a2e;">
+                <p style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:#6b6b73;margin:0;">
+                  TrendingRepo · <a href="${SITE}" style="color:#9595a3;text-decoration:none;">trendingrepo.com</a> ·
+                  <a href="${unsubHref}" style="color:#6b6b73;text-decoration:underline;">Unsubscribe</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  return {
+    subject,
+    html,
+    text,
+    referenceId: `welcome:${input.profileId}`,
+  };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
## Summary

Stage 5 / B.2. Fires a welcome email from the Clerk \`user.created\` webhook handler immediately after the profile upsert. The CTA points to \`/you/alerts?preset=breakout\` so the first click lands on a pre-populated alert form (two clicks → first alert wired).

## New template

\`src/lib/email/templates/welcome.ts\` — pure helper \`renderWelcomeEmail({ handle, profileId, firstName? }) → { subject, html, text, referenceId }\`. Mirrors the established pattern from \`user-alert\` + \`referral-milestone\` (monospace footer, HMAC-signed unsub link via \`EMAIL_UNSUBSCRIBE_SECRET\`).

- **Subject**: "You're in. Catch breakouts before they're cold."
- **HTML/text**: salutation by firstName (fallback "there"), 3-paragraph body, primary CTA button, feature list (Watchlist / Compare / Digest / Refer)

## Webhook integration

\`handleUserCreated\` in \`src/app/api/webhooks/clerk/route.ts\`: after profile upsert + referral attribution, calls \`provider.send(...)\` wrapped in a try/catch that logs and continues. Resend failure must not block account creation.

## Idempotency

No code-side dedup. A retried \`user.created\` webhook will re-send the welcome — Clerk's at-least-once delivery + \`onConflictDoUpdate\` means this is rare. A duplicate welcome is one extra identical email, not a data or security issue. A future PR can add a \`profiles.welcomeEmailSentAt\` column for tight dedup; left out here to keep this PR migration-free.

## Verification

- \`npm run typecheck\` clean
- \`npm run lint:guards\` clean

## Operator deps to activate

| Env | Purpose |
|---|---|
| \`RESEND_API_KEY\` | Send via Resend (already configured per your key drop) |
| \`EMAIL_FROM\` | e.g. \`TrendingRepo <welcome@trendingrepo.com>\` |
| \`EMAIL_UNSUBSCRIBE_SECRET\` | 32-byte random for the HMAC-signed unsub link; without it the link falls back to \`/you/settings\` |
| SPF / DKIM / DMARC on sender domain | Deliverability (Resend dashboard walks this) |

## Test plan (post-deploy)

- [ ] Sign up with a fresh email
- [ ] Verify the welcome email lands within ~30 seconds
- [ ] Click the CTA → deeplinks to \`/you/alerts?preset=breakout\`
- [ ] Verify the breakout preset is pre-selected in AddAlertRuleDialog
- [ ] Verify the unsub link toggles \`email_system=false\` server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)