### PR TITLE
chore(data): refresh huggingface space signals 2026-05-18T20:18:07Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-18T16:06:01.778Z",
+  "ts": "2026-05-18T20:18:07.163Z",
   "count": 1,
-  "durationMs": 6094,
+  "durationMs": 5244,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T16:05:55.686Z",
+  "fetchedAt": "2026-05-18T20:18:01.921Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -246,8 +246,8 @@
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 58,
-      "trendingScore": 58,
+      "likes": 60,
+      "trendingScore": 60,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -262,8 +262,8 @@
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 62,
-      "trendingScore": 56,
+      "likes": 64,
+      "trendingScore": 57,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -525,7 +525,7 @@
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
-      "likes": 7386,
+      "likes": 7387,
       "trendingScore": 29,
       "sdk": "docker",
       "tags": [
@@ -555,6 +555,23 @@
     },
     {
       "rank": 34,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 39,
+      "trendingScore": 29,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 35,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -568,23 +585,6 @@
       ],
       "createdAt": "2026-03-28T19:57:45.000Z",
       "lastModified": "2026-05-15T03:44:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 35,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 37,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -658,6 +658,38 @@
     },
     {
       "rank": 40,
+      "id": "Lakonik/AsymFLUX.2-klein",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
+      "likes": 22,
+      "trendingScore": 22,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:06:55.000Z",
+      "lastModified": "2026-05-14T02:05:05.000Z",
+      "models": []
+    },
+    {
+      "rank": 41,
+      "id": "linoyts/Flux2-Klein-Face-Swap",
+      "author": "linoyts",
+      "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
+      "likes": 382,
+      "trendingScore": 21,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-02-03T14:43:29.000Z",
+      "lastModified": "2026-03-10T10:33:23.000Z",
+      "models": []
+    },
+    {
+      "rank": 42,
       "id": "Overworld/waypoint-1-5",
       "author": "Overworld",
       "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
@@ -673,7 +705,7 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 43,
       "id": "carlofkl/DreamLite",
       "author": "carlofkl",
       "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
@@ -693,27 +725,11 @@
       "models": []
     },
     {
-      "rank": 42,
-      "id": "Lakonik/AsymFLUX.2-klein",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
-      "likes": 21,
-      "trendingScore": 21,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:06:55.000Z",
-      "lastModified": "2026-05-14T02:05:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 43,
+      "rank": 44,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
-      "likes": 823,
+      "likes": 830,
       "trendingScore": 20,
       "sdk": "gradio",
       "tags": [
@@ -723,22 +739,6 @@
       ],
       "createdAt": "2026-01-15T09:50:22.000Z",
       "lastModified": "2026-01-16T13:56:36.000Z",
-      "models": []
-    },
-    {
-      "rank": 44,
-      "id": "linoyts/Flux2-Klein-Face-Swap",
-      "author": "linoyts",
-      "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
-      "likes": 371,
-      "trendingScore": 20,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-02-03T14:43:29.000Z",
-      "lastModified": "2026-03-10T10:33:23.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26058006831

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.