### PR TITLE
fix(security): allow Clerk prod CNAME + Google Fonts in CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -206,16 +206,28 @@ const nextConfig: NextConfig = {
   //     and storage-migration shims in `src/app/layout.tsx`. `'unsafe-eval'`
   //     is needed by a small subset of dynamic-import vendors (ECharts
   //     option compilation, recharts in dev). `*.clerk.dev` /  `*.clerk.com`
-  //     ship the SignIn/SignUp widget assets; Clerk loads Cloudflare
+  //     cover Clerk dev/preview instances; `clerk.trendingrepo.com` is the
+  //     production Frontend API CNAME (it serves `clerk.browser.js` and
+  //     does not match the `*.clerk.com` wildcard). Clerk loads Cloudflare
   //     Turnstile inline as a bot challenge, hence `challenges.cloudflare.com`.
   //     `*.vercel-analytics.com` is allow-listed proactively so we can opt in
   //     to Vercel Analytics later without another CSP roll.
+  //   - style-src: `fonts.googleapis.com` is needed because the Clerk widget
+  //     runtime injects `<link rel="stylesheet" href="…fonts.googleapis.com…">`
+  //     for the Inter face it uses inside the SignIn / UserButton chrome —
+  //     this happens after clerk.browser.js boots, regardless of our own
+  //     `next/font/google` self-hosting.
+  //   - font-src: `fonts.gstatic.com` is the actual woff2 host that the
+  //     above Google Fonts CSS references.
+  //   - worker-src 'self' blob: is required by Clerk for in-flight session
+  //     token rotation; without it, signed-in sessions throw a CSP warning
+  //     in the console and Clerk falls back to a slower main-thread path.
   //   - connect-src: `https:` covers PostHog (us.i.posthog.com), Sentry
   //     (which actually tunnels through our same-origin /api/_sentry-tunnel
-  //     so this is belt-and-braces), and the various JSON APIs the client
-  //     hits. `wss:` covers any future websocket transport (none active
-  //     today). `data:` is needed for blob-source EventStreams used by
-  //     the markdown renderer.
+  //     so this is belt-and-braces), Clerk's FAPI on the custom CNAME, and
+  //     the various JSON APIs the client hits. `wss:` covers any future
+  //     websocket transport (none active today). `data:` is needed for
+  //     blob-source EventStreams used by the markdown renderer.
   //   - frame-src: Clerk SignIn renders Turnstile inside an iframe served
   //     from `challenges.cloudflare.com`; without it the bot challenge fails
   //     to load and signups stall. Clerk hosted pages (`*.clerk.com`,
@@ -229,9 +241,10 @@ const nextConfig: NextConfig = {
     const csp = [
       "default-src 'self'",
       "img-src 'self' data: https: blob:",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.dev https://*.clerk.com https://challenges.cloudflare.com https://*.vercel-analytics.com",
-      "style-src 'self' 'unsafe-inline'",
-      "font-src 'self' data:",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.dev https://*.clerk.com https://clerk.trendingrepo.com https://challenges.cloudflare.com https://*.vercel-analytics.com",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "font-src 'self' data: https://fonts.gstatic.com",
+      "worker-src 'self' blob:",
       "connect-src 'self' https: wss: data:",
       "frame-src 'self' https://*.clerk.dev https://*.clerk.com https://challenges.cloudflare.com",
       "frame-ancestors 'none'",


### PR DESCRIPTION
## Production-breaking CSP regression — hotfix

### Symptom (from prod console)

```
script-src violation: https://clerk.trendingrepo.com/npm/@clerk/clerk-js@5/dist/clerk.browser.js
Clerk: Failed to load Clerk (code="failed_to_load_clerk_js")
Clerk: Failed to load Clerk (code="failed_to_load_clerk_js_timeout")
Uncaught Error: Minified React error #418  ← downstream hydration mismatch
style-src violation: https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700
```

### Root cause

#1575 shipped CSP with `script-src ... https://*.clerk.dev https://*.clerk.com ...` — but Clerk's production Frontend API is served from a **per-project CNAME** (`clerk.trendingrepo.com`) that does **not** match either wildcard. Every visitor's browser blocks the script before Clerk can boot, which:

1. Breaks every sign-in / sign-up surface.
2. Triggers React error #418 (server HTML referenced `<ClerkProvider>` content; client can't reconcile because Clerk JS is blocked).
3. Stalls the Google Fonts request the Clerk widget runtime injects for Inter (which is itself blocked by `style-src`).

### Fix

Additive CSP allowlist in [next.config.ts:229-251](next.config.ts#L229-L251):

| Directive | Added | Why |
|---|---|---|
| `script-src` | `https://clerk.trendingrepo.com` | Prod FAPI CNAME (serves `clerk.browser.js`) |
| `style-src` | `https://fonts.googleapis.com` | Clerk widget injects Inter `<link rel=stylesheet>` |
| `font-src` | `https://fonts.gstatic.com` | The actual `.woff2` host |
| `worker-src` | `'self' blob:` (new directive) | Clerk session token rotation per their docs |

All four sources align with [Clerk's documented CSP recipe](https://clerk.com/docs/guides/secure/best-practices/csp-headers).

Rationale comments above the CSP array updated to explain each addition so future audits don't strip them again.

### Verification plan

- [x] `npm run typecheck` — clean
- [ ] Preview deploy header check: `curl -sI https://<preview>/ | grep -i content-security-policy` — confirm all four sources present
- [ ] Open `https://<preview>/sign-in` in a clean browser tab — Clerk widget renders, no CSP violations in console, no React #418

### Out of scope (followups)

- Migrate to Clerk's `clerkMiddleware({ contentSecurityPolicy: { strict: true } })` for nonce-based strict-dynamic CSP — better than `'unsafe-inline'` + `'unsafe-eval'` but requires `<ClerkProvider dynamic>` and middleware refactor. File followup once this is unblocking-merged.
- Source the Clerk CNAME from `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` instead of hardcoding `clerk.trendingrepo.com` — defensive against domain renames, but not urgent.