### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-19T00:17:19Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-18T20:43:15.622Z",
+  "ts": "2026-05-19T00:17:19.694Z",
   "count": 1,
-  "durationMs": 10974,
+  "durationMs": 11887,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-18T20:43:13.120Z",
+  "lastFetchedAt": "2026-05-19T00:17:16.691Z",
   "windowDays": 7,
   "launches": [
     {
@@ -249,6 +249,36 @@
       "aiAdjacent": true
     },
     {
+      "id": "1124409",
+      "name": "SocLeads 3.0",
+      "tagline": "Scrape emails from socials and maps by location",
+      "description": "SocLeads now scrapes emails from Instagram, Facebook, LinkedIn, YouTube, and Google Maps across entire countries 🌍📧 Geo-filters. More results. No code needed. 🚀",
+      "url": "https://www.producthunt.com/products/socleads?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ALZHOD7ZH2TWYV",
+      "votesCount": 369,
+      "commentsCount": 68,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/9443342b-bf19-49c4-8423-5e1db1415f15.jpeg?auto=format",
+      "topics": [
+        "email",
+        "social-media",
+        "marketing"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1141978",
       "name": "Monid 2.0",
       "tagline": "OpenRouter for agent tools",
@@ -283,36 +313,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
-    },
-    {
-      "id": "1124409",
-      "name": "SocLeads 3.0",
-      "tagline": "Scrape emails from socials and maps by location",
-      "description": "SocLeads now scrapes emails from Instagram, Facebook, LinkedIn, YouTube, and Google Maps across entire countries 🌍📧 Geo-filters. More results. No code needed. 🚀",
-      "url": "https://www.producthunt.com/products/socleads?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/ALZHOD7ZH2TWYV",
-      "votesCount": 354,
-      "commentsCount": 64,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/9443342b-bf19-49c4-8423-5e1db1415f15.jpeg?auto=format",
-      "topics": [
-        "email",
-        "social-media",
-        "marketing"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
     },
     {
       "id": "1136902",
@@ -428,6 +428,65 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
+    },
+    {
+      "id": "1147569",
+      "name": "LobeHub",
+      "tagline": "Your Chief Agent Operator for multi-agent work",
+      "description": "LobeHub is a Chief Agent Operator (CAO) that builds, runs, and coordinates your AI agent team. Describe a goal, and it assembles the right agents/skills, runs tasks in parallel in the cloud, routes work across models, and reports back only when decisions are needed—via your existing channels (Slack/Discord/Telegram/iMessage). Less tab-switching, more outcomes.",
+      "url": "https://www.producthunt.com/products/lobehub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/GDRCLPANDCILEI",
+      "votesCount": 326,
+      "commentsCount": 61,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d91fc33b-29d2-4222-b0dc-977c6a78a670.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
     },
     {
       "id": "1141227",
@@ -598,65 +657,6 @@
         "vercel-day"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1147569",
-      "name": "LobeHub",
-      "tagline": "Your Chief Agent Operator for multi-agent work",
-      "description": "LobeHub is a Chief Agent Operator (CAO) that builds, runs, and coordinates your AI agent team. Describe a goal, and it assembles the right agents/skills, runs tasks in parallel in the cloud, routes work across models, and reports back only when decisions are needed—via your existing channels (Slack/Discord/Telegram/iMessage). Less tab-switching, more outcomes.",
-      "url": "https://www.producthunt.com/products/lobehub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/GDRCLPANDCILEI",
-      "votesCount": 293,
-      "commentsCount": 61,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/d91fc33b-29d2-4222-b0dc-977c6a78a670.png?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1314,6 +1314,36 @@
       "aiAdjacent": true
     },
     {
+      "id": "1149049",
+      "name": "ReactVision Studio",
+      "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
+      "description": "A browser-based visual editor for building AR & VR scenes. Drag and drop 3D objects, generate assets with AI, then ship natively to iOS, Android, and Meta Quest from a single React Native codebase. Open source renderer, Expo-compatible, 100K+ npm installs.",
+      "url": "https://www.producthunt.com/products/reactvision-studio?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/NULQJX32QZRBB6",
+      "votesCount": 204,
+      "commentsCount": 14,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2392e869-311a-4527-8875-bd658e17a404.png?auto=format",
+      "topics": [
+        "virtual-reality",
+        "developer-tools",
+        "augmented-reality"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1139772",
       "name": "Claude Agents for Financial Services",
       "tagline": "Finance agent templates for pitches, KYC, and closing books",
@@ -1491,36 +1521,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1149049",
-      "name": "ReactVision Studio",
-      "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
-      "description": "A browser-based visual editor for building AR & VR scenes. Drag and drop 3D objects, generate assets with AI, then ship natively to iOS, Android, and Meta Quest from a single React Native codebase. Open source renderer, Expo-compatible, 100K+ npm installs.",
-      "url": "https://www.producthunt.com/products/reactvision-studio?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/NULQJX32QZRBB6",
-      "votesCount": 191,
-      "commentsCount": 14,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2392e869-311a-4527-8875-bd658e17a404.png?auto=format",
-      "topics": [
-        "virtual-reality",
-        "developer-tools",
-        "augmented-reality"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2118,6 +2118,54 @@
       ]
     },
     {
+      "id": "1142097",
+      "name": "Shadow",
+      "tagline": "AI computer screen and voice control with custom automation",
+      "description": "Shadow is the AI interface for your Mac. It sees your screen, hears your voice, and runs the prompts you build — on a keyboard shortcut, or in your meetings. 🪄 Skills do the work. Quick Reply drafts emails from what you say and what’s on screen. Voice Typing turns talking into clean text, anywhere. Meeting Skills capture every word and screen, then deliver notes and follow-ups the moment you hang up. Build your own — every Skill is a prompt, a context, and an output.",
+      "url": "https://www.producthunt.com/products/shadow-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/RTMG35ETHSLUIL",
+      "votesCount": 163,
+      "commentsCount": 16,
+      "createdAt": "2026-05-18T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/ff3ba4af-52e1-41a3-9893-5f68be95f072.png?auto=format",
+      "topics": [
+        "productivity",
+        "writing",
+        "meetings"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1146556",
       "name": "Agentic Website Builder 2.0 by Lokuma",
       "tagline": "Design, build, and run your site with a design agent harness",
@@ -2261,29 +2309,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1142101",
-      "name": "Jotform Claude App",
-      "tagline": "Build, edit, and analyze forms directly in Claude",
-      "description": "Build, edit, and analyze forms directly inside Claude using simple conversations. Create forms, edit fields, add logic, search submissions, and get insights, all by describing what you want. No manual setup or switching tools.",
-      "url": "https://www.producthunt.com/products/jotform?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DJ3HA5PIVDFYRP",
-      "votesCount": 157,
-      "commentsCount": 8,
-      "createdAt": "2026-05-12T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/05750b4e-0690-45c4-8068-8f032452a745.gif?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence",
-        "no-code"
-      ],
-      "makers": [],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26068156866

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.