### PR TITLE
chore(data): refresh lobsters signals 2026-05-18T23:40:21Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T21:49:35.680Z",
+  "ts": "2026-05-18T23:40:21.721Z",
   "count": 1,
-  "durationMs": 4082,
+  "durationMs": 8772,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T21:49:31.612Z",
+  "fetchedAt": "2026-05-18T23:40:12.962Z",
   "windowDays": 7,
   "scannedStories": 79,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T21:49:31.612Z",
+  "fetchedAt": "2026-05-18T23:40:12.962Z",
   "windowHours": 72,
   "scannedTotal": 79,
   "stories": [
@@ -405,6 +405,25 @@
       "linkedRepos": []
     },
     {
+      "shortId": "ac0akx",
+      "title": "Programming as Theory Building (1985)",
+      "url": "https://gwern.net/doc/cs/algorithm/1985-naur.pdf",
+      "commentsUrl": "https://lobste.rs/s/ac0akx/programming_as_theory_building_1985",
+      "by": "",
+      "score": 9,
+      "commentCount": 0,
+      "createdUtc": 1779140566,
+      "ageHours": 1.9572222222222222,
+      "trendingScore": 1.1432911733342348,
+      "tags": [
+        "pdf",
+        "practices",
+        "programming"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "bnfm0h",
       "title": "Let's Encrypt Stopping Issuance for Potential Incident",
       "url": "https://letsencrypt.status.io/",
@@ -494,6 +513,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "cjwt5c",
+      "title": "Comprehensive Response to Bambu's AGPLv3 Violations",
+      "url": "https://sfconservancy.org/news/2026/may/18/bambu-studio-3d-printer-agpl-violation-response/",
+      "commentsUrl": "https://lobste.rs/s/cjwt5c/comprehensive_response_bambu_s_agplv3",
+      "by": "",
+      "score": 6,
+      "commentCount": 0,
+      "createdUtc": 1779143049,
+      "ageHours": 1.2675,
+      "trendingScore": 1.015845955901289,
+      "tags": [
+        "law"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "7zppv1",
       "title": "Behind the Scenes Hardening Firefox with Claude Mythos Preview",
       "url": "https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/",
@@ -563,6 +599,23 @@
         "hardware"
       ],
       "description": "<p>AFAIU this is a wired device even if promotional images seem to suggest different.</p>\n",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "5pjoom",
+      "title": "Introducing Casuarina Linux: A glibc-Based Chimera Linux Derivative",
+      "url": "https://casuarina.org/news/introducing-casuarina-linux/",
+      "commentsUrl": "https://lobste.rs/s/5pjoom/introducing_casuarina_linux_glibc_based",
+      "by": "",
+      "score": 4,
+      "commentCount": 2,
+      "createdUtc": 1779145465,
+      "ageHours": 0.5963888888888889,
+      "trendingScore": 0.9561045356564685,
+      "tags": [
+        "linux"
+      ],
+      "description": "",
       "linkedRepos": []
     },
     {
@@ -844,59 +897,6 @@
       "trendingScore": 0.8793911015066856,
       "tags": [
         "hardware"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "pv9i7j",
-      "title": "Formatting an entire 25 million line codebase overnight: the rubyfmt story",
-      "url": "https://stripe.dev/blog/formatting-an-entire-25-million-line-codebase-overnight-the-rubyfmt-story",
-      "commentsUrl": "https://lobste.rs/s/pv9i7j/formatting_entire_25_million_line",
-      "by": "",
-      "score": 11,
-      "commentCount": 1,
-      "createdUtc": 1778176415,
-      "ageHours": 3.6569444444444446,
-      "trendingScore": 0.8175603382650809,
-      "tags": [
-        "ruby"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "dysrh2",
-      "title": "Misconceptions about the UNIX Philosophy (2024)",
-      "url": "https://posixcafe.org/blogs/2024/01/05/0/",
-      "commentsUrl": "https://lobste.rs/s/dysrh2/misconceptions_about_unix_philosophy",
-      "by": "",
-      "score": 6,
-      "commentCount": 3,
-      "createdUtc": 1779128857,
-      "ageHours": 1.8341666666666667,
-      "trendingScore": 0.7991802994087986,
-      "tags": [
-        "unix"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "lynqdm",
-      "title": "De‐bloating Javascript",
-      "url": "https://github.com/naver/lispe/wiki/6.23-De%E2%80%90bloating-Javascript",
-      "commentsUrl": "https://lobste.rs/s/lynqdm/de_bloating_javascript",
-      "by": "",
-      "score": 11,
-      "commentCount": 6,
-      "createdUtc": 1779112520,
-      "ageHours": 3.758888888888889,
-      "trendingScore": 0.7959478904816015,
-      "tags": [
-        "java",
-        "lisp",
-        "wasm"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -197648,3 +197648,9 @@
 {"source":"hackernews","fullName":"kaarhsg-cpu/mcp-guardrail","observedAt":"2026-05-18T22:36:28.066Z"}
 {"source":"hackernews","fullName":"slucerodev/exoarmur-core","observedAt":"2026-05-18T22:36:28.066Z"}
 {"source":"hackernews","fullName":"garyedgington/project_x402","observedAt":"2026-05-18T22:36:28.066Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-18T23:40:20.482Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-18T23:40:20.482Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-18T23:40:20.482Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-18T23:40:20.482Z"}
+{"source":"lobsters","fullName":"greenm01/triad","observedAt":"2026-05-18T23:40:20.482Z"}
+{"source":"lobsters","fullName":"sbz/keygen","observedAt":"2026-05-18T23:40:20.482Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26066838264

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.