### PR TITLE
chore(data): refresh huggingface signals 2026-05-18T10:42:16Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-18T04:43:24.911Z",
+  "ts": "2026-05-18T10:42:15.954Z",
   "count": 1,
-  "durationMs": 8069,
+  "durationMs": 6465,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T04:43:16.845Z",
+  "fetchedAt": "2026-05-18T10:42:09.490Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -8,9 +8,9 @@
       "id": "openbmb/MiniCPM-V-4.6",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6",
-      "downloads": 56518,
-      "likes": 702,
-      "trendingScore": 626,
+      "downloads": 80586,
+      "likes": 740,
+      "trendingScore": 659,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -155,9 +155,9 @@
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic-3",
-      "downloads": 20208,
-      "likes": 366,
-      "trendingScore": 290,
+      "downloads": 24031,
+      "likes": 386,
+      "trendingScore": 305,
       "pipelineTag": "text-to-speech",
       "libraryName": "supertonic",
       "tags": [
@@ -193,16 +193,16 @@
         "pt"
       ],
       "createdAt": "2026-05-06T20:46:20.000Z",
-      "lastModified": "2026-05-06T20:35:37.000Z"
+      "lastModified": "2026-05-18T08:59:01.000Z"
     },
     {
       "rank": 8,
       "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
-      "downloads": 185303,
-      "likes": 237,
-      "trendingScore": 230,
+      "downloads": 268305,
+      "likes": 247,
+      "trendingScore": 239,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -221,16 +221,16 @@
         "conversational"
       ],
       "createdAt": "2026-05-11T12:57:11.000Z",
-      "lastModified": "2026-05-17T14:33:33.000Z"
+      "lastModified": "2026-05-18T05:58:01.000Z"
     },
     {
       "rank": 9,
       "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 181425,
-      "likes": 219,
-      "trendingScore": 210,
+      "downloads": 237613,
+      "likes": 228,
+      "trendingScore": 219,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -354,9 +354,9 @@
       "id": "circlestone-labs/Anima",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima",
-      "downloads": 524067,
-      "likes": 1377,
-      "trendingScore": 148,
+      "downloads": 545205,
+      "likes": 1389,
+      "trendingScore": 159,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
       "tags": [
@@ -370,6 +370,35 @@
     },
     {
       "rank": 15,
+      "id": "ResembleAI/Dramabox",
+      "author": "ResembleAI",
+      "url": "https://huggingface.co/ResembleAI/Dramabox",
+      "downloads": 1001,
+      "likes": 149,
+      "trendingScore": 147,
+      "pipelineTag": "text-to-speech",
+      "libraryName": "ltx-audio-tts",
+      "tags": [
+        "ltx-audio-tts",
+        "dramabox-tts",
+        "tts",
+        "voice-cloning",
+        "audio-generation",
+        "diffusion-transformer",
+        "flow-matching",
+        "ltx-2",
+        "text-to-speech",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:finetune:Lightricks/LTX-2.3",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-17T07:17:52.000Z",
+      "lastModified": "2026-05-13T16:39:38.000Z"
+    },
+    {
+      "rank": 16,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -396,35 +425,6 @@
       ],
       "createdAt": "2026-04-27T12:52:53.000Z",
       "lastModified": "2026-04-28T07:01:37.000Z"
-    },
-    {
-      "rank": 16,
-      "id": "ResembleAI/Dramabox",
-      "author": "ResembleAI",
-      "url": "https://huggingface.co/ResembleAI/Dramabox",
-      "downloads": 936,
-      "likes": 137,
-      "trendingScore": 135,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "ltx-audio-tts",
-      "tags": [
-        "ltx-audio-tts",
-        "dramabox-tts",
-        "tts",
-        "voice-cloning",
-        "audio-generation",
-        "diffusion-transformer",
-        "flow-matching",
-        "ltx-2",
-        "text-to-speech",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:finetune:Lightricks/LTX-2.3",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T07:17:52.000Z",
-      "lastModified": "2026-05-13T16:39:38.000Z"
     },
     {
       "rank": 17,
@@ -502,8 +502,8 @@
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
       "downloads": 0,
-      "likes": 262,
-      "trendingScore": 128,
+      "likes": 273,
+      "trendingScore": 132,
       "pipelineTag": null,
       "libraryName": "mlx",
       "tags": [
@@ -530,8 +530,8 @@
       "author": "TencentARC",
       "url": "https://huggingface.co/TencentARC/Pixal3D",
       "downloads": 0,
-      "likes": 129,
-      "trendingScore": 123,
+      "likes": 136,
+      "trendingScore": 130,
       "pipelineTag": "image-to-3d",
       "libraryName": null,
       "tags": [
@@ -664,9 +664,9 @@
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
-      "downloads": 268773,
-      "likes": 620,
-      "trendingScore": 104,
+      "downloads": 267449,
+      "likes": 622,
+      "trendingScore": 105,
       "pipelineTag": "text-generation",
       "libraryName": null,
       "tags": [
@@ -797,95 +797,12 @@
     },
     {
       "rank": 30,
-      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-      "downloads": 65066,
-      "likes": 261,
-      "trendingScore": 92,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "NemotronH_Nano_Omni_Reasoning_V3",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "multimodal",
-        "any-to-any",
-        "custom_code",
-        "dataset:nvidia/Nemotron-Image-Training-v3",
-        "arxiv:2604.24954",
-        "license:other",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T04:40:42.000Z",
-      "lastModified": "2026-05-05T12:57:20.000Z"
-    },
-    {
-      "rank": 31,
-      "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
-      "author": "dealignai",
-      "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
-      "downloads": 169511,
-      "likes": 1487,
-      "trendingScore": 90,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "gemma4",
-        "abliterated",
-        "uncensored",
-        "crack",
-        "jang",
-        "image-text-to-text",
-        "conversational",
-        "license:gemma",
-        "region:us"
-      ],
-      "createdAt": "2026-04-04T03:02:08.000Z",
-      "lastModified": "2026-04-25T21:33:07.000Z"
-    },
-    {
-      "rank": 32,
-      "id": "unsloth/Qwen3.6-27B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
-      "downloads": 1312422,
-      "likes": 624,
-      "trendingScore": 90,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-22T05:43:37.000Z",
-      "lastModified": "2026-04-22T16:01:39.000Z"
-    },
-    {
-      "rank": 33,
       "id": "ScenemaAI/scenema-audio",
       "author": "ScenemaAI",
       "url": "https://huggingface.co/ScenemaAI/scenema-audio",
-      "downloads": 209,
-      "likes": 86,
-      "trendingScore": 86,
+      "downloads": 237,
+      "likes": 93,
+      "trendingScore": 93,
       "pipelineTag": "text-to-speech",
       "libraryName": "scenema-audio",
       "tags": [
@@ -916,6 +833,89 @@
       ],
       "createdAt": "2026-04-26T01:37:45.000Z",
       "lastModified": "2026-05-14T03:19:58.000Z"
+    },
+    {
+      "rank": 31,
+      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+      "downloads": 65066,
+      "likes": 261,
+      "trendingScore": 92,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "NemotronH_Nano_Omni_Reasoning_V3",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "multimodal",
+        "any-to-any",
+        "custom_code",
+        "dataset:nvidia/Nemotron-Image-Training-v3",
+        "arxiv:2604.24954",
+        "license:other",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-20T04:40:42.000Z",
+      "lastModified": "2026-05-05T12:57:20.000Z"
+    },
+    {
+      "rank": 32,
+      "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
+      "author": "dealignai",
+      "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
+      "downloads": 169511,
+      "likes": 1487,
+      "trendingScore": 90,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "gemma4",
+        "abliterated",
+        "uncensored",
+        "crack",
+        "jang",
+        "image-text-to-text",
+        "conversational",
+        "license:gemma",
+        "region:us"
+      ],
+      "createdAt": "2026-04-04T03:02:08.000Z",
+      "lastModified": "2026-04-25T21:33:07.000Z"
+    },
+    {
+      "rank": 33,
+      "id": "unsloth/Qwen3.6-27B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
+      "downloads": 1312422,
+      "likes": 624,
+      "trendingScore": 90,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-22T05:43:37.000Z",
+      "lastModified": "2026-04-22T16:01:39.000Z"
     },
     {
       "rank": 34,
@@ -1029,6 +1029,33 @@
     },
     {
       "rank": 37,
+      "id": "microsoft/Fara-7B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Fara-7B",
+      "downloads": 16011,
+      "likes": 577,
+      "trendingScore": 82,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_5_vl",
+        "image-text-to-text",
+        "multimodal",
+        "conversational",
+        "en",
+        "arxiv:2511.19663",
+        "license:mit",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-10-30T18:56:59.000Z",
+      "lastModified": "2025-12-11T22:11:43.000Z"
+    },
+    {
+      "rank": 38,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -1056,7 +1083,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1083,33 +1110,6 @@
       ],
       "createdAt": "2026-04-28T12:39:12.000Z",
       "lastModified": "2026-05-09T07:37:22.000Z"
-    },
-    {
-      "rank": 39,
-      "id": "microsoft/Fara-7B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Fara-7B",
-      "downloads": 17170,
-      "likes": 574,
-      "trendingScore": 79,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_5_vl",
-        "image-text-to-text",
-        "multimodal",
-        "conversational",
-        "en",
-        "arxiv:2511.19663",
-        "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-10-30T18:56:59.000Z",
-      "lastModified": "2025-12-11T22:11:43.000Z"
     },
     {
       "rank": 40,
@@ -1246,6 +1246,72 @@
     },
     {
       "rank": 44,
+      "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
+      "downloads": 6462,
+      "likes": 75,
+      "trendingScore": 75,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_5",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "agent",
+        "tool-use",
+        "function-calling",
+        "coder",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:lambda/hermes-agent-reasoning-traces",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T12:53:59.000Z",
+      "lastModified": "2026-05-17T01:57:24.000Z"
+    },
+    {
+      "rank": 45,
+      "id": "Cactus-Compute/needle",
+      "author": "Cactus-Compute",
+      "url": "https://huggingface.co/Cactus-Compute/needle",
+      "downloads": 241,
+      "likes": 75,
+      "trendingScore": 74,
+      "pipelineTag": null,
+      "libraryName": "jax",
+      "tags": [
+        "jax",
+        "custom",
+        "function-calling",
+        "tool-use",
+        "encoder-decoder",
+        "edge",
+        "on-device",
+        "flax",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-03-16T04:01:31.000Z",
+      "lastModified": "2026-05-13T09:32:17.000Z"
+    },
+    {
+      "rank": 46,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -1265,7 +1331,32 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 45,
+      "rank": 47,
+      "id": "inclusionAI/Ring-2.6-1T",
+      "author": "inclusionAI",
+      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
+      "downloads": 2406,
+      "likes": 74,
+      "trendingScore": 73,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "bailing_hybrid",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:mit",
+        "eval-results",
+        "compressed-tensors",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:10:02.000Z",
+      "lastModified": "2026-05-18T09:47:28.000Z"
+    },
+    {
+      "rank": 48,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -1288,32 +1379,7 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 46,
-      "id": "Cactus-Compute/needle",
-      "author": "Cactus-Compute",
-      "url": "https://huggingface.co/Cactus-Compute/needle",
-      "downloads": 221,
-      "likes": 70,
-      "trendingScore": 69,
-      "pipelineTag": null,
-      "libraryName": "jax",
-      "tags": [
-        "jax",
-        "custom",
-        "function-calling",
-        "tool-use",
-        "encoder-decoder",
-        "edge",
-        "on-device",
-        "flax",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-03-16T04:01:31.000Z",
-      "lastModified": "2026-05-13T09:32:17.000Z"
-    },
-    {
-      "rank": 47,
+      "rank": 49,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -1345,12 +1411,12 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 48,
+      "rank": 50,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
-      "downloads": 16739,
-      "likes": 89,
+      "downloads": 18203,
+      "likes": 90,
       "trendingScore": 67,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -1378,31 +1444,56 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 49,
-      "id": "inclusionAI/Ring-2.6-1T",
-      "author": "inclusionAI",
-      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
-      "downloads": 1468,
-      "likes": 68,
+      "rank": 51,
+      "id": "internlm/Intern-S2-Preview",
+      "author": "internlm",
+      "url": "https://huggingface.co/internlm/Intern-S2-Preview",
+      "downloads": 1168,
+      "likes": 67,
       "trendingScore": 67,
-      "pipelineTag": "text-generation",
+      "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "bailing_hybrid",
-        "text-generation",
+        "intern_s2_preview",
+        "image-text-to-text",
         "conversational",
         "custom_code",
-        "license:mit",
-        "compressed-tensors",
+        "license:apache-2.0",
+        "eval-results",
         "region:us"
       ],
-      "createdAt": "2026-05-14T08:10:02.000Z",
-      "lastModified": "2026-05-15T13:16:22.000Z"
+      "createdAt": "2026-05-15T03:49:25.000Z",
+      "lastModified": "2026-05-18T08:00:41.000Z"
     },
     {
-      "rank": 50,
+      "rank": 52,
+      "id": "Aratako/Irodori-TTS-500M-v3",
+      "author": "Aratako",
+      "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
+      "downloads": 0,
+      "likes": 67,
+      "trendingScore": 66,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "speech",
+        "voice",
+        "tts",
+        "text-to-speech",
+        "ja",
+        "base_model:Aratako/Irodori-TTS-500M-v2",
+        "base_model:finetune:Aratako/Irodori-TTS-500M-v2",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T02:15:21.000Z",
+      "lastModified": "2026-05-12T14:25:54.000Z"
+    },
+    {
+      "rank": 53,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1447,7 +1538,7 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 51,
+      "rank": 54,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -1474,7 +1565,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 52,
+      "rank": 55,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -1507,32 +1598,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 53,
-      "id": "Aratako/Irodori-TTS-500M-v3",
-      "author": "Aratako",
-      "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
-      "downloads": 0,
-      "likes": 63,
-      "trendingScore": 62,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "speech",
-        "voice",
-        "tts",
-        "text-to-speech",
-        "ja",
-        "base_model:Aratako/Irodori-TTS-500M-v2",
-        "base_model:finetune:Aratako/Irodori-TTS-500M-v2",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T02:15:21.000Z",
-      "lastModified": "2026-05-12T14:25:54.000Z"
-    },
-    {
-      "rank": 54,
+      "rank": 56,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -1564,11 +1630,11 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 55,
+      "rank": 57,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-      "downloads": 2164,
+      "downloads": 2414,
       "likes": 64,
       "trendingScore": 61,
       "pipelineTag": "any-to-any",
@@ -1593,30 +1659,7 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 56,
-      "id": "internlm/Intern-S2-Preview",
-      "author": "internlm",
-      "url": "https://huggingface.co/internlm/Intern-S2-Preview",
-      "downloads": 1059,
-      "likes": 61,
-      "trendingScore": 61,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "intern_s2_preview",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T03:49:25.000Z",
-      "lastModified": "2026-05-15T04:23:26.000Z"
-    },
-    {
-      "rank": 57,
+      "rank": 58,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -1644,7 +1687,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 58,
+      "rank": 59,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -1671,7 +1714,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 59,
+      "rank": 60,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -1696,47 +1739,6 @@
       ],
       "createdAt": "2026-03-11T21:25:57.000Z",
       "lastModified": "2026-05-07T07:39:32.000Z"
-    },
-    {
-      "rank": 60,
-      "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
-      "downloads": 1762,
-      "likes": 58,
-      "trendingScore": 58,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_5",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "agent",
-        "tool-use",
-        "function-calling",
-        "coder",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:lambda/hermes-agent-reasoning-traces",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T12:53:59.000Z",
-      "lastModified": "2026-05-17T01:57:24.000Z"
     },
     {
       "rank": 61,
@@ -1796,9 +1798,9 @@
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
-      "downloads": 67,
-      "likes": 55,
-      "trendingScore": 55,
+      "downloads": 73,
+      "likes": 56,
+      "trendingScore": 56,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -1817,6 +1819,37 @@
     },
     {
       "rank": 64,
+      "id": "fastino/gliguard-LLMGuardrails-300M",
+      "author": "fastino",
+      "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
+      "downloads": 2071,
+      "likes": 56,
+      "trendingScore": 55,
+      "pipelineTag": "text-classification",
+      "libraryName": "gliner2",
+      "tags": [
+        "gliner2",
+        "safetensors",
+        "extractor",
+        "safety",
+        "moderation",
+        "guardrails",
+        "text-classification",
+        "multi-label-classification",
+        "jailbreak-detection",
+        "toxicity-classification",
+        "en",
+        "arxiv:2605.07982",
+        "base_model:fastino/gliner2-base-v1",
+        "base_model:finetune:fastino/gliner2-base-v1",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-09T04:20:48.000Z",
+      "lastModified": "2026-05-14T16:04:55.000Z"
+    },
+    {
+      "rank": 65,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -1860,7 +1893,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 65,
+      "rank": 66,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -1876,37 +1909,6 @@
       ],
       "createdAt": "2026-05-10T00:28:02.000Z",
       "lastModified": "2026-05-12T09:46:36.000Z"
-    },
-    {
-      "rank": 66,
-      "id": "fastino/gliguard-LLMGuardrails-300M",
-      "author": "fastino",
-      "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
-      "downloads": 1970,
-      "likes": 55,
-      "trendingScore": 54,
-      "pipelineTag": "text-classification",
-      "libraryName": "gliner2",
-      "tags": [
-        "gliner2",
-        "safetensors",
-        "extractor",
-        "safety",
-        "moderation",
-        "guardrails",
-        "text-classification",
-        "multi-label-classification",
-        "jailbreak-detection",
-        "toxicity-classification",
-        "en",
-        "arxiv:2605.07982",
-        "base_model:fastino/gliner2-base-v1",
-        "base_model:finetune:fastino/gliner2-base-v1",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T04:20:48.000Z",
-      "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
       "rank": 67,
@@ -2070,6 +2072,38 @@
     },
     {
       "rank": 72,
+      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "downloads": 40301,
+      "likes": 53,
+      "trendingScore": 50,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "gemma4",
+        "moe",
+        "vision",
+        "multimodal",
+        "agentic",
+        "coding",
+        "image-text-to-text",
+        "en",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-14T16:24:48.000Z",
+      "lastModified": "2026-05-14T17:07:52.000Z"
+    },
+    {
+      "rank": 73,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2103,38 +2137,6 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 73,
-      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "downloads": 33588,
-      "likes": 52,
-      "trendingScore": 49,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "moe",
-        "vision",
-        "multimodal",
-        "agentic",
-        "coding",
-        "image-text-to-text",
-        "en",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-14T16:24:48.000Z",
-      "lastModified": "2026-05-14T17:07:52.000Z"
-    },
-    {
       "rank": 74,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
@@ -2166,6 +2168,33 @@
     },
     {
       "rank": 75,
+      "id": "Lakonik/AsymFLUX.2-klein-9B",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
+      "downloads": 1608,
+      "likes": 48,
+      "trendingScore": 48,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "flow-matching",
+        "pixel-diffusion",
+        "pixel-generation",
+        "flux2",
+        "text-to-image",
+        "arxiv:2605.12964",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T20:19:24.000Z",
+      "lastModified": "2026-05-14T02:37:15.000Z"
+    },
+    {
+      "rank": 76,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -2196,7 +2225,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 76,
+      "rank": 77,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -2221,11 +2250,11 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 77,
+      "rank": 78,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
-      "downloads": 227,
+      "downloads": 247,
       "likes": 49,
       "trendingScore": 47,
       "pipelineTag": "text-to-image",
@@ -2241,7 +2270,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 78,
+      "rank": 79,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -2278,33 +2307,6 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 79,
-      "id": "Lakonik/AsymFLUX.2-klein-9B",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
-      "downloads": 1142,
-      "likes": 47,
-      "trendingScore": 47,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "flow-matching",
-        "pixel-diffusion",
-        "pixel-generation",
-        "flux2",
-        "text-to-image",
-        "arxiv:2605.12964",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T20:19:24.000Z",
-      "lastModified": "2026-05-14T02:37:15.000Z"
-    },
-    {
       "rank": 80,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
@@ -2334,6 +2336,26 @@
     },
     {
       "rank": 81,
+      "id": "facebook/VGGT-Omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/VGGT-Omega",
+      "downloads": 0,
+      "likes": 48,
+      "trendingScore": 46,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "facebook",
+        "meta-pytorch",
+        "en",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-17T20:47:45.000Z",
+      "lastModified": "2026-05-14T21:23:21.000Z"
+    },
+    {
+      "rank": 82,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -2356,7 +2378,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 82,
+      "rank": 83,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -2389,7 +2411,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 83,
+      "rank": 84,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -2420,7 +2442,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 84,
+      "rank": 85,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -2436,7 +2458,7 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 85,
+      "rank": 86,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -2473,27 +2495,31 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 86,
-      "id": "facebook/VGGT-Omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/VGGT-Omega",
-      "downloads": 0,
-      "likes": 44,
-      "trendingScore": 42,
-      "pipelineTag": null,
-      "libraryName": null,
+      "rank": 87,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
+      "downloads": 495,
+      "likes": 40,
+      "trendingScore": 40,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
       "tags": [
-        "facebook",
-        "meta-pytorch",
-        "en",
-        "license:cc-by-nc-4.0",
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-03-17T20:47:45.000Z",
-      "lastModified": "2026-05-14T21:23:21.000Z"
+      "createdAt": "2026-05-13T15:12:13.000Z",
+      "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -2510,30 +2536,6 @@
       ],
       "createdAt": "2026-05-05T23:12:08.000Z",
       "lastModified": "2026-05-08T23:21:12.000Z"
-    },
-    {
-      "rank": 88,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "downloads": 416,
-      "likes": 39,
-      "trendingScore": 39,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T15:12:13.000Z",
-      "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
       "rank": 89,
@@ -2564,6 +2566,33 @@
     },
     {
       "rank": 90,
+      "id": "Qwen/Qwen3.5-9B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
+      "downloads": 8044107,
+      "likes": 1452,
+      "trendingScore": 37,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.5-9B-Base",
+        "base_model:finetune:Qwen/Qwen3.5-9B-Base",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-02-27T12:58:26.000Z",
+      "lastModified": "2026-03-02T00:51:43.000Z"
+    },
+    {
+      "rank": 91,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -2595,7 +2624,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 91,
+      "rank": 92,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -2618,7 +2647,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 92,
+      "rank": 93,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -2644,7 +2673,31 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
+      "id": "hexgrad/Kokoro-82M",
+      "author": "hexgrad",
+      "url": "https://huggingface.co/hexgrad/Kokoro-82M",
+      "downloads": 9699227,
+      "likes": 6161,
+      "trendingScore": 35,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "text-to-speech",
+        "en",
+        "arxiv:2306.07691",
+        "arxiv:2203.02395",
+        "base_model:yl4579/StyleTTS2-LJSpeech",
+        "base_model:finetune:yl4579/StyleTTS2-LJSpeech",
+        "doi:10.57967/hf/4329",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2024-12-26T00:20:08.000Z",
+      "lastModified": "2025-04-10T18:12:48.000Z"
+    },
+    {
+      "rank": 95,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -2668,7 +2721,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 94,
+      "rank": 96,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -2685,7 +2738,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 95,
+      "rank": 97,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -2709,7 +2762,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 96,
+      "rank": 98,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -2735,7 +2788,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 97,
+      "rank": 99,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -2751,7 +2804,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 98,
+      "rank": 100,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -2778,31 +2831,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 99,
-      "id": "hexgrad/Kokoro-82M",
-      "author": "hexgrad",
-      "url": "https://huggingface.co/hexgrad/Kokoro-82M",
-      "downloads": 9722996,
-      "likes": 6159,
-      "trendingScore": 34,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "text-to-speech",
-        "en",
-        "arxiv:2306.07691",
-        "arxiv:2203.02395",
-        "base_model:yl4579/StyleTTS2-LJSpeech",
-        "base_model:finetune:yl4579/StyleTTS2-LJSpeech",
-        "doi:10.57967/hf/4329",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2024-12-26T00:20:08.000Z",
-      "lastModified": "2025-04-10T18:12:48.000Z"
-    },
-    {
-      "rank": 100,
+      "rank": 101,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -2831,7 +2860,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 101,
+      "rank": 102,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -2876,7 +2905,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -2921,7 +2950,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -2965,7 +2994,47 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 104,
+      "rank": 105,
+      "id": "meta-llama/Llama-3.1-8B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
+      "downloads": 10442933,
+      "likes": 5849,
+      "trendingScore": 33,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "base_model:meta-llama/Llama-3.1-8B",
+        "base_model:finetune:meta-llama/Llama-3.1-8B",
+        "license:llama3.1",
+        "eval-results",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-07-18T08:56:00.000Z",
+      "lastModified": "2024-09-25T17:00:57.000Z"
+    },
+    {
+      "rank": 106,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -2984,7 +3053,7 @@
       "lastModified": "2026-05-01T16:08:38.000Z"
     },
     {
-      "rank": 105,
+      "rank": 107,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -3028,7 +3097,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 106,
+      "rank": 108,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3053,7 +3122,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 107,
+      "rank": 109,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -3098,38 +3167,11 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 108,
-      "id": "Qwen/Qwen3.5-9B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
-      "downloads": 8133488,
-      "likes": 1446,
-      "trendingScore": 32,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.5-9B-Base",
-        "base_model:finetune:Qwen/Qwen3.5-9B-Base",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-02-27T12:58:26.000Z",
-      "lastModified": "2026-03-02T00:51:43.000Z"
-    },
-    {
-      "rank": 109,
+      "rank": 110,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
-      "downloads": 196,
+      "downloads": 179,
       "likes": 114,
       "trendingScore": 32,
       "pipelineTag": null,
@@ -3151,7 +3193,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 110,
+      "rank": 111,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -3184,7 +3226,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 111,
+      "rank": 112,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -3208,7 +3250,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 112,
+      "rank": 113,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -3235,7 +3277,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 113,
+      "rank": 114,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3266,7 +3308,7 @@
       "lastModified": "2026-05-07T19:24:05.000Z"
     },
     {
-      "rank": 114,
+      "rank": 115,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -3308,7 +3350,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 115,
+      "rank": 116,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -3336,7 +3378,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -3362,7 +3404,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -3394,7 +3436,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -3419,46 +3461,6 @@
       ],
       "createdAt": "2026-04-20T00:55:32.000Z",
       "lastModified": "2026-05-14T22:39:27.000Z"
-    },
-    {
-      "rank": 119,
-      "id": "meta-llama/Llama-3.1-8B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
-      "downloads": 10025379,
-      "likes": 5845,
-      "trendingScore": 30,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "base_model:meta-llama/Llama-3.1-8B",
-        "base_model:finetune:meta-llama/Llama-3.1-8B",
-        "license:llama3.1",
-        "eval-results",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-07-18T08:56:00.000Z",
-      "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
       "rank": 120,
@@ -3750,7 +3752,7 @@
       "id": "Alissonerdx/BFS-Best-Face-Swap",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
-      "downloads": 91928,
+      "downloads": 93163,
       "likes": 540,
       "trendingScore": 28,
       "pipelineTag": "image-to-image",
@@ -3780,6 +3782,33 @@
     },
     {
       "rank": 131,
+      "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
+      "downloads": 24211,
+      "likes": 29,
+      "trendingScore": 28,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-9B",
+        "base_model:quantized:Qwen/Qwen3.5-9B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T13:34:47.000Z",
+      "lastModified": "2026-05-16T12:39:00.000Z"
+    },
+    {
+      "rank": 132,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -3798,7 +3827,7 @@
       "lastModified": "2026-04-30T01:03:50.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -3838,7 +3867,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -3875,7 +3904,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 134,
+      "rank": 135,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -3918,7 +3947,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 135,
+      "rank": 136,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -3938,7 +3967,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 136,
+      "rank": 137,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -3963,11 +3992,11 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 137,
+      "rank": 138,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
-      "downloads": 1287,
+      "downloads": 1372,
       "likes": 31,
       "trendingScore": 27,
       "pipelineTag": "time-series-forecasting",
@@ -3991,7 +4020,34 @@
       "lastModified": "2026-05-14T14:23:46.000Z"
     },
     {
-      "rank": 138,
+      "rank": 139,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/bytedance-research/Lance",
+      "downloads": 0,
+      "likes": 27,
+      "trendingScore": 27,
+      "pipelineTag": "any-to-any",
+      "libraryName": "Lance",
+      "tags": [
+        "Lance",
+        "safetensors",
+        "multimodal",
+        "image-generation",
+        "video-generation",
+        "image-editing",
+        "video-understanding",
+        "any-to-any",
+        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T08:05:57.000Z",
+      "lastModified": "2026-05-18T04:24:28.000Z"
+    },
+    {
+      "rank": 140,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -4036,7 +4092,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 139,
+      "rank": 141,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -4063,7 +4119,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 140,
+      "rank": 142,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -4108,7 +4164,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 141,
+      "rank": 143,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -4134,7 +4190,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 142,
+      "rank": 144,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -4156,34 +4212,29 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 143,
-      "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
-      "downloads": 17426,
-      "likes": 27,
+      "rank": 145,
+      "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
+      "author": "systms",
+      "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
+      "downloads": 410,
+      "likes": 26,
       "trendingScore": 26,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": null,
+      "libraryName": "diffusers",
       "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-9B",
-        "base_model:quantized:Qwen/Qwen3.5-9B",
+        "diffusers",
+        "lora",
+        "ltx-video",
+        "base_model:Lightricks/LTX-Video",
+        "base_model:adapter:Lightricks/LTX-Video",
         "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "region:us"
       ],
-      "createdAt": "2026-05-13T13:34:47.000Z",
-      "lastModified": "2026-05-16T12:39:00.000Z"
+      "createdAt": "2026-05-13T09:22:55.000Z",
+      "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 144,
+      "rank": 146,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -4221,7 +4272,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 145,
+      "rank": 147,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -4239,7 +4290,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 146,
+      "rank": 148,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -4265,7 +4316,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 147,
+      "rank": 149,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -4285,7 +4336,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 148,
+      "rank": 150,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -4312,7 +4363,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 149,
+      "rank": 151,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -4338,7 +4389,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 150,
+      "rank": 152,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -4364,7 +4415,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 151,
+      "rank": 153,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -4401,29 +4452,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 152,
-      "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
-      "author": "systms",
-      "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
-      "downloads": 353,
-      "likes": 25,
-      "trendingScore": 25,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ltx-video",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T09:22:55.000Z",
-      "lastModified": "2026-05-13T19:23:38.000Z"
-    },
-    {
-      "rank": 153,
+      "rank": 154,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -4439,7 +4468,46 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 154,
+      "rank": 155,
+      "id": "ggml-org/MiniCPM-V-4.6-GGUF",
+      "author": "ggml-org",
+      "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
+      "downloads": 14378,
+      "likes": 25,
+      "trendingScore": 25,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "image-text-to-text",
+        "base_model:openbmb/MiniCPM-V-4.6",
+        "base_model:quantized:openbmb/MiniCPM-V-4.6",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-11T21:35:21.000Z",
+      "lastModified": "2026-05-11T21:40:48.000Z"
+    },
+    {
+      "rank": 156,
+      "id": "rizzlaa/instaraww-2.x-workflow-recreated",
+      "author": "rizzlaa",
+      "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
+      "downloads": 0,
+      "likes": 25,
+      "trendingScore": 25,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T21:50:44.000Z",
+      "lastModified": "2026-05-16T22:29:06.000Z"
+    },
+    {
+      "rank": 157,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -4471,7 +4539,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 155,
+      "rank": 158,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -4495,7 +4563,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 156,
+      "rank": 159,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
@@ -4540,7 +4608,7 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 157,
+      "rank": 160,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -4567,7 +4635,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 158,
+      "rank": 161,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -4592,7 +4660,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 159,
+      "rank": 162,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -4628,7 +4696,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 160,
+      "rank": 163,
       "id": "pyannote/speaker-diarization-3.1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
@@ -4660,7 +4728,7 @@
       "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 161,
+      "rank": 164,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -4699,7 +4767,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 162,
+      "rank": 165,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -4715,7 +4783,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 163,
+      "rank": 166,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -4736,151 +4804,13 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 164,
-      "id": "ggml-org/MiniCPM-V-4.6-GGUF",
-      "author": "ggml-org",
-      "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
-      "downloads": 11869,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "image-text-to-text",
-        "base_model:openbmb/MiniCPM-V-4.6",
-        "base_model:quantized:openbmb/MiniCPM-V-4.6",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-11T21:35:21.000Z",
-      "lastModified": "2026-05-11T21:40:48.000Z"
-    },
-    {
-      "rank": 165,
-      "id": "Qwen/Qwen3.6-27B-FP8",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
-      "downloads": 3087118,
-      "likes": 196,
-      "trendingScore": 23,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "fp8",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2026-04-21T07:51:33.000Z",
-      "lastModified": "2026-04-24T02:39:18.000Z"
-    },
-    {
-      "rank": 166,
-      "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-      "downloads": 166640,
-      "likes": 649,
-      "trendingScore": 23,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen3",
-        "qwen",
-        "text-generation",
-        "arxiv:2505.09388",
-        "base_model:Qwen/Qwen3-Coder-30B-A3B-Instruct",
-        "base_model:quantized:Qwen/Qwen3-Coder-30B-A3B-Instruct",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2025-07-31T10:27:38.000Z",
-      "lastModified": "2026-01-30T06:29:38.000Z"
-    },
-    {
       "rank": 167,
-      "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
-      "author": "vrgamedevgirl84",
-      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
-      "downloads": 0,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T23:58:14.000Z",
-      "lastModified": "2026-05-09T03:08:46.000Z"
-    },
-    {
-      "rank": 168,
-      "id": "Abiray/Sulphur-2-base-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
-      "downloads": 42952,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": "text-to-video",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "quantized",
-        "text-to-video",
-        "base_model:SulphurAI/Sulphur-2-base",
-        "base_model:quantized:SulphurAI/Sulphur-2-base",
-        "region:us"
-      ],
-      "createdAt": "2026-05-10T15:01:12.000Z",
-      "lastModified": "2026-05-12T04:19:47.000Z"
-    },
-    {
-      "rank": 169,
-      "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-      "downloads": 1506365,
-      "likes": 1489,
-      "trendingScore": 23,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_tts",
-        "text-to-speech",
-        "arxiv:2601.15621",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-21T08:56:49.000Z",
-      "lastModified": "2026-01-29T08:00:54.000Z"
-    },
-    {
-      "rank": 170,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
-      "downloads": 4863331,
-      "likes": 5698,
-      "trendingScore": 23,
+      "downloads": 4818342,
+      "likes": 5700,
+      "trendingScore": 24,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
       "tags": [
@@ -4919,13 +4849,13 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 171,
+      "rank": 168,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
-      "downloads": 283,
-      "likes": 24,
-      "trendingScore": 23,
+      "downloads": 291,
+      "likes": 25,
+      "trendingScore": 24,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
@@ -4961,12 +4891,127 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
+      "rank": 169,
+      "id": "Qwen/Qwen3.6-27B-FP8",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
+      "downloads": 3087118,
+      "likes": 196,
+      "trendingScore": 23,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "fp8",
+        "region:us",
+        "deploy:azure"
+      ],
+      "createdAt": "2026-04-21T07:51:33.000Z",
+      "lastModified": "2026-04-24T02:39:18.000Z"
+    },
+    {
+      "rank": 170,
+      "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+      "downloads": 166640,
+      "likes": 649,
+      "trendingScore": 23,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen3",
+        "qwen",
+        "text-generation",
+        "arxiv:2505.09388",
+        "base_model:Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "base_model:quantized:Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2025-07-31T10:27:38.000Z",
+      "lastModified": "2026-01-30T06:29:38.000Z"
+    },
+    {
+      "rank": 171,
+      "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
+      "author": "vrgamedevgirl84",
+      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
+      "downloads": 0,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T23:58:14.000Z",
+      "lastModified": "2026-05-09T03:08:46.000Z"
+    },
+    {
       "rank": 172,
+      "id": "Abiray/Sulphur-2-base-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
+      "downloads": 42952,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "text-to-video",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "quantized",
+        "text-to-video",
+        "base_model:SulphurAI/Sulphur-2-base",
+        "base_model:quantized:SulphurAI/Sulphur-2-base",
+        "region:us"
+      ],
+      "createdAt": "2026-05-10T15:01:12.000Z",
+      "lastModified": "2026-05-12T04:19:47.000Z"
+    },
+    {
+      "rank": 173,
+      "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "downloads": 1518342,
+      "likes": 1490,
+      "trendingScore": 23,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_tts",
+        "text-to-speech",
+        "arxiv:2601.15621",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-01-21T08:56:49.000Z",
+      "lastModified": "2026-01-29T08:00:54.000Z"
+    },
+    {
+      "rank": 174,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
-      "downloads": 26216514,
-      "likes": 3009,
+      "downloads": 26601814,
+      "likes": 3010,
       "trendingScore": 23,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -4993,7 +5038,43 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 173,
+      "rank": 175,
+      "id": "lightonai/Agent-ModernColBERT",
+      "author": "lightonai",
+      "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
+      "downloads": 982,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "PyLate",
+      "tags": [
+        "PyLate",
+        "safetensors",
+        "modernbert",
+        "ColBERT",
+        "sentence-transformers",
+        "sentence-similarity",
+        "feature-extraction",
+        "generated_from_trainer",
+        "dataset_size:5238",
+        "loss:CachedContrastive",
+        "en",
+        "dataset:Tevatron/AgentIR-data",
+        "arxiv:2603.04384",
+        "arxiv:1908.10084",
+        "arxiv:2101.06983",
+        "base_model:lightonai/GTE-ModernColBERT-v1",
+        "base_model:finetune:lightonai/GTE-ModernColBERT-v1",
+        "license:apache-2.0",
+        "text-embeddings-inference",
+        "endpoints_compatible",
+        "region:eu"
+      ],
+      "createdAt": "2026-05-12T12:55:37.000Z",
+      "lastModified": "2026-05-12T14:20:08.000Z"
+    },
+    {
+      "rank": 176,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -5024,7 +5105,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 174,
+      "rank": 177,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -5053,7 +5134,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 175,
+      "rank": 178,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -5098,7 +5179,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 176,
+      "rank": 179,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -5125,7 +5206,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 177,
+      "rank": 180,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5151,43 +5232,31 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 178,
-      "id": "lightonai/Agent-ModernColBERT",
-      "author": "lightonai",
-      "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
-      "downloads": 761,
-      "likes": 22,
+      "rank": 181,
+      "id": "Prior-Labs/tabpfn_3",
+      "author": "Prior-Labs",
+      "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
+      "downloads": 5571,
+      "likes": 24,
       "trendingScore": 22,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "PyLate",
+      "pipelineTag": "tabular-classification",
+      "libraryName": null,
       "tags": [
-        "PyLate",
-        "safetensors",
-        "modernbert",
-        "ColBERT",
-        "sentence-transformers",
-        "sentence-similarity",
-        "feature-extraction",
-        "generated_from_trainer",
-        "dataset_size:5238",
-        "loss:CachedContrastive",
-        "en",
-        "dataset:Tevatron/AgentIR-data",
-        "arxiv:2603.04384",
-        "arxiv:1908.10084",
-        "arxiv:2101.06983",
-        "base_model:lightonai/GTE-ModernColBERT-v1",
-        "base_model:finetune:lightonai/GTE-ModernColBERT-v1",
-        "license:apache-2.0",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "region:eu"
+        "chemistry",
+        "biology",
+        "finance",
+        "legal",
+        "climate",
+        "medical",
+        "tabular-classification",
+        "license:other",
+        "region:us"
       ],
-      "createdAt": "2026-05-12T12:55:37.000Z",
-      "lastModified": "2026-05-12T14:20:08.000Z"
+      "createdAt": "2026-05-05T10:36:16.000Z",
+      "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 179,
+      "rank": 182,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -5232,7 +5301,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 180,
+      "rank": 183,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -5260,7 +5329,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 181,
+      "rank": 184,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -5287,58 +5356,7 @@
       "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 182,
-      "id": "Prior-Labs/tabpfn_3",
-      "author": "Prior-Labs",
-      "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
-      "downloads": 5283,
-      "likes": 23,
-      "trendingScore": 21,
-      "pipelineTag": "tabular-classification",
-      "libraryName": null,
-      "tags": [
-        "chemistry",
-        "biology",
-        "finance",
-        "legal",
-        "climate",
-        "medical",
-        "tabular-classification",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-05T10:36:16.000Z",
-      "lastModified": "2026-05-12T11:33:27.000Z"
-    },
-    {
-      "rank": 183,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 0,
-      "likes": 21,
-      "trendingScore": 21,
-      "pipelineTag": "any-to-any",
-      "libraryName": "Lance",
-      "tags": [
-        "Lance",
-        "safetensors",
-        "multimodal",
-        "image-generation",
-        "video-generation",
-        "image-editing",
-        "video-understanding",
-        "any-to-any",
-        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-18T04:24:28.000Z"
-    },
-    {
-      "rank": 184,
+      "rank": 185,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -5366,7 +5384,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 185,
+      "rank": 186,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -5399,7 +5417,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 186,
+      "rank": 187,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -5424,7 +5442,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 187,
+      "rank": 188,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -5461,7 +5479,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 188,
+      "rank": 189,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -5504,7 +5522,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 189,
+      "rank": 190,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -5528,7 +5546,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 190,
+      "rank": 191,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -5552,7 +5570,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 191,
+      "rank": 192,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5584,7 +5602,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 192,
+      "rank": 193,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -5613,11 +5631,11 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 193,
+      "rank": 194,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
-      "downloads": 10136518,
+      "downloads": 9993219,
       "likes": 991,
       "trendingScore": 20,
       "pipelineTag": "voice-activity-detection",
@@ -5644,11 +5662,11 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
-      "downloads": 17436,
+      "downloads": 18501,
       "likes": 20,
       "trendingScore": 20,
       "pipelineTag": "feature-extraction",
@@ -5680,11 +5698,11 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 195,
+      "rank": 196,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
-      "downloads": 30084,
+      "downloads": 36700,
       "likes": 20,
       "trendingScore": 20,
       "pipelineTag": "text-generation",
@@ -5712,7 +5730,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -5757,7 +5775,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -5790,7 +5808,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 198,
+      "rank": 199,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -5812,7 +5830,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 199,
+      "rank": 200,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -5839,7 +5857,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 200,
+      "rank": 201,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -5855,7 +5873,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 201,
+      "rank": 202,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -5872,7 +5890,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 202,
+      "rank": 203,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -5895,7 +5913,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 203,
+      "rank": 204,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -5920,7 +5938,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 204,
+      "rank": 205,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -5956,7 +5974,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 205,
+      "rank": 206,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -5985,7 +6003,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 206,
+      "rank": 207,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -6015,7 +6033,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 207,
+      "rank": 208,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -6033,7 +6051,7 @@
       "lastModified": "2026-05-15T10:14:24.000Z"
     },
     {
-      "rank": 208,
+      "rank": 209,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -6055,7 +6073,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 209,
+      "rank": 210,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -6089,7 +6107,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 210,
+      "rank": 211,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -6113,7 +6131,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 211,
+      "rank": 212,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -6139,7 +6157,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 212,
+      "rank": 213,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -6161,7 +6179,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 213,
+      "rank": 214,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -6190,7 +6208,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 214,
+      "rank": 215,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -6235,11 +6253,11 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 215,
+      "rank": 216,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
-      "downloads": 12735,
+      "downloads": 15112,
       "likes": 18,
       "trendingScore": 18,
       "pipelineTag": "image-text-to-text",
@@ -6261,7 +6279,7 @@
       "lastModified": "2026-05-11T14:29:36.000Z"
     },
     {
-      "rank": 216,
+      "rank": 217,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -6306,7 +6324,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 217,
+      "rank": 218,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -6335,12 +6353,12 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 218,
+      "rank": 219,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
-      "downloads": 7234719,
-      "likes": 4592,
+      "downloads": 7550707,
+      "likes": 4615,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -6364,7 +6382,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 219,
+      "rank": 220,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -6393,7 +6411,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 220,
+      "rank": 221,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -6438,7 +6456,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 221,
+      "rank": 222,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -6470,7 +6488,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 222,
+      "rank": 223,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -6500,7 +6518,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 223,
+      "rank": 224,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6521,7 +6539,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 224,
+      "rank": 225,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -6550,7 +6568,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 225,
+      "rank": 226,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -6571,7 +6589,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 226,
+      "rank": 227,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -6616,7 +6634,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 227,
+      "rank": 228,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -6645,7 +6663,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 228,
+      "rank": 229,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -6673,12 +6691,12 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 229,
+      "rank": 230,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 293250,
-      "likes": 257,
+      "downloads": 291552,
+      "likes": 263,
       "trendingScore": 17,
       "pipelineTag": "mask-generation",
       "libraryName": "checkpoint",
@@ -6695,12 +6713,12 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 230,
+      "rank": 231,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
-      "downloads": 61146,
-      "likes": 833,
+      "downloads": 65614,
+      "likes": 835,
       "trendingScore": 17,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -6720,7 +6738,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 231,
+      "rank": 232,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -6743,12 +6761,12 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 232,
+      "rank": 233,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
-      "downloads": 7616415,
-      "likes": 543,
+      "downloads": 7771076,
+      "likes": 544,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -6770,7 +6788,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 233,
+      "rank": 234,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -6797,11 +6815,11 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 234,
+      "rank": 235,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
-      "downloads": 7104,
+      "downloads": 13100,
       "likes": 17,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
@@ -6823,11 +6841,11 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 235,
+      "rank": 236,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
-      "downloads": 0,
+      "downloads": 139,
       "likes": 20,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
@@ -6868,7 +6886,69 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 236,
+      "rank": 237,
+      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "author": "fal",
+      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "downloads": 41939,
+      "likes": 1310,
+      "trendingScore": 17,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "qwen",
+        "qwen-image-edit",
+        "qwen-image-edit-2511",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "camera-control",
+        "image-editing",
+        "image-to-image",
+        "gaussian-splatting",
+        "fal",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T17:01:15.000Z",
+      "lastModified": "2026-01-07T17:06:01.000Z"
+    },
+    {
+      "rank": 238,
+      "id": "ByteDance-Seed/Cola-DLM",
+      "author": "ByteDance-Seed",
+      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
+      "downloads": 0,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "text-generation",
+        "language-model",
+        "diffusion",
+        "latent-diffusion",
+        "flow-matching",
+        "text-vae",
+        "pytorch",
+        "research",
+        "en",
+        "arxiv:2605.06548",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T07:55:26.000Z",
+      "lastModified": "2026-05-15T09:38:05.000Z"
+    },
+    {
+      "rank": 239,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -6893,7 +6973,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 237,
+      "rank": 240,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -6928,7 +7008,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 238,
+      "rank": 241,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -6973,7 +7053,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 239,
+      "rank": 242,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -7000,39 +7080,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 240,
-      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "author": "fal",
-      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "downloads": 40352,
-      "likes": 1309,
-      "trendingScore": 16,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "qwen",
-        "qwen-image-edit",
-        "qwen-image-edit-2511",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "camera-control",
-        "image-editing",
-        "image-to-image",
-        "gaussian-splatting",
-        "fal",
-        "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-07T17:01:15.000Z",
-      "lastModified": "2026-01-07T17:06:01.000Z"
-    },
-    {
-      "rank": 241,
+      "rank": 243,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -7061,7 +7109,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 242,
+      "rank": 244,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -7084,7 +7132,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 243,
+      "rank": 245,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -7128,7 +7176,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 244,
+      "rank": 246,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -7173,7 +7221,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 245,
+      "rank": 247,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -7191,7 +7239,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 246,
+      "rank": 248,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -7236,11 +7284,11 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 247,
+      "rank": 249,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
-      "downloads": 1331,
+      "downloads": 1730,
       "likes": 16,
       "trendingScore": 16,
       "pipelineTag": "token-classification",
@@ -7274,37 +7322,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 248,
-      "id": "ByteDance-Seed/Cola-DLM",
-      "author": "ByteDance-Seed",
-      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
-      "downloads": 0,
-      "likes": 16,
-      "trendingScore": 16,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "text-generation",
-        "language-model",
-        "diffusion",
-        "latent-diffusion",
-        "flow-matching",
-        "text-vae",
-        "pytorch",
-        "research",
-        "en",
-        "arxiv:2605.06548",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T07:55:26.000Z",
-      "lastModified": "2026-05-15T09:38:05.000Z"
-    },
-    {
-      "rank": 249,
+      "rank": 250,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -7321,7 +7339,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 250,
+      "rank": 251,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -7348,7 +7366,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 251,
+      "rank": 252,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -7393,7 +7411,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 252,
+      "rank": 253,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -7423,7 +7441,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 253,
+      "rank": 254,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7452,7 +7470,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 254,
+      "rank": 255,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -7482,7 +7500,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 255,
+      "rank": 256,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -7527,7 +7545,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 256,
+      "rank": 257,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -7562,7 +7580,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 257,
+      "rank": 258,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -7590,7 +7608,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 258,
+      "rank": 259,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -7619,7 +7637,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -7644,7 +7662,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -7672,7 +7690,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -7700,7 +7718,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -7731,7 +7749,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -7776,7 +7794,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -7808,7 +7826,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -7835,7 +7853,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 266,
+      "rank": 267,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -7858,7 +7876,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 267,
+      "rank": 268,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -7891,7 +7909,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 268,
+      "rank": 269,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -7918,12 +7936,12 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 269,
+      "rank": 270,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
-      "downloads": 8547830,
-      "likes": 3544,
+      "downloads": 8566608,
+      "likes": 3545,
       "trendingScore": 15,
       "pipelineTag": "text-to-speech",
       "libraryName": "coqui",
@@ -7937,7 +7955,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 270,
+      "rank": 271,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -7960,7 +7978,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 271,
+      "rank": 272,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -7986,11 +8004,11 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 272,
+      "rank": 273,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
-      "downloads": 564,
+      "downloads": 652,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -8018,7 +8036,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 273,
+      "rank": 274,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -8048,11 +8066,11 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 274,
+      "rank": 275,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
-      "downloads": 132,
+      "downloads": 159,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -8081,7 +8099,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 275,
+      "rank": 276,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -8101,11 +8119,11 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 276,
+      "rank": 277,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
-      "downloads": 2682,
+      "downloads": 2709,
       "likes": 16,
       "trendingScore": 15,
       "pipelineTag": "time-series-forecasting",
@@ -8129,11 +8147,11 @@
       "lastModified": "2026-05-14T14:23:31.000Z"
     },
     {
-      "rank": 277,
+      "rank": 278,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
-      "downloads": 741,
+      "downloads": 1305,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
@@ -8152,14 +8170,14 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T03:51:55.000Z",
-      "lastModified": "2026-05-15T04:23:50.000Z"
+      "lastModified": "2026-05-18T08:01:35.000Z"
     },
     {
-      "rank": 278,
+      "rank": 279,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
-      "downloads": 35558,
+      "downloads": 36160,
       "likes": 81,
       "trendingScore": 15,
       "pipelineTag": null,
@@ -8173,7 +8191,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 279,
+      "rank": 280,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8191,7 +8209,75 @@
       "lastModified": "2026-05-17T17:24:14.000Z"
     },
     {
-      "rank": 280,
+      "rank": 281,
+      "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
+      "author": "OmerHagage",
+      "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
+      "downloads": 85,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "ltx-2",
+        "ltx-video",
+        "text-to-video",
+        "audio-video",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T20:51:17.000Z",
+      "lastModified": "2026-05-13T21:37:14.000Z"
+    },
+    {
+      "rank": 282,
+      "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
+      "downloads": 12477,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:quantized:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T12:44:22.000Z",
+      "lastModified": "2026-05-16T12:38:58.000Z"
+    },
+    {
+      "rank": 283,
+      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "downloads": 34,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": null,
+      "libraryName": "nemo",
+      "tags": [
+        "nemo",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T21:52:25.000Z",
+      "lastModified": "2026-05-16T05:35:07.000Z"
+    },
+    {
+      "rank": 284,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -8215,7 +8301,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 281,
+      "rank": 285,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -8242,7 +8328,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 282,
+      "rank": 286,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -8270,7 +8356,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 283,
+      "rank": 287,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -8298,7 +8384,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 284,
+      "rank": 288,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -8317,7 +8403,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 285,
+      "rank": 289,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -8349,7 +8435,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 286,
+      "rank": 290,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -8378,7 +8464,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 287,
+      "rank": 291,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -8405,7 +8491,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 288,
+      "rank": 292,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8429,7 +8515,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 289,
+      "rank": 293,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -8455,7 +8541,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 290,
+      "rank": 294,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -8486,7 +8572,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 291,
+      "rank": 295,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -8514,7 +8600,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 292,
+      "rank": 296,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -8537,7 +8623,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 293,
+      "rank": 297,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -8571,7 +8657,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 294,
+      "rank": 298,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -8597,7 +8683,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 295,
+      "rank": 299,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -8639,7 +8725,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 296,
+      "rank": 300,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -8677,11 +8763,11 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 297,
+      "rank": 301,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
-      "downloads": 963,
+      "downloads": 964,
       "likes": 31,
       "trendingScore": 14,
       "pipelineTag": null,
@@ -8696,7 +8782,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 298,
+      "rank": 302,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -8716,35 +8802,12 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 299,
-      "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
-      "author": "OmerHagage",
-      "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
-      "downloads": 58,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "ltx-2",
-        "ltx-video",
-        "text-to-video",
-        "audio-video",
-        "en",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T20:51:17.000Z",
-      "lastModified": "2026-05-13T21:37:14.000Z"
-    },
-    {
-      "rank": 300,
+      "rank": 303,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
-      "downloads": 420449,
-      "likes": 129,
+      "downloads": 436157,
+      "likes": 131,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -8766,11 +8829,11 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 301,
+      "rank": 304,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-      "downloads": 2,
+      "downloads": 24,
       "likes": 15,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
@@ -8808,55 +8871,36 @@
         "conversational"
       ],
       "createdAt": "2026-05-15T08:53:53.000Z",
-      "lastModified": "2026-05-17T02:12:47.000Z"
+      "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 302,
-      "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
-      "downloads": 9494,
-      "likes": 14,
+      "rank": 305,
+      "id": "google/embeddinggemma-300m",
+      "author": "google",
+      "url": "https://huggingface.co/google/embeddinggemma-300m",
+      "downloads": 1841879,
+      "likes": 1651,
       "trendingScore": 14,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
       "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:quantized:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
+        "sentence-transformers",
+        "safetensors",
+        "gemma3_text",
+        "sentence-similarity",
+        "feature-extraction",
+        "text-embeddings-inference",
+        "arxiv:2509.20354",
+        "license:gemma",
+        "eval-results",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T12:44:22.000Z",
-      "lastModified": "2026-05-16T12:38:58.000Z"
-    },
-    {
-      "rank": 303,
-      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "downloads": 13,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": null,
-      "libraryName": "nemo",
-      "tags": [
-        "nemo",
-        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-15T21:52:25.000Z",
-      "lastModified": "2026-05-16T05:35:07.000Z"
+      "createdAt": "2025-07-17T19:53:55.000Z",
+      "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 304,
+      "rank": 306,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -8885,7 +8929,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 305,
+      "rank": 307,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -8930,7 +8974,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 306,
+      "rank": 308,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -8975,7 +9019,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 307,
+      "rank": 309,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -9004,7 +9048,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 308,
+      "rank": 310,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -9031,7 +9075,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 309,
+      "rank": 311,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -9076,7 +9120,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 310,
+      "rank": 312,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -9103,7 +9147,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 311,
+      "rank": 313,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -9134,7 +9178,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 312,
+      "rank": 314,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9158,7 +9202,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 313,
+      "rank": 315,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -9182,7 +9226,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 314,
+      "rank": 316,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -9212,7 +9256,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 315,
+      "rank": 317,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -9257,7 +9301,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 316,
+      "rank": 318,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -9284,7 +9328,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 317,
+      "rank": 319,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -9320,7 +9364,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -9351,7 +9395,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 319,
+      "rank": 321,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -9382,7 +9426,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 320,
+      "rank": 322,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -9415,7 +9459,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 321,
+      "rank": 323,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -9444,7 +9488,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 322,
+      "rank": 324,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -9468,7 +9512,7 @@
       "lastModified": "2026-04-16T18:11:27.000Z"
     },
     {
-      "rank": 323,
+      "rank": 325,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -9494,7 +9538,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 324,
+      "rank": 326,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -9524,7 +9568,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 325,
+      "rank": 327,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -9542,7 +9586,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 326,
+      "rank": 328,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -9573,7 +9617,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 327,
+      "rank": 329,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -9594,7 +9638,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 328,
+      "rank": 330,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -9614,7 +9658,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 329,
+      "rank": 331,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -9645,33 +9689,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 330,
-      "id": "google/embeddinggemma-300m",
-      "author": "google",
-      "url": "https://huggingface.co/google/embeddinggemma-300m",
-      "downloads": 1810783,
-      "likes": 1648,
-      "trendingScore": 13,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "gemma3_text",
-        "sentence-similarity",
-        "feature-extraction",
-        "text-embeddings-inference",
-        "arxiv:2509.20354",
-        "license:gemma",
-        "eval-results",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-07-17T19:53:55.000Z",
-      "lastModified": "2025-09-25T15:11:17.000Z"
-    },
-    {
-      "rank": 331,
+      "rank": 332,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -9699,11 +9717,11 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 332,
+      "rank": 333,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
-      "downloads": 105,
+      "downloads": 216,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
@@ -9730,11 +9748,11 @@
       "lastModified": "2026-05-16T08:42:52.000Z"
     },
     {
-      "rank": 333,
+      "rank": 334,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
-      "downloads": 371,
+      "downloads": 434,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": "image-to-video",
@@ -9757,11 +9775,11 @@
       "lastModified": "2026-05-15T03:55:17.000Z"
     },
     {
-      "rank": 334,
+      "rank": 335,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
-      "downloads": 16015,
+      "downloads": 16122,
       "likes": 82,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
@@ -9795,11 +9813,11 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 335,
+      "rank": 336,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
-      "downloads": 1351,
+      "downloads": 1439,
       "likes": 14,
       "trendingScore": 13,
       "pipelineTag": "time-series-forecasting",
@@ -9823,11 +9841,11 @@
       "lastModified": "2026-05-14T14:23:12.000Z"
     },
     {
-      "rank": 336,
+      "rank": 337,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
-      "downloads": 157,
+      "downloads": 160,
       "likes": 299,
       "trendingScore": 13,
       "pipelineTag": "image-to-video",
@@ -9850,11 +9868,11 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 337,
+      "rank": 338,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
-      "downloads": 6074426,
+      "downloads": 6104860,
       "likes": 1023,
       "trendingScore": 13,
       "pipelineTag": "feature-extraction",
@@ -9880,11 +9898,11 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 338,
+      "rank": 339,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
-      "downloads": 2171,
+      "downloads": 5063,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": null,
@@ -9910,7 +9928,65 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 339,
+      "rank": 340,
+      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "author": "sensenova",
+      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "downloads": 382,
+      "likes": 14,
+      "trendingScore": 13,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "neo_chat",
+        "feature-extraction",
+        "multimodal",
+        "text-to-image",
+        "image-to-text",
+        "image-editing",
+        "interleaved-generation",
+        "custom_code",
+        "any-to-any",
+        "arxiv:2502.01522",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T09:54:29.000Z",
+      "lastModified": "2026-05-16T06:48:11.000Z"
+    },
+    {
+      "rank": 341,
+      "id": "chiennv/Orthrus-Qwen3-8B",
+      "author": "chiennv",
+      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
+      "downloads": 1535,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "diffusion",
+        "parallel-decoding",
+        "orthrus",
+        "conversational",
+        "custom_code",
+        "arxiv:2605.12825",
+        "license:cc-by-4.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T17:59:34.000Z",
+      "lastModified": "2026-05-16T22:44:53.000Z"
+    },
+    {
+      "rank": 342,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -9955,7 +10031,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 340,
+      "rank": 343,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -9982,7 +10058,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 341,
+      "rank": 344,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -10010,7 +10086,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 342,
+      "rank": 345,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -10043,7 +10119,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 343,
+      "rank": 346,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -10059,7 +10135,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 344,
+      "rank": 347,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -10082,7 +10158,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 345,
+      "rank": 348,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -10116,7 +10192,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 346,
+      "rank": 349,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -10136,7 +10212,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 347,
+      "rank": 350,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -10171,7 +10247,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 348,
+      "rank": 351,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -10201,7 +10277,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 349,
+      "rank": 352,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -10222,7 +10298,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 350,
+      "rank": 353,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -10251,7 +10327,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 351,
+      "rank": 354,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -10281,7 +10357,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 352,
+      "rank": 355,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -10309,7 +10385,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 353,
+      "rank": 356,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -10338,7 +10414,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 354,
+      "rank": 357,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -10370,7 +10446,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 355,
+      "rank": 358,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -10399,7 +10475,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 356,
+      "rank": 359,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -10434,7 +10510,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 357,
+      "rank": 360,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -10456,7 +10532,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 358,
+      "rank": 361,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -10473,7 +10549,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 359,
+      "rank": 362,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -10511,7 +10587,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 360,
+      "rank": 363,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -10550,7 +10626,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 361,
+      "rank": 364,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -10587,7 +10663,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 362,
+      "rank": 365,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -10611,11 +10687,11 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 363,
+      "rank": 366,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
-      "downloads": 1366,
+      "downloads": 1641,
       "likes": 41,
       "trendingScore": 12,
       "pipelineTag": null,
@@ -10638,36 +10714,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 364,
-      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "author": "sensenova",
-      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "downloads": 372,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "neo_chat",
-        "feature-extraction",
-        "multimodal",
-        "text-to-image",
-        "image-to-text",
-        "image-editing",
-        "interleaved-generation",
-        "custom_code",
-        "any-to-any",
-        "arxiv:2502.01522",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T09:54:29.000Z",
-      "lastModified": "2026-05-16T06:48:11.000Z"
-    },
-    {
-      "rank": 365,
+      "rank": 367,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -10685,7 +10732,51 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 366,
+      "rank": 368,
+      "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
+      "downloads": 83064,
+      "likes": 23,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5_moe",
+        "unsloth",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "compressed-tensors",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T07:12:17.000Z",
+      "lastModified": "2026-05-06T18:50:29.000Z"
+    },
+    {
+      "rank": 369,
+      "id": "infly/Infinity-Parser2-Flash",
+      "author": "infly",
+      "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
+      "downloads": 4190,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-02-27T07:54:48.000Z",
+      "lastModified": "2026-05-16T01:59:44.000Z"
+    },
+    {
+      "rank": 370,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -10730,7 +10821,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 367,
+      "rank": 371,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -10772,7 +10863,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 368,
+      "rank": 372,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -10798,7 +10889,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 369,
+      "rank": 373,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -10823,7 +10914,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 370,
+      "rank": 374,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -10840,7 +10931,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 371,
+      "rank": 375,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -10868,7 +10959,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 372,
+      "rank": 376,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -10894,7 +10985,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 373,
+      "rank": 377,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -10921,7 +11012,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 374,
+      "rank": 378,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -10949,7 +11040,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 375,
+      "rank": 379,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -10982,7 +11073,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 376,
+      "rank": 380,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -11016,7 +11107,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 377,
+      "rank": 381,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -11045,7 +11136,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 378,
+      "rank": 382,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -11074,7 +11165,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 379,
+      "rank": 383,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -11107,7 +11198,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 380,
+      "rank": 384,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -11134,7 +11225,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 381,
+      "rank": 385,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -11164,7 +11255,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 382,
+      "rank": 386,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11187,7 +11278,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 383,
+      "rank": 387,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -11213,7 +11304,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 384,
+      "rank": 388,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -11237,7 +11328,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 385,
+      "rank": 389,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -11264,7 +11355,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 386,
+      "rank": 390,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -11294,7 +11385,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 387,
+      "rank": 391,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -11328,7 +11419,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 388,
+      "rank": 392,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -11344,7 +11435,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 389,
+      "rank": 393,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -11375,7 +11466,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 390,
+      "rank": 394,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -11397,7 +11488,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 391,
+      "rank": 395,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -11417,7 +11508,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 392,
+      "rank": 396,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -11439,7 +11530,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 393,
+      "rank": 397,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11470,7 +11561,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 394,
+      "rank": 398,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -11499,11 +11590,11 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 395,
+      "rank": 399,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-      "downloads": 5057,
+      "downloads": 5454,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -11536,7 +11627,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 396,
+      "rank": 400,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -11561,7 +11652,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 397,
+      "rank": 401,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -11586,7 +11677,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 398,
+      "rank": 402,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -11621,36 +11712,11 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 399,
-      "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
-      "downloads": 71926,
-      "likes": 22,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_5_moe",
-        "unsloth",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "compressed-tensors",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T07:12:17.000Z",
-      "lastModified": "2026-05-06T18:50:29.000Z"
-    },
-    {
-      "rank": 400,
+      "rank": 403,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
-      "downloads": 6603,
+      "downloads": 6707,
       "likes": 51,
       "trendingScore": 11,
       "pipelineTag": "text-to-image",
@@ -11670,7 +11736,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 401,
+      "rank": 404,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -11698,40 +11764,11 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 402,
-      "id": "chiennv/Orthrus-Qwen3-8B",
-      "author": "chiennv",
-      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
-      "downloads": 1366,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "diffusion",
-        "parallel-decoding",
-        "orthrus",
-        "conversational",
-        "custom_code",
-        "arxiv:2605.12825",
-        "license:cc-by-4.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T17:59:34.000Z",
-      "lastModified": "2026-05-16T22:44:53.000Z"
-    },
-    {
-      "rank": 403,
+      "rank": 405,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 5291,
+      "downloads": 12526,
       "likes": 12,
       "trendingScore": 11,
       "pipelineTag": null,
@@ -11759,7 +11796,35 @@
       "lastModified": "2026-05-16T21:22:27.000Z"
     },
     {
-      "rank": 404,
+      "rank": 406,
+      "id": "0G-AI/0GM-1.0-35B-A3B-0427",
+      "author": "0G-AI",
+      "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
+      "downloads": 299,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "moe",
+        "mixture-of-experts",
+        "conversational",
+        "en",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T02:18:11.000Z",
+      "lastModified": "2026-05-14T02:31:20.000Z"
+    },
+    {
+      "rank": 407,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -11788,7 +11853,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 405,
+      "rank": 408,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -11822,7 +11887,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 406,
+      "rank": 409,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -11867,7 +11932,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 407,
+      "rank": 410,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -11893,7 +11958,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 408,
+      "rank": 411,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -11922,7 +11987,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 409,
+      "rank": 412,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -11947,7 +12012,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 410,
+      "rank": 413,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -11982,7 +12047,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 411,
+      "rank": 414,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -12009,7 +12074,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 412,
+      "rank": 415,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -12054,7 +12119,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 413,
+      "rank": 416,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -12076,7 +12141,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 414,
+      "rank": 417,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -12108,7 +12173,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 415,
+      "rank": 418,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -12133,7 +12198,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 416,
+      "rank": 419,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -12157,7 +12222,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 417,
+      "rank": 420,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -12185,7 +12250,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 418,
+      "rank": 421,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -12228,7 +12293,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 419,
+      "rank": 422,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -12252,7 +12317,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 420,
+      "rank": 423,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -12297,7 +12362,7 @@
       "lastModified": "2026-04-07T16:23:12.000Z"
     },
     {
-      "rank": 421,
+      "rank": 424,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -12342,7 +12407,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 422,
+      "rank": 425,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -12371,7 +12436,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 423,
+      "rank": 426,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -12403,7 +12468,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 424,
+      "rank": 427,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -12425,7 +12490,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 425,
+      "rank": 428,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -12449,7 +12514,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -12471,7 +12536,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -12496,7 +12561,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -12524,7 +12589,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -12548,7 +12613,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -12575,7 +12640,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 431,
+      "rank": 434,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -12600,7 +12665,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 432,
+      "rank": 435,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -12617,7 +12682,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 433,
+      "rank": 436,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -12641,7 +12706,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 434,
+      "rank": 437,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -12665,7 +12730,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 435,
+      "rank": 438,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -12698,7 +12763,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 436,
+      "rank": 439,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -12732,7 +12797,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 437,
+      "rank": 440,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -12754,7 +12819,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 438,
+      "rank": 441,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -12777,7 +12842,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 439,
+      "rank": 442,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -12797,7 +12862,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 440,
+      "rank": 443,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -12829,7 +12894,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 441,
+      "rank": 444,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -12868,7 +12933,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 442,
+      "rank": 445,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -12902,7 +12967,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 443,
+      "rank": 446,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -12926,7 +12991,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 444,
+      "rank": 447,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -12959,7 +13024,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 445,
+      "rank": 448,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -12979,7 +13044,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 446,
+      "rank": 449,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -13008,7 +13073,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 447,
+      "rank": 450,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -13030,7 +13095,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 448,
+      "rank": 451,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -13062,7 +13127,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 449,
+      "rank": 452,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -13089,7 +13154,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 450,
+      "rank": 453,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -13130,7 +13195,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 451,
+      "rank": 454,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -13174,7 +13239,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 452,
+      "rank": 455,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -13205,7 +13270,7 @@
       "lastModified": "2026-05-13T08:04:57.000Z"
     },
     {
-      "rank": 453,
+      "rank": 456,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -13223,7 +13288,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 454,
+      "rank": 457,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -13262,7 +13327,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 455,
+      "rank": 458,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -13301,11 +13366,11 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 456,
+      "rank": 459,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
-      "downloads": 650,
+      "downloads": 697,
       "likes": 11,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -13335,7 +13400,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 457,
+      "rank": 460,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -13363,7 +13428,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 458,
+      "rank": 461,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -13385,11 +13450,11 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 459,
+      "rank": 462,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
-      "downloads": 68,
+      "downloads": 75,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "text-to-video",
@@ -13413,11 +13478,11 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 460,
+      "rank": 463,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
-      "downloads": 2745270,
+      "downloads": 2746492,
       "likes": 689,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -13431,30 +13496,11 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 461,
-      "id": "infly/Infinity-Parser2-Flash",
-      "author": "infly",
-      "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
-      "downloads": 1160,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_5",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-02-27T07:54:48.000Z",
-      "lastModified": "2026-05-16T01:59:44.000Z"
-    },
-    {
-      "rank": 462,
+      "rank": 464,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
-      "downloads": 3653,
+      "downloads": 4262,
       "likes": 12,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -13482,7 +13528,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 463,
+      "rank": 465,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -13512,11 +13558,11 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 464,
+      "rank": 466,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
-      "downloads": 1007,
+      "downloads": 1038,
       "likes": 12,
       "trendingScore": 10,
       "pipelineTag": "time-series-forecasting",
@@ -13540,7 +13586,7 @@
       "lastModified": "2026-05-14T14:23:39.000Z"
     },
     {
-      "rank": 465,
+      "rank": 467,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -13568,11 +13614,11 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 466,
+      "rank": 468,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
-      "downloads": 6893145,
+      "downloads": 5252488,
       "likes": 1536,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -13599,39 +13645,11 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 467,
-      "id": "0G-AI/0GM-1.0-35B-A3B-0427",
-      "author": "0G-AI",
-      "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
-      "downloads": 237,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "moe",
-        "mixture-of-experts",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T02:18:11.000Z",
-      "lastModified": "2026-05-14T02:31:20.000Z"
-    },
-    {
-      "rank": 468,
+      "rank": 469,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
-      "downloads": 3832,
+      "downloads": 4425,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -13657,7 +13675,72 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 469,
+      "rank": 470,
+      "id": "unsloth/Qwen3.5-4B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
+      "downloads": 623699,
+      "likes": 252,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:quantized:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-03-02T05:46:32.000Z",
+      "lastModified": "2026-03-02T14:08:17.000Z"
+    },
+    {
+      "rank": 471,
+      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "downloads": 7214,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "gemma4",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "creative writing",
+        "translation",
+        "visual novels",
+        "finetune",
+        "roleplay",
+        "rp",
+        "image-text-to-text",
+        "en",
+        "ja",
+        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T06:59:32.000Z",
+      "lastModified": "2026-05-18T04:44:23.000Z"
+    },
+    {
+      "rank": 472,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -13684,7 +13767,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 470,
+      "rank": 473,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -13710,7 +13793,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 471,
+      "rank": 474,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -13738,7 +13821,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 472,
+      "rank": 475,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -13764,7 +13847,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 473,
+      "rank": 476,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -13808,7 +13891,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 474,
+      "rank": 477,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -13848,7 +13931,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 475,
+      "rank": 478,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -13884,7 +13967,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 476,
+      "rank": 479,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -13928,7 +14011,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 477,
+      "rank": 480,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -13953,7 +14036,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 478,
+      "rank": 481,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -13998,7 +14081,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 479,
+      "rank": 482,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -14017,7 +14100,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 480,
+      "rank": 483,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -14042,7 +14125,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 481,
+      "rank": 484,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -14081,7 +14164,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 482,
+      "rank": 485,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -14098,7 +14181,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 483,
+      "rank": 486,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -14126,7 +14209,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 484,
+      "rank": 487,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -14155,7 +14238,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 485,
+      "rank": 488,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -14180,7 +14263,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 486,
+      "rank": 489,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -14215,7 +14298,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 487,
+      "rank": 490,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -14245,7 +14328,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 488,
+      "rank": 491,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -14281,7 +14364,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 489,
+      "rank": 492,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -14304,7 +14387,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 490,
+      "rank": 493,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -14321,7 +14404,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 491,
+      "rank": 494,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -14341,7 +14424,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 492,
+      "rank": 495,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -14368,7 +14451,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 493,
+      "rank": 496,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -14392,7 +14475,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 494,
+      "rank": 497,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -14414,7 +14497,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 495,
+      "rank": 498,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -14446,11 +14529,11 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 496,
+      "rank": 499,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
-      "downloads": 146046,
+      "downloads": 149996,
       "likes": 472,
       "trendingScore": 9,
       "pipelineTag": "image-to-image",
@@ -14473,7 +14556,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 497,
+      "rank": 500,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -14501,7 +14584,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 498,
+      "rank": 501,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -14519,7 +14602,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 499,
+      "rank": 502,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -14544,7 +14627,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 500,
+      "rank": 503,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -14567,7 +14650,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 501,
+      "rank": 504,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -14585,7 +14668,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 502,
+      "rank": 505,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -14620,7 +14703,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 503,
+      "rank": 506,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -14648,7 +14731,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 504,
+      "rank": 507,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -14670,7 +14753,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 505,
+      "rank": 508,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -14697,7 +14780,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 506,
+      "rank": 509,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -14722,7 +14805,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 507,
+      "rank": 510,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -14756,7 +14839,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 508,
+      "rank": 511,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -14779,7 +14862,7 @@
       "lastModified": "2026-05-11T03:49:52.000Z"
     },
     {
-      "rank": 509,
+      "rank": 512,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -14806,7 +14889,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 510,
+      "rank": 513,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -14833,7 +14916,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 511,
+      "rank": 514,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -14874,7 +14957,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 512,
+      "rank": 515,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -14904,7 +14987,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 513,
+      "rank": 516,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -14941,7 +15024,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 514,
+      "rank": 517,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -14973,7 +15056,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 515,
+      "rank": 518,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -15015,7 +15098,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 516,
+      "rank": 519,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -15045,7 +15128,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 517,
+      "rank": 520,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -15090,7 +15173,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 518,
+      "rank": 521,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -15117,11 +15200,11 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 519,
+      "rank": 522,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
-      "downloads": 7281,
+      "downloads": 8127,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -15143,11 +15226,11 @@
       "lastModified": "2026-05-11T14:57:26.000Z"
     },
     {
-      "rank": 520,
+      "rank": 523,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
-      "downloads": 2569,
+      "downloads": 2786,
       "likes": 10,
       "trendingScore": 9,
       "pipelineTag": "time-series-forecasting",
@@ -15171,36 +15254,11 @@
       "lastModified": "2026-05-14T14:23:21.000Z"
     },
     {
-      "rank": 521,
-      "id": "unsloth/Qwen3.5-4B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
-      "downloads": 616148,
-      "likes": 251,
-      "trendingScore": 9,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:quantized:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-02T05:46:32.000Z",
-      "lastModified": "2026-03-02T14:08:17.000Z"
-    },
-    {
-      "rank": 522,
+      "rank": 524,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
-      "downloads": 4484,
+      "downloads": 5168,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -15230,11 +15288,11 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 523,
+      "rank": 525,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
-      "downloads": 5337,
+      "downloads": 5379,
       "likes": 55,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -15260,45 +15318,158 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 524,
-      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "downloads": 3728,
+      "rank": 526,
+      "id": "black-forest-labs/FLUX.2-small-decoder",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
+      "downloads": 189174,
+      "likes": 130,
+      "trendingScore": 9,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "image-editing",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-06T16:08:58.000Z",
+      "lastModified": "2026-04-07T20:42:04.000Z"
+    },
+    {
+      "rank": 527,
+      "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
+      "author": "stable-diffusion-v1-5",
+      "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
+      "downloads": 1720098,
+      "likes": 1112,
+      "trendingScore": 9,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "stable-diffusion",
+        "stable-diffusion-diffusers",
+        "text-to-image",
+        "arxiv:2207.12598",
+        "arxiv:2112.10752",
+        "arxiv:2103.00020",
+        "arxiv:2205.11487",
+        "arxiv:1910.09700",
+        "license:creativeml-openrail-m",
+        "endpoints_compatible",
+        "diffusers:StableDiffusionPipeline",
+        "region:us"
+      ],
+      "createdAt": "2024-08-30T09:48:48.000Z",
+      "lastModified": "2024-09-07T16:20:30.000Z"
+    },
+    {
+      "rank": 528,
+      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "downloads": 17011,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "text-generation-inference",
+        "gguf",
         "unsloth",
-        "gemma4",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "creative writing",
-        "translation",
-        "visual novels",
-        "finetune",
-        "roleplay",
-        "rp",
+        "qwen",
+        "qwen3_5_moe",
         "image-text-to-text",
-        "en",
-        "ja",
-        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "base_model:finetune:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "base_model:Qwen/Qwen3.5-122B-A10B",
+        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-13T06:59:32.000Z",
-      "lastModified": "2026-05-18T04:18:14.000Z"
+      "createdAt": "2026-05-15T19:03:18.000Z",
+      "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 525,
+      "rank": 529,
+      "id": "moonshotai/Kimi-K2.5",
+      "author": "moonshotai",
+      "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
+      "downloads": 1707896,
+      "likes": 2787,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "kimi_k25",
+        "feature-extraction",
+        "compressed-tensors",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "arxiv:2602.02276",
+        "license:other",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-01-01T06:06:03.000Z",
+      "lastModified": "2026-04-30T03:56:40.000Z"
+    },
+    {
+      "rank": 530,
+      "id": "Abiray/ZAYA1-8B-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
+      "downloads": 1720,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "zaya",
+        "moe",
+        "zyphra",
+        "text-generation",
+        "reasoning",
+        "base_model:Zyphra/ZAYA1-8B",
+        "base_model:quantized:Zyphra/ZAYA1-8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T13:23:12.000Z",
+      "lastModified": "2026-05-16T14:23:36.000Z"
+    },
+    {
+      "rank": 531,
+      "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
+      "author": "maximsobolev275",
+      "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
+      "downloads": 0,
+      "likes": 12,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-05-04T14:01:04.000Z",
+      "lastModified": "2026-05-15T13:00:33.000Z"
+    },
+    {
+      "rank": 532,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -15325,7 +15496,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 526,
+      "rank": 533,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -15349,7 +15520,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 527,
+      "rank": 534,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -15369,7 +15540,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 528,
+      "rank": 535,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -15396,7 +15567,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 529,
+      "rank": 536,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -15415,7 +15586,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 530,
+      "rank": 537,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -15449,7 +15620,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 531,
+      "rank": 538,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -15481,7 +15652,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 532,
+      "rank": 539,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -15503,7 +15674,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 533,
+      "rank": 540,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -15548,7 +15719,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 534,
+      "rank": 541,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -15567,7 +15738,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 535,
+      "rank": 542,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -15601,7 +15772,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 536,
+      "rank": 543,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -15629,7 +15800,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 537,
+      "rank": 544,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -15657,7 +15828,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 538,
+      "rank": 545,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -15680,7 +15851,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 539,
+      "rank": 546,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -15707,7 +15878,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 540,
+      "rank": 547,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -15752,7 +15923,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 541,
+      "rank": 548,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -15788,7 +15959,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 542,
+      "rank": 549,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -15828,7 +15999,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 543,
+      "rank": 550,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -15857,7 +16028,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 544,
+      "rank": 551,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -15885,7 +16056,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 545,
+      "rank": 552,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -15904,7 +16075,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 546,
+      "rank": 553,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -15923,7 +16094,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 547,
+      "rank": 554,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -15955,7 +16126,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 548,
+      "rank": 555,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -15982,7 +16153,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 549,
+      "rank": 556,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -16004,7 +16175,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 550,
+      "rank": 557,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -16022,7 +16193,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 551,
+      "rank": 558,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -16051,7 +16222,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 552,
+      "rank": 559,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -16096,7 +16267,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 553,
+      "rank": 560,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -16117,7 +16288,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 554,
+      "rank": 561,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -16145,7 +16316,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 555,
+      "rank": 562,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -16166,11 +16337,11 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 556,
+      "rank": 563,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
-      "downloads": 47730,
+      "downloads": 49244,
       "likes": 38,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -16202,7 +16373,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 557,
+      "rank": 564,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -16247,7 +16418,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 558,
+      "rank": 565,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -16273,7 +16444,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 559,
+      "rank": 566,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -16296,7 +16467,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 560,
+      "rank": 567,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -16321,7 +16492,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 561,
+      "rank": 568,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -16356,7 +16527,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 562,
+      "rank": 569,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -16401,7 +16572,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 563,
+      "rank": 570,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -16428,7 +16599,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 564,
+      "rank": 571,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -16457,7 +16628,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 565,
+      "rank": 572,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -16476,7 +16647,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 566,
+      "rank": 573,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -16497,7 +16668,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 567,
+      "rank": 574,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -16523,7 +16694,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 568,
+      "rank": 575,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -16549,7 +16720,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 569,
+      "rank": 576,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -16586,7 +16757,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 570,
+      "rank": 577,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -16631,7 +16802,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 571,
+      "rank": 578,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -16656,7 +16827,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 572,
+      "rank": 579,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -16673,7 +16844,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 573,
+      "rank": 580,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -16700,7 +16871,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 574,
+      "rank": 581,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -16718,7 +16889,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 575,
+      "rank": 582,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -16743,7 +16914,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 576,
+      "rank": 583,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -16775,32 +16946,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 577,
-      "id": "black-forest-labs/FLUX.2-small-decoder",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
-      "downloads": 188886,
-      "likes": 129,
-      "trendingScore": 8,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "image-editing",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-06T16:08:58.000Z",
-      "lastModified": "2026-04-07T20:42:04.000Z"
-    },
-    {
-      "rank": 578,
+      "rank": 584,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -16821,7 +16967,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 579,
+      "rank": 585,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -16840,7 +16986,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 580,
+      "rank": 586,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -16871,7 +17017,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 581,
+      "rank": 587,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -16894,91 +17040,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 582,
-      "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
-      "author": "stable-diffusion-v1-5",
-      "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
-      "downloads": 1715787,
-      "likes": 1111,
-      "trendingScore": 8,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "stable-diffusion",
-        "stable-diffusion-diffusers",
-        "text-to-image",
-        "arxiv:2207.12598",
-        "arxiv:2112.10752",
-        "arxiv:2103.00020",
-        "arxiv:2205.11487",
-        "arxiv:1910.09700",
-        "license:creativeml-openrail-m",
-        "endpoints_compatible",
-        "diffusers:StableDiffusionPipeline",
-        "region:us"
-      ],
-      "createdAt": "2024-08-30T09:48:48.000Z",
-      "lastModified": "2024-09-07T16:20:30.000Z"
-    },
-    {
-      "rank": 583,
-      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "downloads": 13205,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-122B-A10B",
-        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T19:03:18.000Z",
-      "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 584,
-      "id": "moonshotai/Kimi-K2.5",
-      "author": "moonshotai",
-      "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
-      "downloads": 1764592,
-      "likes": 2786,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "kimi_k25",
-        "feature-extraction",
-        "compressed-tensors",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "arxiv:2602.02276",
-        "license:other",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-01-01T06:06:03.000Z",
-      "lastModified": "2026-04-30T03:56:40.000Z"
-    },
-    {
-      "rank": 585,
+      "rank": 588,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -17016,11 +17078,11 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 586,
+      "rank": 589,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
-      "downloads": 90697,
+      "downloads": 91217,
       "likes": 204,
       "trendingScore": 8,
       "pipelineTag": "image-to-image",
@@ -17044,7 +17106,78 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 587,
+      "rank": 590,
+      "id": "black-forest-labs/FLUX.1-Kontext-dev",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+      "downloads": 79376,
+      "likes": 2623,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-generation",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "arxiv:2506.15742",
+        "license:other",
+        "diffusers:FluxKontextPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-05-28T22:23:43.000Z",
+      "lastModified": "2026-01-01T15:35:36.000Z"
+    },
+    {
+      "rank": 591,
+      "id": "Playtime-AI/Wan2.2_Model_Archive",
+      "author": "Playtime-AI",
+      "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T12:27:16.000Z",
+      "lastModified": "2026-05-15T13:04:24.000Z"
+    },
+    {
+      "rank": 592,
+      "id": "Abiray/HiDream-O1-Image-Dev-FP8",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "image-generation",
+        "fp8",
+        "quantization",
+        "safetensors",
+        "hidream",
+        "distilled",
+        "image-text-to-image",
+        "base_model:HiDream-ai/HiDream-O1-Image-Dev",
+        "base_model:quantized:HiDream-ai/HiDream-O1-Image-Dev",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T17:04:38.000Z",
+      "lastModified": "2026-05-11T17:13:39.000Z"
+    },
+    {
+      "rank": 593,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -17070,7 +17203,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 588,
+      "rank": 594,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -17087,7 +17220,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 589,
+      "rank": 595,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -17110,33 +17243,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 590,
-      "id": "black-forest-labs/FLUX.1-Kontext-dev",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
-      "downloads": 75421,
-      "likes": 2612,
-      "trendingScore": 7,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-generation",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "arxiv:2506.15742",
-        "license:other",
-        "diffusers:FluxKontextPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-05-28T22:23:43.000Z",
-      "lastModified": "2026-01-01T15:35:36.000Z"
-    },
-    {
-      "rank": 591,
+      "rank": 596,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -17164,7 +17271,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 592,
+      "rank": 597,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -17207,7 +17314,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 593,
+      "rank": 598,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -17242,7 +17349,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 594,
+      "rank": 599,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -17267,7 +17374,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 595,
+      "rank": 600,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -17297,7 +17404,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 596,
+      "rank": 601,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -17326,7 +17433,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 597,
+      "rank": 602,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -17353,7 +17460,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 598,
+      "rank": 603,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -17379,7 +17486,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 599,
+      "rank": 604,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -17410,7 +17517,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 600,
+      "rank": 605,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -17428,7 +17535,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 601,
+      "rank": 606,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -17457,7 +17564,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 602,
+      "rank": 607,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -17480,7 +17587,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 603,
+      "rank": 608,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -17525,7 +17632,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 604,
+      "rank": 609,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -17551,7 +17658,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 605,
+      "rank": 610,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -17579,7 +17686,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 606,
+      "rank": 611,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -17617,7 +17724,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 607,
+      "rank": 612,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -17644,7 +17751,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 608,
+      "rank": 613,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -17670,7 +17777,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 609,
+      "rank": 614,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -17688,7 +17795,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 610,
+      "rank": 615,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -17714,7 +17821,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 611,
+      "rank": 616,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -17738,7 +17845,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 612,
+      "rank": 617,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -17779,7 +17886,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 613,
+      "rank": 618,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -17796,7 +17903,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 614,
+      "rank": 619,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -17829,7 +17936,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 615,
+      "rank": 620,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -17863,7 +17970,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 616,
+      "rank": 621,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -17902,7 +18009,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 617,
+      "rank": 622,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -17932,7 +18039,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 618,
+      "rank": 623,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -17968,7 +18075,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 619,
+      "rank": 624,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -17994,7 +18101,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 620,
+      "rank": 625,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -18030,7 +18137,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 621,
+      "rank": 626,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -18060,7 +18167,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 622,
+      "rank": 627,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -18098,7 +18205,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 623,
+      "rank": 628,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -18133,7 +18240,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 624,
+      "rank": 629,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -18158,7 +18265,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 625,
+      "rank": 630,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -18175,7 +18282,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 626,
+      "rank": 631,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -18217,7 +18324,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 627,
+      "rank": 632,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -18247,11 +18354,11 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 628,
+      "rank": 633,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
-      "downloads": 339991,
+      "downloads": 337391,
       "likes": 165,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -18272,7 +18379,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 629,
+      "rank": 634,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -18300,7 +18407,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 630,
+      "rank": 635,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -18317,7 +18424,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 631,
+      "rank": 636,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -18344,7 +18451,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 632,
+      "rank": 637,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -18387,7 +18494,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 633,
+      "rank": 638,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -18427,7 +18534,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 634,
+      "rank": 639,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -18451,7 +18558,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 635,
+      "rank": 640,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -18480,7 +18587,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 636,
+      "rank": 641,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -18506,7 +18613,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 637,
+      "rank": 642,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -18534,7 +18641,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 638,
+      "rank": 643,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -18573,7 +18680,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 639,
+      "rank": 644,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -18597,7 +18704,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 640,
+      "rank": 645,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -18625,7 +18732,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 641,
+      "rank": 646,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -18657,7 +18764,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 642,
+      "rank": 647,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -18687,7 +18794,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 643,
+      "rank": 648,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -18716,7 +18823,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 644,
+      "rank": 649,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -18744,7 +18851,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 645,
+      "rank": 650,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -18768,7 +18875,7 @@
       "lastModified": "2026-04-23T03:18:40.000Z"
     },
     {
-      "rank": 646,
+      "rank": 651,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -18801,7 +18908,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 647,
+      "rank": 652,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -18830,7 +18937,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 648,
+      "rank": 653,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -18850,7 +18957,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 649,
+      "rank": 654,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -18879,7 +18986,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 650,
+      "rank": 655,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -18903,7 +19010,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 651,
+      "rank": 656,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -18933,7 +19040,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 652,
+      "rank": 657,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -18963,7 +19070,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 653,
+      "rank": 658,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -18981,7 +19088,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 654,
+      "rank": 659,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -18998,7 +19105,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 655,
+      "rank": 660,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -19034,7 +19141,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 656,
+      "rank": 661,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -19065,7 +19172,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 657,
+      "rank": 662,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -19104,7 +19211,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 658,
+      "rank": 663,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -19135,7 +19242,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 659,
+      "rank": 664,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -19168,7 +19275,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 660,
+      "rank": 665,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -19196,7 +19303,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 661,
+      "rank": 666,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -19221,7 +19328,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 662,
+      "rank": 667,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -19244,7 +19351,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 663,
+      "rank": 668,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -19272,7 +19379,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 664,
+      "rank": 669,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -19305,7 +19412,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 665,
+      "rank": 670,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -19335,7 +19442,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 666,
+      "rank": 671,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -19370,7 +19477,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 667,
+      "rank": 672,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -19402,7 +19509,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 668,
+      "rank": 673,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -19427,11 +19534,11 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 669,
+      "rank": 674,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
-      "downloads": 137342,
+      "downloads": 151970,
       "likes": 33,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -19450,7 +19557,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 670,
+      "rank": 675,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -19477,7 +19584,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 671,
+      "rank": 676,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -19500,11 +19607,11 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 672,
+      "rank": 677,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
-      "downloads": 126,
+      "downloads": 133,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -19525,11 +19632,11 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 673,
+      "rank": 678,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
-      "downloads": 24418,
+      "downloads": 25236,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -19557,7 +19664,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 674,
+      "rank": 679,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -19602,7 +19709,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 675,
+      "rank": 680,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -19634,11 +19741,11 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 676,
+      "rank": 681,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
-      "downloads": 82,
+      "downloads": 157,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -19661,24 +19768,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 677,
-      "id": "Playtime-AI/Wan2.2_Model_Archive",
-      "author": "Playtime-AI",
-      "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T12:27:16.000Z",
-      "lastModified": "2026-05-15T13:04:24.000Z"
-    },
-    {
-      "rank": 678,
+      "rank": 682,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -19704,11 +19794,11 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 679,
+      "rank": 683,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
-      "downloads": 9759,
+      "downloads": 10632,
       "likes": 12,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -19734,11 +19824,11 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 680,
+      "rank": 684,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
-      "downloads": 154967,
+      "downloads": 156259,
       "likes": 76,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -19766,11 +19856,11 @@
       "lastModified": "2026-04-17T20:15:06.000Z"
     },
     {
-      "rank": 681,
+      "rank": 685,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
-      "downloads": 6910,
+      "downloads": 8664,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -19793,37 +19883,11 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 682,
-      "id": "Abiray/ZAYA1-8B-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
-      "downloads": 644,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "zaya",
-        "moe",
-        "zyphra",
-        "text-generation",
-        "reasoning",
-        "base_model:Zyphra/ZAYA1-8B",
-        "base_model:quantized:Zyphra/ZAYA1-8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T13:23:12.000Z",
-      "lastModified": "2026-05-16T14:23:36.000Z"
-    },
-    {
-      "rank": 683,
+      "rank": 686,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
-      "downloads": 3269321,
+      "downloads": 3268730,
       "likes": 3140,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -19847,11 +19911,11 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 684,
+      "rank": 687,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
-      "downloads": 2854,
+      "downloads": 2973,
       "likes": 62,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -19892,35 +19956,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 685,
-      "id": "Abiray/HiDream-O1-Image-Dev-FP8",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "image-generation",
-        "fp8",
-        "quantization",
-        "safetensors",
-        "hidream",
-        "distilled",
-        "image-text-to-image",
-        "base_model:HiDream-ai/HiDream-O1-Image-Dev",
-        "base_model:quantized:HiDream-ai/HiDream-O1-Image-Dev",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T17:04:38.000Z",
-      "lastModified": "2026-05-11T17:13:39.000Z"
-    },
-    {
-      "rank": 686,
+      "rank": 688,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -19949,12 +19985,12 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 687,
+      "rank": 689,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
-      "downloads": 279517,
-      "likes": 543,
+      "downloads": 279459,
+      "likes": 545,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
       "libraryName": null,
@@ -19981,7 +20017,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 688,
+      "rank": 690,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -20011,7 +20047,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 689,
+      "rank": 691,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -20028,11 +20064,11 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 690,
+      "rank": 692,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
-      "downloads": 43329,
+      "downloads": 43067,
       "likes": 1085,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -20045,11 +20081,11 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 691,
+      "rank": 693,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
-      "downloads": 110,
+      "downloads": 400,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -20086,11 +20122,11 @@
       "lastModified": "2026-05-17T01:57:40.000Z"
     },
     {
-      "rank": 692,
+      "rank": 694,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "downloads": 1538,
+      "downloads": 1722,
       "likes": 10,
       "trendingScore": 7,
       "pipelineTag": "text-to-video",
@@ -20109,27 +20145,11 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 693,
-      "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
-      "author": "maximsobolev275",
-      "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "region:us"
-      ],
-      "createdAt": "2026-05-04T14:01:04.000Z",
-      "lastModified": "2026-05-15T13:00:33.000Z"
-    },
-    {
-      "rank": 694,
+      "rank": 695,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
-      "downloads": 106,
+      "downloads": 140,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -20154,11 +20174,11 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 695,
+      "rank": 696,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
-      "downloads": 223,
+      "downloads": 2124,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -20180,7 +20200,265 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 696,
+      "rank": 697,
+      "id": "TheDrummer/Rocinante-X-12B-v1",
+      "author": "TheDrummer",
+      "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
+      "downloads": 813,
+      "likes": 80,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "mistral",
+        "base_model:mistralai/Mistral-Nemo-Instruct-2407",
+        "base_model:finetune:mistralai/Mistral-Nemo-Instruct-2407",
+        "region:us"
+      ],
+      "createdAt": "2026-01-19T06:47:46.000Z",
+      "lastModified": "2026-01-25T11:55:28.000Z"
+    },
+    {
+      "rank": 698,
+      "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
+      "author": "jinaai",
+      "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
+      "downloads": 45186,
+      "likes": 9,
+      "trendingScore": 7,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl_audio",
+        "feature-extraction",
+        "embedding",
+        "qwen3",
+        "jina-embeddings-v5",
+        "sentence-transformers",
+        "multimodal",
+        "vision",
+        "audio",
+        "vllm",
+        "video",
+        "image-feature-extraction",
+        "audio-feature-extraction",
+        "video-feature-extraction",
+        "sentence-similarity",
+        "custom_code",
+        "multilingual",
+        "arxiv:2605.08384",
+        "base_model:jinaai/jina-embeddings-v5-omni-small",
+        "base_model:finetune:jinaai/jina-embeddings-v5-omni-small",
+        "license:cc-by-nc-4.0",
+        "region:eu"
+      ],
+      "createdAt": "2026-03-31T14:07:19.000Z",
+      "lastModified": "2026-05-17T10:53:03.000Z"
+    },
+    {
+      "rank": 699,
+      "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
+      "author": "jinaai",
+      "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
+      "downloads": 44392,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llava_eurobert_audio",
+        "feature-extraction",
+        "embedding",
+        "jina-embeddings-v5",
+        "sentence-transformers",
+        "multimodal",
+        "vision",
+        "audio",
+        "vllm",
+        "video",
+        "image-feature-extraction",
+        "audio-feature-extraction",
+        "video-feature-extraction",
+        "sentence-similarity",
+        "custom_code",
+        "multilingual",
+        "arxiv:2605.08384",
+        "base_model:jinaai/jina-embeddings-v5-omni-nano",
+        "base_model:finetune:jinaai/jina-embeddings-v5-omni-nano",
+        "license:cc-by-nc-4.0",
+        "region:eu"
+      ],
+      "createdAt": "2026-03-31T21:51:13.000Z",
+      "lastModified": "2026-05-17T10:52:10.000Z"
+    },
+    {
+      "rank": 700,
+      "id": "answerdotai/ModernBERT-base",
+      "author": "answerdotai",
+      "url": "https://huggingface.co/answerdotai/ModernBERT-base",
+      "downloads": 1859221,
+      "likes": 1042,
+      "trendingScore": 7,
+      "pipelineTag": "fill-mask",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "onnx",
+        "safetensors",
+        "modernbert",
+        "fill-mask",
+        "masked-lm",
+        "long-context",
+        "en",
+        "arxiv:2412.13663",
+        "license:apache-2.0",
+        "region:us",
+        "deploy:azure"
+      ],
+      "createdAt": "2024-12-11T11:38:06.000Z",
+      "lastModified": "2025-01-15T20:11:48.000Z"
+    },
+    {
+      "rank": 701,
+      "id": "kjanh/KhanhTTS-OmniVoice",
+      "author": "kjanh",
+      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
+      "downloads": 3055,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "omnivoice",
+        "text-to-speech",
+        "vi",
+        "en",
+        "arxiv:2604.00688",
+        "base_model:k2-fsa/OmniVoice",
+        "base_model:finetune:k2-fsa/OmniVoice",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T02:00:22.000Z",
+      "lastModified": "2026-05-16T04:32:12.000Z"
+    },
+    {
+      "rank": 702,
+      "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
+      "author": "DavidAU",
+      "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
+      "downloads": 24,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "unsloth",
+        "heretic",
+        "uncensored",
+        "abliterated",
+        "fine tune",
+        "creative",
+        "creative writing",
+        "fiction writing",
+        "plot generation",
+        "sub-plot generation",
+        "story generation",
+        "scene continue",
+        "storytelling",
+        "fiction story",
+        "science fiction",
+        "romance",
+        "all genres",
+        "story",
+        "writing",
+        "vivid prosing",
+        "vivid writing",
+        "fiction",
+        "roleplaying",
+        "bfloat16",
+        "all use cases",
+        "conversational"
+      ],
+      "createdAt": "2026-05-12T03:08:34.000Z",
+      "lastModified": "2026-05-17T02:12:30.000Z"
+    },
+    {
+      "rank": 703,
+      "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+      "author": "GestaltLabs",
+      "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+      "downloads": 3131,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "qwen3.6",
+        "qwen3_5",
+        "mtp",
+        "speculative-decoding",
+        "conversational",
+        "nsc-ace",
+        "saber",
+        "ornstein",
+        "agentic",
+        "tool-calling",
+        "llama.cpp",
+        "quantized",
+        "multimodal",
+        "image-text-to-text",
+        "base_model:GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+        "base_model:quantized:GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T18:45:53.000Z",
+      "lastModified": "2026-05-14T12:07:07.000Z"
+    },
+    {
+      "rank": 704,
+      "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
+      "author": "TrevorJS",
+      "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
+      "downloads": 64472,
+      "likes": 67,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "abliteration",
+        "uncensored",
+        "gemma-4",
+        "text-generation",
+        "en",
+        "base_model:TrevorJS/gemma-4-E4B-it-uncensored",
+        "base_model:quantized:TrevorJS/gemma-4-E4B-it-uncensored",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-04T03:45:30.000Z",
+      "lastModified": "2026-04-05T16:05:23.000Z"
+    },
+    {
+      "rank": 705,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -20208,7 +20486,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 697,
+      "rank": 706,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -20247,7 +20525,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 698,
+      "rank": 707,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -20280,7 +20558,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 699,
+      "rank": 708,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -20309,7 +20587,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 700,
+      "rank": 709,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -20339,7 +20617,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 701,
+      "rank": 710,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -20384,7 +20662,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 702,
+      "rank": 711,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -20413,7 +20691,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 703,
+      "rank": 712,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -20458,12 +20736,12 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 704,
+      "rank": 713,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
-      "downloads": 56430,
-      "likes": 192,
+      "downloads": 50929,
+      "likes": 195,
       "trendingScore": 6,
       "pipelineTag": null,
       "libraryName": "mlx",
@@ -20491,7 +20769,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 705,
+      "rank": 714,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -20535,7 +20813,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 706,
+      "rank": 715,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -20561,7 +20839,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 707,
+      "rank": 716,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -20587,7 +20865,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 708,
+      "rank": 717,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -20619,7 +20897,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 709,
+      "rank": 718,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -20642,7 +20920,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 710,
+      "rank": 719,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -20685,7 +20963,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 711,
+      "rank": 720,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -20730,7 +21008,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 712,
+      "rank": 721,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -20775,7 +21053,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 713,
+      "rank": 722,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -20802,7 +21080,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 714,
+      "rank": 723,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -20829,7 +21107,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 715,
+      "rank": 724,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -20854,7 +21132,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 716,
+      "rank": 725,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -20893,7 +21171,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 717,
+      "rank": 726,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -20918,7 +21196,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 718,
+      "rank": 727,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -20946,7 +21224,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 719,
+      "rank": 728,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -20971,7 +21249,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 720,
+      "rank": 729,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -20987,7 +21265,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 721,
+      "rank": 730,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -21014,7 +21292,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 722,
+      "rank": 731,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -21046,7 +21324,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 723,
+      "rank": 732,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -21076,7 +21354,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 724,
+      "rank": 733,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -21108,7 +21386,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 725,
+      "rank": 734,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -21136,7 +21414,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 726,
+      "rank": 735,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -21162,7 +21440,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 727,
+      "rank": 736,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -21187,7 +21465,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 728,
+      "rank": 737,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -21216,7 +21494,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 729,
+      "rank": 738,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -21258,7 +21536,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 730,
+      "rank": 739,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -21285,7 +21563,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 731,
+      "rank": 740,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -21330,7 +21608,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 732,
+      "rank": 741,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -21356,7 +21634,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 733,
+      "rank": 742,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -21376,7 +21654,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 734,
+      "rank": 743,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -21403,7 +21681,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 735,
+      "rank": 744,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -21445,7 +21723,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 736,
+      "rank": 745,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -21472,7 +21750,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 737,
+      "rank": 746,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -21506,7 +21784,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 738,
+      "rank": 747,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -21535,7 +21813,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 739,
+      "rank": 748,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -21562,7 +21840,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 740,
+      "rank": 749,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -21589,7 +21867,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 741,
+      "rank": 750,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -21616,7 +21894,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 742,
+      "rank": 751,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -21644,7 +21922,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 743,
+      "rank": 752,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -21667,7 +21945,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 744,
+      "rank": 753,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -21698,7 +21976,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 745,
+      "rank": 754,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -21743,7 +22021,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 746,
+      "rank": 755,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -21765,7 +22043,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 747,
+      "rank": 756,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -21791,7 +22069,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 748,
+      "rank": 757,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -21817,7 +22095,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 749,
+      "rank": 758,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -21848,7 +22126,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 750,
+      "rank": 759,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -21871,7 +22149,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 751,
+      "rank": 760,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -21901,7 +22179,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 752,
+      "rank": 761,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -21933,7 +22211,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 753,
+      "rank": 762,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -21962,7 +22240,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 754,
+      "rank": 763,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -21994,7 +22272,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 755,
+      "rank": 764,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -22026,7 +22304,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 756,
+      "rank": 765,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -22057,7 +22335,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 757,
+      "rank": 766,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -22088,7 +22366,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 758,
+      "rank": 767,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -22111,7 +22389,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 759,
+      "rank": 768,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -22138,7 +22416,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 760,
+      "rank": 769,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -22183,7 +22461,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 761,
+      "rank": 770,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -22201,7 +22479,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 762,
+      "rank": 771,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -22224,7 +22502,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 763,
+      "rank": 772,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -22254,7 +22532,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 764,
+      "rank": 773,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -22293,7 +22571,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 765,
+      "rank": 774,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -22331,7 +22609,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 766,
+      "rank": 775,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -22369,7 +22647,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 767,
+      "rank": 776,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -22414,7 +22692,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 768,
+      "rank": 777,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -22439,7 +22717,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 769,
+      "rank": 778,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -22473,7 +22751,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 770,
+      "rank": 779,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -22498,7 +22776,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 771,
+      "rank": 780,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -22531,7 +22809,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 772,
+      "rank": 781,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -22558,7 +22836,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 773,
+      "rank": 782,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -22588,7 +22866,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 774,
+      "rank": 783,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -22620,7 +22898,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 775,
+      "rank": 784,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -22653,27 +22931,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 776,
-      "id": "TheDrummer/Rocinante-X-12B-v1",
-      "author": "TheDrummer",
-      "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
-      "downloads": 803,
-      "likes": 79,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "mistral",
-        "base_model:mistralai/Mistral-Nemo-Instruct-2407",
-        "base_model:finetune:mistralai/Mistral-Nemo-Instruct-2407",
-        "region:us"
-      ],
-      "createdAt": "2026-01-19T06:47:46.000Z",
-      "lastModified": "2026-01-25T11:55:28.000Z"
-    },
-    {
-      "rank": 777,
+      "rank": 785,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -22691,7 +22949,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 778,
+      "rank": 786,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -22714,7 +22972,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 779,
+      "rank": 787,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -22746,7 +23004,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 780,
+      "rank": 788,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -22791,7 +23049,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 781,
+      "rank": 789,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -22832,7 +23090,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 782,
+      "rank": 790,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -22871,7 +23129,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 783,
+      "rank": 791,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -22898,7 +23156,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 784,
+      "rank": 792,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -22935,7 +23193,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 785,
+      "rank": 793,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -22971,7 +23229,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 786,
+      "rank": 794,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -22989,11 +23247,11 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 787,
+      "rank": 795,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
-      "downloads": 2786,
+      "downloads": 3067,
       "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -23028,11 +23286,11 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 788,
+      "rank": 796,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
-      "downloads": 45166052,
+      "downloads": 45716238,
       "likes": 460,
       "trendingScore": 6,
       "pipelineTag": "feature-extraction",
@@ -23064,7 +23322,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 789,
+      "rank": 797,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -23093,7 +23351,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 790,
+      "rank": 798,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -23120,11 +23378,11 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 791,
+      "rank": 799,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
-      "downloads": 92,
+      "downloads": 90,
       "likes": 50,
       "trendingScore": 6,
       "pipelineTag": "any-to-any",
@@ -23147,7 +23405,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 792,
+      "rank": 800,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -23174,11 +23432,11 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 793,
+      "rank": 801,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
-      "downloads": 21418,
+      "downloads": 21097,
       "likes": 37,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -23204,7 +23462,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 794,
+      "rank": 802,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -23231,7 +23489,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 795,
+      "rank": 803,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -23262,46 +23520,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 796,
-      "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
-      "author": "jinaai",
-      "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
-      "downloads": 48216,
-      "likes": 8,
-      "trendingScore": 6,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl_audio",
-        "feature-extraction",
-        "embedding",
-        "qwen3",
-        "jina-embeddings-v5",
-        "sentence-transformers",
-        "multimodal",
-        "vision",
-        "audio",
-        "vllm",
-        "video",
-        "image-feature-extraction",
-        "audio-feature-extraction",
-        "video-feature-extraction",
-        "sentence-similarity",
-        "custom_code",
-        "multilingual",
-        "arxiv:2605.08384",
-        "base_model:jinaai/jina-embeddings-v5-omni-small",
-        "base_model:finetune:jinaai/jina-embeddings-v5-omni-small",
-        "license:cc-by-nc-4.0",
-        "region:eu"
-      ],
-      "createdAt": "2026-03-31T14:07:19.000Z",
-      "lastModified": "2026-05-17T10:53:03.000Z"
-    },
-    {
-      "rank": 797,
+      "rank": 804,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -23319,7 +23538,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 798,
+      "rank": 805,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -23338,45 +23557,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 799,
-      "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
-      "author": "jinaai",
-      "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
-      "downloads": 50864,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llava_eurobert_audio",
-        "feature-extraction",
-        "embedding",
-        "jina-embeddings-v5",
-        "sentence-transformers",
-        "multimodal",
-        "vision",
-        "audio",
-        "vllm",
-        "video",
-        "image-feature-extraction",
-        "audio-feature-extraction",
-        "video-feature-extraction",
-        "sentence-similarity",
-        "custom_code",
-        "multilingual",
-        "arxiv:2605.08384",
-        "base_model:jinaai/jina-embeddings-v5-omni-nano",
-        "base_model:finetune:jinaai/jina-embeddings-v5-omni-nano",
-        "license:cc-by-nc-4.0",
-        "region:eu"
-      ],
-      "createdAt": "2026-03-31T21:51:13.000Z",
-      "lastModified": "2026-05-17T10:52:10.000Z"
-    },
-    {
-      "rank": 800,
+      "rank": 806,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -23403,7 +23584,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 801,
+      "rank": 807,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -23428,11 +23609,11 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 802,
+      "rank": 808,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
-      "downloads": 39,
+      "downloads": 42,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -23458,12 +23639,12 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 803,
+      "rank": 809,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
-      "downloads": 66205,
-      "likes": 2391,
+      "downloads": 65958,
+      "likes": 2390,
       "trendingScore": 6,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -23482,11 +23663,11 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 804,
+      "rank": 810,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
-      "downloads": 43128,
+      "downloads": 42664,
       "likes": 30,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -23512,11 +23693,11 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 805,
+      "rank": 811,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
-      "downloads": 1977455,
+      "downloads": 1955539,
       "likes": 277,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -23539,7 +23720,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 806,
+      "rank": 812,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -23570,7 +23751,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 807,
+      "rank": 813,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -23592,11 +23773,11 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 808,
+      "rank": 814,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
-      "downloads": 57,
+      "downloads": 69,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -23622,11 +23803,11 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 809,
+      "rank": 815,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
-      "downloads": 3519,
+      "downloads": 4272,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -23651,7 +23832,7 @@
       "lastModified": "2026-05-15T23:48:37.000Z"
     },
     {
-      "rank": 810,
+      "rank": 816,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -23672,7 +23853,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 811,
+      "rank": 817,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -23708,7 +23889,7 @@
       "lastModified": "2026-04-22T14:03:41.000Z"
     },
     {
-      "rank": 812,
+      "rank": 818,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -23731,11 +23912,11 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 813,
+      "rank": 819,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
-      "downloads": 690,
+      "downloads": 1116,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -23764,7 +23945,7 @@
       "lastModified": "2026-05-17T20:41:40.000Z"
     },
     {
-      "rank": 814,
+      "rank": 820,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -23809,7 +23990,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 815,
+      "rank": 821,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -23831,39 +24012,11 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 816,
-      "id": "answerdotai/ModernBERT-base",
-      "author": "answerdotai",
-      "url": "https://huggingface.co/answerdotai/ModernBERT-base",
-      "downloads": 1844066,
-      "likes": 1041,
-      "trendingScore": 6,
-      "pipelineTag": "fill-mask",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "onnx",
-        "safetensors",
-        "modernbert",
-        "fill-mask",
-        "masked-lm",
-        "long-context",
-        "en",
-        "arxiv:2412.13663",
-        "license:apache-2.0",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2024-12-11T11:38:06.000Z",
-      "lastModified": "2025-01-15T20:11:48.000Z"
-    },
-    {
-      "rank": 817,
+      "rank": 822,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
-      "downloads": 405848,
+      "downloads": 423343,
       "likes": 85,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -23889,11 +24042,11 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 818,
+      "rank": 823,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
-      "downloads": 54,
+      "downloads": 58,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -23916,7 +24069,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 819,
+      "rank": 824,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -23941,11 +24094,11 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 820,
+      "rank": 825,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
-      "downloads": 21987,
+      "downloads": 23244,
       "likes": 140,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -23974,11 +24127,11 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 821,
+      "rank": 826,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
-      "downloads": 1230257,
+      "downloads": 1253501,
       "likes": 155,
       "trendingScore": 6,
       "pipelineTag": "time-series-forecasting",
@@ -23997,7 +24150,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 822,
+      "rank": 827,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -24026,11 +24179,11 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 823,
+      "rank": 828,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
-      "downloads": 66315,
+      "downloads": 66759,
       "likes": 233,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-image",
@@ -24046,7 +24199,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 824,
+      "rank": 829,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -24091,11 +24244,11 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 825,
+      "rank": 830,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
-      "downloads": 927,
+      "downloads": 959,
       "likes": 479,
       "trendingScore": 6,
       "pipelineTag": "text-to-speech",
@@ -24112,11 +24265,11 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 826,
+      "rank": 831,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
-      "downloads": 163,
+      "downloads": 243,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -24142,35 +24295,10 @@
         "region:us"
       ],
       "createdAt": "2026-05-14T17:57:09.000Z",
-      "lastModified": "2026-05-18T03:09:40.000Z"
+      "lastModified": "2026-05-18T05:10:11.000Z"
     },
     {
-      "rank": 827,
-      "id": "kjanh/KhanhTTS-OmniVoice",
-      "author": "kjanh",
-      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
-      "downloads": 165,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "omnivoice",
-        "text-to-speech",
-        "vi",
-        "en",
-        "arxiv:2604.00688",
-        "base_model:k2-fsa/OmniVoice",
-        "base_model:finetune:k2-fsa/OmniVoice",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T02:00:22.000Z",
-      "lastModified": "2026-05-16T04:32:12.000Z"
-    },
-    {
-      "rank": 828,
+      "rank": 832,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -24198,92 +24326,11 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 829,
-      "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
-      "author": "DavidAU",
-      "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
-      "downloads": 14,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "unsloth",
-        "heretic",
-        "uncensored",
-        "abliterated",
-        "fine tune",
-        "creative",
-        "creative writing",
-        "fiction writing",
-        "plot generation",
-        "sub-plot generation",
-        "story generation",
-        "scene continue",
-        "storytelling",
-        "fiction story",
-        "science fiction",
-        "romance",
-        "all genres",
-        "story",
-        "writing",
-        "vivid prosing",
-        "vivid writing",
-        "fiction",
-        "roleplaying",
-        "bfloat16",
-        "all use cases",
-        "conversational"
-      ],
-      "createdAt": "2026-05-12T03:08:34.000Z",
-      "lastModified": "2026-05-17T02:12:30.000Z"
-    },
-    {
-      "rank": 830,
-      "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
-      "author": "GestaltLabs",
-      "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
-      "downloads": 2631,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "qwen3.6",
-        "qwen3_5",
-        "mtp",
-        "speculative-decoding",
-        "conversational",
-        "nsc-ace",
-        "saber",
-        "ornstein",
-        "agentic",
-        "tool-calling",
-        "llama.cpp",
-        "quantized",
-        "multimodal",
-        "image-text-to-text",
-        "base_model:GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
-        "base_model:quantized:GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T18:45:53.000Z",
-      "lastModified": "2026-05-14T12:07:07.000Z"
-    },
-    {
-      "rank": 831,
+      "rank": 833,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
-      "downloads": 33,
+      "downloads": 56,
       "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -24312,11 +24359,11 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 832,
+      "rank": 834,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
-      "downloads": 5218,
+      "downloads": 5483,
       "likes": 11,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -24354,11 +24401,11 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 833,
+      "rank": 835,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
-      "downloads": 22266,
+      "downloads": 23079,
       "likes": 137,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -24381,38 +24428,11 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 834,
-      "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
-      "author": "TrevorJS",
-      "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
-      "downloads": 85730,
-      "likes": 66,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "abliteration",
-        "uncensored",
-        "gemma-4",
-        "text-generation",
-        "en",
-        "base_model:TrevorJS/gemma-4-E4B-it-uncensored",
-        "base_model:quantized:TrevorJS/gemma-4-E4B-it-uncensored",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-04T03:45:30.000Z",
-      "lastModified": "2026-04-05T16:05:23.000Z"
-    },
-    {
-      "rank": 835,
+      "rank": 836,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
-      "downloads": 5320,
+      "downloads": 7273,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -24435,7 +24455,202 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 836,
+      "rank": 837,
+      "id": "intfloat/multilingual-e5-small",
+      "author": "intfloat",
+      "url": "https://huggingface.co/intfloat/multilingual-e5-small",
+      "downloads": 8459029,
+      "likes": 319,
+      "trendingScore": 6,
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "pytorch",
+        "onnx",
+        "safetensors",
+        "openvino",
+        "bert",
+        "mteb",
+        "Sentence Transformers",
+        "sentence-similarity",
+        "multilingual",
+        "af",
+        "am",
+        "ar",
+        "as",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "br",
+        "bs",
+        "ca",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "el",
+        "en",
+        "eo",
+        "es",
+        "et"
+      ],
+      "createdAt": "2023-06-30T07:31:03.000Z",
+      "lastModified": "2026-04-02T02:16:05.000Z"
+    },
+    {
+      "rank": 838,
+      "id": "meta-llama/Llama-2-7b",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-2-7b",
+      "downloads": 247,
+      "likes": 4489,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama",
+        "llama-2",
+        "text-generation",
+        "en",
+        "arxiv:2307.09288",
+        "license:llama2",
+        "region:us"
+      ],
+      "createdAt": "2023-07-09T07:34:35.000Z",
+      "lastModified": "2024-04-17T08:12:44.000Z"
+    },
+    {
+      "rank": 839,
+      "id": "Comfy-Org/z_image",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/z_image",
+      "downloads": 169340,
+      "likes": 230,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
+      "tags": [
+        "diffusion-single-file",
+        "comfyui",
+        "region:us"
+      ],
+      "createdAt": "2026-01-27T01:23:23.000Z",
+      "lastModified": "2026-01-27T16:10:00.000Z"
+    },
+    {
+      "rank": 840,
+      "id": "Alissonerdx/EditAnything",
+      "author": "Alissonerdx",
+      "url": "https://huggingface.co/Alissonerdx/EditAnything",
+      "downloads": 107,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "video",
+        "video-editing",
+        "ltxv",
+        "ltx-2.3",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-01T08:12:57.000Z",
+      "lastModified": "2026-05-18T09:50:17.000Z"
+    },
+    {
+      "rank": 841,
+      "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
+      "downloads": 44,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "Any-Step",
+        "Text-to-Video",
+        "text-to-video",
+        "en",
+        "arxiv:2605.13724",
+        "arxiv:2503.19325",
+        "base_model:Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        "base_model:finetune:Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        "license:other",
+        "diffusers:WanAnyFlowPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T12:30:23.000Z",
+      "lastModified": "2026-05-14T07:09:38.000Z"
+    },
+    {
+      "rank": 842,
+      "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
+      "downloads": 10980,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.5-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T14:30:19.000Z",
+      "lastModified": "2026-05-18T03:22:32.000Z"
+    },
+    {
+      "rank": 843,
+      "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
+      "author": "noctrex",
+      "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
+      "downloads": 1543,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen",
+        "qwen3_5_moe",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Jackrong/Qwopus3.6-27B-v1-preview",
+        "base_model:quantized:Jackrong/Qwopus3.6-27B-v1-preview",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T21:42:10.000Z",
+      "lastModified": "2026-05-17T16:25:53.000Z"
+    },
+    {
+      "rank": 844,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -24462,7 +24677,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 837,
+      "rank": 845,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -24498,7 +24713,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 838,
+      "rank": 846,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -24543,7 +24758,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 839,
+      "rank": 847,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -24588,7 +24803,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 840,
+      "rank": 848,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -24618,11 +24833,11 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 841,
+      "rank": 849,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
-      "downloads": 81655,
+      "downloads": 80546,
       "likes": 223,
       "trendingScore": 5,
       "pipelineTag": "image-to-image",
@@ -24644,7 +24859,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 842,
+      "rank": 850,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -24679,7 +24894,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 843,
+      "rank": 851,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -24707,7 +24922,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 844,
+      "rank": 852,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -24733,7 +24948,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 845,
+      "rank": 853,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -24759,7 +24974,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 846,
+      "rank": 854,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -24785,7 +25000,7 @@
       "lastModified": "2026-05-06T20:09:03.000Z"
     },
     {
-      "rank": 847,
+      "rank": 855,
       "id": "TheDrummer/Skyfall-31B-v4.2",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
@@ -24805,7 +25020,7 @@
       "lastModified": "2026-04-03T20:52:19.000Z"
     },
     {
-      "rank": 848,
+      "rank": 856,
       "id": "LiquidAI/LFM2-24B-A2B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
@@ -24843,7 +25058,7 @@
       "lastModified": "2026-03-30T12:54:26.000Z"
     },
     {
-      "rank": 849,
+      "rank": 857,
       "id": "nvidia/GR00T-N1.7-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
@@ -24863,7 +25078,7 @@
       "lastModified": "2026-04-23T19:09:30.000Z"
     },
     {
-      "rank": 850,
+      "rank": 858,
       "id": "Aratako/Irodori-TTS-500M",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
@@ -24886,7 +25101,7 @@
       "lastModified": "2026-03-18T11:03:56.000Z"
     },
     {
-      "rank": 851,
+      "rank": 859,
       "id": "Qwen/Qwen3.5-0.8B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
@@ -24909,7 +25124,7 @@
       "lastModified": "2026-04-23T11:14:09.000Z"
     },
     {
-      "rank": 852,
+      "rank": 860,
       "id": "z-lab/Qwen3.5-9B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
@@ -24942,7 +25157,7 @@
       "lastModified": "2026-04-07T14:29:47.000Z"
     },
     {
-      "rank": 853,
+      "rank": 861,
       "id": "Winnougan/Must_Have_Klein_9b_loras",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
@@ -24964,7 +25179,7 @@
       "lastModified": "2026-03-26T22:03:08.000Z"
     },
     {
-      "rank": 854,
+      "rank": 862,
       "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
@@ -24991,7 +25206,7 @@
       "lastModified": "2026-04-05T16:05:28.000Z"
     },
     {
-      "rank": 855,
+      "rank": 863,
       "id": "100percentrobot/LTX-2.3-Audio-Reactive-LORA",
       "author": "100percentrobot",
       "url": "https://huggingface.co/100percentrobot/LTX-2.3-Audio-Reactive-LORA",
@@ -25015,7 +25230,7 @@
       "lastModified": "2026-04-10T15:12:18.000Z"
     },
     {
-      "rank": 856,
+      "rank": 864,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -25042,7 +25257,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 857,
+      "rank": 865,
       "id": "YJX-Xiaomi/ControlFoley",
       "author": "YJX-Xiaomi",
       "url": "https://huggingface.co/YJX-Xiaomi/ControlFoley",
@@ -25066,7 +25281,7 @@
       "lastModified": "2026-04-22T02:02:09.000Z"
     },
     {
-      "rank": 858,
+      "rank": 866,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -25106,7 +25321,7 @@
       "lastModified": "2026-04-19T00:19:49.000Z"
     },
     {
-      "rank": 859,
+      "rank": 867,
       "id": "lovis93/crt-animation-terminal-ltx-2.3-lora",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/crt-animation-terminal-ltx-2.3-lora",
@@ -25132,7 +25347,7 @@
       "lastModified": "2026-04-20T16:33:16.000Z"
     },
     {
-      "rank": 860,
+      "rank": 868,
       "id": "uva-cv-lab/OmniShotCut",
       "author": "uva-cv-lab",
       "url": "https://huggingface.co/uva-cv-lab/OmniShotCut",
@@ -25150,7 +25365,7 @@
       "lastModified": "2026-04-28T14:59:54.000Z"
     },
     {
-      "rank": 861,
+      "rank": 869,
       "id": "Yutian10/AnyRecon",
       "author": "Yutian10",
       "url": "https://huggingface.co/Yutian10/AnyRecon",
@@ -25168,11 +25383,11 @@
       "lastModified": "2026-04-27T02:17:02.000Z"
     },
     {
-      "rank": 862,
+      "rank": 870,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
-      "downloads": 256674,
+      "downloads": 259513,
       "likes": 29,
       "trendingScore": 5,
       "pipelineTag": "image-text-to-text",
@@ -25194,7 +25409,7 @@
       "lastModified": "2026-04-30T21:34:35.000Z"
     },
     {
-      "rank": 863,
+      "rank": 871,
       "id": "vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
@@ -25217,11 +25432,11 @@
       "lastModified": "2026-04-24T02:25:18.000Z"
     },
     {
-      "rank": 864,
+      "rank": 872,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
-      "downloads": 11276,
+      "downloads": 11970,
       "likes": 13,
       "trendingScore": 5,
       "pipelineTag": "image-text-to-text",
@@ -25248,7 +25463,7 @@
       "lastModified": "2026-05-06T21:03:47.000Z"
     },
     {
-      "rank": 865,
+      "rank": 873,
       "id": "Comfy-Org/void-model",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/void-model",
@@ -25266,7 +25481,7 @@
       "lastModified": "2026-05-07T10:17:55.000Z"
     },
     {
-      "rank": 866,
+      "rank": 874,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
@@ -25296,7 +25511,7 @@
       "lastModified": "2026-04-27T23:59:16.000Z"
     },
     {
-      "rank": 867,
+      "rank": 875,
       "id": "TheBurgstall/ltx-2.3-bodypositivity-lora",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/ltx-2.3-bodypositivity-lora",
@@ -25323,7 +25538,7 @@
       "lastModified": "2026-04-26T10:38:55.000Z"
     },
     {
-      "rank": 868,
+      "rank": 876,
       "id": "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
@@ -25353,7 +25568,7 @@
       "lastModified": "2026-05-05T17:25:56.000Z"
     },
     {
-      "rank": 869,
+      "rank": 877,
       "id": "GAi92/anima-loras",
       "author": "GAi92",
       "url": "https://huggingface.co/GAi92/anima-loras",
@@ -25374,7 +25589,7 @@
       "lastModified": "2026-05-08T23:44:33.000Z"
     },
     {
-      "rank": 870,
+      "rank": 878,
       "id": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
@@ -25401,7 +25616,7 @@
       "lastModified": "2026-05-06T05:56:30.000Z"
     },
     {
-      "rank": 871,
+      "rank": 879,
       "id": "XiaomiMiMo/MiMo-V2.5-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Base",
@@ -25430,7 +25645,7 @@
       "lastModified": "2026-05-08T10:25:24.000Z"
     },
     {
-      "rank": 872,
+      "rank": 880,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit",
@@ -25459,7 +25674,7 @@
       "lastModified": "2026-04-29T04:36:33.000Z"
     },
     {
-      "rank": 873,
+      "rank": 881,
       "id": "sokann/Qwen3.6-27B-GGUF-4.256bpw",
       "author": "sokann",
       "url": "https://huggingface.co/sokann/Qwen3.6-27B-GGUF-4.256bpw",
@@ -25483,7 +25698,7 @@
       "lastModified": "2026-04-30T05:52:10.000Z"
     },
     {
-      "rank": 874,
+      "rank": 882,
       "id": "Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
@@ -25528,7 +25743,7 @@
       "lastModified": "2026-04-30T00:55:51.000Z"
     },
     {
-      "rank": 875,
+      "rank": 883,
       "id": "mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
@@ -25573,7 +25788,7 @@
       "lastModified": "2026-04-30T08:28:27.000Z"
     },
     {
-      "rank": 876,
+      "rank": 884,
       "id": "OrobasVault/Geodesic-Phantom-12B",
       "author": "OrobasVault",
       "url": "https://huggingface.co/OrobasVault/Geodesic-Phantom-12B",
@@ -25614,7 +25829,7 @@
       "lastModified": "2026-05-01T03:53:12.000Z"
     },
     {
-      "rank": 877,
+      "rank": 885,
       "id": "Egor-3926/ToxicLord",
       "author": "Egor-3926",
       "url": "https://huggingface.co/Egor-3926/ToxicLord",
@@ -25644,7 +25859,7 @@
       "lastModified": "2026-04-30T20:07:44.000Z"
     },
     {
-      "rank": 878,
+      "rank": 886,
       "id": "Playtime-AI/LTX-2.3-Jenna_Coleman",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Jenna_Coleman",
@@ -25661,7 +25876,7 @@
       "lastModified": "2026-05-01T11:07:58.000Z"
     },
     {
-      "rank": 879,
+      "rank": 887,
       "id": "abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
       "author": "abhinand",
       "url": "https://huggingface.co/abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
@@ -25691,7 +25906,7 @@
       "lastModified": "2026-05-01T15:22:45.000Z"
     },
     {
-      "rank": 880,
+      "rank": 888,
       "id": "Naphula/Salamander-24B-v1",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/Salamander-24B-v1",
@@ -25736,7 +25951,7 @@
       "lastModified": "2026-05-02T10:32:50.000Z"
     },
     {
-      "rank": 881,
+      "rank": 889,
       "id": "Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
@@ -25753,7 +25968,7 @@
       "lastModified": "2026-05-04T13:20:35.000Z"
     },
     {
-      "rank": 882,
+      "rank": 890,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -25782,7 +25997,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 883,
+      "rank": 891,
       "id": "chromadb/context-1",
       "author": "chromadb",
       "url": "https://huggingface.co/chromadb/context-1",
@@ -25807,7 +26022,7 @@
       "lastModified": "2026-03-30T01:02:07.000Z"
     },
     {
-      "rank": 884,
+      "rank": 892,
       "id": "abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
       "author": "abovespec",
       "url": "https://huggingface.co/abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
@@ -25827,7 +26042,7 @@
       "lastModified": "2026-05-04T03:28:29.000Z"
     },
     {
-      "rank": 885,
+      "rank": 893,
       "id": "bond005/whisper-podlodka-turbo",
       "author": "bond005",
       "url": "https://huggingface.co/bond005/whisper-podlodka-turbo",
@@ -25862,7 +26077,7 @@
       "lastModified": "2026-01-29T10:12:53.000Z"
     },
     {
-      "rank": 886,
+      "rank": 894,
       "id": "nvidia/canary-qwen-2.5b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/canary-qwen-2.5b",
@@ -25907,7 +26122,7 @@
       "lastModified": "2026-04-21T12:31:18.000Z"
     },
     {
-      "rank": 887,
+      "rank": 895,
       "id": "lightx2v/Wan2.2-Distill-Loras",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-Distill-Loras",
@@ -25935,7 +26150,7 @@
       "lastModified": "2025-12-17T08:00:53.000Z"
     },
     {
-      "rank": 888,
+      "rank": 896,
       "id": "Qwen/Qwen3.5-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-27B",
@@ -25960,7 +26175,7 @@
       "lastModified": "2026-04-24T02:54:49.000Z"
     },
     {
-      "rank": 889,
+      "rank": 897,
       "id": "mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
@@ -25983,7 +26198,7 @@
       "lastModified": "2026-04-23T08:30:31.000Z"
     },
     {
-      "rank": 890,
+      "rank": 898,
       "id": "sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
@@ -26022,7 +26237,7 @@
       "lastModified": "2026-04-29T00:23:13.000Z"
     },
     {
-      "rank": 891,
+      "rank": 899,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit",
@@ -26050,7 +26265,7 @@
       "lastModified": "2026-04-29T06:58:31.000Z"
     },
     {
-      "rank": 892,
+      "rank": 900,
       "id": "Harley-ml/Tenete-8M",
       "author": "Harley-ml",
       "url": "https://huggingface.co/Harley-ml/Tenete-8M",
@@ -26080,7 +26295,7 @@
       "lastModified": "2026-05-05T14:34:26.000Z"
     },
     {
-      "rank": 893,
+      "rank": 901,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -26117,7 +26332,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 894,
+      "rank": 902,
       "id": "nvidia/omni-embed-nemotron-3b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/omni-embed-nemotron-3b",
@@ -26153,7 +26368,7 @@
       "lastModified": "2026-05-06T18:02:16.000Z"
     },
     {
-      "rank": 895,
+      "rank": 903,
       "id": "fal/flux-2-klein-4b-spritesheet-lora",
       "author": "fal",
       "url": "https://huggingface.co/fal/flux-2-klein-4b-spritesheet-lora",
@@ -26187,7 +26402,7 @@
       "lastModified": "2026-01-21T14:44:55.000Z"
     },
     {
-      "rank": 896,
+      "rank": 904,
       "id": "DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
@@ -26232,7 +26447,7 @@
       "lastModified": "2026-03-09T07:04:55.000Z"
     },
     {
-      "rank": 897,
+      "rank": 905,
       "id": "Comfy-Org/ltx-2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/ltx-2",
@@ -26249,7 +26464,7 @@
       "lastModified": "2026-03-08T17:36:30.000Z"
     },
     {
-      "rank": 898,
+      "rank": 906,
       "id": "silveroxides/LTX-2.3-Quants",
       "author": "silveroxides",
       "url": "https://huggingface.co/silveroxides/LTX-2.3-Quants",
@@ -26293,7 +26508,7 @@
       "lastModified": "2026-05-03T15:37:37.000Z"
     },
     {
-      "rank": 899,
+      "rank": 907,
       "id": "z-lab/Qwen3.5-35B-A3B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-35B-A3B-PARO",
@@ -26322,7 +26537,7 @@
       "lastModified": "2026-05-08T06:21:10.000Z"
     },
     {
-      "rank": 900,
+      "rank": 908,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -26357,7 +26572,7 @@
       "lastModified": "2026-04-06T02:19:40.000Z"
     },
     {
-      "rank": 901,
+      "rank": 909,
       "id": "OpenMed/privacy-filter-multilingual",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-multilingual",
@@ -26402,7 +26617,7 @@
       "lastModified": "2026-05-03T21:36:31.000Z"
     },
     {
-      "rank": 902,
+      "rank": 910,
       "id": "prism-ml/Bonsai-8B-mlx-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-mlx-1bit",
@@ -26433,7 +26648,7 @@
       "lastModified": "2026-04-18T20:44:19.000Z"
     },
     {
-      "rank": 903,
+      "rank": 911,
       "id": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
@@ -26478,7 +26693,7 @@
       "lastModified": "2025-12-22T10:16:55.000Z"
     },
     {
-      "rank": 904,
+      "rank": 912,
       "id": "zai-org/GLM-5",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5",
@@ -26505,7 +26720,7 @@
       "lastModified": "2026-04-05T07:48:51.000Z"
     },
     {
-      "rank": 905,
+      "rank": 913,
       "id": "Comfy-Org/Wan_2.1_ComfyUI_repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged",
@@ -26523,7 +26738,7 @@
       "lastModified": "2026-01-28T12:44:01.000Z"
     },
     {
-      "rank": 906,
+      "rank": 914,
       "id": "sequelbox/Qwen3.6-27B-Tachibana-Agent",
       "author": "sequelbox",
       "url": "https://huggingface.co/sequelbox/Qwen3.6-27B-Tachibana-Agent",
@@ -26568,7 +26783,7 @@
       "lastModified": "2026-05-07T02:13:23.000Z"
     },
     {
-      "rank": 907,
+      "rank": 915,
       "id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
@@ -26594,7 +26809,7 @@
       "lastModified": "2024-07-03T05:16:11.000Z"
     },
     {
-      "rank": 908,
+      "rank": 916,
       "id": "lynaNSFW/LTX2.3_NSFW_motion",
       "author": "lynaNSFW",
       "url": "https://huggingface.co/lynaNSFW/LTX2.3_NSFW_motion",
@@ -26616,7 +26831,7 @@
       "lastModified": "2026-03-25T12:45:24.000Z"
     },
     {
-      "rank": 909,
+      "rank": 917,
       "id": "mlx-community/DeepSeek-V4-Flash-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit",
@@ -26639,7 +26854,7 @@
       "lastModified": "2026-04-25T00:58:58.000Z"
     },
     {
-      "rank": 910,
+      "rank": 918,
       "id": "Qwen/Qwen3-ForcedAligner-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B",
@@ -26660,7 +26875,7 @@
       "lastModified": "2026-01-30T03:00:55.000Z"
     },
     {
-      "rank": 911,
+      "rank": 919,
       "id": "nvidia/Cosmos-Reason2-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Cosmos-Reason2-8B",
@@ -26689,12 +26904,12 @@
       "lastModified": "2026-04-30T03:16:12.000Z"
     },
     {
-      "rank": 912,
+      "rank": 920,
       "id": "Qwen/Qwen3-VL-4B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct",
-      "downloads": 2557750,
-      "likes": 385,
+      "downloads": 2859913,
+      "likes": 389,
       "trendingScore": 5,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -26718,7 +26933,7 @@
       "lastModified": "2025-10-15T16:15:55.000Z"
     },
     {
-      "rank": 913,
+      "rank": 921,
       "id": "mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
@@ -26763,7 +26978,7 @@
       "lastModified": "2026-05-03T18:58:47.000Z"
     },
     {
-      "rank": 914,
+      "rank": 922,
       "id": "SWivid/F5-TTS",
       "author": "SWivid",
       "url": "https://huggingface.co/SWivid/F5-TTS",
@@ -26784,7 +26999,7 @@
       "lastModified": "2025-03-21T05:05:00.000Z"
     },
     {
-      "rank": 915,
+      "rank": 923,
       "id": "bartowski/google_gemma-4-E4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF",
@@ -26807,7 +27022,7 @@
       "lastModified": "2026-05-03T18:32:47.000Z"
     },
     {
-      "rank": 916,
+      "rank": 924,
       "id": "Ashen3/SNOFS",
       "author": "Ashen3",
       "url": "https://huggingface.co/Ashen3/SNOFS",
@@ -26827,7 +27042,7 @@
       "lastModified": "2026-02-21T20:02:14.000Z"
     },
     {
-      "rank": 917,
+      "rank": 925,
       "id": "Prior-Labs/tabpfn_2_6",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_2_6",
@@ -26851,7 +27066,7 @@
       "lastModified": "2026-04-02T10:00:43.000Z"
     },
     {
-      "rank": 918,
+      "rank": 926,
       "id": "Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
       "author": "Sikaworld1990",
       "url": "https://huggingface.co/Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
@@ -26880,7 +27095,7 @@
       "lastModified": "2026-03-11T17:20:00.000Z"
     },
     {
-      "rank": 919,
+      "rank": 927,
       "id": "google/medgemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-4b-it",
@@ -26924,7 +27139,7 @@
       "lastModified": "2025-10-28T17:24:49.000Z"
     },
     {
-      "rank": 920,
+      "rank": 928,
       "id": "nomic-ai/nomic-embed-text-v1.5-GGUF",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF",
@@ -26947,7 +27162,7 @@
       "lastModified": "2025-04-28T20:14:53.000Z"
     },
     {
-      "rank": 921,
+      "rank": 929,
       "id": "ponpoke/flux2-klein-4b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-4b-uncensored-text-encoder",
@@ -26980,7 +27195,7 @@
       "lastModified": "2026-05-02T11:35:01.000Z"
     },
     {
-      "rank": 922,
+      "rank": 930,
       "id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
       "author": "cardiffnlp",
       "url": "https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment-latest",
@@ -27007,7 +27222,7 @@
       "lastModified": "2025-08-04T07:58:29.000Z"
     },
     {
-      "rank": 923,
+      "rank": 931,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
@@ -27052,7 +27267,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 924,
+      "rank": 932,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
@@ -27082,7 +27297,7 @@
       "lastModified": "2026-05-04T02:04:15.000Z"
     },
     {
-      "rank": 925,
+      "rank": 933,
       "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
@@ -27107,7 +27322,7 @@
       "lastModified": "2025-02-24T03:31:45.000Z"
     },
     {
-      "rank": 926,
+      "rank": 934,
       "id": "microsoft/VibeVoice-Realtime-0.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-Realtime-0.5B",
@@ -27137,7 +27352,7 @@
       "lastModified": "2025-12-12T15:35:46.000Z"
     },
     {
-      "rank": 927,
+      "rank": 935,
       "id": "facebook/sam-audio-large",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam-audio-large",
@@ -27156,7 +27371,7 @@
       "lastModified": "2025-12-30T19:52:21.000Z"
     },
     {
-      "rank": 928,
+      "rank": 936,
       "id": "cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
       "author": "cognica",
       "url": "https://huggingface.co/cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
@@ -27183,7 +27398,7 @@
       "lastModified": "2026-05-16T07:11:10.000Z"
     },
     {
-      "rank": 929,
+      "rank": 937,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
@@ -27205,7 +27420,7 @@
       "lastModified": "2026-04-14T13:43:30.000Z"
     },
     {
-      "rank": 930,
+      "rank": 938,
       "id": "F16/z-image-turbo-flow-dpo",
       "author": "F16",
       "url": "https://huggingface.co/F16/z-image-turbo-flow-dpo",
@@ -27235,7 +27450,7 @@
       "lastModified": "2026-04-09T18:43:34.000Z"
     },
     {
-      "rank": 931,
+      "rank": 939,
       "id": "Jiunsong/supergemma4-e4b-abliterated",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-e4b-abliterated",
@@ -27266,7 +27481,7 @@
       "lastModified": "2026-04-17T13:20:56.000Z"
     },
     {
-      "rank": 932,
+      "rank": 940,
       "id": "deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
       "author": "deucebucket",
       "url": "https://huggingface.co/deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
@@ -27300,7 +27515,7 @@
       "lastModified": "2026-05-15T05:30:04.000Z"
     },
     {
-      "rank": 933,
+      "rank": 941,
       "id": "deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
       "author": "deepsweet",
       "url": "https://huggingface.co/deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
@@ -27326,7 +27541,7 @@
       "lastModified": "2026-05-10T15:18:41.000Z"
     },
     {
-      "rank": 934,
+      "rank": 942,
       "id": "Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Phil2Sat",
       "url": "https://huggingface.co/Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -27354,7 +27569,7 @@
       "lastModified": "2025-11-07T19:24:03.000Z"
     },
     {
-      "rank": 935,
+      "rank": 943,
       "id": "tencent/HunyuanVideo",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HunyuanVideo",
@@ -27374,7 +27589,7 @@
       "lastModified": "2025-03-06T15:39:29.000Z"
     },
     {
-      "rank": 936,
+      "rank": 944,
       "id": "mradermacher/Mistral-Nemo-2407-12B-Thinking-Claude-Gemini-GPT5.2-Uncensored-HERETIC-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Mistral-Nemo-2407-12B-Thinking-Claude-Gemini-GPT5.2-Uncensored-HERETIC-GGUF",
@@ -27419,7 +27634,7 @@
       "lastModified": "2026-01-10T03:19:10.000Z"
     },
     {
-      "rank": 937,
+      "rank": 945,
       "id": "KyleHessling1/Qwopus-GLM-18B-Merged-GGUF",
       "author": "KyleHessling1",
       "url": "https://huggingface.co/KyleHessling1/Qwopus-GLM-18B-Merged-GGUF",
@@ -27460,7 +27675,7 @@
       "lastModified": "2026-04-20T16:48:29.000Z"
     },
     {
-      "rank": 938,
+      "rank": 946,
       "id": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
@@ -27485,7 +27700,7 @@
       "lastModified": "2025-05-29T13:13:34.000Z"
     },
     {
-      "rank": 939,
+      "rank": 947,
       "id": "z-lab/Qwen3.5-4B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-4B-DFlash",
@@ -27518,7 +27733,7 @@
       "lastModified": "2026-04-07T14:29:28.000Z"
     },
     {
-      "rank": 940,
+      "rank": 948,
       "id": "ovi054/QIE-2511-Color-Grade-Transfer-LoRA",
       "author": "ovi054",
       "url": "https://huggingface.co/ovi054/QIE-2511-Color-Grade-Transfer-LoRA",
@@ -27539,7 +27754,7 @@
       "lastModified": "2026-05-06T18:12:57.000Z"
     },
     {
-      "rank": 941,
+      "rank": 949,
       "id": "Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound",
@@ -27562,7 +27777,7 @@
       "lastModified": "2026-05-01T13:20:17.000Z"
     },
     {
-      "rank": 942,
+      "rank": 950,
       "id": "RunDiffusion/Juggernaut-XI-v11",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XI-v11",
@@ -27596,7 +27811,7 @@
       "lastModified": "2026-05-08T17:23:19.000Z"
     },
     {
-      "rank": 943,
+      "rank": 951,
       "id": "Systran/faster-whisper-large-v3",
       "author": "Systran",
       "url": "https://huggingface.co/Systran/faster-whisper-large-v3",
@@ -27641,7 +27856,7 @@
       "lastModified": "2023-11-23T09:41:12.000Z"
     },
     {
-      "rank": 944,
+      "rank": 952,
       "id": "colbert-ir/colbertv2.0",
       "author": "colbert-ir",
       "url": "https://huggingface.co/colbert-ir/colbertv2.0",
@@ -27671,7 +27886,7 @@
       "lastModified": "2024-04-05T20:18:44.000Z"
     },
     {
-      "rank": 945,
+      "rank": 953,
       "id": "FacebookAI/xlm-roberta-base",
       "author": "FacebookAI",
       "url": "https://huggingface.co/FacebookAI/xlm-roberta-base",
@@ -27716,7 +27931,7 @@
       "lastModified": "2024-02-19T12:48:21.000Z"
     },
     {
-      "rank": 946,
+      "rank": 954,
       "id": "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
@@ -27734,7 +27949,7 @@
       "lastModified": "2026-02-26T07:46:49.000Z"
     },
     {
-      "rank": 947,
+      "rank": 955,
       "id": "oongaboongahacker/Gemini-Nano",
       "author": "oongaboongahacker",
       "url": "https://huggingface.co/oongaboongahacker/Gemini-Nano",
@@ -27750,7 +27965,7 @@
       "lastModified": "2024-06-25T08:45:00.000Z"
     },
     {
-      "rank": 948,
+      "rank": 956,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -27774,7 +27989,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 949,
+      "rank": 957,
       "id": "tarn59/pixel_art_style_lora_z_image_turbo",
       "author": "tarn59",
       "url": "https://huggingface.co/tarn59/pixel_art_style_lora_z_image_turbo",
@@ -27797,7 +28012,7 @@
       "lastModified": "2025-11-30T15:16:04.000Z"
     },
     {
-      "rank": 950,
+      "rank": 958,
       "id": "drbaph/OmniVoice-bf16",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/OmniVoice-bf16",
@@ -27842,7 +28057,7 @@
       "lastModified": "2026-04-02T20:50:23.000Z"
     },
     {
-      "rank": 951,
+      "rank": 959,
       "id": "zooeyy/Style-Transfer",
       "author": "zooeyy",
       "url": "https://huggingface.co/zooeyy/Style-Transfer",
@@ -27865,7 +28080,7 @@
       "lastModified": "2026-02-06T05:28:09.000Z"
     },
     {
-      "rank": 952,
+      "rank": 960,
       "id": "google/gemma-3-12b-it-qat-q4_0-unquantized",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized",
@@ -27910,7 +28125,7 @@
       "lastModified": "2025-04-15T21:07:07.000Z"
     },
     {
-      "rank": 953,
+      "rank": 961,
       "id": "Qwen/Qwen3-Reranker-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Reranker-0.6B",
@@ -27937,7 +28152,7 @@
       "lastModified": "2026-04-16T08:55:59.000Z"
     },
     {
-      "rank": 954,
+      "rank": 962,
       "id": "nvidia/parakeet-tdt-0.6b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2",
@@ -27976,7 +28191,7 @@
       "lastModified": "2026-04-13T13:49:50.000Z"
     },
     {
-      "rank": 955,
+      "rank": 963,
       "id": "apple/DepthPro-hf",
       "author": "apple",
       "url": "https://huggingface.co/apple/DepthPro-hf",
@@ -28000,7 +28215,7 @@
       "lastModified": "2025-02-28T18:31:40.000Z"
     },
     {
-      "rank": 956,
+      "rank": 964,
       "id": "Qwen/Qwen3-ASR-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-0.6B",
@@ -28023,7 +28238,7 @@
       "lastModified": "2026-01-30T03:00:21.000Z"
     },
     {
-      "rank": 957,
+      "rank": 965,
       "id": "cstr/qwen3-asr-1.7b-GGUF",
       "author": "cstr",
       "url": "https://huggingface.co/cstr/qwen3-asr-1.7b-GGUF",
@@ -28068,7 +28283,7 @@
       "lastModified": "2026-04-11T17:41:11.000Z"
     },
     {
-      "rank": 958,
+      "rank": 966,
       "id": "TheDrummer/Cydonia-24B-v4.3",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Cydonia-24B-v4.3",
@@ -28088,7 +28303,7 @@
       "lastModified": "2025-12-17T15:08:15.000Z"
     },
     {
-      "rank": 959,
+      "rank": 967,
       "id": "tencent/HY-OmniWeaving",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-OmniWeaving",
@@ -28114,7 +28329,7 @@
       "lastModified": "2026-05-06T10:16:28.000Z"
     },
     {
-      "rank": 960,
+      "rank": 968,
       "id": "google/paligemma-3b-pt-224",
       "author": "google",
       "url": "https://huggingface.co/google/paligemma-3b-pt-224",
@@ -28157,7 +28372,7 @@
       "lastModified": "2024-09-21T10:14:25.000Z"
     },
     {
-      "rank": 961,
+      "rank": 969,
       "id": "XRXRX/X-Voice",
       "author": "XRXRX",
       "url": "https://huggingface.co/XRXRX/X-Voice",
@@ -28177,7 +28392,7 @@
       "lastModified": "2026-05-05T08:15:34.000Z"
     },
     {
-      "rank": 962,
+      "rank": 970,
       "id": "lemonyins/Qwen3.6-27B-uncensored-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-uncensored-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -28208,7 +28423,7 @@
       "lastModified": "2026-05-07T10:29:03.000Z"
     },
     {
-      "rank": 963,
+      "rank": 971,
       "id": "unsloth/Qwen3.5-397B-A17B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF",
@@ -28234,11 +28449,11 @@
       "lastModified": "2026-03-07T04:33:56.000Z"
     },
     {
-      "rank": 964,
+      "rank": 972,
       "id": "dphn/Dolphin3.0-Llama3.1-8B-GGUF",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin3.0-Llama3.1-8B-GGUF",
-      "downloads": 51086,
+      "downloads": 51594,
       "likes": 172,
       "trendingScore": 5,
       "pipelineTag": null,
@@ -28270,7 +28485,7 @@
       "lastModified": "2025-01-05T17:17:21.000Z"
     },
     {
-      "rank": 965,
+      "rank": 973,
       "id": "apple/Sharp",
       "author": "apple",
       "url": "https://huggingface.co/apple/Sharp",
@@ -28290,7 +28505,7 @@
       "lastModified": "2025-12-18T17:38:39.000Z"
     },
     {
-      "rank": 966,
+      "rank": 974,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1",
@@ -28319,7 +28534,7 @@
       "lastModified": "2026-01-31T17:47:55.000Z"
     },
     {
-      "rank": 967,
+      "rank": 975,
       "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
       "author": "Baraje",
       "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
@@ -28342,11 +28557,11 @@
       "lastModified": "2026-04-22T06:19:53.000Z"
     },
     {
-      "rank": 968,
+      "rank": 976,
       "id": "facebook/seamless-m4t-v2-large",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/seamless-m4t-v2-large",
-      "downloads": 82743,
+      "downloads": 81612,
       "likes": 982,
       "trendingScore": 5,
       "pipelineTag": "automatic-speech-recognition",
@@ -28387,7 +28602,7 @@
       "lastModified": "2024-01-04T12:48:26.000Z"
     },
     {
-      "rank": 969,
+      "rank": 977,
       "id": "BAAI/bge-large-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-large-en-v1.5",
@@ -28424,7 +28639,7 @@
       "lastModified": "2024-02-21T02:51:44.000Z"
     },
     {
-      "rank": 970,
+      "rank": 978,
       "id": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
@@ -28469,7 +28684,7 @@
       "lastModified": "2025-12-31T06:30:55.000Z"
     },
     {
-      "rank": 971,
+      "rank": 979,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
@@ -28514,7 +28729,7 @@
       "lastModified": "2026-03-20T20:50:41.000Z"
     },
     {
-      "rank": 972,
+      "rank": 980,
       "id": "nvidia/gpt-oss-120b-Eagle3-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v3",
@@ -28541,7 +28756,7 @@
       "lastModified": "2026-05-08T16:33:12.000Z"
     },
     {
-      "rank": 973,
+      "rank": 981,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2",
@@ -28572,7 +28787,7 @@
       "lastModified": "2026-05-06T17:42:34.000Z"
     },
     {
-      "rank": 974,
+      "rank": 982,
       "id": "Ardenzard/Qwen3.6-27B-DFlash-GGUF",
       "author": "Ardenzard",
       "url": "https://huggingface.co/Ardenzard/Qwen3.6-27B-DFlash-GGUF",
@@ -28604,7 +28819,7 @@
       "lastModified": "2026-04-28T17:48:00.000Z"
     },
     {
-      "rank": 975,
+      "rank": 983,
       "id": "localweights/Qwen3.6-35B-A3B-MTP-IQ4_XS-Q8nextn-GGUF",
       "author": "localweights",
       "url": "https://huggingface.co/localweights/Qwen3.6-35B-A3B-MTP-IQ4_XS-Q8nextn-GGUF",
@@ -28633,7 +28848,7 @@
       "lastModified": "2026-05-07T16:32:28.000Z"
     },
     {
-      "rank": 976,
+      "rank": 984,
       "id": "OsaurusAI/ZAYA1-8B-MXFP4",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/ZAYA1-8B-MXFP4",
@@ -28667,7 +28882,7 @@
       "lastModified": "2026-05-10T08:32:01.000Z"
     },
     {
-      "rank": 977,
+      "rank": 985,
       "id": "nvidia/audio-flamingo-next-hf",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/audio-flamingo-next-hf",
@@ -28709,7 +28924,7 @@
       "lastModified": "2026-05-13T18:38:05.000Z"
     },
     {
-      "rank": 978,
+      "rank": 986,
       "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
@@ -28734,7 +28949,7 @@
       "lastModified": "2025-02-24T03:32:35.000Z"
     },
     {
-      "rank": 979,
+      "rank": 987,
       "id": "microsoft/Florence-2-large",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Florence-2-large",
@@ -28760,11 +28975,11 @@
       "lastModified": "2025-08-04T17:09:36.000Z"
     },
     {
-      "rank": 980,
+      "rank": 988,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 228954,
+      "downloads": 217198,
       "likes": 423,
       "trendingScore": 5,
       "pipelineTag": "text-generation",
@@ -28801,7 +29016,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 981,
+      "rank": 989,
       "id": "SG161222/RealVisXL_V5.0",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/RealVisXL_V5.0",
@@ -28822,7 +29037,7 @@
       "lastModified": "2024-10-08T16:34:25.000Z"
     },
     {
-      "rank": 982,
+      "rank": 990,
       "id": "Qwen/Qwen3-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-14B",
@@ -28850,7 +29065,7 @@
       "lastModified": "2025-07-26T03:49:23.000Z"
     },
     {
-      "rank": 983,
+      "rank": 991,
       "id": "SakuraLLM/Sakura-GalTransl-14B-v3.8",
       "author": "SakuraLLM",
       "url": "https://huggingface.co/SakuraLLM/Sakura-GalTransl-14B-v3.8",
@@ -28871,7 +29086,7 @@
       "lastModified": "2025-09-11T00:06:50.000Z"
     },
     {
-      "rank": 984,
+      "rank": 992,
       "id": "HiDream-ai/HiDream-E1-1",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-E1-1",
@@ -28898,7 +29113,7 @@
       "lastModified": "2025-07-17T06:10:06.000Z"
     },
     {
-      "rank": 985,
+      "rank": 993,
       "id": "ByteDance/Ouro-1.4B",
       "author": "ByteDance",
       "url": "https://huggingface.co/ByteDance/Ouro-1.4B",
@@ -28925,7 +29140,7 @@
       "lastModified": "2026-01-18T20:38:56.000Z"
     },
     {
-      "rank": 986,
+      "rank": 994,
       "id": "google/alphagenome-all-folds",
       "author": "google",
       "url": "https://huggingface.co/google/alphagenome-all-folds",
@@ -28944,7 +29159,7 @@
       "lastModified": "2026-01-27T21:13:30.000Z"
     },
     {
-      "rank": 987,
+      "rank": 995,
       "id": "HauhauCS/Qwen3.5-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-27B-Uncensored-HauhauCS-Aggressive",
@@ -28970,7 +29185,7 @@
       "lastModified": "2026-04-05T19:00:48.000Z"
     },
     {
-      "rank": 988,
+      "rank": 996,
       "id": "F16/z-image-turbo-sda",
       "author": "F16",
       "url": "https://huggingface.co/F16/z-image-turbo-sda",
@@ -28998,11 +29213,11 @@
       "lastModified": "2026-04-09T18:43:58.000Z"
     },
     {
-      "rank": 989,
+      "rank": 997,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
-      "downloads": 4858,
+      "downloads": 4865,
       "likes": 5,
       "trendingScore": 5,
       "pipelineTag": "feature-extraction",
@@ -29025,7 +29240,7 @@
       "lastModified": "2026-05-14T09:54:39.000Z"
     },
     {
-      "rank": 990,
+      "rank": 998,
       "id": "Itau-Unibanco/NorBERTo-large",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo-large",
@@ -29047,7 +29262,7 @@
       "lastModified": "2026-04-28T13:37:01.000Z"
     },
     {
-      "rank": 991,
+      "rank": 999,
       "id": "QuantTrio/Qwen3.6-35B-A3B-AWQ",
       "author": "QuantTrio",
       "url": "https://huggingface.co/QuantTrio/Qwen3.6-35B-A3B-AWQ",
@@ -29076,7 +29291,7 @@
       "lastModified": "2026-04-17T05:10:04.000Z"
     },
     {
-      "rank": 992,
+      "rank": 1000,
       "id": "mlx-community/Qwen3.6-27B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-4bit",
@@ -29099,247 +29314,6 @@
       ],
       "createdAt": "2026-04-22T14:07:38.000Z",
       "lastModified": "2026-04-22T15:19:35.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "ertghiu256/Qwen3-4B-distill-deepseek-opus-gemini",
-      "author": "ertghiu256",
-      "url": "https://huggingface.co/ertghiu256/Qwen3-4B-distill-deepseek-opus-gemini",
-      "downloads": 235,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "text-generation-inference",
-        "unsloth",
-        "conversational",
-        "en",
-        "dataset:Jackrong/DeepSeek-V4-Distill-8000x",
-        "dataset:angrygiraffe/claude-opus-4.6-4.7-reasoning-8.7k",
-        "dataset:Roman1111111/gemini-3.1-pro-hard-high-reasoning",
-        "base_model:Qwen/Qwen3-4B",
-        "base_model:finetune:Qwen/Qwen3-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T13:46:32.000Z",
-      "lastModified": "2026-05-10T03:22:20.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "CabalResearch/Anima-Canny-Scribble-Adjustable-Control-LoRA",
-      "author": "CabalResearch",
-      "url": "https://huggingface.co/CabalResearch/Anima-Canny-Scribble-Adjustable-Control-LoRA",
-      "downloads": 152,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T19:24:43.000Z",
-      "lastModified": "2026-05-08T19:37:47.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "openbmb/MiniCPM-V-4.6-BNB",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-BNB",
-      "downloads": 575,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "minicpmv4_6",
-        "minicpm-v",
-        "multimodal",
-        "image-text-to-text",
-        "conversational",
-        "arxiv:2604.27393",
-        "arxiv:2509.18154",
-        "arxiv:2408.01800",
-        "license:apache-2.0",
-        "4-bit",
-        "bitsandbytes",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T07:09:38.000Z",
-      "lastModified": "2026-05-11T14:29:31.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "LH-Tech-AI/Quark-v2-0.5M",
-      "author": "LH-Tech-AI",
-      "url": "https://huggingface.co/LH-Tech-AI/Quark-v2-0.5M",
-      "downloads": 174,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "tiny-model",
-        "sub-1M",
-        "small",
-        "tiny",
-        "quark",
-        "1m",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T09:59:12.000Z",
-      "lastModified": "2026-05-09T10:25:44.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "Playtime-AI/LTX-2.3_Sulphur-Ball_Gag",
-      "author": "Playtime-AI",
-      "url": "https://huggingface.co/Playtime-AI/LTX-2.3_Sulphur-Ball_Gag",
-      "downloads": 0,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:43:58.000Z",
-      "lastModified": "2026-05-12T10:47:22.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "LCO-Embedding/LCO-Embedding-Omni-3B-2605",
-      "author": "LCO-Embedding",
-      "url": "https://huggingface.co/LCO-Embedding/LCO-Embedding-Omni-3B-2605",
-      "downloads": 195,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_5_omni_thinker",
-        "image-text-to-text",
-        "multimodal-embedding",
-        "feature-extraction",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T07:47:32.000Z",
-      "lastModified": "2026-05-14T23:55:13.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "intfloat/multilingual-e5-small",
-      "author": "intfloat",
-      "url": "https://huggingface.co/intfloat/multilingual-e5-small",
-      "downloads": 8435032,
-      "likes": 318,
-      "trendingScore": 5,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "pytorch",
-        "onnx",
-        "safetensors",
-        "openvino",
-        "bert",
-        "mteb",
-        "Sentence Transformers",
-        "sentence-similarity",
-        "multilingual",
-        "af",
-        "am",
-        "ar",
-        "as",
-        "az",
-        "be",
-        "bg",
-        "bn",
-        "br",
-        "bs",
-        "ca",
-        "cs",
-        "cy",
-        "da",
-        "de",
-        "el",
-        "en",
-        "eo",
-        "es",
-        "et"
-      ],
-      "createdAt": "2023-06-30T07:31:03.000Z",
-      "lastModified": "2026-04-02T02:16:05.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "google/madlad400-3b-mt",
-      "author": "google",
-      "url": "https://huggingface.co/google/madlad400-3b-mt",
-      "downloads": 471308,
-      "likes": 199,
-      "trendingScore": 5,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "t5",
-        "text2text-generation",
-        "text-generation-inference",
-        "translation",
-        "multilingual",
-        "en",
-        "ru",
-        "es",
-        "fr",
-        "de",
-        "it",
-        "pt",
-        "pl",
-        "nl",
-        "vi",
-        "tr",
-        "sv",
-        "id",
-        "ro",
-        "cs",
-        "zh",
-        "hu",
-        "ja",
-        "th",
-        "fi",
-        "fa",
-        "uk"
-      ],
-      "createdAt": "2023-11-27T15:58:33.000Z",
-      "lastModified": "2023-11-27T15:58:35.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26028507436

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.