### PR TITLE
chore(data): refresh arxiv signals 2026-05-18T20:20:31Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-18T16:08:22.700Z",
+  "ts": "2026-05-18T20:20:23.140Z",
   "count": 1,
-  "durationMs": 62220,
+  "durationMs": 62641,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T16:08:22.992Z",
+  "fetchedAt": "2026-05-18T20:20:23.414Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -162,6 +162,20 @@
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
     },
     {
+      "arxivId": "2605.16193v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
+      "arxivId": "2605.16191v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
       "arxivId": "2605.16184v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -309,6 +323,13 @@
       "lastEnrichedAt": "2026-05-18T05:00:32.019Z"
     },
     {
+      "arxivId": "2605.16117v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
       "arxivId": "2605.16116v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -335,6 +356,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-18T05:00:32.019Z"
+    },
+    {
+      "arxivId": "2605.16107v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
     },
     {
       "arxivId": "2605.16103v1",
@@ -419,6 +447,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-18T05:00:32.019Z"
+    },
+    {
+      "arxivId": "2605.16077v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
     },
     {
       "arxivId": "2605.16076v1",
@@ -617,11 +652,32 @@
       "lastEnrichedAt": "2026-05-18T05:00:32.019Z"
     },
     {
+      "arxivId": "2605.15990v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
       "arxivId": "2605.15980v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
+    },
+    {
+      "arxivId": "2605.15978v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
+      "arxivId": "2605.15976v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
     },
     {
       "arxivId": "2605.15967v1",
@@ -715,6 +771,20 @@
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
     },
     {
+      "arxivId": "2605.15915v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
+      "arxivId": "2605.15913v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
       "arxivId": "2605.15908v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -741,6 +811,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
+    },
+    {
+      "arxivId": "2605.15886v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
     },
     {
       "arxivId": "2605.15876v1",
@@ -785,6 +862,13 @@
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
     },
     {
+      "arxivId": "2605.15848v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
       "arxivId": "2605.15843v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -820,6 +904,13 @@
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
     },
     {
+      "arxivId": "2605.15815v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
       "arxivId": "2605.15803v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -832,6 +923,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
+    },
+    {
+      "arxivId": "2605.15794v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
     },
     {
       "arxivId": "2605.15792v1",
@@ -848,118 +946,6 @@
       "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
     },
     {
-      "arxivId": "2605.15760v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
-    },
-    {
-      "arxivId": "2605.15755v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
-    },
-    {
-      "arxivId": "2605.16193v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.16191v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.16117v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.16107v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.16077v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15990v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15978v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15976v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15915v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15913v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15886v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15848v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15815v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
-      "arxivId": "2605.15794v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
-    },
-    {
       "arxivId": "2605.15763v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -967,11 +953,25 @@
       "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
     },
     {
+      "arxivId": "2605.15760v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
+    },
+    {
       "arxivId": "2605.15759v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-18T16:08:22.992Z"
+    },
+    {
+      "arxivId": "2605.15755v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-18T10:51:42.962Z"
     },
     {
       "arxivId": "2605.15726v1",

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T16:07:20.493Z",
+  "fetchedAt": "2026-05-18T20:19:20.513Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -195803,3 +195803,13 @@
 {"source":"hackernews","fullName":"slucerodev/exoarmur-core","observedAt":"2026-05-18T20:04:30.386Z"}
 {"source":"hackernews","fullName":"garyedgington/project_x402","observedAt":"2026-05-18T20:04:30.386Z"}
 {"source":"hackernews","fullName":"maioio/genesis-architect","observedAt":"2026-05-18T20:04:30.386Z"}
+{"source":"arxiv","fullName":"arquicanedo/paper-json","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"hito2448/res2clip","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"zhipeixu/genshield","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"mingqiangwu/echo-forcing","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"fabian-mor/sae-ft","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"yyliu01/grouprevision","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"lokiniuniu/ghost","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"vossera/bootstrapagent","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"chowrunfa/dimmem","observedAt":"2026-05-18T20:20:23.134Z"}
+{"source":"arxiv","fullName":"tally0818/nudgerl","observedAt":"2026-05-18T20:20:23.134Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26058072810

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.