### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-18T10:44:19Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-18T04:47:26.734Z",
+  "ts": "2026-05-18T10:44:18.975Z",
   "count": 1,
-  "durationMs": 3201,
+  "durationMs": 3083,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T04:47:23.536Z",
+  "fetchedAt": "2026-05-18T10:44:15.894Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -8,7 +8,7 @@
       "id": "TuringEnterprises/Open-MM-RL",
       "author": "TuringEnterprises",
       "url": "https://huggingface.co/datasets/TuringEnterprises/Open-MM-RL",
-      "downloads": 6089,
+      "downloads": 6695,
       "likes": 113,
       "trendingScore": 94,
       "tags": [
@@ -40,7 +40,7 @@
       "id": "PsiBotAI/SynData",
       "author": "PsiBotAI",
       "url": "https://huggingface.co/datasets/PsiBotAI/SynData",
-      "downloads": 29284,
+      "downloads": 33959,
       "likes": 138,
       "trendingScore": 91,
       "tags": [
@@ -99,8 +99,8 @@
       "id": "angrygiraffe/claude-opus-4.6-4.7-reasoning-8.7k",
       "author": "angrygiraffe",
       "url": "https://huggingface.co/datasets/angrygiraffe/claude-opus-4.6-4.7-reasoning-8.7k",
-      "downloads": 2715,
-      "likes": 121,
+      "downloads": 2923,
+      "likes": 124,
       "trendingScore": 68,
       "tags": [
         "task_categories:text-generation",
@@ -134,9 +134,9 @@
       "id": "AlienKevin/SWE-ZERO-12M-trajectories",
       "author": "AlienKevin",
       "url": "https://huggingface.co/datasets/AlienKevin/SWE-ZERO-12M-trajectories",
-      "downloads": 6550,
-      "likes": 66,
-      "trendingScore": 64,
+      "downloads": 7083,
+      "likes": 68,
+      "trendingScore": 66,
       "tags": [
         "task_categories:text-generation",
         "language:en",
@@ -364,9 +364,9 @@
       "id": "lambda/hermes-agent-reasoning-traces",
       "author": "lambda",
       "url": "https://huggingface.co/datasets/lambda/hermes-agent-reasoning-traces",
-      "downloads": 7822,
-      "likes": 320,
-      "trendingScore": 26,
+      "downloads": 7712,
+      "likes": 321,
+      "trendingScore": 27,
       "tags": [
         "task_categories:text-generation",
         "language:en",
@@ -394,6 +394,65 @@
     },
     {
       "rank": 14,
+      "id": "TeichAI/DeepSeek-v4-Pro-Agent",
+      "author": "TeichAI",
+      "url": "https://huggingface.co/datasets/TeichAI/DeepSeek-v4-Pro-Agent",
+      "downloads": 2316,
+      "likes": 31,
+      "trendingScore": 26,
+      "tags": [
+        "size_categories:1K<n<10K",
+        "format:json",
+        "format:agent-traces",
+        "modality:tabular",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "region:us",
+        "agent-traces",
+        "pi",
+        "distillation",
+        "deepseek/deepseek-v4-pro",
+        "teich"
+      ],
+      "createdAt": "2026-05-09T06:15:11.000Z",
+      "lastModified": "2026-05-12T04:27:13.000Z"
+    },
+    {
+      "rank": 15,
+      "id": "5CD-AI/Viet-Handwriting-OCR-v2",
+      "author": "5CD-AI",
+      "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
+      "downloads": 78,
+      "likes": 27,
+      "trendingScore": 25,
+      "tags": [
+        "task_categories:image-to-text",
+        "language:vi",
+        "size_categories:10K<n<100K",
+        "format:parquet",
+        "format:optimized-parquet",
+        "modality:image",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2408.12480",
+        "region:us",
+        "ocr",
+        "text-recognition",
+        "handwriting",
+        "handwriting-recognition",
+        "vietnamese"
+      ],
+      "createdAt": "2026-05-10T22:38:24.000Z",
+      "lastModified": "2026-05-10T23:25:43.000Z"
+    },
+    {
+      "rank": 16,
       "id": "nvidia/Nemotron-Image-Training-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/datasets/nvidia/Nemotron-Image-Training-v3",
@@ -417,7 +476,7 @@
       "lastModified": "2026-04-28T08:35:01.000Z"
     },
     {
-      "rank": 15,
+      "rank": 17,
       "id": "apptek-com/apptek_callcenter_dialogues",
       "author": "apptek-com",
       "url": "https://huggingface.co/datasets/apptek-com/apptek_callcenter_dialogues",
@@ -451,7 +510,7 @@
       "lastModified": "2026-05-08T22:49:17.000Z"
     },
     {
-      "rank": 16,
+      "rank": 18,
       "id": "iletisim/dezenformasyon-bultenleri",
       "author": "iletisim",
       "url": "https://huggingface.co/datasets/iletisim/dezenformasyon-bultenleri",
@@ -486,12 +545,12 @@
       "lastModified": "2026-05-03T09:10:37.000Z"
     },
     {
-      "rank": 17,
+      "rank": 19,
       "id": "Qwen/WebWorldData",
       "author": "Qwen",
       "url": "https://huggingface.co/datasets/Qwen/WebWorldData",
-      "downloads": 554,
-      "likes": 31,
+      "downloads": 576,
+      "likes": 34,
       "trendingScore": 23,
       "tags": [
         "task_categories:text-generation",
@@ -523,35 +582,36 @@
       "lastModified": "2026-05-08T12:12:49.000Z"
     },
     {
-      "rank": 18,
-      "id": "TeichAI/DeepSeek-v4-Pro-Agent",
-      "author": "TeichAI",
-      "url": "https://huggingface.co/datasets/TeichAI/DeepSeek-v4-Pro-Agent",
-      "downloads": 2256,
-      "likes": 27,
+      "rank": 20,
+      "id": "alibaba-multimodal-industrial-ai/IndustryBench",
+      "author": "alibaba-multimodal-industrial-ai",
+      "url": "https://huggingface.co/datasets/alibaba-multimodal-industrial-ai/IndustryBench",
+      "downloads": 143,
+      "likes": 23,
       "trendingScore": 22,
       "tags": [
+        "task_categories:question-answering",
+        "task_categories:text-generation",
+        "language:zh",
+        "language:en",
+        "language:ru",
+        "language:vi",
+        "license:mit",
         "size_categories:1K<n<10K",
-        "format:json",
-        "format:agent-traces",
-        "modality:tabular",
+        "format:csv",
         "modality:text",
         "library:datasets",
-        "library:dask",
+        "library:pandas",
         "library:polars",
         "library:mlcroissant",
-        "region:us",
-        "agent-traces",
-        "pi",
-        "distillation",
-        "deepseek/deepseek-v4-pro",
-        "teich"
+        "arxiv:2605.10267",
+        "region:us"
       ],
-      "createdAt": "2026-05-09T06:15:11.000Z",
-      "lastModified": "2026-05-12T04:27:13.000Z"
+      "createdAt": "2026-05-12T06:15:11.000Z",
+      "lastModified": "2026-05-13T05:23:50.000Z"
     },
     {
-      "rank": 19,
+      "rank": 21,
       "id": "Modotte/CodeX-2M-Thinking",
       "author": "Modotte",
       "url": "https://huggingface.co/datasets/Modotte/CodeX-2M-Thinking",
@@ -590,7 +650,42 @@
       "lastModified": "2026-02-10T07:23:38.000Z"
     },
     {
-      "rank": 20,
+      "rank": 22,
+      "id": "blanchon/opencs2_dataset",
+      "author": "blanchon",
+      "url": "https://huggingface.co/datasets/blanchon/opencs2_dataset",
+      "downloads": 21088,
+      "likes": 21,
+      "trendingScore": 21,
+      "tags": [
+        "task_categories:video-classification",
+        "task_categories:reinforcement-learning",
+        "task_categories:other",
+        "language:en",
+        "license:cc-by-4.0",
+        "size_categories:100K<n<1M",
+        "format:parquet",
+        "modality:tabular",
+        "modality:text",
+        "modality:video",
+        "modality:audio",
+        "library:datasets",
+        "library:pandas",
+        "library:polars",
+        "library:mlcroissant",
+        "region:us",
+        "opencs2",
+        "counter-strike-2",
+        "torchcodec",
+        "video",
+        "audio",
+        "parquet"
+      ],
+      "createdAt": "2026-05-08T00:14:06.000Z",
+      "lastModified": "2026-05-04T15:38:59.000Z"
+    },
+    {
+      "rank": 23,
       "id": "SALT-NLP/SWE-chat",
       "author": "SALT-NLP",
       "url": "https://huggingface.co/datasets/SALT-NLP/SWE-chat",
@@ -623,7 +718,7 @@
       "lastModified": "2026-04-29T15:05:22.000Z"
     },
     {
-      "rank": 21,
+      "rank": 24,
       "id": "r0b0tlab/deepseek-hermes-reasoning-traces",
       "author": "r0b0tlab",
       "url": "https://huggingface.co/datasets/r0b0tlab/deepseek-hermes-reasoning-traces",
@@ -658,7 +753,7 @@
       "lastModified": "2026-05-04T00:18:27.000Z"
     },
     {
-      "rank": 22,
+      "rank": 25,
       "id": "ShadenA/MathNet",
       "author": "ShadenA",
       "url": "https://huggingface.co/datasets/ShadenA/MathNet",
@@ -699,101 +794,6 @@
       ],
       "createdAt": "2026-04-23T20:41:46.000Z",
       "lastModified": "2026-04-27T23:48:47.000Z"
-    },
-    {
-      "rank": 23,
-      "id": "alibaba-multimodal-industrial-ai/IndustryBench",
-      "author": "alibaba-multimodal-industrial-ai",
-      "url": "https://huggingface.co/datasets/alibaba-multimodal-industrial-ai/IndustryBench",
-      "downloads": 120,
-      "likes": 20,
-      "trendingScore": 19,
-      "tags": [
-        "task_categories:question-answering",
-        "task_categories:text-generation",
-        "language:zh",
-        "language:en",
-        "language:ru",
-        "language:vi",
-        "license:mit",
-        "size_categories:1K<n<10K",
-        "format:csv",
-        "modality:text",
-        "library:datasets",
-        "library:pandas",
-        "library:polars",
-        "library:mlcroissant",
-        "arxiv:2605.10267",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T06:15:11.000Z",
-      "lastModified": "2026-05-13T05:23:50.000Z"
-    },
-    {
-      "rank": 24,
-      "id": "5CD-AI/Viet-Handwriting-OCR-v2",
-      "author": "5CD-AI",
-      "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
-      "downloads": 64,
-      "likes": 20,
-      "trendingScore": 19,
-      "tags": [
-        "task_categories:image-to-text",
-        "language:vi",
-        "size_categories:10K<n<100K",
-        "format:parquet",
-        "format:optimized-parquet",
-        "modality:image",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "arxiv:2408.12480",
-        "region:us",
-        "ocr",
-        "text-recognition",
-        "handwriting",
-        "handwriting-recognition",
-        "vietnamese"
-      ],
-      "createdAt": "2026-05-10T22:38:24.000Z",
-      "lastModified": "2026-05-10T23:25:43.000Z"
-    },
-    {
-      "rank": 25,
-      "id": "blanchon/opencs2_dataset",
-      "author": "blanchon",
-      "url": "https://huggingface.co/datasets/blanchon/opencs2_dataset",
-      "downloads": 20733,
-      "likes": 19,
-      "trendingScore": 19,
-      "tags": [
-        "task_categories:video-classification",
-        "task_categories:reinforcement-learning",
-        "task_categories:other",
-        "language:en",
-        "license:cc-by-4.0",
-        "size_categories:100K<n<1M",
-        "format:parquet",
-        "modality:tabular",
-        "modality:text",
-        "modality:video",
-        "modality:audio",
-        "library:datasets",
-        "library:pandas",
-        "library:polars",
-        "library:mlcroissant",
-        "region:us",
-        "opencs2",
-        "counter-strike-2",
-        "torchcodec",
-        "video",
-        "audio",
-        "parquet"
-      ],
-      "createdAt": "2026-05-08T00:14:06.000Z",
-      "lastModified": "2026-05-04T15:38:59.000Z"
     },
     {
       "rank": 26,
@@ -848,6 +848,30 @@
     },
     {
       "rank": 28,
+      "id": "HuggingFaceFW/fineweb",
+      "author": "HuggingFaceFW",
+      "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb",
+      "downloads": 934037,
+      "likes": 2803,
+      "trendingScore": 18,
+      "tags": [
+        "task_categories:text-generation",
+        "language:en",
+        "license:odc-by",
+        "size_categories:10B<n<100B",
+        "modality:tabular",
+        "modality:text",
+        "arxiv:2306.01116",
+        "arxiv:2109.07445",
+        "arxiv:2406.17557",
+        "doi:10.57967/hf/2493",
+        "region:us"
+      ],
+      "createdAt": "2024-04-18T14:33:13.000Z",
+      "lastModified": "2025-07-11T20:16:53.000Z"
+    },
+    {
+      "rank": 29,
       "id": "HuggingFaceFW/fineweb-edu",
       "author": "HuggingFaceFW",
       "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu",
@@ -877,7 +901,7 @@
       "lastModified": "2025-07-11T20:16:53.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "junwatu/indonesian-recipes",
       "author": "junwatu",
       "url": "https://huggingface.co/datasets/junwatu/indonesian-recipes",
@@ -907,12 +931,12 @@
       "lastModified": "2026-05-09T06:36:26.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "openai/gsm8k",
       "author": "openai",
       "url": "https://huggingface.co/datasets/openai/gsm8k",
-      "downloads": 921740,
-      "likes": 1314,
+      "downloads": 923053,
+      "likes": 1316,
       "trendingScore": 16,
       "tags": [
         "benchmark:official",
@@ -939,7 +963,7 @@
       "lastModified": "2026-03-23T10:18:13.000Z"
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "ning423/deepseek-hermes-reasoning-traces",
       "author": "ning423",
       "url": "https://huggingface.co/datasets/ning423/deepseek-hermes-reasoning-traces",
@@ -974,7 +998,7 @@
       "lastModified": "2026-05-04T00:18:27.000Z"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "AlicanKiraz0/Cybersecurity-Dataset-Fenrir-v2.1",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/datasets/AlicanKiraz0/Cybersecurity-Dataset-Fenrir-v2.1",
@@ -1001,7 +1025,7 @@
       "lastModified": "2026-04-22T10:29:32.000Z"
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "sequelbox/Tachibana4-DeepSeek-V4-Pro",
       "author": "sequelbox",
       "url": "https://huggingface.co/datasets/sequelbox/Tachibana4-DeepSeek-V4-Pro",
@@ -1044,7 +1068,7 @@
       "lastModified": "2026-05-07T01:09:32.000Z"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "cais/mmlu",
       "author": "cais",
       "url": "https://huggingface.co/datasets/cais/mmlu",
@@ -1077,31 +1101,22 @@
       "lastModified": "2024-03-08T20:36:26.000Z"
     },
     {
-      "rank": 35,
-      "id": "HuggingFaceFW/fineweb",
-      "author": "HuggingFaceFW",
-      "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb",
-      "downloads": 922535,
-      "likes": 2800,
+      "rank": 36,
+      "id": "camvsl/Articraft-10K",
+      "author": "camvsl",
+      "url": "https://huggingface.co/datasets/camvsl/Articraft-10K",
+      "downloads": 1598,
+      "likes": 16,
       "trendingScore": 15,
       "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "license:odc-by",
-        "size_categories:10B<n<100B",
-        "modality:tabular",
-        "modality:text",
-        "arxiv:2306.01116",
-        "arxiv:2109.07445",
-        "arxiv:2406.17557",
-        "doi:10.57967/hf/2493",
+        "license:cc-by-4.0",
         "region:us"
       ],
-      "createdAt": "2024-04-18T14:33:13.000Z",
-      "lastModified": "2025-07-11T20:16:53.000Z"
+      "createdAt": "2026-05-14T14:36:16.000Z",
+      "lastModified": "2026-05-15T05:05:02.000Z"
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "OwnedByDanes/Usenet-Corpus-1980-2013",
       "author": "OwnedByDanes",
       "url": "https://huggingface.co/datasets/OwnedByDanes/Usenet-Corpus-1980-2013",
@@ -1142,7 +1157,7 @@
       "lastModified": "2026-05-05T16:17:39.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "badlogicgames/pi-mono",
       "author": "badlogicgames",
       "url": "https://huggingface.co/datasets/badlogicgames/pi-mono",
@@ -1172,7 +1187,7 @@
       "lastModified": "2026-04-06T13:10:36.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
       "author": "sequelbox",
       "url": "https://huggingface.co/datasets/sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
@@ -1215,7 +1230,7 @@
       "lastModified": "2026-04-30T17:12:47.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "Inferact/codex_swebenchpro_traces",
       "author": "Inferact",
       "url": "https://huggingface.co/datasets/Inferact/codex_swebenchpro_traces",
@@ -1237,7 +1252,7 @@
       "lastModified": "2026-05-07T01:13:21.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "5551z/VisCoR_Contrast",
       "author": "5551z",
       "url": "https://huggingface.co/datasets/5551z/VisCoR_Contrast",
@@ -1260,11 +1275,11 @@
       "lastModified": "2026-04-30T01:37:13.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "llm-jp/Jagle",
       "author": "llm-jp",
       "url": "https://huggingface.co/datasets/llm-jp/Jagle",
-      "downloads": 707,
+      "downloads": 760,
       "likes": 14,
       "trendingScore": 14,
       "tags": [
@@ -1278,22 +1293,37 @@
       "lastModified": "2026-05-12T00:53:55.000Z"
     },
     {
-      "rank": 42,
-      "id": "camvsl/Articraft-10K",
-      "author": "camvsl",
-      "url": "https://huggingface.co/datasets/camvsl/Articraft-10K",
-      "downloads": 1170,
-      "likes": 15,
+      "rank": 43,
+      "id": "Exgentic/agent-llm-traces",
+      "author": "Exgentic",
+      "url": "https://huggingface.co/datasets/Exgentic/agent-llm-traces",
+      "downloads": 1386,
+      "likes": 14,
       "trendingScore": 14,
       "tags": [
-        "license:cc-by-4.0",
-        "region:us"
+        "task_categories:text-generation",
+        "language:en",
+        "license:cdla-permissive-2.0",
+        "size_categories:1K<n<10K",
+        "format:parquet",
+        "modality:tabular",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "region:us",
+        "llm",
+        "traces",
+        "opentelemetry",
+        "benchmarks",
+        "agents"
       ],
-      "createdAt": "2026-05-14T14:36:16.000Z",
-      "lastModified": "2026-05-15T05:05:02.000Z"
+      "createdAt": "2026-05-07T13:59:42.000Z",
+      "lastModified": "2026-05-14T18:50:50.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "TAAC2026/data_sample_1000",
       "author": "TAAC2026",
       "url": "https://huggingface.co/datasets/TAAC2026/data_sample_1000",
@@ -1318,7 +1348,7 @@
       "lastModified": "2026-04-10T09:07:28.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "dianetc/OBLIQ-Bench",
       "author": "dianetc",
       "url": "https://huggingface.co/datasets/dianetc/OBLIQ-Bench",
@@ -1345,36 +1375,6 @@
       ],
       "createdAt": "2026-05-06T00:10:36.000Z",
       "lastModified": "2026-05-09T18:30:15.000Z"
-    },
-    {
-      "rank": 45,
-      "id": "Exgentic/agent-llm-traces",
-      "author": "Exgentic",
-      "url": "https://huggingface.co/datasets/Exgentic/agent-llm-traces",
-      "downloads": 1356,
-      "likes": 13,
-      "trendingScore": 13,
-      "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "license:cdla-permissive-2.0",
-        "size_categories:1K<n<10K",
-        "format:parquet",
-        "modality:tabular",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "region:us",
-        "llm",
-        "traces",
-        "opentelemetry",
-        "benchmarks",
-        "agents"
-      ],
-      "createdAt": "2026-05-07T13:59:42.000Z",
-      "lastModified": "2026-05-14T18:50:50.000Z"
     },
     {
       "rank": 46,


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26028601655

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.