### PR TITLE
chore(data): refresh mcp liveness 2026-05-18T10:51:22Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T04:59:42.077Z",
+  "fetchedAt": "2026-05-18T10:51:18.540Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -33,15 +33,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "martin111ma-za5d/swiss-truth-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "rashforddamion/rivalsearch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "deniselewis200081/rail": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -49,11 +41,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aryankeluskar/polymarket-mcp": {
+    "martin111ma-za5d/swiss-truth-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "heather-macavelia/ai-agent-index": {
+    "deniselewis200081/rail": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aryankeluskar/polymarket-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -61,15 +57,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "fabsforward2-zhoi/sbb-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "agentmail": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "re-rank/uiux-mcp": {
+    "heather-macavelia/ai-agent-index": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "fabsforward2-zhoi/sbb-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gvzq/flight-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -81,11 +81,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "gvzq/flight-mcp": {
+    "re-rank/uiux-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ayni-protocol/ayni": {
+    "hugeicons/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -97,15 +97,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "bh-rat/context-awesome": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "microsoft/learn_mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "quantoracle/quantoracle": {
+    "bh-rat/context-awesome": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -113,15 +109,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "icons8community/icons8mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "brave": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "cloud101.kr/cloud101kr": {
+    "icons8community/icons8mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ayni-protocol/ayni": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -137,7 +133,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hugeicons/mcp-server": {
+    "quantoracle/quantoracle": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -149,23 +145,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rfi-irfos/ternlang": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hola-ps65/siil-ostomy-store": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "linxule/mcp-music-studio": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "blockscout/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sigai/cancersupport": {
+    "rfi-irfos/ternlang": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cloud101.kr/cloud101kr": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -181,19 +169,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hjsh200219/fortuneteller": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "supabase": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "theconstructionstandard/the-construction-standard": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "isdaniel/mcp_weather_server": {
+    "etweisberg/mlb-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -201,7 +181,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "minitim222/harvard-mit-course-recommendation": {
+    "hjsh200219/fortuneteller": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -213,7 +193,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "info-g03l/catalunya-2022": {
+    "minitim222/harvard-mit-course-recommendation": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sigai/cancersupport": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -221,15 +205,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "waldzellai/clear-thought": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "imviky-zzzr/tickerr-live-status": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "davidcho/ca-building-code-mcp": {
+    "isdaniel/mcp_weather_server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -241,7 +217,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "alexandria-shai-eden/caselaw": {
+    "davidcho/ca-building-code-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "info-g03l/catalunya-2022": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -249,19 +229,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "alexandria-shai-eden/caselaw": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "linxule/mcp-music-studio": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "strale-io/strale": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "etweisberg/mlb-mcp": {
+    "waldzellai/clear-thought": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "googledrive": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hellokitty-v/smithery-mcp-servers": {
+    "theconstructionstandard/the-construction-standard": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -269,15 +253,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "hola-ps65/siil-ostomy-store": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "googledrive": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "tbakerx/instant-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "code-rabi/littlesis-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ucpchecker/ucp-checker": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -285,31 +269,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "modellix/modellix-docs": {
+    "code-rabi/littlesis-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jon-ag46/troystack": {
+    "imviky-zzzr/tickerr-live-status": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "linxule/lotus-wisdom-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "artvepa80/hefestoai": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "maximumsats/maximumsats": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "chuhuoyuan/cloudflare": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arizeai/docs": {
+    "hellokitty-v/smithery-mcp-servers": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -317,11 +285,31 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "agonzalez/prueba-mcp-seeker": {
+    "modellix/modellix-docs": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jarvis-stark1985/superhero-mcp-server": {
+    "maximumsats/maximumsats": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jon-ag46/troystack": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "chuhuoyuan/cloudflare": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ucpchecker/ucp-checker": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "arizeai/docs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "artvepa80/hefestoai": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -333,10 +321,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "glassnode/glassnode-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "exa-labs/websets-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
@@ -345,11 +329,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "nekzus/npm-sentinel-mcp": {
+    "jarvis-stark1985/superhero-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "glassnode/glassnode-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
     "apogeoapi/apogeoapi-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nekzus/npm-sentinel-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -365,11 +357,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "sfiorini/youtube-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "jina": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sfiorini/youtube-mcp": {
+    "blake365/macrostrat-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -381,19 +377,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "parallel/search": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "pinkpixel-dev/web-scout-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "blake365/macrostrat-mcp": {
+    "parallel/search": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "trello": {
+    "kkjdaniel/bgg-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agonzalez/prueba-mcp-seeker": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -401,15 +397,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "linxule/lotus-wisdom-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "bopmarket/marketplace": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "linell/grimoire-mcp": {
+    "googletasks": {
       "isStdio": true,
       "livenessInferred": true
     },
     "smithery-ai/national-weather-service": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "linell/grimoire-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -421,19 +425,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "contrastcyber/contrastapi": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "jacksmith3888/wuwa-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "faresyoussef94/aws-knowledge-mcp": {
+    "trello": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "googletasks": {
+    "contrastcyber/contrastapi": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -441,11 +441,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "agentidx/zarq-risk": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kkjdaniel/bgg-mcp": {
+    "faresyoussef94/aws-knowledge-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -453,11 +449,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "onetrip/pulse": {
+    "gamzadongza/danbooru-tags-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "gamzadongza/danbooru-tags-mcp": {
+    "onetrip/pulse": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -465,15 +461,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "wtf-just-happened/stock-moves-explained": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "king-of-the-grackles/discourse-forum-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "tavily": {
+    "node2flow/binance": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wtf-just-happened/stock-moves-explained": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -485,7 +481,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "node2flow/binance": {
+    "tavily": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -497,11 +493,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "agentidx/zarq-risk": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "googlesuper": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "rubenayla/partle": {
+    "sgroy10/speclock": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -509,7 +509,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "sgroy10/speclock": {
+    "convrgent/aeo-scanner": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -521,7 +521,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "outlook": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "fibonex/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rubenayla/partle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hirofumitorato/japan-ani-search-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -533,19 +545,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hirofumitorato/japan-ani-search-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "cyberweasel777/botindex-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
     "glmarket2007-m1qh/gyotak-fish-market": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ing-christopherleon/preciomx": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -557,19 +561,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rbxwilliams/tmcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "agentpact/marketplace": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/la-final": {
+    "ing-christopherleon/preciomx": {
       "isStdio": true,
       "livenessInferred": true
     },
     "greetwell/travel": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "santiago.blanco.vilchez/la-final": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -581,19 +585,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/aaa": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fruitflies/connect": {
+    "rbxwilliams/tmcp": {
       "isStdio": true,
       "livenessInferred": true
     },
     "huangmy157/ddd": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "howard-eridani/spark": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -605,11 +601,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "apideck/mcp-server": {
+    "seahbk1006/seahboonkeong-chat-bnmapi": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "seahbk1006/seahboonkeong-chat-bnmapi": {
+    "apideck/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -617,19 +613,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "howard-eridani/spark": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "outtolunch/outtolunch": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "cuthongthai/vimo-financial-intelligence": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aparajithn/agent-utils": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "christos/eoa-intermediaries": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "fruitflies/connect": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jthora/archangel-agency-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -641,7 +641,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "actiongate/actiongate": {
+    "aws/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -649,7 +649,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aws/docs": {
+    "aparajithn/agent-utils": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -661,15 +661,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "cuthongthai/vimo-financial-intelligence": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "actiongate/actiongate": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "jalpp/chessagine": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "naimterrache/bjj-belt-progress": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ateam-ai/ateam": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -681,7 +681,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "flashalpha/options-analytics": {
+    "ateam-ai/ateam": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "santiago.blanco.vilchez/aaa": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -697,23 +701,27 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "arabimaak/gulf-arabic": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "icons8community/icons8mpc": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aparajithn/agent-utils-mcp-new": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "plith/plith": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "info-kk33/askmia_app": {
+    "arabimaak/gulf-arabic": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "naimterrache/bjj-belt-progress": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zerion/zerion-api": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mcpdotdirect/starknet-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aparajithn/agent-utils-mcp-new": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -725,11 +733,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "mansamarkets/mansa": {
+    "icons8community/icons8mpc": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "aigen/defi-data": {
+    "flashalpha/options-analytics": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -737,15 +745,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "forage-shopping/forage-shopping": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "getkin/agent-infrastructure": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "mcpdotdirect/starknet-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "forage-shopping/forage-shopping": {
+    "info-kk33/askmia_app": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -753,11 +761,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "saju-from-seoul/saju": {
+    "aigen/defi-data": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "secureship/docs": {
+    "mansamarkets/mansa": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "vestara/america-law-graph": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "saju-from-seoul/saju": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -781,15 +797,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "eren-solutions/report-needs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "garfield-bb/hap_paas2025": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "reitsmasieto-wq/overcome-stress": {
+    "secureship/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -797,11 +809,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "petabloom/podcasts": {
+    "reitsmasieto-wq/overcome-stress": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "infobip-mcp/search": {
+    "petabloom/podcasts": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -813,10 +825,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "underground-district/ucd-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "composio/context7": {
       "isStdio": true,
       "livenessInferred": true
@@ -825,11 +833,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rabqatab/lexlink-ko-mcp": {
+    "dhanyyudi/bmkg-id": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "dhanyyudi/bmkg-id": {
+    "infobip-mcp/search": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -841,19 +849,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "imhiroki/toolrank": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "lightpaper/lightpaper": {
       "isStdio": true,
       "livenessInferred": true
     },
     "chirag127/clear-thought-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "santiago.blanco.vilchez/aaav": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -865,7 +865,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "rabqatab/lexlink-ko-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "arjunkmrm/devin": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "santiago.blanco.vilchez/aaav": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -877,11 +885,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "eren-solutions/report-needs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ckbk/subwayinfo-nyc": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "intake-triage/steadyfetch": {
+    "underground-district/ucd-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "imhiroki/toolrank": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -909,11 +925,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/santiago-cpa": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rahular101/test-101": {
+    "florian/weavely": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -929,6 +941,18 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "santiago.blanco.vilchez/santiago-cpa": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rahular101/test-101": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aas-ee/open-websearch": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "safeagent/token-safety": {
       "isStdio": true,
       "livenessInferred": true
@@ -937,15 +961,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "intake-triage/steadyfetch": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "santiago.blanco.vilchez/asd": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "nicks-brn/promptscan": {
+    "carscout/carscout": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "plainyogurt21/clintrials-mcp": {
+    "atiprashant/buyhatke-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -953,7 +981,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "atars-mcp/aarnaai": {
+    "plainyogurt21/clintrials-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -961,7 +989,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "atars-mcp/aarnaai": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "petrsovadina/sukl-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nicks-brn/promptscan": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -981,15 +1017,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ebenova/legal-docs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "ahmed2real/thinkzone": {
       "isStdio": true,
       "livenessInferred": true
     },
     "preetrajdeo/autoapply-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ebenova/legal-docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1013,10 +1049,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hashirsiddiqui15/ami-bookstore-mcp-h": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "iamalexander/readwise-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -1025,7 +1057,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "feedbk-ai/mcp-server": {
+    "hashirsiddiqui15/ami-bookstore-mcp-h": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1049,6 +1081,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "feedbk-ai/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "peerpush/peerpush_mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -1057,11 +1093,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "koumoul/opendata": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "alex-kenny-lee-vfjv/panko-food-safety": {
       "isStdio": true,
       "livenessInferred": true
     },
     "benzsevern/devpilot": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "easyreg/private-number-plates": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1117,11 +1161,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rafsilva85/skillflow": {
+    "mgao/jobdatalake": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "mgao/jobdatalake": {
+    "rafsilva85/skillflow": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1149,11 +1193,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "vdineshk/sg-gst-calculator-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "refund-decide/notary": {
+    "henry-ships/sparkforge": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1169,7 +1209,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "vdineshk/sg-cpf-calculator-mcp": {
+    "refund-decide/notary": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "refetch/web": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "vdineshk/sg-gst-calculator-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1177,7 +1225,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "refetch/web": {
+    "vdineshk/sg-cpf-calculator-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1189,11 +1237,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "nageshyp/vsf-club": {
+    "autonsol/sol-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
     "nicholasemccormick/meetsync-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nageshyp/vsf-club": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1245,19 +1297,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "luis.ticas1/vsfclub2": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "conner-m4el/helium-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "srimaan.yarram/vsfclubmcpsrimaan": {
+    "luis.ticas1/vsfclub2": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kishore.venkata.m/weathermcpmvk": {
+    "srimaan.yarram/vsfclubmcpsrimaan": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1270,6 +1318,10 @@
       "livenessInferred": true
     },
     "luis.ticas1/vsfclub4": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kishore.venkata.m/weathermcpmvk": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1286,6 +1338,10 @@
       "livenessInferred": true
     },
     "hypnoticmeditations/meditation-recommender": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "myceliumlabs/prospector-mcp-email-finder": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1329,15 +1385,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "evan-follis-u0ll/preflight": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "satoshidata/wallet-intelligence": {
       "isStdio": true,
       "livenessInferred": true
     },
     "victor/musashi": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "evan-follis-u0ll/preflight": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1401,11 +1457,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "seizedata/trx-categorization-mcp": {
+    "cyanheads/openalex-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "cyanheads/openalex-mcp-server": {
+    "seizedata/trx-categorization-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1417,11 +1473,31 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "vivid/vivid-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "govbase/govbase": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ralf/fyndling": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "vinaybhosle/shippingrates-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "luis.ticas1/vsfclub3": {
       "isStdio": true,
       "livenessInferred": true
     },
     "swamy.fwd/av-weatheropen-api-secure": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mountainmystic/hederatoolbox": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1438,10 +1514,6 @@
       "livenessInferred": true
     },
     "spajjuri.pro/vsfclubnew6": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vivid/vivid-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1557,407 +1629,175 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "0x01feng/flowspec mcp": {
+    "fabio662/yield agentic hub": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "amilcarex/strapi mcp suite": {
+    "code-yeongyu/lsp-tools-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "randallt21/monarch money mcp server": {
+    "solomonneas/reelgrep-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "fdslk/wechat-mp-mcp": {
+    "forgemeshlabs/forgemesh-imagegen": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "arqawa/code_nav mcp": {
+    "thinhbv/tradingview mcp bridge": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "geekmai90/ticktick mcp cli": {
+    "tszaks/keynote-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "leandrosflora/consignado mcp local": {
+    "oaslananka/reflow-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ambermem/amber": {
+    "vidhijav/myrsu mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "theriz78/custom-browser-mcp": {
+    "actalumen/@actalumen/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "formswrite/formswrite mcp": {
+    "lucs1590/study-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "panelica/panelica-mcp": {
+    "dimitrispasakaleris/whatsapp mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "vinades/mcp-dauthau": {
+    "dimitrispasakaleris/gmail-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "dtrain473/strava mcp server": {
+    "sfluv/sfluv-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kage1020/docs-mcp": {
+    "rglgg/rgl-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "whitehornltd/ibmi-mcp": {
+    "mrchartist/x algorithm toolkit": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jagoff/obsidian-mcp-complete": {
+    "hopkdj/fenshitu mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "shaktisinhchavda/memory-mcp": {
+    "elliotttate/pix-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "livshitz/mcp-github": {
+    "gnanam1990/kitepass-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "parkviewlab/ebony-enriching": {
+    "cledupe/csv mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "multivon-ai/multivon-mcp": {
+    "pawel-up/lupa mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "nikhilgogulwar/universalbench-mcp": {
+    "mrnewdelhi/mailosaur mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "aigen-protocol/aigen protocol": {
+    "musadev147/antigravity mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "makeamouse/fish-bridge-mcp": {
+    "ai.autorfp/mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "raya2912/newsletter generator": {
+    "spacemolt/gameserver": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "qelos-io/@qelos/better-mcp": {
+    "janmacher02-xl8y/sec-edgar-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "zw-awa/ssh-session-mcp": {
+    "cyanheads/clinicaltrialsgov-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "cap-of-tea/gdd (giggly-dazzling-duckling)": {
+    "turbopuffer": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "mehdisakalypr-cpu/@gapup/mcp-knowledge": {
+    "secondsim/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "mcpcatalogs/mcpcatalogs": {
+    "himalayas/himalayas-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "drolosoft/go-docs-mcp": {
+    "ghostrouter/ghostrouter-web": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "goyalnikhil02/github oauth mcp server": {
+    "leonid-rise/base44-sdk-docs": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "destiner/faucet-mcp": {
+    "rei02061986/patent-space-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "skroes/whisper-mcp": {
+    "skymoore/grokipedia-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "maxkuminov/obsidian mcp (pgvector + ollama, self-hosted)": {
+    "cameronapak/free-use-bible-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "svharivinod/tallyprime mcp server": {
+    "aleatoric/causal-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "piquesignal/pique signal": {
+    "docfork/mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "lordbasilaiassistant-sudo/mcpagent": {
+    "clickhouse": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sharpdogs/mcp db server": {
+    "clarityai": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "x0base/mcp-security-toolkit": {
+    "youtube": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "khalidsat/mcp-opencode-blender": {
+    "googlecalendar": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "yesidevelop/acme operations assistant": {
+    "browserbase": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "lliwi/mcp osint server": {
+    "notion": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "decksaga/market pulse mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kaminari-ad/@kaminari-ad/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pasteai/pasteai": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "proplineapi/propline": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shomechakraborty/scientific tools mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thinkcol/lenx mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "influqa/cryptoagentmail": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "doorman11991/budget-aware-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "artkeyai/bhived": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "blackwell-systems/knowing": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "timwal78/mcp-paywall": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "coding-dev-tools/click-to-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "guimaster97/markdown web scraper api": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mountainmystic/hederatoolbox": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vinaybhosle/shippingrates-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ralf/fyndling": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "myceliumlabs/prospector-mcp-email-finder": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "govbase/govbase": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "easyreg/private-number-plates": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "zerion/zerion-api": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "koumoul/opendata": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "autonsol/sol-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "henry-ships/sparkforge": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vestara/america-law-graph": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aas-ee/open-websearch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "carscout/carscout": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "florian/weavely": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "atiprashant/buyhatke-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "convrgent/aeo-scanner": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "outlook": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jaxsbr/local_lense": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sam-david/postgres-safe-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "demeostep/postgresql mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fred-drake/gmail mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "finedesignz/cj mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rahulpowar/prismic content mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "eliasbiondo/reddit mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "danielkristofik/claude-tws-connect": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "keepgoing-dev/keepgoing mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "schwarztim/cimc-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "josetapiauex/youtube video downloader mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "amarisaster/discord cloud mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "gwbischof/keila-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mvacaporale/claude usage mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "easyhak/youtube search & download mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "timepointai/timepoint mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "darrenoakey/daz command mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alvis1337/elitepvpers sro pserver mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aaronmeis/dice mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "xelber/new relic mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "caol64/wenyan mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "nhannpl/winnipeg city mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rowlando/coros-workout-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shubby98/email-insights": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "steiner385/mcp github issue priority server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "devirokkam/task mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "evilbuck/hackernews job scraper": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "forloopcodes/context+": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "izyuumi/find library mcp server": {
+    "github": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3613,10 +3453,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "jthora/archangel-agency-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "heznpc/iconnect-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -3998,6 +3834,170 @@
       "livenessInferred": true
     },
     "cleburn/aegis mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "castrillon89/siigo mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "neuzhou/mcphub": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "n24q02m/better telegram mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hongnoul/mit-dining-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "authensor/authensor-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nextlevelbuilder/goclaw mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "itunified-io/mcp-cloudflare": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "itunified-io/mcp-opnsense": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "itunified-io/mcp-tailscale": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "0xbrainkid/agentfolio-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wiseriaai/lucid-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jayden-dong/mcphub": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gunjankum06/mypostmanserver": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gaopengbin/cesium-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rafapra3008/lu-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "servicialo/servicialo": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "iseppo/e-arveldaja mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "toadlybroodle/satring-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/teladoc mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dadcz/aitop club": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ebbfijsf/agent-reader": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "victorgulchenko/mimiq mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sonaiengine/graph-tool-call": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "0xzcov/mcp-omnifun": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/mtg-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "i-can-hack/pdf-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dan24ou-cpu/palate-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "transparentlyok/mcp context manager": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "davidsimoes/digisign-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "amcharts/amcharts 5 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "feedoracle/feedoracle compliance mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "stackbilt-dev/stackbilt": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markgregg/low-code ui mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "smart-mcp-proxy/mcpproxy-go": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pantagrueliste/tei-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ajitpratap0/gosqlx": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "timkulbaev/mcp-linkedin": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "custodia-admin/pagebolt": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/lego-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wecantdoit/magni mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "iris-eval/iris-eval/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26028925459

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.