### PR TITLE
chore(data): refresh lobsters signals 2026-05-18T20:17:44Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T17:40:58.947Z",
+  "ts": "2026-05-18T20:17:44.586Z",
   "count": 1,
-  "durationMs": 6089,
+  "durationMs": 4076,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T17:40:52.871Z",
+  "fetchedAt": "2026-05-18T20:17:40.523Z",
   "windowDays": 7,
-  "scannedStories": 80,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T17:40:52.871Z",
+  "fetchedAt": "2026-05-18T20:17:40.523Z",
   "windowHours": 72,
-  "scannedTotal": 80,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -104,6 +104,41 @@
       "tags": [
         "linux",
         "security"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "0wbazw",
+      "title": "Haiku OS runs on M1 Macs now",
+      "url": "https://www.osnews.com/story/144985/haiku-os-runs-on-m1-macs-now/",
+      "commentsUrl": "https://lobste.rs/s/0wbazw/haiku_os_runs_on_m1_macs_now",
+      "by": "",
+      "score": 17,
+      "commentCount": 0,
+      "createdUtc": 1779128966,
+      "ageHours": 1.8038888888888889,
+      "trendingScore": 2.2914331263759458,
+      "tags": [
+        "mac",
+        "unix"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "xckxda",
+      "title": "The Quiet Renovation at Bitwarden",
+      "url": "https://blog.ppb1701.com/the-quiet-renovation-at-bitwarden",
+      "commentsUrl": "https://lobste.rs/s/xckxda/quiet_renovation_at_bitwarden",
+      "by": "",
+      "score": 15,
+      "commentCount": 4,
+      "createdUtc": 1779128893,
+      "ageHours": 1.8241666666666667,
+      "trendingScore": 2.0057926778447297,
+      "tags": [
+        "privacy"
       ],
       "description": "",
       "linkedRepos": []
@@ -831,6 +866,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "dysrh2",
+      "title": "Misconceptions about the UNIX Philosophy (2024)",
+      "url": "https://posixcafe.org/blogs/2024/01/05/0/",
+      "commentsUrl": "https://lobste.rs/s/dysrh2/misconceptions_about_unix_philosophy",
+      "by": "",
+      "score": 6,
+      "commentCount": 3,
+      "createdUtc": 1779128857,
+      "ageHours": 1.8341666666666667,
+      "trendingScore": 0.7991802994087986,
+      "tags": [
+        "unix"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "lynqdm",
       "title": "De‐bloating Javascript",
       "url": "https://github.com/naver/lispe/wiki/6.23-De%E2%80%90bloating-Javascript",
@@ -845,59 +897,6 @@
         "java",
         "lisp",
         "wasm"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "ap9dum",
-      "title": "Find bugs in YOUR code using OpenCode, Llama.cpp and Qwen3.6",
-      "url": "http://wtarreau.blogspot.com/2026/05/find-bugs-in-your-code-using-opencode.html",
-      "commentsUrl": "https://lobste.rs/s/ap9dum/find_bugs_your_code_using_opencode_llama",
-      "by": "",
-      "score": 4,
-      "commentCount": 1,
-      "createdUtc": 1779097884,
-      "ageHours": 0.9630555555555556,
-      "trendingScore": 0.784242365958901,
-      "tags": [
-        "debugging",
-        "vibecoding"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "qbliwt",
-      "title": "wayland.fyi minimalist wayland special interest group",
-      "url": "https://wayland.fyi/",
-      "commentsUrl": "https://lobste.rs/s/qbliwt/wayland_fyi_minimalist_wayland_special",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1778425518,
-      "ageHours": 1.44,
-      "trendingScore": 0.7836684099087093,
-      "tags": [
-        "linux"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "pk0e1r",
-      "title": "Programming Still Sucks",
-      "url": "https://www.stvn.sh/writing/programming-still-sucks-fqffhyp",
-      "commentsUrl": "https://lobste.rs/s/pk0e1r/programming_still_sucks",
-      "by": "",
-      "score": 37,
-      "commentCount": 11,
-      "createdUtc": 1778137407,
-      "ageHours": 11.1225,
-      "trendingScore": 0.7783534449287028,
-      "tags": [
-        "culture",
-        "practices"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -195803,3 +195803,9 @@
 {"source":"hackernews","fullName":"slucerodev/exoarmur-core","observedAt":"2026-05-18T20:04:30.386Z"}
 {"source":"hackernews","fullName":"garyedgington/project_x402","observedAt":"2026-05-18T20:04:30.386Z"}
 {"source":"hackernews","fullName":"maioio/genesis-architect","observedAt":"2026-05-18T20:04:30.386Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-18T20:17:43.221Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-18T20:17:43.221Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-18T20:17:43.221Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-18T20:17:43.221Z"}
+{"source":"lobsters","fullName":"greenm01/triad","observedAt":"2026-05-18T20:17:43.221Z"}
+{"source":"lobsters","fullName":"sbz/keygen","observedAt":"2026-05-18T20:17:43.221Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26057990703

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.