### PR TITLE
chore(data): refresh lobsters signals 2026-05-18T14:44:09Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T10:49:15.460Z",
+  "ts": "2026-05-18T14:44:09.622Z",
   "count": 1,
-  "durationMs": 4342,
+  "durationMs": 6778,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T10:49:11.132Z",
+  "fetchedAt": "2026-05-18T14:44:02.858Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T10:49:11.132Z",
+  "fetchedAt": "2026-05-18T14:44:02.858Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "29pm2f",

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -193780,3 +193780,10 @@
 {"source":"bluesky","fullName":"mdpabel/blue","observedAt":"2026-05-18T12:48:24.691Z"}
 {"source":"bluesky","fullName":"mdpabel/bluesky-autoposter","observedAt":"2026-05-18T12:48:24.691Z"}
 {"source":"bluesky","fullName":"daruyanagi/daruyanagi.github.io","observedAt":"2026-05-18T12:48:24.691Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-18T14:44:08.371Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-18T14:44:08.371Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-18T14:44:08.371Z"}
+{"source":"lobsters","fullName":"greenm01/triad","observedAt":"2026-05-18T14:44:08.371Z"}
+{"source":"lobsters","fullName":"sbz/keygen","observedAt":"2026-05-18T14:44:08.371Z"}
+{"source":"lobsters","fullName":"orinimron123/cve-2026-40369-exploit","observedAt":"2026-05-18T14:44:08.371Z"}
+{"source":"lobsters","fullName":"ortegaalfredo/vulns-ai","observedAt":"2026-05-18T14:44:08.371Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26040658536

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.