### PR TITLE
chore(data): refresh mcp liveness 2026-05-18T20:20:35Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T16:15:39.088Z",
+  "fetchedAt": "2026-05-18T20:20:30.841Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -1585,26 +1585,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ai.buywhere/buywhere-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.auxen/auxen": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.autonomad/computeback": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.anomalyarmor/armor-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.adeu/adeu": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "raye-deng/open-code-review": {
       "isStdio": true,
       "livenessInferred": true
@@ -1625,7 +1605,27 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "ai.anomalyarmor/armor-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ai.getperspective/mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ai.adeu/adeu": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ai.buywhere/buywhere-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ai.autonomad/computeback": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ai.auxen/auxen": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1789,6 +1789,50 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "irahulstomar/brain-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "miracorhan/open google image generator mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "opsconduit/jobber-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "logly-uk/logly mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "migratorywhale/stackchan-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yksanjo/yksanjo/gmem": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yalcin/ta-lib-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "josephibra/cryptosense-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "7majesty-m/terminal-guardian-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ramakrishnan24689/agent 365": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mohamadalhusseinie/openmembrain": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ai.autorfp/mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -1870,926 +1914,6 @@
       "livenessInferred": true
     },
     "github": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "lasawno99/browser mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "wenninghan/eflowcode image mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shotatanikawa/hookray-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "df4u1t/security intelligence mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ghul0/club-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shahidla/mcp server for sap odata v4": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "uicheck-ai/@uicheck/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "acearv09876/capturemind": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kao273183/mk-qa-master": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mit9/mcp-elevenreader": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "onion-ai/onion-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "uarlouski/testrail mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "octodamus/octodamus market intelligence": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "automatelab-tech/automatelab-ai-seo": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "colapsis/transfa": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "smongsdev/my-obscura-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "daniel3303/equibles": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kunalkhanna2007-sys/mcp-networkbot": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "whdrnr2583-cmd/token-meter": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "daniel3303/mcp manager": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "warwickwood-cell/gengeo": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pantelisgeorgiadis/dicomweb mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "robertocirillo/mcp-elicitation-proxy": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "xlisp/thoughtgraph-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "programmersio-ibmi/ibm i mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mikz/simpleshop mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rpieterse/metatrader 5 mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rpieterse/google sheets mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "automatelab-tech/automatelab-n8n-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "allied-business-solutions/ninjaone mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "luxxon-dev/luxxon": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thotischner/observability-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aliphi/touchdesigner-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rpieterse/google sheets oauth mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "simplifyaimm/mcp demo - document search server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pp-szkolenia/mcp job search server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aikogilpin/serac": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dnotitia/akb": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "creatorcrawl/creatorcrawl": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dmang-dev/mcp-bizhawk": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "chesterguan/calledit": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aza-ali/turbowebfetch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "elytrasec/elytra security mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "teodorofodocrispin-cmyk/trustboost-pii-sanitizer": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "minikdj/birding planner": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aisofialuz/agent-memory-hub": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "treeeeeeeeeeeeee/lsl-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thedavidquan01/ad library mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "boltybolterson/agentpulse-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thewillmoss/anchor-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "a2cr/a2cr": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thefranceway/mcp-ad4m": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hectortemich/@deonpay/mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "agu-oli/mcp latin tools server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "praveenm282/university course catalog mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ahmedselimmansor-ctrl/oracle cloud infrastructure (oci) mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "juanqui/joulescope-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jbertus/openart-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ahmedselimmansor-ctrl/alibaba cloud mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "trisetiohidayat/notion db mcp helper": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ahmedselimmansor-ctrl/ibm cloud mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hargurjeet/database-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "theogirardin/mcp-lbc": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "chirag1749/vybog mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ahmedselimmansor-ctrl/facebook mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ahmedselimmansor-ctrl/instagram mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kao273183/mk-spec-master": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "xavier-hernandez/speaches-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ahmedselimmansor-ctrl/gcp mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ahmedselimmansor-ctrl/linkedin mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thithegoat/of-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "saihm-admin/saihm": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "abhishek-kumawa/salesforce mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alephantai/alephant mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mithun4elp/briefkit-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "wolido/openaaas-mcp-adapter": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "veerps57/memento": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dmang-dev/mcp-ppsspp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "yurzs/fatsecret-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "drbaher/sign-cli": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sh6drack/zen-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "teampolarity/cosmos": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jiayuuwang/vercel mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jiayuuwang/asana mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jiayuuwang/supabase mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jiayuuwang/hubspot mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jiayuuwang/airtable mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "deficlow/hyperstore mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jpzip/jpzip mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "christian-beep383/carryfeed": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dalboki/sonsuchup-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kao273183/mk-plan-master": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "enmanuelmag/heimdall": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dropdat/@dropdat/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "xhae123/leafeep-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "evan-crx/permisapi-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "yucx-go/agent-knowledge": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "untitledfinancial/dpx-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alexzavialov/mcp-travel-art": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "floe-labs/floe payments and credit": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "simonedelvecchio93-ops/homeradar-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ptorsten/humaans-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "deficlow/zipp-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "evidai/pay-per-call-mcp — usdc · x402 · ai agent billing | lemoncake": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "0x01feng/flowspec mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "amilcarex/strapi mcp suite": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "randallt21/monarch money mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fdslk/wechat-mp-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arqawa/code_nav mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "geekmai90/ticktick mcp cli": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "leandrosflora/consignado mcp local": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ambermem/amber": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "theriz78/custom-browser-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "formswrite/formswrite mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "panelica/panelica-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vinades/mcp-dauthau": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dtrain473/strava mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kage1020/docs-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "whitehornltd/ibmi-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jagoff/obsidian-mcp-complete": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shaktisinhchavda/memory-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "livshitz/mcp-github": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "parkviewlab/ebony-enriching": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "multivon-ai/multivon-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "nikhilgogulwar/universalbench-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aigen-protocol/aigen protocol": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "makeamouse/fish-bridge-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "raya2912/newsletter generator": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "qelos-io/@qelos/better-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "zw-awa/ssh-session-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "cap-of-tea/gdd (giggly-dazzling-duckling)": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mehdisakalypr-cpu/@gapup/mcp-knowledge": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mcpcatalogs/mcpcatalogs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "drolosoft/go-docs-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "goyalnikhil02/github oauth mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "destiner/faucet-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "skroes/whisper-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "maxkuminov/obsidian mcp (pgvector + ollama, self-hosted)": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "svharivinod/tallyprime mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "piquesignal/pique signal": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "lordbasilaiassistant-sudo/mcpagent": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sharpdogs/mcp db server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "x0base/mcp-security-toolkit": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "khalidsat/mcp-opencode-blender": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "yesidevelop/acme operations assistant": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "930m310n/geomelon-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "lliwi/mcp osint server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "decksaga/market pulse mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kaminari-ad/@kaminari-ad/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pasteai/pasteai": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "proplineapi/propline": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shomechakraborty/scientific tools mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thinkcol/lenx mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "influqa/cryptoagentmail": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "doorman11991/budget-aware-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "artkeyai/bhived": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "blackwell-systems/knowing": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "timwal78/mcp-paywall": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "coding-dev-tools/click-to-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "guimaster97/markdown web scraper api": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.cookiy/cookiy": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.conveo/conveo": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.complyhat/compliance": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.compeller/compel": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.com.mcp/contabo": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.com.mcp/skills-search": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.com.mcp/registry": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.com.mcp/hapi-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.clarid/compliance": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.cirra/salesforce-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.chinamarketing/intelligence": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.childpsychiatry/library": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.childanxiety/library": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.childadhd/library": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.byteray/byteray-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.buywhere/catalog-api": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.buyersense/buyersense": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.bringyour/bringyour": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.borealhost/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.bluenexus/universal-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.bezal/local-commerce": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.baselight/baselight": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.bankee/inferventis-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.autonomad/travel": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.autoblocks/contextlayer-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.auteng/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.auteng/docs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.artidrop/artidrop": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.appdeploy/deploy-app": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.anzenna/anzenna": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.ankimcp/anki-mcp-server-addon": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.ankimcp/anki-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.alpic.test/test-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.alpic.mcp/alpic-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.aliengiraffe/spotdb": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.agenttrust/mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.agentrapay/agentra": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.agenticshelf/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.agenticshelf/graffeo": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.agentic-news/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.agentdm/agentdm": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.adweave/meta-ads-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.adramp/google-ads": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.adadvisor/mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.abmeter/abmeter": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.aarna/atars-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "agency.lona/trading": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ac.tandem/docs-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ficus33/trackingtime mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "averyy/pcb parts mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rulords/google docs, drive & sheets mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bach-ai-tools/indian stock exchange api2 mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "oshimayoan/tokopedia mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bjulius/query counter mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "soulberto/@slorenzot/mcp-azure": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mathankarthik18/corpus mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hightemp/go_serper_mcp_server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jaigouk/atlassian mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shravan1610/n8n mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "byndcloud/unofficial dex crm mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sameershrivastava-sf/salesforce mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "carmeloricarte/gitlab mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "lusha-oss/lusha mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kim-nguyenkhn/baby design ui mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mattintech/pybtmcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "roberthamel/websearch-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jissac/solaguard mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "coding-pioneers/monti apm mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mikdeangelis/meta ads mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "larrygmaguire-hash/slack note capture mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3989,26 +3113,899 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ai.contextstudios/mcp": {
-      "uptime7d": 0,
-      "isStdio": false,
-      "livenessInferred": false
+    "docat0209/graphql-to-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
     },
-    "ai.complyme.mcp/mcp": {
-      "uptime7d": 0,
-      "isStdio": false,
-      "livenessInferred": false
+    "docat0209/mcp-openapi": {
+      "isStdio": true,
+      "livenessInferred": true
     },
-    "ac.inference.sh/mcp": {
-      "uptime7d": 0,
-      "isStdio": false,
-      "livenessInferred": false
+    "vhspace/ipa mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "delian-research/brain-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "desvert/otparse-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "t-campbell18/mixpanel mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aicre8dev/aicre8 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "flexloopy/mcp wechat official accounts spider": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wolfe-jam/gemini-faf-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "omega-memory/omega": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wolfe-jam/rust-faf-mcp rmcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "binodrajpandey/mcp server example": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zahidhasanaunto/mcp-nestjs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp-hertz": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/rover mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/hellofresh mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp-drizly": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agentpact/clawpact mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "manavaga/web3 signals — crypto signal intelligence": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jcc-ne/mcp-skill-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zaq2989/agent-net": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "for-sunny/hebbian-mind-enterprise": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "conorbronsdon/substack-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pshanesmith/nrf-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gamittal-ak/akamai traffic mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "quantum3-labs/arbuilder": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "heelc/vmysql-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "salvo10f/godotiq": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp-wingstop": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/goodrx mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/enterprise rent-a-car mcp connector": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/sephora mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jayantcbx/google search console + ga4 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "erodenn/fetch-guard": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "martijnpieters/eduframe-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kim-geonil/mcp atlassian": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "harshsareen03/ai customer support agent": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "byaxe/keynote-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agentbase1/agentbase mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "featherflow/bitscale mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ankit-aglawe/tokencost-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "chrisgve/workspace qdrant mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "signbee/signbee-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "elisymlabs/elisym mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "elliotllliu/agentshield": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jaggernaut007/nexus-mcp-ci": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zhangchaokai1/zotero-word-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "robbyczgw-cla/web-search-plus-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mikkoparkkola/nab": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rgbcap/hwpx-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "santiagosanmartinn/mcp sapui5 server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rodrigoramosrs/flowstepmcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "2811jh/survey cross-analysis mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "worlddebugger/freqtrade-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "strale-io/strale-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "arithym-io/arithym": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "santanu2908/demo-mcp-01": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/godot-forge": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "psychquant/che-word-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jongall45/frontrun mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "adamescj/pokemcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tunnelhub/tunnelhub mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "parsecular/parsec-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "alex-rimerman/statcast mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "delega-dev/delega-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "robhunter/agentdeals": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "blacktwist/blacktwist mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "betson-g/browser-inspector-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cristiano-c1/truth-anchor-agent": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "giorgikemo/mcp-seo-audit": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yusong652/pfc-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gpartin/cryptoguard": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mbrummerstedt/powerbi analyst mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "19147951441/openclaw-xiaozhi mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "scrapercity/scrapercity-cli": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gdwn-bldr/stateweave": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tjameswilliams/ai charts": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tarminarx/req-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ecmulli/aspen catalog mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tonywmnix/google tasks mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "maxronner/task-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jamesanz/video-toolkit-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cocaxcode/api testing mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kagioneko/memory-engine-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zachsai/hevy mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp-wag": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "memjar/axe fleet mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/kfc mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/burger king mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/lemonade mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "xdarkzx/audacitymcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "402md/@402md/mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "heznpc/iconnect-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bitswype/thunderbird mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nautilusoss/tinyman mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "studiomeyer-io/mcp-video": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "maxfain/basedagents": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ctf2009/castlecall mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp carvana": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/aldi mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp connector for sam's club": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/trader joe's mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/nordstrom mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp-publix": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp-apple": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/@striderlabs/mcp-shakeshack": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "py2755/aiogram-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "prmichaelsen/gcloud-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "afrinov8/cft mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bddda/windsurf ai interceptor": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "shreshtthh/laptop hardware mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "abdulhamid-n/ticktick-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "stamnhq/stamn mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yjcho9317/nworks": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "youhai020616/xiaohongshu-skill": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "knewstimek/agent-tool": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "alialobidm/playwright mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "adamkrawczyk/agentpact": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sarmadparvez/postgresql-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "manticoresoftware/manticore search mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/lumamcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/seedancemcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/soramcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/seedreammcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/veomcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/sunomcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/xfinity mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/coursera mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/linkedin mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gorakudo/yomitan mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "icyhot09/opengrok mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zwwz22/xiaobai print mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "adjia/mail mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ruchiayeon/telegram mcp server & channel monitor": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jwbb903/cloudflare ai image mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "genyk1p/learning hub": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wwqdrh/cmd-line-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "solmon2011/guardrails mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "exidian-tech/placed mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "devilsfave/dagpipe pipeline generator": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "renl/meshimize": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "scheduleonce/oncehub": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bamwor-dev/bamwor-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "houtini-ai/carousels mcp from houtini": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zefarie/pterodactyl-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nach-dakwale/domain checker": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "destrayon/connapse": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/brewers almanack": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "realwigu/mcp-doctor": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "devfinprojects/gas mcp server advanced": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kyurish/mcp-dashboards": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "autonsol/sol mcp — solana token risk & signals": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "quantgeekdev/google-calendar-mcp-app": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "callobuzz/cob-shopify-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/warhammer oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "oluwatunmise-olat/mcp-server-logs-sieve": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "realcrabcut/crabcut": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cmeans/clipboard-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "segfaultsorcerer/heap-seance": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "shenchensucc/chen's ai copy": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "azoraqua/minestom mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hunterpercival/apex mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sueinchoi/nonmem-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ai-nurmamat/mcp session memory bridge": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mxn2020/forge engine mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "msuicaut/mesh mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "guinnessnet/maipharm domae mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jflamb/fdic bankfind mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dswillden/digital brain mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "teileelektronik/easyeda pro mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "klutometis/opencode-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dannymaaz/easypanel mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rob-9/edstem-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "warnes-innovations/obo-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hlebtkachenko/pohoda mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/hopper mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/mcp-turo": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/zipcar mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/petsmart mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "intelagentstudios/intelagent mcp template": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mcp-telegram/mcp-telegram": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "newageflyfish-max/volthq-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "acedatacloud/fluxmcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kud/trakt mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mikan-atomoki/text-to-model": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "moneyflowz367/affilync mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "masonbesmer/discord mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cleburn/aegis mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "castrillon89/siigo mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "neuzhou/mcphub": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "n24q02m/better telegram mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hongnoul/mit-dining-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "authensor/authensor-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nextlevelbuilder/goclaw mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "itunified-io/mcp-cloudflare": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "itunified-io/mcp-opnsense": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "itunified-io/mcp-tailscale": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "0xbrainkid/agentfolio-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wiseriaai/lucid-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jayden-dong/mcphub": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gunjankum06/mypostmanserver": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gaopengbin/cesium-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rafapra3008/lu-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "servicialo/servicialo": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "iseppo/e-arveldaja mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "toadlybroodle/satring-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/teladoc mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dadcz/aitop club": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ebbfijsf/agent-reader": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "victorgulchenko/mimiq mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sonaiengine/graph-tool-call": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "0xzcov/mcp-omnifun": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/mtg-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "i-can-hack/pdf-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dan24ou-cpu/palate-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "transparentlyok/mcp context manager": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "davidsimoes/digisign-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "amcharts/amcharts 5 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "feedoracle/feedoracle compliance mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "stackbilt-dev/stackbilt": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markgregg/low-code ui mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "smart-mcp-proxy/mcpproxy-go": {
+      "isStdio": true,
+      "livenessInferred": true
     }
   },
   "counts": {
     "total": 1000,
-    "http": 3,
-    "stdio": 997,
+    "http": 0,
+    "stdio": 1000,
     "okThisRun": 0
   }
 }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26058133671

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.