### PR TITLE
chore(data): refresh lobsters signals 2026-05-18T10:49:15Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T05:50:31.676Z",
+  "ts": "2026-05-18T10:49:15.460Z",
   "count": 1,
-  "durationMs": 3882,
+  "durationMs": 4342,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T05:50:27.809Z",
+  "fetchedAt": "2026-05-18T10:49:11.132Z",
   "windowDays": 7,
   "scannedStories": 79,
   "mentions": {
@@ -197,14 +197,14 @@
     },
     "sander110419/lightroom-cc-on-linux": {
       "count7d": 1,
-      "scoreSum7d": 21,
+      "scoreSum7d": 23,
       "topStory": {
         "shortId": "l34yuj",
         "title": "Claude Code managed to get Adobe Lightroom working on Linux",
-        "score": 21,
+        "score": 23,
         "url": "https://github.com/sander110419/lightroom-cc-on-linux",
         "commentsUrl": "https://lobste.rs/s/l34yuj/claude_code_managed_get_adobe_lightroom",
-        "hoursSincePosted": 16.870555555555555
+        "hoursSincePosted": 21.849444444444444
       },
       "stories": [
         {
@@ -213,11 +213,11 @@
           "url": "https://github.com/sander110419/lightroom-cc-on-linux",
           "commentsUrl": "https://lobste.rs/s/l34yuj/claude_code_managed_get_adobe_lightroom",
           "by": "",
-          "score": 21,
+          "score": 23,
           "commentCount": 4,
           "createdUtc": 1779022693,
-          "ageHours": 16.870555555555555,
-          "trendingScore": 0.25617825646357734,
+          "ageHours": 21.849444444444444,
+          "trendingScore": 0.19747423298236724,
           "tags": [
             "linux",
             "vibecoding"
@@ -449,7 +449,7 @@
     {
       "fullName": "sander110419/lightroom-cc-on-linux",
       "count7d": 1,
-      "scoreSum7d": 21
+      "scoreSum7d": 23
     },
     {
       "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T05:50:27.809Z",
+  "fetchedAt": "2026-05-18T10:49:11.132Z",
   "windowHours": 72,
   "scannedTotal": 79,
   "stories": [
@@ -274,6 +274,25 @@
       "linkedRepos": []
     },
     {
+      "shortId": "ynxkj6",
+      "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
+      "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
+      "commentsUrl": "https://lobste.rs/s/ynxkj6/researcher_says_microsoft_secretly",
+      "by": "",
+      "score": 38,
+      "commentCount": 4,
+      "createdUtc": 1779073563,
+      "ageHours": 7.7188888888888885,
+      "trendingScore": 1.2541765347097873,
+      "tags": [
+        "programming",
+        "security",
+        "windows"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "neclbs",
       "title": "Native all the way, until you need text",
       "url": "https://justsitandgrin.im/posts/native-all-the-way-until-you-need-text/",
@@ -346,25 +365,6 @@
       "trendingScore": 1.1700683971771915,
       "tags": [
         "linux"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "ynxkj6",
-      "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
-      "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
-      "commentsUrl": "https://lobste.rs/s/ynxkj6/researcher_says_microsoft_secretly",
-      "by": "",
-      "score": 12,
-      "commentCount": 0,
-      "createdUtc": 1779073563,
-      "ageHours": 2.74,
-      "trendingScore": 1.1628233219610766,
-      "tags": [
-        "programming",
-        "security",
-        "windows"
       ],
       "description": "",
       "linkedRepos": []
@@ -831,6 +831,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "ap9dum",
+      "title": "Find bugs in YOUR code using OpenCode, Llama.cpp and Qwen3.6",
+      "url": "http://wtarreau.blogspot.com/2026/05/find-bugs-in-your-code-using-opencode.html",
+      "commentsUrl": "https://lobste.rs/s/ap9dum/find_bugs_your_code_using_opencode_llama",
+      "by": "",
+      "score": 4,
+      "commentCount": 1,
+      "createdUtc": 1779097884,
+      "ageHours": 0.9630555555555556,
+      "trendingScore": 0.784242365958901,
+      "tags": [
+        "debugging",
+        "vibecoding"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "qbliwt",
       "title": "wayland.fyi minimalist wayland special interest group",
       "url": "https://wayland.fyi/",
@@ -878,25 +896,6 @@
       "trendingScore": 0.7779888843127277,
       "tags": [
         "design"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "nbceks",
-      "title": "Volkswagen- detects when your tests are being run in a CI server, and makes them pass (2015)",
-      "url": "https://github.com/auchenberg/volkswagen",
-      "commentsUrl": "https://lobste.rs/s/nbceks/volkswagen_detects_when_your_tests_are",
-      "by": "",
-      "score": 7,
-      "commentCount": 3,
-      "createdUtc": 1778834424,
-      "ageHours": 2.3466666666666667,
-      "trendingScore": 0.7724378297860046,
-      "tags": [
-        "javascript",
-        "satire",
-        "testing"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -192861,3 +192861,8 @@
 {"source":"devto","fullName":"docling-project/docling-serve","observedAt":"2026-05-18T10:09:50.074Z"}
 {"source":"devto","fullName":"fasterxml/jackson","observedAt":"2026-05-18T10:09:50.074Z"}
 {"source":"devto","fullName":"nees-anna/nees-core-developer-preview","observedAt":"2026-05-18T10:09:50.074Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-18T10:49:14.057Z"}
+{"source":"lobsters","fullName":"greenm01/triad","observedAt":"2026-05-18T10:49:14.057Z"}
+{"source":"lobsters","fullName":"sbz/keygen","observedAt":"2026-05-18T10:49:14.057Z"}
+{"source":"lobsters","fullName":"orinimron123/cve-2026-40369-exploit","observedAt":"2026-05-18T10:49:14.057Z"}
+{"source":"lobsters","fullName":"ortegaalfredo/vulns-ai","observedAt":"2026-05-18T10:49:14.057Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26028829306

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.