### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-18T17:36:06Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-18T14:37:51.154Z",
+  "ts": "2026-05-18T17:36:06.484Z",
   "count": 1,
-  "durationMs": 14464,
+  "durationMs": 10856,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-18T14:37:47.856Z",
+  "lastFetchedAt": "2026-05-18T17:36:03.708Z",
   "windowDays": 7,
   "launches": [
     {
@@ -458,6 +458,36 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
+    },
+    {
+      "id": "1124409",
+      "name": "SocLeads 3.0",
+      "tagline": "Scrape emails from socials and maps by location",
+      "description": "SocLeads now scrapes emails from Instagram, Facebook, LinkedIn, YouTube, and Google Maps across entire countries 🌍📧 Geo-filters. More results. No code needed. 🚀",
+      "url": "https://www.producthunt.com/products/socleads?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ALZHOD7ZH2TWYV",
+      "votesCount": 314,
+      "commentsCount": 61,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/9443342b-bf19-49c4-8423-5e1db1415f15.jpeg?auto=format",
+      "topics": [
+        "email",
+        "social-media",
+        "marketing"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
     },
     {
       "id": "1136169",
@@ -936,36 +966,6 @@
       "aiAdjacent": false
     },
     {
-      "id": "1124409",
-      "name": "SocLeads 3.0",
-      "tagline": "Scrape emails from socials and maps by location",
-      "description": "SocLeads now scrapes emails from Instagram, Facebook, LinkedIn, YouTube, and Google Maps across entire countries 🌍📧 Geo-filters. More results. No code needed. 🚀",
-      "url": "https://www.producthunt.com/products/socleads?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/ALZHOD7ZH2TWYV",
-      "votesCount": 259,
-      "commentsCount": 58,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/9443342b-bf19-49c4-8423-5e1db1415f15.jpeg?auto=format",
-      "topics": [
-        "email",
-        "social-media",
-        "marketing"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
       "id": "1050396",
       "name": "Genpire",
       "tagline": "Make Real Products with AI, literally.",
@@ -988,6 +988,65 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1147569",
+      "name": "LobeHub",
+      "tagline": "Your Chief Agent Operator for multi-agent work",
+      "description": "LobeHub is a Chief Agent Operator (CAO) that builds, runs, and coordinates your AI agent team. Describe a goal, and it assembles the right agents/skills, runs tasks in parallel in the cloud, routes work across models, and reports back only when decisions are needed—via your existing channels (Slack/Discord/Telegram/iMessage). Less tab-switching, more outcomes.",
+      "url": "https://www.producthunt.com/products/lobehub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/GDRCLPANDCILEI",
+      "votesCount": 237,
+      "commentsCount": 59,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d91fc33b-29d2-4222-b0dc-977c6a78a670.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence"
+      ],
+      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1278,65 +1337,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1147569",
-      "name": "LobeHub",
-      "tagline": "Your Chief Agent Operator for multi-agent work",
-      "description": "LobeHub is a Chief Agent Operator (CAO) that builds, runs, and coordinates your AI agent team. Describe a goal, and it assembles the right agents/skills, runs tasks in parallel in the cloud, routes work across models, and reports back only when decisions are needed—via your existing channels (Slack/Discord/Telegram/iMessage). Less tab-switching, more outcomes.",
-      "url": "https://www.producthunt.com/products/lobehub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/GDRCLPANDCILEI",
-      "votesCount": 203,
-      "commentsCount": 42,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/d91fc33b-29d2-4222-b0dc-977c6a78a670.png?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1139500",
       "name": "deepsec",
       "tagline": "Open-source coding security harness",
@@ -1569,6 +1569,36 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
+    },
+    {
+      "id": "1149049",
+      "name": "ReactVision Studio",
+      "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
+      "description": "A browser-based visual editor for building AR & VR scenes. Drag and drop 3D objects, generate assets with AI, then ship natively to iOS, Android, and Meta Quest from a single React Native codebase. Open source renderer, Expo-compatible, 100K+ npm installs.",
+      "url": "https://www.producthunt.com/products/reactvision-studio?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/NULQJX32QZRBB6",
+      "votesCount": 183,
+      "commentsCount": 13,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2392e869-311a-4527-8875-bd658e17a404.png?auto=format",
+      "topics": [
+        "virtual-reality",
+        "developer-tools",
+        "augmented-reality"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
     },
     {
       "id": "1139758",
@@ -2134,36 +2164,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1149049",
-      "name": "ReactVision Studio",
-      "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
-      "description": "A browser-based visual editor for building AR & VR scenes. Drag and drop 3D objects, generate assets with AI, then ship natively to iOS, Android, and Meta Quest from a single React Native codebase. Open source renderer, Expo-compatible, 100K+ npm installs.",
-      "url": "https://www.producthunt.com/products/reactvision-studio?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/NULQJX32QZRBB6",
-      "votesCount": 160,
-      "commentsCount": 12,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2392e869-311a-4527-8875-bd658e17a404.png?auto=format",
-      "topics": [
-        "virtual-reality",
-        "developer-tools",
-        "augmented-reality"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26049775179

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.