### PR TITLE
chore(data): refresh huggingface space signals 2026-05-18T16:06:02Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-18T10:49:18.659Z",
+  "ts": "2026-05-18T16:06:01.778Z",
   "count": 1,
-  "durationMs": 5279,
+  "durationMs": 6094,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T10:49:13.382Z",
+  "fetchedAt": "2026-05-18T16:05:55.686Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -25,8 +25,8 @@
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/spaces/TencentARC/Pixal3D",
-      "likes": 159,
-      "trendingScore": 146,
+      "likes": 164,
+      "trendingScore": 151,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -78,8 +78,8 @@
       "id": "r3gm/wan2-2-fp8da-aoti-preview-2",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview-2",
-      "likes": 1225,
-      "trendingScore": 130,
+      "likes": 1229,
+      "trendingScore": 131,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -95,8 +95,8 @@
       "id": "mikeee/qwen-7b-chat",
       "author": "mikeee",
       "url": "https://huggingface.co/spaces/mikeee/qwen-7b-chat",
-      "likes": 266,
-      "trendingScore": 104,
+      "likes": 269,
+      "trendingScore": 106,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -111,8 +111,8 @@
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/spaces/Supertone/supertonic-3",
-      "likes": 126,
-      "trendingScore": 104,
+      "likes": 132,
+      "trendingScore": 106,
       "sdk": "static",
       "tags": [
         "static",
@@ -164,8 +164,8 @@
       "id": "techfreakworm/LTX2.3-Studio",
       "author": "techfreakworm",
       "url": "https://huggingface.co/spaces/techfreakworm/LTX2.3-Studio",
-      "likes": 108,
-      "trendingScore": 71,
+      "likes": 109,
+      "trendingScore": 72,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -246,8 +246,8 @@
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 57,
-      "trendingScore": 57,
+      "likes": 58,
+      "trendingScore": 58,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -259,6 +259,23 @@
     },
     {
       "rank": 16,
+      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
+      "author": "cbensimon",
+      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
+      "likes": 62,
+      "trendingScore": 56,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:08:17.000Z",
+      "lastModified": "2026-05-14T11:52:10.000Z",
+      "models": []
+    },
+    {
+      "rank": 17,
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
@@ -272,23 +289,6 @@
       ],
       "createdAt": "2025-12-19T05:20:19.000Z",
       "lastModified": "2026-05-17T02:27:17.000Z",
-      "models": []
-    },
-    {
-      "rank": 17,
-      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
-      "author": "cbensimon",
-      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 59,
-      "trendingScore": 55,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:08:17.000Z",
-      "lastModified": "2026-05-14T11:52:10.000Z",
       "models": []
     },
     {
@@ -522,6 +522,23 @@
     },
     {
       "rank": 32,
+      "id": "mteb/leaderboard",
+      "author": "mteb",
+      "url": "https://huggingface.co/spaces/mteb/leaderboard",
+      "likes": 7386,
+      "trendingScore": 29,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "leaderboard",
+        "region:us"
+      ],
+      "createdAt": "2022-09-29T11:29:23.000Z",
+      "lastModified": "2026-05-18T15:44:09.000Z",
+      "models": []
+    },
+    {
+      "rank": 33,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -537,7 +554,7 @@
       "models": []
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -554,11 +571,11 @@
       "models": []
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 35,
+      "likes": 37,
       "trendingScore": 29,
       "sdk": "gradio",
       "tags": [
@@ -568,23 +585,6 @@
       ],
       "createdAt": "2026-04-30T19:11:32.000Z",
       "lastModified": "2026-05-13T17:12:57.000Z",
-      "models": []
-    },
-    {
-      "rank": 35,
-      "id": "mteb/leaderboard",
-      "author": "mteb",
-      "url": "https://huggingface.co/spaces/mteb/leaderboard",
-      "likes": 7385,
-      "trendingScore": 28,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "leaderboard",
-        "region:us"
-      ],
-      "createdAt": "2022-09-29T11:29:23.000Z",
-      "lastModified": "2026-05-17T23:26:26.000Z",
       "models": []
     },
     {
@@ -694,6 +694,22 @@
     },
     {
       "rank": 42,
+      "id": "Lakonik/AsymFLUX.2-klein",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
+      "likes": 21,
+      "trendingScore": 21,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:06:55.000Z",
+      "lastModified": "2026-05-14T02:05:05.000Z",
+      "models": []
+    },
+    {
+      "rank": 43,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -710,7 +726,7 @@
       "models": []
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -726,7 +742,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
       "author": "BoobyBoobs",
       "url": "https://huggingface.co/spaces/BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
@@ -742,7 +758,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "NucleusAI/nucleus-image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/spaces/NucleusAI/nucleus-image",
@@ -758,12 +774,12 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "huggingface/physics-intern",
       "author": "huggingface",
       "url": "https://huggingface.co/spaces/huggingface/physics-intern",
-      "likes": 21,
-      "trendingScore": 19,
+      "likes": 22,
+      "trendingScore": 20,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -772,22 +788,6 @@
       ],
       "createdAt": "2026-04-09T06:56:52.000Z",
       "lastModified": "2026-05-12T14:59:53.000Z",
-      "models": []
-    },
-    {
-      "rank": 47,
-      "id": "Lakonik/AsymFLUX.2-klein",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
-      "likes": 19,
-      "trendingScore": 19,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:06:55.000Z",
-      "lastModified": "2026-05-14T02:05:05.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26045155617

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.