### PR TITLE
chore(data): promote unknown mentions 2026-05-18T08:31:57Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-17T07:23:14.870Z",
-  "totalUnknownMentions": 179884,
-  "distinctRepos": 16806,
+  "generatedAt": "2026-05-18T08:31:55.794Z",
+  "totalUnknownMentions": 191554,
+  "distinctRepos": 17625,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 136,
+      "totalCount": 145,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -16,11 +16,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "vercel/next.js",
-      "totalCount": 133,
+      "totalCount": 143,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -29,7 +29,20 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "oven-sh/bun",
+      "totalCount": 124,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T03:53:18.691Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "hmbown/deepseek-tui",
@@ -45,6 +58,32 @@
       "lastSeenAt": "2026-05-15T06:46:20.813Z"
     },
     {
+      "fullName": "antirez/ds4",
+      "totalCount": 82,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T15:39:28.530Z",
+      "lastSeenAt": "2026-05-18T03:31:51.517Z"
+    },
+    {
+      "fullName": "vitejs/vite",
+      "totalCount": 79,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+    },
+    {
       "fullName": "facebook/react",
       "totalCount": 78,
       "sourceCount": 4,
@@ -58,21 +97,8 @@
       "lastSeenAt": "2026-05-15T11:31:13.243Z"
     },
     {
-      "fullName": "vitejs/vite",
-      "totalCount": 77,
-      "sourceCount": 4,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 69,
+      "totalCount": 70,
       "sourceCount": 4,
       "sources": [
         "awesome-skills",
@@ -81,7 +107,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
     },
     {
       "fullName": "kolapsis/maintenant",
@@ -97,20 +123,8 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "microsoft/vscode",
-      "totalCount": 140,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-13T00:23:31.968Z"
-    },
-    {
       "fullName": "onyks-os/transparenttorproxy",
-      "totalCount": 135,
+      "totalCount": 145,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -118,11 +132,23 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T11:34:16.788Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "microsoft/vscode",
+      "totalCount": 141,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-17T17:48:32.737Z"
     },
     {
       "fullName": "graemeg/blaise",
-      "totalCount": 114,
+      "totalCount": 124,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -130,19 +156,31 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-08T06:11:19.000Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
-      "fullName": "oven-sh/bun",
-      "totalCount": 108,
+      "fullName": "minishlab/semble",
+      "totalCount": 111,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-18T04:41:26.919Z"
+    },
+    {
+      "fullName": "ninjahawk/hollow-agentos",
+      "totalCount": 103,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "hackernews",
-        "lobsters"
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-16T10:40:06.669Z"
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "scosman/cursed_browser",
@@ -194,7 +232,7 @@
     },
     {
       "fullName": "manojmallick/sigmap",
-      "totalCount": 95,
+      "totalCount": 97,
       "sourceCount": 3,
       "sources": [
         "devto",
@@ -202,11 +240,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
-      "fullName": "ninjahawk/hollow-agentos",
-      "totalCount": 93,
+      "fullName": "leaningtech/browsercode",
+      "totalCount": 96,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -214,7 +252,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "nvlabs/cuda-oxide",
@@ -253,20 +291,8 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "leaningtech/browsercode",
-      "totalCount": 86,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
       "fullName": "sifter-ai/sifter",
-      "totalCount": 83,
+      "totalCount": 84,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -274,11 +300,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
     },
     {
       "fullName": "reviewstage/stage-cli",
-      "totalCount": 82,
+      "totalCount": 84,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -286,19 +312,7 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T17:19:14.533Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
-      "fullName": "antirez/ds4",
-      "totalCount": 81,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T15:39:28.530Z",
-      "lastSeenAt": "2026-05-15T06:46:20.813Z"
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "waybarrios/opencode-power-pack",
@@ -326,7 +340,7 @@
     },
     {
       "fullName": "tanstack/router",
-      "totalCount": 74,
+      "totalCount": 76,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -334,11 +348,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-02T04:02:25.023Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "higangssh/homebutler",
-      "totalCount": 73,
+      "totalCount": 75,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -346,11 +360,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
     },
     {
       "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 71,
+      "totalCount": 72,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -358,7 +372,7 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
     },
     {
       "fullName": "sambigeara/pollen",
@@ -383,6 +397,18 @@
       ],
       "firstSeenAt": "2026-05-03T17:17:34.365Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "angular/angular",
+      "totalCount": 63,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "lalitshankarch/rvcore",
@@ -445,16 +471,52 @@
       "lastSeenAt": "2026-05-07T21:45:14.561Z"
     },
     {
-      "fullName": "angular/angular",
-      "totalCount": 56,
+      "fullName": "jameslockman/griffin-powermate-driver",
+      "totalCount": 57,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-11T21:52:07.915Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "torrix-ai/install",
+      "totalCount": 55,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "ollama/ollama",
+      "totalCount": 55,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+    },
+    {
+      "fullName": "uw-syfi/vibe-serve",
+      "totalCount": 54,
+      "sourceCount": 3,
+      "sources": [
+        "arxiv",
+        "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-16T10:40:06.669Z"
+      "firstSeenAt": "2026-05-08T16:57:07.580Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "minio/minio",
@@ -469,18 +531,6 @@
       "lastSeenAt": "2026-05-09T08:04:55.501Z"
     },
     {
-      "fullName": "ollama/ollama",
-      "totalCount": 53,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
       "fullName": "n8n-io/n8n",
       "totalCount": 52,
       "sourceCount": 3,
@@ -491,6 +541,18 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-16T08:13:18.750Z"
+    },
+    {
+      "fullName": "genymobile/scrcpy",
+      "totalCount": 50,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T08:45:16.184Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -517,6 +579,42 @@
       "lastSeenAt": "2026-05-07T10:14:50.031Z"
     },
     {
+      "fullName": "anthropics/claude-for-legal",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-12T20:52:08.570Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "navid-m/flightsim",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+    },
+    {
+      "fullName": "vercel/ai",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+    },
+    {
       "fullName": "wrtnlabs/autobe",
       "totalCount": 47,
       "sourceCount": 3,
@@ -527,18 +625,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
-    },
-    {
-      "fullName": "jameslockman/griffin-powermate-driver",
-      "totalCount": 46,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-11T21:52:07.915Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
     },
     {
       "fullName": "nooga/let-go",
@@ -553,30 +639,6 @@
       "lastSeenAt": "2026-05-11T01:25:31.639Z"
     },
     {
-      "fullName": "navid-m/flightsim",
-      "totalCount": 45,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
-      "fullName": "vercel/ai",
-      "totalCount": 45,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
       "fullName": "mage0535/hermes-memory-installer",
       "totalCount": 45,
       "sourceCount": 3,
@@ -589,16 +651,16 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "uw-syfi/vibe-serve",
+      "fullName": "simdjson/simdjson",
       "totalCount": 44,
       "sourceCount": 3,
       "sources": [
-        "arxiv",
         "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-08T16:57:07.580Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "firstSeenAt": "2026-05-07T15:39:28.530Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "vllm-project/vllm",
@@ -613,20 +675,8 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "torrix-ai/install",
-      "totalCount": 42,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
       "fullName": "0xmassi/webclaw",
-      "totalCount": 40,
+      "totalCount": 41,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -634,71 +684,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
-    },
-    {
-      "fullName": "genymobile/scrcpy",
-      "totalCount": 39,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-02T08:45:16.184Z",
-      "lastSeenAt": "2026-05-16T10:48:12.257Z"
-    },
-    {
-      "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 36,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
-    },
-    {
-      "fullName": "zed-industries/zed",
-      "totalCount": 35,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
-    },
-    {
-      "fullName": "anthropics/claude-for-legal",
-      "totalCount": 34,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-12T20:52:08.570Z",
-      "lastSeenAt": "2026-05-16T10:48:12.257Z"
-    },
-    {
-      "fullName": "tidwall/btype",
-      "totalCount": 31,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-10T15:16:19.509Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
     },
     {
       "fullName": "statewright/statewright",
-      "totalCount": 28,
+      "totalCount": 41,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -706,23 +696,47 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-12T17:04:51.325Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
-      "fullName": "tabularisdb/tabularis",
-      "totalCount": 27,
+      "fullName": "igorganapolsky/thumbgate",
+      "totalCount": 37,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+    },
+    {
+      "fullName": "tidwall/btype",
+      "totalCount": 37,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "devto",
-        "hackernews"
+        "hackernews",
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
+      "firstSeenAt": "2026-05-10T15:16:19.509Z",
+      "lastSeenAt": "2026-05-17T15:12:58.057Z"
+    },
+    {
+      "fullName": "zed-industries/zed",
+      "totalCount": 36,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
     },
     {
       "fullName": "v12-security/pocs",
-      "totalCount": 24,
+      "totalCount": 36,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -730,11 +744,23 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-16T10:40:06.669Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "junegunn/fzf",
+      "totalCount": 35,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-18T05:12:55.510Z"
     },
     {
       "fullName": "iliaal/fastchart",
-      "totalCount": 23,
+      "totalCount": 33,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -742,7 +768,91 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "trycua/cua",
+      "totalCount": 29,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "hackernews",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+    },
+    {
+      "fullName": "tabularisdb/tabularis",
+      "totalCount": 29,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+    },
+    {
+      "fullName": "rust-lang/rust",
+      "totalCount": 27,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "eza-community/eza",
+      "totalCount": 26,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-18T05:12:55.510Z"
+    },
+    {
+      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
+      "totalCount": 21,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:43:54.808Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "open-webui/open-webui",
+      "totalCount": 19,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T04:53:38.982Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "floci-io/floci",
+      "totalCount": 19,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T09:59:04.902Z",
+      "lastSeenAt": "2026-05-17T21:12:09.791Z"
     },
     {
       "fullName": "skyhook-io/radar",
@@ -758,7 +868,7 @@
     },
     {
       "fullName": "duriantaco/skylos",
-      "totalCount": 13,
+      "totalCount": 14,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -766,19 +876,7 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
-    },
-    {
-      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
-      "totalCount": 11,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:43:54.808Z",
-      "lastSeenAt": "2026-05-16T10:48:12.257Z"
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
     },
     {
       "fullName": "aattaran/deepclaude",
@@ -794,14 +892,25 @@
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 134,
+      "totalCount": 141,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-17T07:18:38.648Z"
+      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+    },
+    {
+      "fullName": "wojtczyk/trust",
+      "totalCount": 136,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T07:40:15.618Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "nexu-io/open-design",
@@ -815,15 +924,15 @@
       "lastSeenAt": "2026-05-11T19:17:39.871Z"
     },
     {
-      "fullName": "wojtczyk/trust",
-      "totalCount": 125,
+      "fullName": "jigjoy-ai/mozaik",
+      "totalCount": 123,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T07:40:15.618Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "translate-tools/transly",
@@ -848,15 +957,26 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
-      "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 113,
+      "fullName": "raiyanyahya/kit",
+      "totalCount": 114,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T09:05:56.174Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "samplexbro/agentsmesh",
+      "totalCount": 110,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "jossephus/chuchu",
@@ -870,17 +990,6 @@
       "lastSeenAt": "2026-05-16T00:18:32.194Z"
     },
     {
-      "fullName": "samplexbro/agentsmesh",
-      "totalCount": 108,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
       "fullName": "opensensenova/sensenova-u1",
       "totalCount": 105,
       "sourceCount": 2,
@@ -890,28 +999,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
-    },
-    {
-      "fullName": "raiyanyahya/kit",
-      "totalCount": 103,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T09:05:56.174Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "minishlab/semble",
-      "totalCount": 102,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-10T13:55:10.529Z"
     },
     {
       "fullName": "ifixai-ai/diagnostic",
@@ -936,6 +1023,50 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
+      "fullName": "warwickwood-cell/gengeo-agent-registry",
+      "totalCount": 96,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "facebookresearch/tuna-2",
+      "totalCount": 95,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T23:09:58.018Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "celestoai/smolvm",
+      "totalCount": 95,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+    },
+    {
+      "fullName": "orhun/ratty",
+      "totalCount": 94,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
       "fullName": "openmoss/moss-audio",
       "totalCount": 94,
       "sourceCount": 2,
@@ -947,15 +1078,37 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "celestoai/smolvm",
+      "fullName": "drcathicks/learning-opportunities",
       "totalCount": 93,
       "sourceCount": 2,
       "sources": [
-        "devto",
+        "bluesky",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "avarok-cybersecurity/atlas",
+      "totalCount": 92,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "facebook/pyrefly",
+      "totalCount": 92,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-02T17:16:19.580Z",
+      "lastSeenAt": "2026-05-17T23:08:31.913Z"
     },
     {
       "fullName": "emad-elsaid/xlog",
@@ -1013,6 +1166,17 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 87,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-18T00:10:02.617Z"
+    },
+    {
       "fullName": "cubiczan/consensus-hardening-protocol",
       "totalCount": 87,
       "sourceCount": 2,
@@ -1035,39 +1199,6 @@
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
     },
     {
-      "fullName": "warwickwood-cell/gengeo-agent-registry",
-      "totalCount": 86,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "facebookresearch/tuna-2",
-      "totalCount": 85,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T23:09:58.018Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "orhun/ratty",
-      "totalCount": 84,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-16T10:40:06.669Z"
-    },
-    {
       "fullName": "regent-vcs/re_gent",
       "totalCount": 84,
       "sourceCount": 2,
@@ -1088,28 +1219,6 @@
       ],
       "firstSeenAt": "2026-05-02T03:28:11.836Z",
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
-    },
-    {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 83,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-16T10:40:06.669Z"
-    },
-    {
-      "fullName": "facebook/pyrefly",
-      "totalCount": 83,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T17:16:19.580Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
     },
     {
       "fullName": "v4bel/dirtyfrag",
@@ -1156,17 +1265,6 @@
       "lastSeenAt": "2026-05-09T18:44:58.134Z"
     },
     {
-      "fullName": "avarok-cybersecurity/atlas",
-      "totalCount": 82,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
       "fullName": "dmarshaltu/coord",
       "totalCount": 82,
       "sourceCount": 2,
@@ -1189,6 +1287,17 @@
       "lastSeenAt": "2026-05-12T14:38:16.802Z"
     },
     {
+      "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
+      "totalCount": 81,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T17:19:14.533Z",
+      "lastSeenAt": "2026-05-17T19:35:50.604Z"
+    },
+    {
       "fullName": "friday-platform/friday-studio",
       "totalCount": 81,
       "sourceCount": 2,
@@ -1200,26 +1309,15 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "drcathicks/learning-opportunities",
-      "totalCount": 80,
+      "fullName": "narghev/askdiff",
+      "totalCount": 79,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
-      "totalCount": 80,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T17:19:14.533Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "bep/grrep",
@@ -1332,17 +1430,6 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "narghev/askdiff",
-      "totalCount": 77,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
       "fullName": "wiaahmarketplace/typerion-oss",
       "totalCount": 77,
       "sourceCount": 2,
@@ -1363,6 +1450,17 @@
       ],
       "firstSeenAt": "2026-05-03T10:34:44.583Z",
       "lastSeenAt": "2026-05-11T11:39:37.103Z"
+    },
+    {
+      "fullName": "tsirysndr/rockbox-zig",
+      "totalCount": 76,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T15:17:55.542Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "datadog/java-reggie",
@@ -1429,6 +1527,17 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "harnexa/nexa-gauge",
+      "totalCount": 74,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T01:29:16.934Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "autoloops/upskill",
@@ -1517,6 +1626,28 @@
       ],
       "firstSeenAt": "2026-05-02T21:01:52.519Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "penthertz/luksbox",
+      "totalCount": 72,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-08T16:47:08.670Z",
+      "lastSeenAt": "2026-05-17T23:08:31.913Z"
+    },
+    {
+      "fullName": "wesm/kata",
+      "totalCount": 72,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-04T08:58:50.862Z",
+      "lastSeenAt": "2026-05-17T17:48:32.737Z"
     },
     {
       "fullName": "phel-lang/phel-lang",
@@ -1618,6 +1749,17 @@
       "lastSeenAt": "2026-05-08T17:55:29.602Z"
     },
     {
+      "fullName": "jher7/tokenyst",
+      "totalCount": 71,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T20:33:23.845Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
       "fullName": "fsnotify/fsnotify",
       "totalCount": 71,
       "sourceCount": 2,
@@ -1651,15 +1793,15 @@
       "lastSeenAt": "2026-05-12T19:09:34.978Z"
     },
     {
-      "fullName": "wesm/kata",
-      "totalCount": 71,
+      "fullName": "heymrun/heym",
+      "totalCount": 70,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
-        "hackernews"
+        "devto",
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-04T08:58:50.862Z",
-      "lastSeenAt": "2026-05-12T19:09:34.978Z"
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "webstonehq/tuxedo",
@@ -1693,6 +1835,17 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-12T14:51:56.628Z"
+    },
+    {
+      "fullName": "pion/rtwatch",
+      "totalCount": 69,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T14:44:37.003Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "sudarshan8417/tfdrift",
@@ -1772,15 +1925,15 @@
       "lastSeenAt": "2026-05-04T11:06:19.016Z"
     },
     {
-      "fullName": "heymrun/heym",
+      "fullName": "derekpascarella/universaldreamcastpatcher",
       "totalCount": 68,
       "sourceCount": 2,
       "sources": [
-        "devto",
-        "reddit"
+        "bluesky",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-18T00:10:02.617Z"
     },
     {
       "fullName": "codeabra/iai-mcp",
@@ -1904,39 +2057,6 @@
       "lastSeenAt": "2026-05-08T16:28:40.683Z"
     },
     {
-      "fullName": "tsirysndr/rockbox-zig",
-      "totalCount": 65,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T15:17:55.542Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "derekpascarella/universaldreamcastpatcher",
-      "totalCount": 65,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-15T20:36:14.081Z"
-    },
-    {
-      "fullName": "harnexa/nexa-gauge",
-      "totalCount": 64,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T01:29:16.934Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
       "fullName": "advisories/ghsa-vp62-r36r-9xqp",
       "totalCount": 64,
       "sourceCount": 2,
@@ -1981,6 +2101,17 @@
       "lastSeenAt": "2026-05-09T01:29:16.934Z"
     },
     {
+      "fullName": "enmanuelmag/heimdall-mcp",
+      "totalCount": 63,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
       "fullName": "merkoba/meltdown",
       "totalCount": 63,
       "sourceCount": 2,
@@ -1989,17 +2120,6 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-09T03:39:00.340Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "penthertz/luksbox",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T16:47:08.670Z",
       "lastSeenAt": "2026-05-16T00:18:32.194Z"
     },
     {
@@ -2045,6 +2165,28 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-08T09:54:31.486Z"
+    },
+    {
+      "fullName": "chojs23/concord",
+      "totalCount": 62,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+    },
+    {
+      "fullName": "perufitlife/supabase-security-skill",
+      "totalCount": 62,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T13:30:06.157Z",
+      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "argoproj/argo-cd",
@@ -2143,138 +2285,6 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-01T07:51:01.444Z",
-      "lastSeenAt": "2026-05-08T06:27:42.545Z"
-    },
-    {
-      "fullName": "aurite-ai/agent-verifier",
-      "totalCount": 61,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-12T14:38:16.802Z"
-    },
-    {
-      "fullName": "lobstertrap/tank-os",
-      "totalCount": 61,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-10T17:12:08.615Z"
-    },
-    {
-      "fullName": "lifthrasiir/wah",
-      "totalCount": 61,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T10:35:18.415Z",
-      "lastSeenAt": "2026-05-10T10:08:57.038Z"
-    },
-    {
-      "fullName": "lucemia/trading-agents-plugin",
-      "totalCount": 61,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T16:10:15.985Z",
-      "lastSeenAt": "2026-05-09T14:44:37.003Z"
-    },
-    {
-      "fullName": "mlc-ai/web-llm",
-      "totalCount": 61,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T11:17:51.493Z",
-      "lastSeenAt": "2026-05-09T10:03:44.824Z"
-    },
-    {
-      "fullName": "gebruder/wirken",
-      "totalCount": 61,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T04:02:25.023Z",
-      "lastSeenAt": "2026-05-09T01:29:16.934Z"
-    },
-    {
-      "fullName": "swatto/node-fastcgi",
-      "totalCount": 61,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T11:34:16.788Z",
-      "lastSeenAt": "2026-05-08T08:09:14.506Z"
-    },
-    {
-      "fullName": "perufitlife/supabase-security-skill",
-      "totalCount": 60,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T13:30:06.157Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
-      "fullName": "kernalix7/winpodx",
-      "totalCount": 60,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-12T22:37:31.780Z"
-    },
-    {
-      "fullName": "p32929/rotato",
-      "totalCount": 60,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T21:10:06.425Z",
-      "lastSeenAt": "2026-05-09T20:33:23.845Z"
-    },
-    {
-      "fullName": "alexellis/k3sup",
-      "totalCount": 60,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T15:36:48.177Z",
-      "lastSeenAt": "2026-05-08T11:33:06.098Z"
-    },
-    {
-      "fullName": "entireio/git-sync",
-      "totalCount": 60,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-08T06:27:42.545Z"
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26022367402

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.