### PR TITLE
fix(onboarding): harden welcome email unsubscribe

### DIFF
--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -1,0 +1,82 @@
+// GET /api/email/unsubscribe?scope=<scope>&p=<profileId>&t=<hmac>
+//
+// One-click account-email unsubscribe for profile-backed emails. Public,
+// no auth: the HMAC binds the preference change to one profile id and one
+// email scope, so users can unsubscribe directly from old inbox links.
+
+import { eq } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+import { db } from "@/lib/db/client";
+import { profiles } from "@/lib/db/schema/profiles";
+import {
+  parseEmailUnsubscribeScope,
+  verifyEmailUnsubscribeToken,
+  type EmailUnsubscribeScope,
+} from "@/lib/email/unsubscribe";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function getBaseUrl(request: NextRequest): string {
+  const env = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (env && env.length > 0) return env.replace(/\/+$/, "");
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+function redirect(
+  request: NextRequest,
+  status: "invalid" | "server" | "ok",
+  scope?: EmailUnsubscribeScope,
+): NextResponse {
+  const baseUrl = getBaseUrl(request);
+  const suffix =
+    status === "ok"
+      ? `email_unsubscribed=${encodeURIComponent(scope ?? "unknown")}`
+      : `email_unsubscribe=${status}`;
+  return NextResponse.redirect(`${baseUrl}/you/settings?${suffix}`, {
+    status: 302,
+  });
+}
+
+async function applyUnsubscribe(
+  profileId: string,
+  scope: EmailUnsubscribeScope,
+): Promise<void> {
+  if (scope === "referral_updates") {
+    await db
+      .update(profiles)
+      .set({ emailReferralUpdates: false })
+      .where(eq(profiles.id, profileId));
+    return;
+  }
+
+  await db
+    .update(profiles)
+    .set({ emailSystem: false })
+    .where(eq(profiles.id, profileId));
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const url = new URL(request.url);
+  const scope = parseEmailUnsubscribeScope(url.searchParams.get("scope"));
+  const profileId = url.searchParams.get("p") ?? "";
+  const token = url.searchParams.get("t") ?? "";
+
+  if (
+    !scope ||
+    !verifyEmailUnsubscribeToken(scope, profileId, token)
+  ) {
+    return redirect(request, "invalid");
+  }
+
+  try {
+    await applyUnsubscribe(profileId, scope);
+  } catch (err) {
+    console.error("[api:email:unsubscribe] db update failed", err);
+    return redirect(request, "server", scope);
+  }
+
+  return redirect(request, "ok", scope);
+}

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -233,13 +233,20 @@ async function handleUserCreated(
       profileId: insertedProfile.id,
       firstName: data.first_name,
     });
-    await provider.send({
+    const result = await provider.send({
       to: email,
       from: resolveEmailFrom(),
       subject: rendered.subject,
       html: rendered.html,
       text: rendered.text,
     });
+    if (!result.ok) {
+      console.warn("[clerk-webhook] welcome email send failed", {
+        clerkUserId: data.id,
+        provider: provider.name,
+        error: result.error,
+      });
+    }
   } catch (err) {
     console.warn("[clerk-webhook] welcome email send failed", data.id, err);
   }

--- a/src/lib/__vitest__/email-unsubscribe.test.ts
+++ b/src/lib/__vitest__/email-unsubscribe.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildEmailUnsubscribeUrl,
+  verifyEmailUnsubscribeToken,
+} from "@/lib/email/unsubscribe";
+import { renderWelcomeEmail } from "@/lib/email/templates/welcome";
+
+const priorSecret = process.env.SESSION_SECRET;
+
+afterEach(() => {
+  if (priorSecret === undefined) delete process.env.SESSION_SECRET;
+  else process.env.SESSION_SECRET = priorSecret;
+});
+
+describe("email unsubscribe links", () => {
+  it("builds and verifies scoped profile unsubscribe tokens", () => {
+    process.env.SESSION_SECRET = "test-secret-" + "s".repeat(40);
+    const profileId = "11111111-1111-4111-8111-111111111111";
+
+    const url = new URL(buildEmailUnsubscribeUrl("system", profileId));
+    expect(url.pathname).toBe("/api/email/unsubscribe");
+    expect(url.searchParams.get("scope")).toBe("system");
+    expect(url.searchParams.get("p")).toBe(profileId);
+
+    const token = url.searchParams.get("t");
+    expect(token).toBeTruthy();
+    expect(verifyEmailUnsubscribeToken("system", profileId, token!)).toBe(
+      true,
+    );
+    expect(
+      verifyEmailUnsubscribeToken("referral_updates", profileId, token!),
+    ).toBe(false);
+  });
+
+  it("keeps welcome email unsubscribe on the account-email route", () => {
+    process.env.SESSION_SECRET = "test-secret-" + "s".repeat(40);
+    const rendered = renderWelcomeEmail({
+      handle: "operator",
+      profileId: "22222222-2222-4222-8222-222222222222",
+      firstName: "<Mirko>",
+    });
+
+    expect(rendered.html).toContain("/api/email/unsubscribe?");
+    expect(rendered.html).toContain("scope=system");
+    expect(rendered.html).not.toContain("kind=system");
+    expect(rendered.html).not.toContain("sig=");
+    expect(rendered.html).toContain("Hey &lt;Mirko&gt;");
+  });
+});

--- a/src/lib/email/templates/referral-milestone.ts
+++ b/src/lib/email/templates/referral-milestone.ts
@@ -13,9 +13,8 @@
 // HMAC-signed unsubscribe link that toggles `email_referral_updates=false`
 // without requiring auth (the HMAC binds the link to one profile).
 
-import { createHmac } from "node:crypto";
-
 import type { ReferralMilestoneKey } from "@/lib/db/schema/referrals";
+import { buildEmailUnsubscribeUrl } from "@/lib/email/unsubscribe";
 
 export type MilestoneKey = ReferralMilestoneKey;
 
@@ -87,15 +86,6 @@ function escapeHtml(s: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function base64url(input: Buffer | string): string {
-  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
-  return buf
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
-}
-
 /**
  * Build a SESSION_SECRET-HMAC unsubscribe URL. Format:
  *
@@ -111,12 +101,7 @@ function base64url(input: Buffer | string): string {
  * this template is still safe to render in dev without env wiring.
  */
 function unsubscribeUrl(profileId: string): string {
-  const secret = process.env.SESSION_SECRET?.trim();
-  if (!secret) return `${SITE}/you?action=unsubscribe-referral-updates`;
-  const sig = createHmac("sha256", secret)
-    .update(`referral_updates:${profileId}`)
-    .digest();
-  return `${SITE}/api/email/unsubscribe?scope=referral_updates&p=${encodeURIComponent(profileId)}&t=${base64url(sig)}`;
+  return buildEmailUnsubscribeUrl("referral_updates", profileId);
 }
 
 /**

--- a/src/lib/email/templates/welcome.ts
+++ b/src/lib/email/templates/welcome.ts
@@ -13,7 +13,7 @@
 // link that toggles `email_system=false` without requiring auth (the
 // HMAC binds the link to one profile).
 
-import { createHmac } from "node:crypto";
+import { buildEmailUnsubscribeUrl } from "@/lib/email/unsubscribe";
 
 const SITE = "https://trendingrepo.com";
 
@@ -33,25 +33,11 @@ export interface WelcomeEmailOutput {
   referenceId: string;
 }
 
-function unsubscribeUrl(profileId: string): string {
-  const secret = process.env.EMAIL_UNSUBSCRIBE_SECRET ?? "";
-  if (!secret) {
-    // No secret configured (dev / test) — degrade to the settings link so
-    // the user can self-unsub via the UI instead of a signed query string.
-    return `${SITE}/you/settings`;
-  }
-  const sig = createHmac("sha256", secret)
-    .update(`unsub:system:${profileId}`)
-    .digest("hex")
-    .slice(0, 32);
-  return `${SITE}/api/email/unsubscribe?p=${encodeURIComponent(profileId)}&kind=system&sig=${sig}`;
-}
-
 export function renderWelcomeEmail(
   input: WelcomeEmailInput,
 ): WelcomeEmailOutput {
   const greeting = input.firstName?.trim() || "there";
-  const unsubHref = unsubscribeUrl(input.profileId);
+  const unsubHref = buildEmailUnsubscribeUrl("system", input.profileId);
   const ctaHref = `${SITE}/you/alerts?preset=breakout`;
 
   const subject = "You're in. Catch breakouts before they're cold.";

--- a/src/lib/email/unsubscribe.ts
+++ b/src/lib/email/unsubscribe.ts
@@ -1,0 +1,73 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const SITE = "https://trendingrepo.com";
+
+export const EMAIL_UNSUBSCRIBE_SCOPES = [
+  "referral_updates",
+  "system",
+] as const;
+export type EmailUnsubscribeScope = (typeof EMAIL_UNSUBSCRIBE_SCOPES)[number];
+
+const FALLBACK_PATHS: Record<EmailUnsubscribeScope, string> = {
+  referral_updates: "/you?action=unsubscribe-referral-updates",
+  system: "/you/settings",
+};
+
+function base64url(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function secret(): string | null {
+  const raw = process.env.SESSION_SECRET?.trim();
+  return raw && raw.length > 0 ? raw : null;
+}
+
+function sign(scope: EmailUnsubscribeScope, profileId: string): Buffer | null {
+  const raw = secret();
+  if (!raw) return null;
+  return createHmac("sha256", raw).update(`${scope}:${profileId}`).digest();
+}
+
+export function buildEmailUnsubscribeUrl(
+  scope: EmailUnsubscribeScope,
+  profileId: string,
+): string {
+  const sig = sign(scope, profileId);
+  if (!sig) return `${SITE}${FALLBACK_PATHS[scope]}`;
+  return `${SITE}/api/email/unsubscribe?scope=${scope}&p=${encodeURIComponent(
+    profileId,
+  )}&t=${base64url(sig)}`;
+}
+
+export function parseEmailUnsubscribeScope(
+  raw: string | null,
+): EmailUnsubscribeScope | null {
+  return EMAIL_UNSUBSCRIBE_SCOPES.includes(raw as EmailUnsubscribeScope)
+    ? (raw as EmailUnsubscribeScope)
+    : null;
+}
+
+export function verifyEmailUnsubscribeToken(
+  scope: EmailUnsubscribeScope,
+  profileId: string,
+  token: string,
+): boolean {
+  if (!profileId || !token) return false;
+  const expected = sign(scope, profileId);
+  if (!expected) return false;
+
+  let actual: Buffer;
+  try {
+    actual = Buffer.from(token, "base64url");
+  } catch {
+    return false;
+  }
+  return (
+    actual.length === expected.length && timingSafeEqual(actual, expected)
+  );
+}


### PR DESCRIPTION
Follow-up to #1786. The original PR auto-merged before these review fixes landed.\n\nFixes the welcome-email blockers:\n- add /api/email/unsubscribe for profile-backed account email preferences\n- share SESSION_SECRET-HMAC unsubscribe URL generation across welcome and referral milestone emails\n- make the welcome email use scope=system&p=...&t=... instead of the non-existent kind/sig route\n- log provider.send({ ok: false }) failures from the Clerk webhook path so Resend 4xx/5xx/quota/config errors are observable\n- add focused Vitest coverage for token verification and welcome-template link shape\n\nLocal validation:\n- npm run typecheck\n- npm run lint:guards\n- npm run lint (47 existing warnings, 0 errors)\n- npm run test:hooks -- src/lib/__vitest__/email-unsubscribe.test.ts\n- npm audit --audit-level=high\n- git diff --check HEAD~1..HEAD