### PR TITLE
chore(data): refresh lobsters signals 2026-05-18T21:49:35Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T20:17:44.586Z",
+  "ts": "2026-05-18T21:49:35.680Z",
   "count": 1,
-  "durationMs": 4076,
+  "durationMs": 4082,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T20:17:40.523Z",
+  "fetchedAt": "2026-05-18T21:49:31.612Z",
   "windowDays": 7,
   "scannedStories": 79,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T20:17:40.523Z",
+  "fetchedAt": "2026-05-18T21:49:31.612Z",
   "windowHours": 72,
   "scannedTotal": 79,
   "stories": [
@@ -52,6 +52,23 @@
       "trendingScore": 3.9577962461440155,
       "tags": [
         "go"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "xckxda",
+      "title": "The Quiet Renovation at Bitwarden",
+      "url": "https://blog.ppb1701.com/the-quiet-renovation-at-bitwarden",
+      "commentsUrl": "https://lobste.rs/s/xckxda/quiet_renovation_at_bitwarden",
+      "by": "",
+      "score": 42,
+      "commentCount": 9,
+      "createdUtc": 1779128893,
+      "ageHours": 3.355,
+      "trendingScore": 3.3893005153054343,
+      "tags": [
+        "privacy"
       ],
       "description": "",
       "linkedRepos": []
@@ -114,31 +131,14 @@
       "url": "https://www.osnews.com/story/144985/haiku-os-runs-on-m1-macs-now/",
       "commentsUrl": "https://lobste.rs/s/0wbazw/haiku_os_runs_on_m1_macs_now",
       "by": "",
-      "score": 17,
-      "commentCount": 0,
+      "score": 29,
+      "commentCount": 2,
       "createdUtc": 1779128966,
-      "ageHours": 1.8038888888888889,
-      "trendingScore": 2.2914331263759458,
+      "ageHours": 3.334722222222222,
+      "trendingScore": 2.3535871367114463,
       "tags": [
         "mac",
         "unix"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "xckxda",
-      "title": "The Quiet Renovation at Bitwarden",
-      "url": "https://blog.ppb1701.com/the-quiet-renovation-at-bitwarden",
-      "commentsUrl": "https://lobste.rs/s/xckxda/quiet_renovation_at_bitwarden",
-      "by": "",
-      "score": 15,
-      "commentCount": 4,
-      "createdUtc": 1779128893,
-      "ageHours": 1.8241666666666667,
-      "trendingScore": 2.0057926778447297,
-      "tags": [
-        "privacy"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -196733,3 +196733,9 @@
 {"source":"twitter","fullName":"alchaincyf/huashu","observedAt":"2026-05-18T21:43:10.495Z"}
 {"source":"twitter","fullName":"heygen-com/hyperf","observedAt":"2026-05-18T21:43:10.495Z"}
 {"source":"twitter","fullName":"conardli/garden-s","observedAt":"2026-05-18T21:43:10.495Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-18T21:49:34.394Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-18T21:49:34.394Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-18T21:49:34.394Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-18T21:49:34.394Z"}
+{"source":"lobsters","fullName":"greenm01/triad","observedAt":"2026-05-18T21:49:34.394Z"}
+{"source":"lobsters","fullName":"sbz/keygen","observedAt":"2026-05-18T21:49:34.394Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26062452627

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.