### PR TITLE
feat(onboarding): day-3 nudge + day-7 retention crons (S5.B.3+B.4)

### DIFF
--- a/.github/workflows/cron-onboarding-day3.yml
+++ b/.github/workflows/cron-onboarding-day3.yml
@@ -1,0 +1,75 @@
+name: Cron - onboarding day-3 nudge
+
+# Fires POST /api/cron/onboarding/day3-nudge daily at 09:37 UTC.
+# Off the :00/:30 marks per the platform's anti-thundering-herd
+# convention. 09:37 UTC ≈ mid-morning Europe / late-morning US-East —
+# decent open-rate window.
+#
+# Pre-activation operator step (one-time):
+#   vercel env add DAY3_NUDGE_NOT_BEFORE production
+#   # paste the deploy timestamp (e.g. 2026-05-18T07:00:00Z) so the
+#   # first run skips every user older than the welcome-email rollout
+#
+# Required repo config:
+#   secrets.CRON_SECRET     — must match server CRON_SECRET env
+#   vars.TRENDINGREPO_URL   — optional; defaults to prod URL
+
+on:
+  schedule:
+    - cron: "37 9 * * *"
+  workflow_dispatch:
+    inputs:
+      dry:
+        description: "Set true to count eligible without sending"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cron-onboarding-day3
+  cancel-in-progress: false
+
+env:
+  BASE_URL: ${{ vars.TRENDINGREPO_URL || vars.STARSCREENER_URL || 'https://trendingrepo.com' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /api/cron/onboarding/day3-nudge
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          DRY: ${{ inputs.dry || 'false' }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET is unset — refusing to fire unauthenticated"
+            exit 1
+          fi
+
+          URL="$BASE_URL/api/cron/onboarding/day3-nudge"
+          if [ "$DRY" = "true" ]; then
+            URL="$URL?dry=1"
+          fi
+
+          code=$(curl -sS -o /tmp/out -w "%{http_code}" -X POST \
+            "$URL" \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            -H "Content-Type: application/json" \
+            -d '{}')
+          echo "HTTP $code"
+          if command -v jq >/dev/null 2>&1 && jq . /tmp/out >/dev/null 2>&1; then
+            jq . /tmp/out | head -c 4000
+          else
+            head -c 4000 /tmp/out
+          fi
+          echo
+          if [ "$code" != "200" ]; then
+            echo "::error::day3-nudge call failed ($code)"
+            exit 1
+          fi
+          if command -v jq >/dev/null 2>&1; then
+            jq -e '.ok == true' /tmp/out > /dev/null
+          fi

--- a/.github/workflows/cron-onboarding-day7.yml
+++ b/.github/workflows/cron-onboarding-day7.yml
@@ -1,0 +1,74 @@
+name: Cron - onboarding day-7 retention
+
+# Fires POST /api/cron/onboarding/day7-retention daily at 10:13 UTC.
+# Late-morning Europe / mid-morning US-East. Deliberately spaced ~30
+# minutes after the day-3 nudge so each cron's outbound traffic doesn't
+# contend with the other's Resend quota.
+#
+# Pre-activation operator step (one-time):
+#   vercel env add DAY7_RETENTION_NOT_BEFORE production
+#   # paste the deploy timestamp so the first run skips pre-rollout users
+#
+# Required repo config:
+#   secrets.CRON_SECRET     — must match server CRON_SECRET env
+#   vars.TRENDINGREPO_URL   — optional; defaults to prod URL
+
+on:
+  schedule:
+    - cron: "13 10 * * *"
+  workflow_dispatch:
+    inputs:
+      dry:
+        description: "Set true to count eligible without sending"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cron-onboarding-day7
+  cancel-in-progress: false
+
+env:
+  BASE_URL: ${{ vars.TRENDINGREPO_URL || vars.STARSCREENER_URL || 'https://trendingrepo.com' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: POST /api/cron/onboarding/day7-retention
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          DRY: ${{ inputs.dry || 'false' }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET is unset — refusing to fire unauthenticated"
+            exit 1
+          fi
+
+          URL="$BASE_URL/api/cron/onboarding/day7-retention"
+          if [ "$DRY" = "true" ]; then
+            URL="$URL?dry=1"
+          fi
+
+          code=$(curl -sS -o /tmp/out -w "%{http_code}" -X POST \
+            "$URL" \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            -H "Content-Type: application/json" \
+            -d '{}')
+          echo "HTTP $code"
+          if command -v jq >/dev/null 2>&1 && jq . /tmp/out >/dev/null 2>&1; then
+            jq . /tmp/out | head -c 4000
+          else
+            head -c 4000 /tmp/out
+          fi
+          echo
+          if [ "$code" != "200" ]; then
+            echo "::error::day7-retention call failed ($code)"
+            exit 1
+          fi
+          if command -v jq >/dev/null 2>&1; then
+            jq -e '.ok == true' /tmp/out > /dev/null
+          fi

--- a/src/app/api/cron/onboarding/day3-nudge/route.ts
+++ b/src/app/api/cron/onboarding/day3-nudge/route.ts
@@ -1,0 +1,196 @@
+// Cron route — day-3 onboarding nudge.
+//
+// Runs daily. Finds profiles whose createdAt is in the [now-3.5d, now-2.5d]
+// window AND who haven't created any alert rule yet (count = 0 on
+// alertRules.profileId). Sends the day-3 nudge email via Resend.
+//
+// Why a window not a single day: cron schedule is daily so a single
+// "exactly 3 days ago" cutoff would miss any user whose 3-day mark
+// happened to fall between two runs. The 24h-wide window catches every
+// user within the typical drift.
+//
+// First-deploy safety: a DAY3_NUDGE_NOT_BEFORE env var (ISO timestamp,
+// optional) lets the operator gate the first activation — without it the
+// cron would fire to every profile in the [now-3.5d, now-2.5d] window
+// the moment it goes live, including users from before the welcome
+// email existed.
+//
+// Auth: CRON_SECRET via verifyCronAuth. Same trust boundary as every
+// other cron route.
+//
+// Response shape:
+//   200 { ok: true, durationMs, eligible, sent, errors: [...] }
+
+import { and, count, eq, gte, isNull, lt, sql } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+import { verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
+import { errorEnvelope } from "@/lib/api/error-response";
+import { db } from "@/lib/db/client";
+import { alertRules } from "@/lib/db/schema/alerts";
+import { profiles } from "@/lib/db/schema/profiles";
+import { getEmailProvider, resolveEmailFrom } from "@/lib/email/send";
+import { renderDay3NudgeEmail } from "@/lib/email/templates/day3-nudge";
+
+// lint-allow: no-parsebody - no-body cron endpoint; verifyCronAuth is the trust boundary.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NUDGE_WINDOW_BACK_DAYS_HIGH = 3.5;
+const NUDGE_WINDOW_BACK_DAYS_LOW = 2.5;
+
+interface NudgeOk {
+  ok: true;
+  durationMs: number;
+  eligible: number;
+  sent: number;
+  errors: Array<{ profileId: string; error: string }>;
+  dryRun: boolean;
+}
+
+interface NudgeErr {
+  ok: false;
+  error: string;
+}
+
+function parseDryRun(url: URL): boolean {
+  const raw = url.searchParams.get("dry");
+  if (!raw) return false;
+  const v = raw.toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+function notBeforeFromEnv(): Date | null {
+  const raw = process.env.DAY3_NUDGE_NOT_BEFORE;
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed);
+}
+
+async function handle(
+  req: NextRequest,
+): Promise<NextResponse<NudgeOk | NudgeErr>> {
+  const verdict = verifyCronAuth(req);
+  if (verdict.kind !== "ok") {
+    const status = verdict.kind === "not_configured" ? 503 : 401;
+    return NextResponse.json(errorEnvelope(verdict.kind), {
+      status,
+    }) as NextResponse<NudgeErr>;
+  }
+  const oversize = withBodySizeLimit(req);
+  if (oversize) return oversize as NextResponse<NudgeErr>;
+
+  const url = new URL(req.url);
+  const dryRun = parseDryRun(url);
+  const start = Date.now();
+
+  const dayMs = 24 * 60 * 60 * 1000;
+  const nowMs = Date.now();
+  const lowerMs = nowMs - NUDGE_WINDOW_BACK_DAYS_HIGH * dayMs;
+  const upperMs = nowMs - NUDGE_WINDOW_BACK_DAYS_LOW * dayMs;
+  const lower = new Date(lowerMs);
+  const upper = new Date(upperMs);
+  const notBefore = notBeforeFromEnv();
+
+  try {
+    // 1. Find candidate profiles in the day-3 window who are still active.
+    const candidates = await db
+      .select({
+        id: profiles.id,
+        handle: profiles.handle,
+        email: profiles.email,
+        displayName: profiles.displayName,
+        createdAt: profiles.createdAt,
+      })
+      .from(profiles)
+      .where(
+        and(
+          gte(profiles.createdAt, lower),
+          lt(profiles.createdAt, upper),
+          isNull(profiles.deletedAt),
+          eq(profiles.emailSystem, true),
+        ),
+      );
+
+    // First-deploy short-circuit: skip users created before NOT_BEFORE so
+    // the cron doesn't spam old users on first activation.
+    const eligibleCandidates = notBefore
+      ? candidates.filter((c) => c.createdAt.getTime() >= notBefore.getTime())
+      : candidates;
+
+    // 2. For each candidate, check if they have any alert rules. We do
+    //    this in a small loop rather than a NOT EXISTS subquery to keep
+    //    the SQL portable across the codebase's Drizzle usage; the
+    //    expected candidate count is small (low double-digits/day).
+    const provider = getEmailProvider();
+    const from = resolveEmailFrom();
+    const errors: Array<{ profileId: string; error: string }> = [];
+    let sent = 0;
+
+    for (const profile of eligibleCandidates) {
+      try {
+        const ruleCountRows = await db
+          .select({ n: count() })
+          .from(alertRules)
+          .where(eq(alertRules.profileId, profile.id));
+        const ruleCount = Number(ruleCountRows[0]?.n ?? 0);
+        if (ruleCount > 0) continue;
+
+        if (dryRun) {
+          // Count as "would-send" but don't burn provider quota.
+          sent += 1;
+          continue;
+        }
+
+        const rendered = renderDay3NudgeEmail({
+          handle: profile.handle,
+          profileId: profile.id,
+          firstName: profile.displayName,
+        });
+        const result = await provider.send({
+          to: profile.email,
+          from,
+          subject: rendered.subject,
+          html: rendered.html,
+          text: rendered.text,
+        });
+        if (result.ok) {
+          sent += 1;
+        } else {
+          errors.push({ profileId: profile.id, error: result.error });
+        }
+      } catch (err) {
+        errors.push({
+          profileId: profile.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      durationMs: Date.now() - start,
+      eligible: eligibleCandidates.length,
+      sent,
+      errors,
+      dryRun,
+    });
+  } catch (err) {
+    console.error("[cron.onboarding.day3-nudge] error", err);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : "unknown_error",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+// Silence unused import lint (kept for future SQL-side filtering refactor).
+void sql;
+
+export const GET = handle;
+export const POST = handle;

--- a/src/app/api/cron/onboarding/day7-retention/route.ts
+++ b/src/app/api/cron/onboarding/day7-retention/route.ts
@@ -1,0 +1,189 @@
+// Cron route — day-7 retention email.
+//
+// Runs daily. Finds profiles whose createdAt is in the [now-7.5d, now-6.5d]
+// window AND who are still active (not soft-deleted, emailSystem=true).
+// Sends a generic "what surged this week" digest with up to 3 top-breakout
+// names (sourced from getDerivedRepos snapshot).
+//
+// Unlike the day-3 nudge, this is unconditional — every profile in the
+// week-1 window gets the retention touch regardless of their activation
+// state. The intent is to remind every fresh user that breakouts are
+// happening with or without them, and offer a low-friction CTA back.
+//
+// First-deploy safety: same DAY7_RETENTION_NOT_BEFORE env-var gate as
+// the day-3 nudge.
+
+import { and, gte, isNull, lt } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+import { verifyCronAuth } from "@/lib/api/auth";
+import { withBodySizeLimit } from "@/lib/api-helpers";
+import { errorEnvelope } from "@/lib/api/error-response";
+import { db } from "@/lib/db/client";
+import { profiles } from "@/lib/db/schema/profiles";
+import { getDerivedRepos } from "@/lib/derived-repos";
+import { getEmailProvider, resolveEmailFrom } from "@/lib/email/send";
+import { renderDay7RetentionEmail } from "@/lib/email/templates/day7-retention";
+
+// lint-allow: no-parsebody - no-body cron endpoint; verifyCronAuth is the trust boundary.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RETENTION_WINDOW_BACK_DAYS_HIGH = 7.5;
+const RETENTION_WINDOW_BACK_DAYS_LOW = 6.5;
+const TOP_N = 3;
+
+interface RetentionOk {
+  ok: true;
+  durationMs: number;
+  eligible: number;
+  sent: number;
+  errors: Array<{ profileId: string; error: string }>;
+  topRepos: string[];
+  dryRun: boolean;
+}
+
+interface RetentionErr {
+  ok: false;
+  error: string;
+}
+
+function parseDryRun(url: URL): boolean {
+  const raw = url.searchParams.get("dry");
+  if (!raw) return false;
+  const v = raw.toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+function notBeforeFromEnv(): Date | null {
+  const raw = process.env.DAY7_RETENTION_NOT_BEFORE;
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed);
+}
+
+function pickTopBreakouts(): string[] {
+  try {
+    const repos = getDerivedRepos();
+    return repos
+      .filter((r) => r.movementStatus === "breakout")
+      .sort((a, b) => (b.momentumScore ?? 0) - (a.momentumScore ?? 0))
+      .slice(0, TOP_N)
+      .map((r) => r.fullName);
+  } catch {
+    return [];
+  }
+}
+
+async function handle(
+  req: NextRequest,
+): Promise<NextResponse<RetentionOk | RetentionErr>> {
+  const verdict = verifyCronAuth(req);
+  if (verdict.kind !== "ok") {
+    const status = verdict.kind === "not_configured" ? 503 : 401;
+    return NextResponse.json(errorEnvelope(verdict.kind), {
+      status,
+    }) as NextResponse<RetentionErr>;
+  }
+  const oversize = withBodySizeLimit(req);
+  if (oversize) return oversize as NextResponse<RetentionErr>;
+
+  const url = new URL(req.url);
+  const dryRun = parseDryRun(url);
+  const start = Date.now();
+
+  const dayMs = 24 * 60 * 60 * 1000;
+  const nowMs = Date.now();
+  const lowerMs = nowMs - RETENTION_WINDOW_BACK_DAYS_HIGH * dayMs;
+  const upperMs = nowMs - RETENTION_WINDOW_BACK_DAYS_LOW * dayMs;
+  const lower = new Date(lowerMs);
+  const upper = new Date(upperMs);
+  const notBefore = notBeforeFromEnv();
+  const topBreakouts = pickTopBreakouts();
+
+  try {
+    const candidates = await db
+      .select({
+        id: profiles.id,
+        handle: profiles.handle,
+        email: profiles.email,
+        displayName: profiles.displayName,
+        emailSystem: profiles.emailSystem,
+        createdAt: profiles.createdAt,
+      })
+      .from(profiles)
+      .where(
+        and(
+          gte(profiles.createdAt, lower),
+          lt(profiles.createdAt, upper),
+          isNull(profiles.deletedAt),
+        ),
+      );
+
+    const eligibleCandidates = candidates
+      .filter((c) => c.emailSystem)
+      .filter((c) =>
+        notBefore ? c.createdAt.getTime() >= notBefore.getTime() : true,
+      );
+
+    const provider = getEmailProvider();
+    const from = resolveEmailFrom();
+    const errors: Array<{ profileId: string; error: string }> = [];
+    let sent = 0;
+
+    for (const profile of eligibleCandidates) {
+      try {
+        if (dryRun) {
+          sent += 1;
+          continue;
+        }
+        const rendered = renderDay7RetentionEmail({
+          handle: profile.handle,
+          profileId: profile.id,
+          firstName: profile.displayName,
+          topBreakoutNames: topBreakouts,
+        });
+        const result = await provider.send({
+          to: profile.email,
+          from,
+          subject: rendered.subject,
+          html: rendered.html,
+          text: rendered.text,
+        });
+        if (result.ok) {
+          sent += 1;
+        } else {
+          errors.push({ profileId: profile.id, error: result.error });
+        }
+      } catch (err) {
+        errors.push({
+          profileId: profile.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      durationMs: Date.now() - start,
+      eligible: eligibleCandidates.length,
+      sent,
+      errors,
+      topRepos: topBreakouts,
+      dryRun,
+    });
+  } catch (err) {
+    console.error("[cron.onboarding.day7-retention] error", err);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : "unknown_error",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/src/lib/email/templates/day3-nudge.ts
+++ b/src/lib/email/templates/day3-nudge.ts
@@ -1,0 +1,110 @@
+// Day-3 nudge email template (S5.B.3).
+//
+// Sent by the daily onboarding cron to profiles whose createdAt is in the
+// [now-3.5d, now-2.5d] window AND who haven't created an alert rule yet.
+// CTA links to /you/alerts?preset=breakout (same target as the welcome email)
+// so the activation path is consistent.
+
+import { createHmac } from "node:crypto";
+
+const SITE = "https://trendingrepo.com";
+
+export interface Day3NudgeEmailInput {
+  handle: string;
+  profileId: string;
+  firstName?: string | null;
+}
+
+export interface Day3NudgeEmailOutput {
+  subject: string;
+  html: string;
+  text: string;
+  referenceId: string;
+}
+
+function unsubscribeUrl(profileId: string): string {
+  const secret = process.env.EMAIL_UNSUBSCRIBE_SECRET ?? "";
+  if (!secret) return `${SITE}/you/settings`;
+  const sig = createHmac("sha256", secret)
+    .update(`unsub:system:${profileId}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `${SITE}/api/email/unsubscribe?p=${encodeURIComponent(profileId)}&kind=system&sig=${sig}`;
+}
+
+export function renderDay3NudgeEmail(
+  input: Day3NudgeEmailInput,
+): Day3NudgeEmailOutput {
+  const greeting = input.firstName?.trim() || "there";
+  const unsubHref = unsubscribeUrl(input.profileId);
+  const breakoutHref = `${SITE}/you/alerts?preset=breakout`;
+  const dailyDigestHref = `${SITE}/you/alerts?preset=daily-digest`;
+
+  const subject = "Still interested? Your first alert is 30 seconds away.";
+
+  const text = [
+    `Hey ${greeting},`,
+    "",
+    "You signed up a few days ago but haven't wired any alerts yet. That's",
+    "fine — most TrendingRepo value lands the moment your first rule fires.",
+    "",
+    "Three presets that take one click each:",
+    "",
+    `  Breakout       → ${breakoutHref}`,
+    "  Repos hitting multi-channel momentum in 24h.",
+    "",
+    `  Daily digest   → ${dailyDigestHref}`,
+    "  Top-100 platform breakouts, one email per day.",
+    "",
+    `  Release / mention spike → ${SITE}/you/alerts`,
+    "  Target a specific repo (e.g. anthropics/anthropic-sdk-python).",
+    "",
+    "If TrendingRepo isn't your thing, no hard feelings — reply with",
+    "what you were hoping for and we'll either build it or point you at",
+    "a better tool.",
+    "",
+    "— TrendingRepo team",
+    "",
+    "---",
+    "TrendingRepo · trendingrepo.com",
+    `Unsubscribe: ${unsubHref}`,
+  ].join("\n");
+
+  const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>${escapeHtml(subject)}</title></head>
+<body style="margin:0;padding:0;background:#0b0b0d;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e8e8ea;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;background:#0b0b0d;"><tr><td align="center" style="padding:32px 16px;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;background:#161618;border:1px solid #2a2a2e;border-radius:6px;">
+<tr><td style="padding:28px 32px 8px;"><span style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;letter-spacing:0.18em;text-transform:uppercase;color:#8b8b91;">// 00 STILL HERE?</span></td></tr>
+<tr><td style="padding:0 32px 8px;"><h1 style="font-size:28px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin:0;color:#fafafa;">Your first alert is 30 seconds away.</h1></td></tr>
+<tr><td style="padding:16px 32px 8px;">
+<p style="font-size:15px;line-height:1.55;color:#cccce0;margin:0;">Hey ${escapeHtml(greeting)},</p>
+<p style="font-size:15px;line-height:1.55;color:#cccce0;margin:12px 0 0;">You signed up a few days ago but haven't wired any alerts yet. That's fine — most TrendingRepo value lands the moment your first rule fires.</p>
+<p style="font-size:15px;line-height:1.55;color:#cccce0;margin:12px 0 0;">Three presets that take one click each:</p>
+</td></tr>
+<tr><td align="center" style="padding:16px 32px 4px;">
+<a href="${breakoutHref}" style="display:inline-block;background:#fafafa;color:#0b0b0d;padding:12px 22px;border-radius:4px;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;letter-spacing:0.16em;text-transform:uppercase;font-weight:600;text-decoration:none;">BREAKOUT PRESET →</a>
+</td></tr>
+<tr><td style="padding:8px 32px 8px;font-size:13px;color:#9595a3;text-align:center;">or</td></tr>
+<tr><td align="center" style="padding:0 32px 16px;">
+<a href="${dailyDigestHref}" style="display:inline-block;background:transparent;color:#e8e8ea;padding:12px 22px;border-radius:4px;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;letter-spacing:0.16em;text-transform:uppercase;font-weight:600;text-decoration:none;border:1px solid #2a2a2e;">DAILY DIGEST PRESET</a>
+</td></tr>
+<tr><td style="padding:16px 32px 24px;">
+<p style="font-size:13px;line-height:1.55;color:#9595a3;margin:0;">Not your thing? Reply with what you were hoping for — we'll either build it or point you at a better tool.</p>
+<p style="font-size:13px;line-height:1.55;color:#9595a3;margin:8px 0 0;">— TrendingRepo team</p>
+</td></tr>
+<tr><td style="padding:14px 32px;border-top:1px solid #2a2a2e;">
+<p style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:#6b6b73;margin:0;">TrendingRepo · <a href="${SITE}" style="color:#9595a3;text-decoration:none;">trendingrepo.com</a> · <a href="${unsubHref}" style="color:#6b6b73;text-decoration:underline;">Unsubscribe</a></p>
+</td></tr></table></td></tr></table></body></html>`;
+
+  return {
+    subject,
+    html,
+    text,
+    referenceId: `day3-nudge:${input.profileId}`,
+  };
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}

--- a/src/lib/email/templates/day7-retention.ts
+++ b/src/lib/email/templates/day7-retention.ts
@@ -1,0 +1,117 @@
+// Day-7 retention email template (S5.B.4).
+//
+// Sent by the daily onboarding cron to profiles whose createdAt is in the
+// [now-7.5d, now-6.5d] window. Body is a generic "what's hot this week"
+// digest — no per-user rule events (those come from the weekly digest
+// cron for users who opt in). CTA invites them back to /breakouts.
+
+import { createHmac } from "node:crypto";
+
+const SITE = "https://trendingrepo.com";
+
+export interface Day7RetentionEmailInput {
+  handle: string;
+  profileId: string;
+  firstName?: string | null;
+  /**
+   * Up to 3 top-breakout names (e.g. ["vercel/next.js", "..."]) to inline
+   * in the body. Pass empty array if the cron's derived-repos snapshot
+   * isn't ready — the template degrades gracefully.
+   */
+  topBreakoutNames: ReadonlyArray<string>;
+}
+
+export interface Day7RetentionEmailOutput {
+  subject: string;
+  html: string;
+  text: string;
+  referenceId: string;
+}
+
+function unsubscribeUrl(profileId: string): string {
+  const secret = process.env.EMAIL_UNSUBSCRIBE_SECRET ?? "";
+  if (!secret) return `${SITE}/you/settings`;
+  const sig = createHmac("sha256", secret)
+    .update(`unsub:system:${profileId}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `${SITE}/api/email/unsubscribe?p=${encodeURIComponent(profileId)}&kind=system&sig=${sig}`;
+}
+
+export function renderDay7RetentionEmail(
+  input: Day7RetentionEmailInput,
+): Day7RetentionEmailOutput {
+  const greeting = input.firstName?.trim() || "there";
+  const unsubHref = unsubscribeUrl(input.profileId);
+  const breakoutsHref = `${SITE}/breakouts`;
+  const top3 = input.topBreakoutNames.slice(0, 3);
+
+  const subject = "Your first week on TrendingRepo — here's what surged.";
+
+  const text = [
+    `Hey ${greeting},`,
+    "",
+    "It's been a week since you signed up. Here's what trended on",
+    "TrendingRepo while you were figuring out the rest of your stack:",
+    "",
+    ...(top3.length > 0
+      ? top3.map((name) => `  · ${name}`)
+      : ["  (nothing notable broke out this week — check back next week.)"]),
+    "",
+    `Full breakout list: ${breakoutsHref}`,
+    "",
+    "Want this kind of recap on a regular cadence? Flip on the weekly",
+    `digest at ${SITE}/you/alerts and you'll get one email per week with`,
+    "your watched repos + platform breakouts.",
+    "",
+    "— TrendingRepo team",
+    "",
+    "---",
+    "TrendingRepo · trendingrepo.com",
+    `Unsubscribe: ${unsubHref}`,
+  ].join("\n");
+
+  const top3Html =
+    top3.length > 0
+      ? `<ul style="font-size:14px;line-height:1.55;color:#cccce0;margin:8px 0 0;padding-left:18px;">${top3
+          .map(
+            (name) =>
+              `<li style="margin-bottom:4px;"><a href="${SITE}/repo/${escapeHtml(name)}" style="color:#fafafa;text-decoration:none;font-family:'JetBrains Mono',ui-monospace,monospace;">${escapeHtml(name)}</a></li>`,
+          )
+          .join("")}</ul>`
+      : `<p style="font-size:13px;line-height:1.55;color:#9595a3;margin:8px 0 0;font-style:italic;">Nothing notable broke out this week — check back next week.</p>`;
+
+  const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>${escapeHtml(subject)}</title></head>
+<body style="margin:0;padding:0;background:#0b0b0d;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e8e8ea;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;background:#0b0b0d;"><tr><td align="center" style="padding:32px 16px;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;background:#161618;border:1px solid #2a2a2e;border-radius:6px;">
+<tr><td style="padding:28px 32px 8px;"><span style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;letter-spacing:0.18em;text-transform:uppercase;color:#8b8b91;">// 00 WEEK-1 RECAP</span></td></tr>
+<tr><td style="padding:0 32px 8px;"><h1 style="font-size:26px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin:0;color:#fafafa;">Your first week — here's what surged.</h1></td></tr>
+<tr><td style="padding:16px 32px 8px;">
+<p style="font-size:15px;line-height:1.55;color:#cccce0;margin:0;">Hey ${escapeHtml(greeting)},</p>
+<p style="font-size:15px;line-height:1.55;color:#cccce0;margin:12px 0 0;">It's been a week since you signed up. Here's what trended on TrendingRepo while you were figuring out the rest of your stack:</p>
+${top3Html}
+</td></tr>
+<tr><td align="center" style="padding:20px 32px 8px;">
+<a href="${breakoutsHref}" style="display:inline-block;background:#fafafa;color:#0b0b0d;padding:12px 22px;border-radius:4px;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;letter-spacing:0.16em;text-transform:uppercase;font-weight:600;text-decoration:none;">SEE ALL BREAKOUTS →</a>
+</td></tr>
+<tr><td style="padding:16px 32px 24px;">
+<p style="font-size:13px;line-height:1.55;color:#9595a3;margin:0;">Want this on a regular cadence? Flip on the weekly digest at <a href="${SITE}/you/alerts" style="color:#cccce0;">/you/alerts</a>.</p>
+<p style="font-size:13px;line-height:1.55;color:#9595a3;margin:8px 0 0;">— TrendingRepo team</p>
+</td></tr>
+<tr><td style="padding:14px 32px;border-top:1px solid #2a2a2e;">
+<p style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:#6b6b73;margin:0;">TrendingRepo · <a href="${SITE}" style="color:#9595a3;text-decoration:none;">trendingrepo.com</a> · <a href="${unsubHref}" style="color:#6b6b73;text-decoration:underline;">Unsubscribe</a></p>
+</td></tr></table></td></tr></table></body></html>`;
+
+  return {
+    subject,
+    html,
+    text,
+    referenceId: `day7-retention:${input.profileId}`,
+  };
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
## Summary

Stage 5 / B.3 + B.4 combined — both crons share the same shape, same idempotency model, same operator activation pattern.

## New routes

\`POST /api/cron/onboarding/day3-nudge\` — fires daily at 09:37 UTC
\`POST /api/cron/onboarding/day7-retention\` — fires daily at 10:13 UTC

Both \`CRON_SECRET\`-gated via \`verifyCronAuth\`. Both support \`?dry=1\` for safe operator probing — dry-run counts eligible users without burning provider quota.

## Targeting

| Cron | Window | Extra filter |
|---|---|---|
| day-3 nudge | profiles.createdAt ∈ [now-3.5d, now-2.5d] | + alertRules count = 0 |
| day-7 retention | profiles.createdAt ∈ [now-7.5d, now-6.5d] | — (unconditional) |

Both: \`deletedAt IS NULL\` AND \`emailSystem = true\`.

24h-wide window catches every user even with cron drift.

## First-deploy safety

\`DAY3_NUDGE_NOT_BEFORE\` / \`DAY7_RETENTION_NOT_BEFORE\` env vars (ISO timestamp) let the operator gate the first activation so the cron doesn't fire to pre-rollout users. Without these the cron would target every profile in the historical window the moment it goes live.

## New email templates

\`src/lib/email/templates/day3-nudge.ts\`:
- **Subject**: "Still interested? Your first alert is 30 seconds away."
- **CTAs**: \`BREAKOUT PRESET →\` (primary) + \`DAILY DIGEST PRESET\` (secondary)

\`src/lib/email/templates/day7-retention.ts\`:
- **Subject**: "Your first week on TrendingRepo — here's what surged."
- **Body**: lists top-3 breakout repo full names from \`getDerivedRepos()\`
- **CTA**: \`SEE ALL BREAKOUTS →\` to \`/breakouts\`

Both mirror the welcome email's HTML shell (monospace footer, HMAC-signed unsub link via \`EMAIL_UNSUBSCRIBE_SECRET\`).

## Idempotency

- day-3: \`where rule_count = 0\` filter means it never fires twice for a user who activates between runs.
- day-7: no per-user dedup. The 24h window is exactly 1 day wide so each user gets at most one day-7 email anyway.

## Verification

- \`npm run typecheck\` clean
- \`npm run lint:guards\` clean

## Operator deps to activate (per the keys you just provisioned)

| Env | Purpose |
|---|---|
| \`DAY3_NUDGE_NOT_BEFORE\` | ISO timestamp of welcome-email rollout |
| \`DAY7_RETENTION_NOT_BEFORE\` | ISO timestamp of retention rollout |
| \`RESEND_API_KEY\` / \`EMAIL_FROM\` / \`EMAIL_UNSUBSCRIBE_SECRET\` | Shared with B.2 |

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint:guards\` clean
- [ ] **Post-deploy**: \`gh workflow run cron-onboarding-day3.yml --field dry=true\` → confirm eligible count is sensible
- [ ] Same for day-7. Then fire without dry to send real emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)