### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-18T14:37:51Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-18T00:07:02.664Z",
+  "ts": "2026-05-18T14:37:51.154Z",
   "count": 1,
-  "durationMs": 11525,
+  "durationMs": 14464,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-18T00:06:59.708Z",
+  "lastFetchedAt": "2026-05-18T14:37:47.856Z",
   "windowDays": 7,
   "launches": [
     {
@@ -936,6 +936,36 @@
       "aiAdjacent": false
     },
     {
+      "id": "1124409",
+      "name": "SocLeads 3.0",
+      "tagline": "Scrape emails from socials and maps by location",
+      "description": "SocLeads now scrapes emails from Instagram, Facebook, LinkedIn, YouTube, and Google Maps across entire countries 🌍📧 Geo-filters. More results. No code needed. 🚀",
+      "url": "https://www.producthunt.com/products/socleads?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ALZHOD7ZH2TWYV",
+      "votesCount": 259,
+      "commentsCount": 58,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/9443342b-bf19-49c4-8423-5e1db1415f15.jpeg?auto=format",
+      "topics": [
+        "email",
+        "social-media",
+        "marketing"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1050396",
       "name": "Genpire",
       "tagline": "Make Real Products with AI, literally.",
@@ -1241,6 +1271,65 @@
         "artificial-intelligence"
       ],
       "makers": [],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1147569",
+      "name": "LobeHub",
+      "tagline": "Your Chief Agent Operator for multi-agent work",
+      "description": "LobeHub is a Chief Agent Operator (CAO) that builds, runs, and coordinates your AI agent team. Describe a goal, and it assembles the right agents/skills, runs tasks in parallel in the cloud, routes work across models, and reports back only when decisions are needed—via your existing channels (Slack/Discord/Telegram/iMessage). Less tab-switching, more outcomes.",
+      "url": "https://www.producthunt.com/products/lobehub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/GDRCLPANDCILEI",
+      "votesCount": 203,
+      "commentsCount": 42,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d91fc33b-29d2-4222-b0dc-977c6a78a670.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,
@@ -2059,6 +2148,36 @@
       "aiAdjacent": true
     },
     {
+      "id": "1149049",
+      "name": "ReactVision Studio",
+      "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
+      "description": "A browser-based visual editor for building AR & VR scenes. Drag and drop 3D objects, generate assets with AI, then ship natively to iOS, Android, and Meta Quest from a single React Native codebase. Open source renderer, Expo-compatible, 100K+ npm installs.",
+      "url": "https://www.producthunt.com/products/reactvision-studio?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/NULQJX32QZRBB6",
+      "votesCount": 160,
+      "commentsCount": 12,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2392e869-311a-4527-8875-bd658e17a404.png?auto=format",
+      "topics": [
+        "virtual-reality",
+        "developer-tools",
+        "augmented-reality"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1142580",
       "name": "Adject 2.0",
       "tagline": "Create hyperrealistic product visuals with AI",
@@ -2160,169 +2279,6 @@
         "no-code"
       ],
       "makers": [],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1142190",
-      "name": "Zappy by ZapDigits",
-      "tagline": "Your AI reporting analyst",
-      "description": "Your clients don’t want dashboards. They want answers. Meet Zappy, the AI agent inside ZapDigits that turns marketing data into client-ready reports in seconds. Connect Google Analytics, Search Console, Google Business Profile, and more, then ask questions in plain English. Privacy-first, EU-hosted, no AI training on your data, and no chat storage.",
-      "url": "https://www.producthunt.com/products/zapdigits?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/CPLHRZ53F7X2L6",
-      "votesCount": 155,
-      "commentsCount": 18,
-      "createdAt": "2026-05-09T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/ec9ec45f-885c-49e9-a8a8-00f992e7cc37.gif?auto=format",
-      "topics": [
-        "analytics",
-        "marketing",
-        "data-visualization"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1146210",
-      "name": "Resend Automations",
-      "tagline": "Build event-driven email flows",
-      "description": "Build event-driven email workflows with triggers, conditions, delays, and full run visibility.",
-      "url": "https://www.producthunt.com/products/resend?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/TFDLJKWDHFBEQE",
-      "votesCount": 147,
-      "commentsCount": 5,
-      "createdAt": "2026-05-14T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/3b8d849e-6bd0-45b5-9bd5-899c7e802277.jpeg?auto=format",
-      "topics": [
-        "api-1",
-        "developer-tools"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
-      "id": "1146488",
-      "name": "Gradient Bang",
-      "tagline": "Massively multi-player game played by talking to an LLM",
-      "description": "Gradient Bang is a new kind of software: AI-native, built from the ground up to use LLMs everywhere. The game has a dynamic user interface driven by an LLM, conversational voice input, and to win you have to manage a fleet of AI subagents. You can even program your own subagents and run them in Vercel Sandboxes. Built with Pipecat, Daily WebRTC, Supabase, Vercel.",
-      "url": "https://www.producthunt.com/products/gradient-bang?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/K7ASSL4K4T44K2",
-      "votesCount": 147,
-      "commentsCount": 24,
-      "createdAt": "2026-05-15T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/1fc6ee55-a2fe-4acd-aa46-76381bc4bf22.x-icon?auto=format",
-      "topics": [
-        "artificial-intelligence",
-        "github",
-        "tech",
-        "games",
-        "vercel-day"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26040313116

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.