### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-18T12:50:23Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-18T08:55:50.155Z",
+  "generatedAt": "2026-05-18T12:50:23.436Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26034517523

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.