### PR TITLE
chore(data): refresh huggingface space signals 2026-05-18T10:49:18Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-18T04:53:05.785Z",
+  "ts": "2026-05-18T10:49:18.659Z",
   "count": 1,
-  "durationMs": 4664,
+  "durationMs": 5279,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T04:53:01.124Z",
+  "fetchedAt": "2026-05-18T10:49:13.382Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -25,8 +25,8 @@
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/spaces/TencentARC/Pixal3D",
-      "likes": 153,
-      "trendingScore": 140,
+      "likes": 159,
+      "trendingScore": 146,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -78,8 +78,8 @@
       "id": "r3gm/wan2-2-fp8da-aoti-preview-2",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview-2",
-      "likes": 1173,
-      "trendingScore": 129,
+      "likes": 1225,
+      "trendingScore": 130,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -95,8 +95,8 @@
       "id": "mikeee/qwen-7b-chat",
       "author": "mikeee",
       "url": "https://huggingface.co/spaces/mikeee/qwen-7b-chat",
-      "likes": 262,
-      "trendingScore": 103,
+      "likes": 266,
+      "trendingScore": 104,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -111,8 +111,8 @@
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/spaces/Supertone/supertonic-3",
-      "likes": 115,
-      "trendingScore": 95,
+      "likes": 126,
+      "trendingScore": 104,
       "sdk": "static",
       "tags": [
         "static",
@@ -123,7 +123,7 @@
         "region:us"
       ],
       "createdAt": "2026-05-06T20:45:18.000Z",
-      "lastModified": "2026-05-06T20:35:37.000Z",
+      "lastModified": "2026-05-18T10:24:16.000Z",
       "models": []
     },
     {
@@ -161,6 +161,22 @@
     },
     {
       "rank": 10,
+      "id": "techfreakworm/LTX2.3-Studio",
+      "author": "techfreakworm",
+      "url": "https://huggingface.co/spaces/techfreakworm/LTX2.3-Studio",
+      "likes": 108,
+      "trendingScore": 71,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-01T05:41:26.000Z",
+      "lastModified": "2026-05-13T18:07:02.000Z",
+      "models": []
+    },
+    {
+      "rank": 11,
       "id": "r3gm/wan2-2-fp8da-aoti-preview",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview",
@@ -177,7 +193,7 @@
       "models": []
     },
     {
-      "rank": 11,
+      "rank": 12,
       "id": "kulkas2pintu/wan222",
       "author": "kulkas2pintu",
       "url": "https://huggingface.co/spaces/kulkas2pintu/wan222",
@@ -194,23 +210,23 @@
       "models": []
     },
     {
-      "rank": 12,
-      "id": "techfreakworm/LTX2.3-Studio",
-      "author": "techfreakworm",
-      "url": "https://huggingface.co/spaces/techfreakworm/LTX2.3-Studio",
-      "likes": 103,
-      "trendingScore": 67,
+      "rank": 13,
+      "id": "ysharma/fast-image-studio",
+      "author": "ysharma",
+      "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
+      "likes": 78,
+      "trendingScore": 63,
       "sdk": "gradio",
       "tags": [
         "gradio",
         "region:us"
       ],
-      "createdAt": "2026-05-01T05:41:26.000Z",
-      "lastModified": "2026-05-13T18:07:02.000Z",
+      "createdAt": "2026-04-29T14:15:57.000Z",
+      "lastModified": "2026-04-30T12:10:32.000Z",
       "models": []
     },
     {
-      "rank": 13,
+      "rank": 14,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/spaces/k2-fsa/OmniVoice",
@@ -226,27 +242,27 @@
       "models": []
     },
     {
-      "rank": 14,
-      "id": "ysharma/fast-image-studio",
-      "author": "ysharma",
-      "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
-      "likes": 72,
+      "rank": 15,
+      "id": "ResembleAI/Dramabox",
+      "author": "ResembleAI",
+      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
+      "likes": 57,
       "trendingScore": 57,
       "sdk": "gradio",
       "tags": [
         "gradio",
         "region:us"
       ],
-      "createdAt": "2026-04-29T14:15:57.000Z",
-      "lastModified": "2026-04-30T12:10:32.000Z",
+      "createdAt": "2026-04-28T05:09:42.000Z",
+      "lastModified": "2026-05-14T10:06:44.000Z",
       "models": []
     },
     {
-      "rank": 15,
+      "rank": 16,
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
-      "likes": 1442,
+      "likes": 1444,
       "trendingScore": 55,
       "sdk": "gradio",
       "tags": [
@@ -259,7 +275,24 @@
       "models": []
     },
     {
-      "rank": 16,
+      "rank": 17,
+      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
+      "author": "cbensimon",
+      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
+      "likes": 59,
+      "trendingScore": 55,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:08:17.000Z",
+      "lastModified": "2026-05-14T11:52:10.000Z",
+      "models": []
+    },
+    {
+      "rank": 18,
       "id": "zerogpu-aoti/wan2-2-fp8da-aoti-faster",
       "author": "zerogpu-aoti",
       "url": "https://huggingface.co/spaces/zerogpu-aoti/wan2-2-fp8da-aoti-faster",
@@ -273,39 +306,6 @@
       ],
       "createdAt": "2025-07-30T19:03:28.000Z",
       "lastModified": "2025-12-16T14:37:58.000Z",
-      "models": []
-    },
-    {
-      "rank": 17,
-      "id": "ResembleAI/Dramabox",
-      "author": "ResembleAI",
-      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 54,
-      "trendingScore": 54,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T05:09:42.000Z",
-      "lastModified": "2026-05-14T10:06:44.000Z",
-      "models": []
-    },
-    {
-      "rank": 18,
-      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
-      "author": "cbensimon",
-      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 55,
-      "trendingScore": 51,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:08:17.000Z",
-      "lastModified": "2026-05-14T11:52:10.000Z",
       "models": []
     },
     {
@@ -558,8 +558,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 33,
-      "trendingScore": 28,
+      "likes": 35,
+      "trendingScore": 29,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -575,8 +575,8 @@
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
-      "likes": 7382,
-      "trendingScore": 27,
+      "likes": 7385,
+      "trendingScore": 28,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -584,7 +584,7 @@
         "region:us"
       ],
       "createdAt": "2022-09-29T11:29:23.000Z",
-      "lastModified": "2026-05-13T18:43:10.000Z",
+      "lastModified": "2026-05-17T23:26:26.000Z",
       "models": []
     },
     {
@@ -776,6 +776,22 @@
     },
     {
       "rank": 47,
+      "id": "Lakonik/AsymFLUX.2-klein",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
+      "likes": 19,
+      "trendingScore": 19,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:06:55.000Z",
+      "lastModified": "2026-05-14T02:05:05.000Z",
+      "models": []
+    },
+    {
+      "rank": 48,
       "id": "lerobot/visualize_dataset",
       "author": "lerobot",
       "url": "https://huggingface.co/spaces/lerobot/visualize_dataset",
@@ -791,7 +807,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "openai/privacy-filter",
       "author": "openai",
       "url": "https://huggingface.co/spaces/openai/privacy-filter",
@@ -807,7 +823,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
@@ -820,22 +836,6 @@
       ],
       "createdAt": "2025-12-09T19:01:39.000Z",
       "lastModified": "2026-03-13T17:12:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "Lakonik/AsymFLUX.2-klein",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
-      "likes": 18,
-      "trendingScore": 18,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:06:55.000Z",
-      "lastModified": "2026-05-14T02:05:05.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26028830360

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.