### PR TITLE
chore(data): refresh lobsters signals 2026-05-18T17:40:59Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T14:44:09.622Z",
+  "ts": "2026-05-18T17:40:58.947Z",
   "count": 1,
-  "durationMs": 6778,
+  "durationMs": 6089,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T14:44:02.858Z",
+  "fetchedAt": "2026-05-18T17:40:52.871Z",
   "windowDays": 7,
   "scannedStories": 80,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T14:44:02.858Z",
+  "fetchedAt": "2026-05-18T17:40:52.871Z",
   "windowHours": 72,
   "scannedTotal": 80,
   "stories": [
@@ -831,6 +831,25 @@
       "linkedRepos": []
     },
     {
+      "shortId": "lynqdm",
+      "title": "De‐bloating Javascript",
+      "url": "https://github.com/naver/lispe/wiki/6.23-De%E2%80%90bloating-Javascript",
+      "commentsUrl": "https://lobste.rs/s/lynqdm/de_bloating_javascript",
+      "by": "",
+      "score": 11,
+      "commentCount": 6,
+      "createdUtc": 1779112520,
+      "ageHours": 3.758888888888889,
+      "trendingScore": 0.7959478904816015,
+      "tags": [
+        "java",
+        "lisp",
+        "wasm"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "ap9dum",
       "title": "Find bugs in YOUR code using OpenCode, Llama.cpp and Qwen3.6",
       "url": "http://wtarreau.blogspot.com/2026/05/find-bugs-in-your-code-using-opencode.html",
@@ -879,23 +898,6 @@
       "tags": [
         "culture",
         "practices"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "4guexz",
-      "title": "The anti-minimalist backlash is the bigger story behind Oxygen’s revival",
-      "url": "https://filipfila.wordpress.com/2026/05/10/the-anti-minimalist-backlash-is-the-bigger-story-behind-oxygens-revival/",
-      "commentsUrl": "https://lobste.rs/s/4guexz/anti_minimalist_backlash_is_bigger_story",
-      "by": "",
-      "score": 16,
-      "commentCount": 2,
-      "createdUtc": 1778511011,
-      "ageHours": 5.506388888888889,
-      "trendingScore": 0.7779888843127277,
-      "tags": [
-        "design"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -194616,3 +194616,10 @@
 {"source":"bluesky","fullName":"mmerlijn/msg-hl7","observedAt":"2026-05-18T16:34:28.470Z"}
 {"source":"bluesky","fullName":"kigathi-chege/lyre-billing","observedAt":"2026-05-18T16:34:28.470Z"}
 {"source":"bluesky","fullName":"haspadar/phpstan-rules","observedAt":"2026-05-18T16:34:28.470Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-18T17:40:57.561Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-18T17:40:57.561Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-18T17:40:57.561Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-18T17:40:57.561Z"}
+{"source":"lobsters","fullName":"greenm01/triad","observedAt":"2026-05-18T17:40:57.561Z"}
+{"source":"lobsters","fullName":"sbz/keygen","observedAt":"2026-05-18T17:40:57.561Z"}
+{"source":"lobsters","fullName":"orinimron123/cve-2026-40369-exploit","observedAt":"2026-05-18T17:40:57.561Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26050019280

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.