### PR TITLE
chore(data): refresh huggingface signals 2026-05-19T04:34:50Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-18T20:03:25.616Z",
+  "ts": "2026-05-19T04:34:50.639Z",
   "count": 1,
-  "durationMs": 6413,
+  "durationMs": 7545,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T20:03:19.206Z",
+  "fetchedAt": "2026-05-19T04:34:43.096Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -158,8 +158,8 @@
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic-3",
       "downloads": 24031,
-      "likes": 413,
-      "trendingScore": 315,
+      "likes": 425,
+      "trendingScore": 320,
       "pipelineTag": "text-to-speech",
       "libraryName": "supertonic",
       "tags": [
@@ -203,8 +203,8 @@
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
       "downloads": 268305,
-      "likes": 280,
-      "trendingScore": 265,
+      "likes": 292,
+      "trendingScore": 271,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -231,8 +231,8 @@
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
       "downloads": 237613,
-      "likes": 244,
-      "trendingScore": 226,
+      "likes": 250,
+      "trendingScore": 229,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -357,8 +357,8 @@
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima",
       "downloads": 545205,
-      "likes": 1402,
-      "trendingScore": 170,
+      "likes": 1413,
+      "trendingScore": 181,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
       "tags": [
@@ -376,8 +376,8 @@
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/Dramabox",
       "downloads": 1001,
-      "likes": 158,
-      "trendingScore": 156,
+      "likes": 164,
+      "trendingScore": 162,
       "pipelineTag": "text-to-speech",
       "libraryName": "ltx-audio-tts",
       "tags": [
@@ -401,6 +401,34 @@
     },
     {
       "rank": 16,
+      "id": "froggeric/Qwen-Fixed-Chat-Templates",
+      "author": "froggeric",
+      "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
+      "downloads": 0,
+      "likes": 297,
+      "trendingScore": 146,
+      "pipelineTag": null,
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "jinja",
+        "chat-template",
+        "qwen",
+        "qwen3.5",
+        "qwen3.6",
+        "lm-studio",
+        "llama.cpp",
+        "vllm",
+        "tool-calling",
+        "thinking",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T15:28:14.000Z",
+      "lastModified": "2026-05-16T13:44:07.000Z"
+    },
+    {
+      "rank": 17,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -429,41 +457,13 @@
       "lastModified": "2026-04-28T07:01:37.000Z"
     },
     {
-      "rank": 17,
-      "id": "froggeric/Qwen-Fixed-Chat-Templates",
-      "author": "froggeric",
-      "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
-      "downloads": 0,
-      "likes": 287,
-      "trendingScore": 140,
-      "pipelineTag": null,
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "jinja",
-        "chat-template",
-        "qwen",
-        "qwen3.5",
-        "qwen3.6",
-        "lm-studio",
-        "llama.cpp",
-        "vllm",
-        "tool-calling",
-        "thinking",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T15:28:14.000Z",
-      "lastModified": "2026-05-16T13:44:07.000Z"
-    },
-    {
       "rank": 18,
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/TencentARC/Pixal3D",
       "downloads": 0,
-      "likes": 142,
-      "trendingScore": 135,
+      "likes": 146,
+      "trendingScore": 137,
       "pipelineTag": "image-to-3d",
       "libraryName": null,
       "tags": [
@@ -724,60 +724,12 @@
     },
     {
       "rank": 27,
-      "id": "jackxinning/Leanly_AI",
-      "author": "jackxinning",
-      "url": "https://huggingface.co/jackxinning/Leanly_AI",
-      "downloads": 10822,
-      "likes": 111,
-      "trendingScore": 99,
-      "pipelineTag": "question-answering",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "medical",
-        "question-answering",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-16T10:43:03.000Z",
-      "lastModified": "2026-05-04T07:50:46.000Z"
-    },
-    {
-      "rank": 28,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
-      "downloads": 3819,
-      "likes": 99,
-      "trendingScore": 99,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T13:09:29.000Z",
-      "lastModified": "2026-05-15T10:40:24.000Z"
-    },
-    {
-      "rank": 29,
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "downloads": 6462,
-      "likes": 97,
-      "trendingScore": 96,
+      "likes": 102,
+      "trendingScore": 101,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -810,6 +762,54 @@
       ],
       "createdAt": "2026-05-15T12:53:59.000Z",
       "lastModified": "2026-05-17T01:57:24.000Z"
+    },
+    {
+      "rank": 28,
+      "id": "jackxinning/Leanly_AI",
+      "author": "jackxinning",
+      "url": "https://huggingface.co/jackxinning/Leanly_AI",
+      "downloads": 10822,
+      "likes": 111,
+      "trendingScore": 99,
+      "pipelineTag": "question-answering",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "medical",
+        "question-answering",
+        "en",
+        "zh",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-16T10:43:03.000Z",
+      "lastModified": "2026-05-04T07:50:46.000Z"
+    },
+    {
+      "rank": 29,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+      "downloads": 3819,
+      "likes": 99,
+      "trendingScore": 99,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T13:09:29.000Z",
+      "lastModified": "2026-05-15T10:40:24.000Z"
     },
     {
       "rank": 30,
@@ -1034,6 +1034,86 @@
     },
     {
       "rank": 37,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/bytedance-research/Lance",
+      "downloads": 0,
+      "likes": 84,
+      "trendingScore": 84,
+      "pipelineTag": "any-to-any",
+      "libraryName": "Lance",
+      "tags": [
+        "Lance",
+        "safetensors",
+        "multimodal",
+        "image-generation",
+        "video-generation",
+        "image-editing",
+        "video-understanding",
+        "any-to-any",
+        "arxiv:2605.18678",
+        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T08:05:57.000Z",
+      "lastModified": "2026-05-19T03:14:47.000Z"
+    },
+    {
+      "rank": 38,
+      "id": "microsoft/Fara-7B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Fara-7B",
+      "downloads": 16011,
+      "likes": 578,
+      "trendingScore": 83,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_5_vl",
+        "image-text-to-text",
+        "multimodal",
+        "conversational",
+        "en",
+        "arxiv:2511.19663",
+        "license:mit",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-10-30T18:56:59.000Z",
+      "lastModified": "2025-12-11T22:11:43.000Z"
+    },
+    {
+      "rank": 39,
+      "id": "Cactus-Compute/needle",
+      "author": "Cactus-Compute",
+      "url": "https://huggingface.co/Cactus-Compute/needle",
+      "downloads": 241,
+      "likes": 84,
+      "trendingScore": 83,
+      "pipelineTag": null,
+      "libraryName": "jax",
+      "tags": [
+        "jax",
+        "custom",
+        "function-calling",
+        "tool-use",
+        "encoder-decoder",
+        "edge",
+        "on-device",
+        "flax",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-03-16T04:01:31.000Z",
+      "lastModified": "2026-05-13T09:32:17.000Z"
+    },
+    {
+      "rank": 40,
       "id": "antirez/deepseek-v4-gguf",
       "author": "antirez",
       "url": "https://huggingface.co/antirez/deepseek-v4-gguf",
@@ -1071,34 +1151,7 @@
       "lastModified": "2026-05-12T16:08:16.000Z"
     },
     {
-      "rank": 38,
-      "id": "microsoft/Fara-7B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Fara-7B",
-      "downloads": 16011,
-      "likes": 577,
-      "trendingScore": 82,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_5_vl",
-        "image-text-to-text",
-        "multimodal",
-        "conversational",
-        "en",
-        "arxiv:2511.19663",
-        "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-10-30T18:56:59.000Z",
-      "lastModified": "2025-12-11T22:11:43.000Z"
-    },
-    {
-      "rank": 39,
+      "rank": 41,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -1126,7 +1179,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 40,
+      "rank": 42,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1155,32 +1208,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 41,
-      "id": "Cactus-Compute/needle",
-      "author": "Cactus-Compute",
-      "url": "https://huggingface.co/Cactus-Compute/needle",
-      "downloads": 241,
-      "likes": 80,
-      "trendingScore": 79,
-      "pipelineTag": null,
-      "libraryName": "jax",
-      "tags": [
-        "jax",
-        "custom",
-        "function-calling",
-        "tool-use",
-        "encoder-decoder",
-        "edge",
-        "on-device",
-        "flax",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-03-16T04:01:31.000Z",
-      "lastModified": "2026-05-13T09:32:17.000Z"
-    },
-    {
-      "rank": 42,
+      "rank": 43,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -1206,7 +1234,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -1235,7 +1263,56 @@
       "lastModified": "2026-04-20T12:42:25.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
+      "id": "inclusionAI/Ring-2.6-1T",
+      "author": "inclusionAI",
+      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
+      "downloads": 2406,
+      "likes": 77,
+      "trendingScore": 76,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "bailing_hybrid",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:mit",
+        "eval-results",
+        "compressed-tensors",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:10:02.000Z",
+      "lastModified": "2026-05-18T09:47:28.000Z"
+    },
+    {
+      "rank": 46,
+      "id": "internlm/Intern-S2-Preview",
+      "author": "internlm",
+      "url": "https://huggingface.co/internlm/Intern-S2-Preview",
+      "downloads": 1168,
+      "likes": 76,
+      "trendingScore": 76,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "intern_s2_preview",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T03:49:25.000Z",
+      "lastModified": "2026-05-18T08:00:41.000Z"
+    },
+    {
+      "rank": 47,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -1268,7 +1345,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 45,
+      "rank": 48,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -1313,32 +1390,7 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 46,
-      "id": "inclusionAI/Ring-2.6-1T",
-      "author": "inclusionAI",
-      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
-      "downloads": 2406,
-      "likes": 75,
-      "trendingScore": 74,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "bailing_hybrid",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:mit",
-        "eval-results",
-        "compressed-tensors",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T08:10:02.000Z",
-      "lastModified": "2026-05-18T09:47:28.000Z"
-    },
-    {
-      "rank": 47,
+      "rank": 49,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -1358,31 +1410,7 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 48,
-      "id": "internlm/Intern-S2-Preview",
-      "author": "internlm",
-      "url": "https://huggingface.co/internlm/Intern-S2-Preview",
-      "downloads": 1168,
-      "likes": 73,
-      "trendingScore": 73,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "intern_s2_preview",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T03:49:25.000Z",
-      "lastModified": "2026-05-18T08:00:41.000Z"
-    },
-    {
-      "rank": 49,
+      "rank": 50,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -1405,7 +1433,7 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 50,
+      "rank": 51,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -1438,7 +1466,7 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 51,
+      "rank": 52,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -1470,7 +1498,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 52,
+      "rank": 53,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -1495,7 +1523,7 @@
       "lastModified": "2026-05-12T14:25:54.000Z"
     },
     {
-      "rank": 53,
+      "rank": 54,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1540,7 +1568,7 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 54,
+      "rank": 55,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -1567,7 +1595,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 55,
+      "rank": 56,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -1600,7 +1628,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 56,
+      "rank": 57,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -1632,7 +1660,7 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 57,
+      "rank": 58,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -1661,7 +1689,7 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 58,
+      "rank": 59,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -1689,7 +1717,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 59,
+      "rank": 60,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -1716,7 +1744,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 60,
+      "rank": 61,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -1743,7 +1771,32 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 61,
+      "rank": 62,
+      "id": "AIDC-AI/Ovis2.6-80B-A3B",
+      "author": "AIDC-AI",
+      "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
+      "downloads": 73,
+      "likes": 58,
+      "trendingScore": 58,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "ovis2_6_next",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "arxiv:2508.11737",
+        "arxiv:2405.20797",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T07:57:36.000Z",
+      "lastModified": "2026-05-14T08:44:07.000Z"
+    },
+    {
+      "rank": 63,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -1766,31 +1819,38 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 62,
-      "id": "AIDC-AI/Ovis2.6-80B-A3B",
-      "author": "AIDC-AI",
-      "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
-      "downloads": 73,
-      "likes": 57,
+      "rank": 64,
+      "id": "fastino/gliguard-LLMGuardrails-300M",
+      "author": "fastino",
+      "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
+      "downloads": 2071,
+      "likes": 58,
       "trendingScore": 57,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
+      "pipelineTag": "text-classification",
+      "libraryName": "gliner2",
       "tags": [
+        "gliner2",
         "safetensors",
-        "ovis2_6_next",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "arxiv:2508.11737",
-        "arxiv:2405.20797",
+        "extractor",
+        "safety",
+        "moderation",
+        "guardrails",
+        "text-classification",
+        "multi-label-classification",
+        "jailbreak-detection",
+        "toxicity-classification",
+        "en",
+        "arxiv:2605.07982",
+        "base_model:fastino/gliner2-base-v1",
+        "base_model:finetune:fastino/gliner2-base-v1",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-11T07:57:36.000Z",
-      "lastModified": "2026-05-14T08:44:07.000Z"
+      "createdAt": "2026-05-09T04:20:48.000Z",
+      "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 63,
+      "rank": 65,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -1818,64 +1878,6 @@
       ],
       "createdAt": "2026-04-27T13:37:38.000Z",
       "lastModified": "2026-05-07T04:23:16.000Z"
-    },
-    {
-      "rank": 64,
-      "id": "fastino/gliguard-LLMGuardrails-300M",
-      "author": "fastino",
-      "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
-      "downloads": 2071,
-      "likes": 56,
-      "trendingScore": 55,
-      "pipelineTag": "text-classification",
-      "libraryName": "gliner2",
-      "tags": [
-        "gliner2",
-        "safetensors",
-        "extractor",
-        "safety",
-        "moderation",
-        "guardrails",
-        "text-classification",
-        "multi-label-classification",
-        "jailbreak-detection",
-        "toxicity-classification",
-        "en",
-        "arxiv:2605.07982",
-        "base_model:fastino/gliner2-base-v1",
-        "base_model:finetune:fastino/gliner2-base-v1",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T04:20:48.000Z",
-      "lastModified": "2026-05-14T16:04:55.000Z"
-    },
-    {
-      "rank": 65,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 0,
-      "likes": 55,
-      "trendingScore": 55,
-      "pipelineTag": "any-to-any",
-      "libraryName": "Lance",
-      "tags": [
-        "Lance",
-        "safetensors",
-        "multimodal",
-        "image-generation",
-        "video-generation",
-        "image-editing",
-        "video-understanding",
-        "any-to-any",
-        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-18T15:33:48.000Z"
     },
     {
       "rank": 66,
@@ -2001,6 +2003,58 @@
     },
     {
       "rank": 70,
+      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "downloads": 40301,
+      "likes": 56,
+      "trendingScore": 53,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "gemma4",
+        "moe",
+        "vision",
+        "multimodal",
+        "agentic",
+        "coding",
+        "image-text-to-text",
+        "en",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-14T16:24:48.000Z",
+      "lastModified": "2026-05-14T17:07:52.000Z"
+    },
+    {
+      "rank": 71,
+      "id": "facebook/VGGT-Omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/VGGT-Omega",
+      "downloads": 0,
+      "likes": 55,
+      "trendingScore": 53,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "facebook",
+        "meta-pytorch",
+        "en",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-17T20:47:45.000Z",
+      "lastModified": "2026-05-14T21:23:21.000Z"
+    },
+    {
+      "rank": 72,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2045,7 +2099,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 71,
+      "rank": 73,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2072,39 +2126,7 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 72,
-      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "downloads": 40301,
-      "likes": 54,
-      "trendingScore": 51,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "moe",
-        "vision",
-        "multimodal",
-        "agentic",
-        "coding",
-        "image-text-to-text",
-        "en",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-14T16:24:48.000Z",
-      "lastModified": "2026-05-14T17:07:52.000Z"
-    },
-    {
-      "rank": 73,
+      "rank": 74,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2130,26 +2152,6 @@
       ],
       "createdAt": "2026-04-06T13:19:18.000Z",
       "lastModified": "2026-05-04T17:31:52.000Z"
-    },
-    {
-      "rank": 74,
-      "id": "facebook/VGGT-Omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/VGGT-Omega",
-      "downloads": 0,
-      "likes": 52,
-      "trendingScore": 50,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "facebook",
-        "meta-pytorch",
-        "en",
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-17T20:47:45.000Z",
-      "lastModified": "2026-05-14T21:23:21.000Z"
     },
     {
       "rank": 75,
@@ -2357,63 +2359,12 @@
     },
     {
       "rank": 82,
-      "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
-      "downloads": 3359784,
-      "likes": 718,
-      "trendingScore": 46,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "gemma4",
-        "unsloth",
-        "gemma",
-        "google",
-        "image-text-to-text",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-01T14:42:29.000Z",
-      "lastModified": "2026-05-04T09:45:46.000Z"
-    },
-    {
-      "rank": 83,
-      "id": "google/gemma-4-E2B-it-assistant",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
-      "downloads": 7014,
-      "likes": 45,
-      "trendingScore": 45,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4_assistant",
-        "text-generation",
-        "any-to-any",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T18:35:40.000Z",
-      "lastModified": "2026-05-11T07:51:55.000Z"
-    },
-    {
-      "rank": 84,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
       "downloads": 28917,
-      "likes": 50,
-      "trendingScore": 45,
+      "likes": 52,
+      "trendingScore": 47,
       "pipelineTag": "feature-extraction",
       "libraryName": "transformers",
       "tags": [
@@ -2442,6 +2393,57 @@
       ],
       "createdAt": "2026-04-01T22:06:52.000Z",
       "lastModified": "2026-05-17T10:58:37.000Z"
+    },
+    {
+      "rank": 83,
+      "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
+      "downloads": 3359784,
+      "likes": 718,
+      "trendingScore": 46,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "gemma4",
+        "unsloth",
+        "gemma",
+        "google",
+        "image-text-to-text",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-01T14:42:29.000Z",
+      "lastModified": "2026-05-04T09:45:46.000Z"
+    },
+    {
+      "rank": 84,
+      "id": "google/gemma-4-E2B-it-assistant",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
+      "downloads": 7014,
+      "likes": 45,
+      "trendingScore": 45,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4_assistant",
+        "text-generation",
+        "any-to-any",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T18:35:40.000Z",
+      "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
       "rank": 85,
@@ -2568,6 +2570,36 @@
     },
     {
       "rank": 90,
+      "id": "sapientinc/HRM-Text-1B",
+      "author": "sapientinc",
+      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
+      "downloads": 57,
+      "likes": 39,
+      "trendingScore": 39,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hrm_text",
+        "text-generation",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T15:13:02.000Z",
+      "lastModified": "2026-05-18T07:57:35.000Z"
+    },
+    {
+      "rank": 91,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -2594,7 +2626,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 91,
+      "rank": 92,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -2621,7 +2653,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 92,
+      "rank": 93,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -2653,7 +2685,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -2676,7 +2708,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -2702,7 +2734,7 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 95,
+      "rank": 96,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -2726,7 +2758,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 96,
+      "rank": 97,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -2750,7 +2782,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 97,
+      "rank": 98,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -2767,7 +2799,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 98,
+      "rank": 99,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -2791,7 +2823,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 99,
+      "rank": 100,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -2817,7 +2849,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 100,
+      "rank": 101,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -2833,7 +2865,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 101,
+      "rank": 102,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -2860,7 +2892,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -2889,7 +2921,34 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
+      "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
+      "downloads": 24211,
+      "likes": 35,
+      "trendingScore": 34,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-9B",
+        "base_model:quantized:Qwen/Qwen3.5-9B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T13:34:47.000Z",
+      "lastModified": "2026-05-16T12:39:00.000Z"
+    },
+    {
+      "rank": 105,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -2934,7 +2993,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 104,
+      "rank": 106,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -2979,7 +3038,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 105,
+      "rank": 107,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -3023,7 +3082,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 106,
+      "rank": 108,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3063,7 +3122,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 107,
+      "rank": 109,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3082,7 +3141,7 @@
       "lastModified": "2026-05-01T16:08:38.000Z"
     },
     {
-      "rank": 108,
+      "rank": 110,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -3126,7 +3185,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 109,
+      "rank": 111,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3151,7 +3210,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 110,
+      "rank": 112,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -3196,7 +3255,7 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 111,
+      "rank": 113,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -3222,34 +3281,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 112,
-      "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
-      "downloads": 24211,
-      "likes": 33,
-      "trendingScore": 32,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-9B",
-        "base_model:quantized:Qwen/Qwen3.5-9B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T13:34:47.000Z",
-      "lastModified": "2026-05-16T12:39:00.000Z"
-    },
-    {
-      "rank": 113,
+      "rank": 114,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -3282,7 +3314,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 114,
+      "rank": 115,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -3306,7 +3338,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 115,
+      "rank": 116,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -3333,7 +3365,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3364,7 +3396,7 @@
       "lastModified": "2026-05-07T19:24:05.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -3406,7 +3438,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -3434,7 +3466,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 119,
+      "rank": 120,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -3460,7 +3492,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 120,
+      "rank": 121,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -3492,7 +3524,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 121,
+      "rank": 122,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -3519,7 +3551,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 122,
+      "rank": 123,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -3553,7 +3585,40 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 123,
+      "rank": 124,
+      "id": "Alissonerdx/BFS-Best-Face-Swap",
+      "author": "Alissonerdx",
+      "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+      "downloads": 93163,
+      "likes": 546,
+      "trendingScore": 30,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "qwen-image-edit",
+        "face-swap",
+        "head-swap",
+        "image-editing",
+        "ai-generated",
+        "comfyui",
+        "bfs",
+        "flux 2",
+        "flux",
+        "klein",
+        "image-to-image",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T09:50:28.000Z",
+      "lastModified": "2026-03-08T12:54:54.000Z"
+    },
+    {
+      "rank": 125,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -3584,7 +3649,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 124,
+      "rank": 126,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -3609,7 +3674,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 125,
+      "rank": 127,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -3632,7 +3697,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 126,
+      "rank": 128,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -3659,7 +3724,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 127,
+      "rank": 129,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -3690,7 +3755,35 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 128,
+      "rank": 130,
+      "id": "Datadog/Toto-2.0-2.5B",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
+      "downloads": 1372,
+      "likes": 34,
+      "trendingScore": 29,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-17T16:56:02.000Z",
+      "lastModified": "2026-05-14T14:23:46.000Z"
+    },
+    {
+      "rank": 131,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -3712,7 +3805,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 129,
+      "rank": 132,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -3749,7 +3842,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 130,
+      "rank": 133,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -3771,7 +3864,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 131,
+      "rank": 134,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -3804,59 +3897,71 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 132,
-      "id": "Alissonerdx/BFS-Best-Face-Swap",
-      "author": "Alissonerdx",
-      "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
-      "downloads": 93163,
-      "likes": 540,
+      "rank": 135,
+      "id": "openai/whisper-large-v3",
+      "author": "openai",
+      "url": "https://huggingface.co/openai/whisper-large-v3",
+      "downloads": 4818342,
+      "likes": 5705,
       "trendingScore": 28,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
-        "lora",
-        "qwen-image-edit",
-        "face-swap",
-        "head-swap",
-        "image-editing",
-        "ai-generated",
-        "comfyui",
-        "bfs",
-        "flux 2",
-        "flux",
-        "klein",
-        "image-to-image",
+        "transformers",
+        "pytorch",
+        "jax",
+        "safetensors",
+        "whisper",
+        "automatic-speech-recognition",
+        "audio",
+        "hf-asr-leaderboard",
         "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:mit",
-        "region:us"
+        "zh",
+        "de",
+        "es",
+        "ru",
+        "ko",
+        "fr",
+        "ja",
+        "pt",
+        "tr",
+        "pl",
+        "ca",
+        "nl",
+        "ar",
+        "sv",
+        "it",
+        "id",
+        "hi",
+        "fi",
+        "vi",
+        "he",
+        "uk"
       ],
-      "createdAt": "2025-11-07T09:50:28.000Z",
-      "lastModified": "2026-03-08T12:54:54.000Z"
+      "createdAt": "2023-11-07T18:41:14.000Z",
+      "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 133,
+      "rank": 136,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
       "downloads": 0,
-      "likes": 37,
+      "likes": 69,
       "trendingScore": 27,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
         "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
+        "base_model:adapter:circlestone-labs/Anima",
         "license:other",
         "region:us"
       ],
       "createdAt": "2026-04-27T12:32:06.000Z",
-      "lastModified": "2026-04-30T01:03:50.000Z"
+      "lastModified": "2026-05-17T00:26:38.000Z"
     },
     {
-      "rank": 134,
+      "rank": 137,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -3896,7 +4001,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 135,
+      "rank": 138,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -3933,7 +4038,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 136,
+      "rank": 139,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -3976,7 +4081,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 137,
+      "rank": 140,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -3996,7 +4101,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 138,
+      "rank": 141,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -4021,35 +4126,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 139,
-      "id": "Datadog/Toto-2.0-2.5B",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
-      "downloads": 1372,
-      "likes": 31,
-      "trendingScore": 27,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T16:56:02.000Z",
-      "lastModified": "2026-05-14T14:23:46.000Z"
-    },
-    {
-      "rank": 140,
+      "rank": 142,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4071,7 +4148,7 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 141,
+      "rank": 143,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -4116,7 +4193,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 142,
+      "rank": 144,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -4143,7 +4220,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 143,
+      "rank": 145,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -4188,7 +4265,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 144,
+      "rank": 146,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -4214,7 +4291,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 145,
+      "rank": 147,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -4236,7 +4313,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 146,
+      "rank": 148,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -4252,52 +4329,43 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 147,
-      "id": "openai/whisper-large-v3",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/whisper-large-v3",
-      "downloads": 4818342,
-      "likes": 5703,
+      "rank": 149,
+      "id": "lightonai/Agent-ModernColBERT",
+      "author": "lightonai",
+      "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
+      "downloads": 982,
+      "likes": 26,
       "trendingScore": 26,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "PyLate",
       "tags": [
-        "transformers",
-        "pytorch",
-        "jax",
+        "PyLate",
         "safetensors",
-        "whisper",
-        "automatic-speech-recognition",
-        "audio",
-        "hf-asr-leaderboard",
+        "modernbert",
+        "ColBERT",
+        "sentence-transformers",
+        "sentence-similarity",
+        "feature-extraction",
+        "generated_from_trainer",
+        "dataset_size:5238",
+        "loss:CachedContrastive",
         "en",
-        "zh",
-        "de",
-        "es",
-        "ru",
-        "ko",
-        "fr",
-        "ja",
-        "pt",
-        "tr",
-        "pl",
-        "ca",
-        "nl",
-        "ar",
-        "sv",
-        "it",
-        "id",
-        "hi",
-        "fi",
-        "vi",
-        "he",
-        "uk"
+        "dataset:Tevatron/AgentIR-data",
+        "arxiv:2603.04384",
+        "arxiv:1908.10084",
+        "arxiv:2101.06983",
+        "base_model:lightonai/GTE-ModernColBERT-v1",
+        "base_model:finetune:lightonai/GTE-ModernColBERT-v1",
+        "license:apache-2.0",
+        "text-embeddings-inference",
+        "endpoints_compatible",
+        "region:eu"
       ],
-      "createdAt": "2023-11-07T18:41:14.000Z",
-      "lastModified": "2024-08-12T10:20:10.000Z"
+      "createdAt": "2026-05-12T12:55:37.000Z",
+      "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 148,
+      "rank": 150,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -4335,7 +4403,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 149,
+      "rank": 151,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -4353,7 +4421,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 150,
+      "rank": 152,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -4379,7 +4447,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 151,
+      "rank": 153,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -4399,7 +4467,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 152,
+      "rank": 154,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -4426,7 +4494,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 153,
+      "rank": 155,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -4452,7 +4520,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 154,
+      "rank": 156,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -4478,7 +4546,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 155,
+      "rank": 157,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -4515,7 +4583,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 156,
+      "rank": 158,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -4531,7 +4599,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 157,
+      "rank": 159,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -4554,7 +4622,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 158,
+      "rank": 160,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -4596,7 +4664,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 159,
+      "rank": 161,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -4635,43 +4703,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 160,
-      "id": "lightonai/Agent-ModernColBERT",
-      "author": "lightonai",
-      "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
-      "downloads": 982,
-      "likes": 25,
-      "trendingScore": 25,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "PyLate",
-      "tags": [
-        "PyLate",
-        "safetensors",
-        "modernbert",
-        "ColBERT",
-        "sentence-transformers",
-        "sentence-similarity",
-        "feature-extraction",
-        "generated_from_trainer",
-        "dataset_size:5238",
-        "loss:CachedContrastive",
-        "en",
-        "dataset:Tevatron/AgentIR-data",
-        "arxiv:2603.04384",
-        "arxiv:1908.10084",
-        "arxiv:2101.06983",
-        "base_model:lightonai/GTE-ModernColBERT-v1",
-        "base_model:finetune:lightonai/GTE-ModernColBERT-v1",
-        "license:apache-2.0",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "region:eu"
-      ],
-      "createdAt": "2026-05-12T12:55:37.000Z",
-      "lastModified": "2026-05-12T14:20:08.000Z"
-    },
-    {
-      "rank": 161,
+      "rank": 162,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -4703,7 +4735,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 162,
+      "rank": 163,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -4727,7 +4759,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 163,
+      "rank": 164,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
@@ -4772,7 +4804,7 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 164,
+      "rank": 165,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -4799,7 +4831,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 165,
+      "rank": 166,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -4824,7 +4856,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 166,
+      "rank": 167,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -4860,7 +4892,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 167,
+      "rank": 168,
       "id": "pyannote/speaker-diarization-3.1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
@@ -4892,7 +4924,7 @@
       "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 168,
+      "rank": 169,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -4908,7 +4940,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 169,
+      "rank": 170,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -4929,7 +4961,7 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 170,
+      "rank": 171,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -4956,7 +4988,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 171,
+      "rank": 172,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -4985,7 +5017,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 172,
+      "rank": 173,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -5002,7 +5034,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 173,
+      "rank": 174,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -5023,7 +5055,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 174,
+      "rank": 175,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -5044,7 +5076,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 175,
+      "rank": 176,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -5076,7 +5108,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 176,
+      "rank": 177,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -5107,7 +5139,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 177,
+      "rank": 178,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -5136,7 +5168,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 178,
+      "rank": 179,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -5181,7 +5213,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 179,
+      "rank": 180,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -5208,7 +5240,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 180,
+      "rank": 181,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5234,12 +5266,12 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 181,
+      "rank": 182,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
       "downloads": 5571,
-      "likes": 24,
+      "likes": 25,
       "trendingScore": 22,
       "pipelineTag": "tabular-classification",
       "libraryName": null,
@@ -5258,7 +5290,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 182,
+      "rank": 183,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -5303,12 +5335,12 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 183,
+      "rank": 184,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
-      "downloads": 1207727,
-      "likes": 421,
+      "downloads": 1134317,
+      "likes": 430,
       "trendingScore": 21,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -5331,7 +5363,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 184,
+      "rank": 185,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -5358,7 +5390,7 @@
       "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 185,
+      "rank": 186,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -5394,7 +5426,69 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 186,
+      "rank": 187,
+      "id": "ByteDance-Seed/Cola-DLM",
+      "author": "ByteDance-Seed",
+      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
+      "downloads": 0,
+      "likes": 21,
+      "trendingScore": 21,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "text-generation",
+        "language-model",
+        "diffusion",
+        "latent-diffusion",
+        "flow-matching",
+        "text-vae",
+        "pytorch",
+        "research",
+        "en",
+        "arxiv:2605.06548",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T07:55:26.000Z",
+      "lastModified": "2026-05-15T09:38:05.000Z"
+    },
+    {
+      "rank": 188,
+      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "downloads": 12526,
+      "likes": 23,
+      "trendingScore": 21,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:11:26.000Z",
+      "lastModified": "2026-05-16T21:22:27.000Z"
+    },
+    {
+      "rank": 189,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -5422,7 +5516,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 187,
+      "rank": 190,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -5455,7 +5549,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 188,
+      "rank": 191,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -5480,7 +5574,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 189,
+      "rank": 192,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -5517,7 +5611,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 190,
+      "rank": 193,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -5560,7 +5654,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 191,
+      "rank": 194,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -5584,7 +5678,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 192,
+      "rank": 195,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -5608,7 +5702,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 193,
+      "rank": 196,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5640,7 +5734,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 194,
+      "rank": 197,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -5669,7 +5763,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 195,
+      "rank": 198,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -5700,7 +5794,7 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 196,
+      "rank": 199,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -5732,7 +5826,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 197,
+      "rank": 200,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -5777,7 +5871,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 198,
+      "rank": 201,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -5810,7 +5904,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 199,
+      "rank": 202,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -5832,7 +5926,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 200,
+      "rank": 203,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -5859,7 +5953,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 201,
+      "rank": 204,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -5875,7 +5969,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 202,
+      "rank": 205,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -5892,7 +5986,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 203,
+      "rank": 206,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -5915,7 +6009,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 204,
+      "rank": 207,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -5940,7 +6034,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 205,
+      "rank": 208,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -5976,7 +6070,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 206,
+      "rank": 209,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -6005,7 +6099,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 207,
+      "rank": 210,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -6035,7 +6129,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 208,
+      "rank": 211,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -6053,7 +6147,7 @@
       "lastModified": "2026-05-15T10:14:24.000Z"
     },
     {
-      "rank": 209,
+      "rank": 212,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6098,7 +6192,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 210,
+      "rank": 213,
       "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
       "author": "fal",
       "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
@@ -6130,200 +6224,13 @@
       "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
-      "rank": 211,
-      "id": "ByteDance-Seed/Cola-DLM",
-      "author": "ByteDance-Seed",
-      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
-      "downloads": 0,
-      "likes": 19,
-      "trendingScore": 19,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "text-generation",
-        "language-model",
-        "diffusion",
-        "latent-diffusion",
-        "flow-matching",
-        "text-vae",
-        "pytorch",
-        "research",
-        "en",
-        "arxiv:2605.06548",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T07:55:26.000Z",
-      "lastModified": "2026-05-15T09:38:05.000Z"
-    },
-    {
-      "rank": 212,
-      "id": "AesSedai/MiMo-V2.5-GGUF",
-      "author": "AesSedai",
-      "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
-      "downloads": 7035,
-      "likes": 31,
-      "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:XiaomiMiMo/MiMo-V2.5",
-        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-29T01:54:42.000Z",
-      "lastModified": "2026-05-07T10:17:59.000Z"
-    },
-    {
-      "rank": 213,
-      "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
-      "downloads": 41,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "audio-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "moss_music",
-        "music",
-        "music-understanding",
-        "audio",
-        "audio-language-model",
-        "moss",
-        "moss-music",
-        "lyrics-asr",
-        "music-captioning",
-        "chord-recognition",
-        "audio-text-to-text",
-        "custom_code",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-21T09:25:53.000Z",
-      "lastModified": "2026-05-01T15:12:38.000Z"
-    },
-    {
       "rank": 214,
-      "id": "kpsss34/Walkyrie-1.3B-v1.0",
-      "author": "kpsss34",
-      "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
-      "downloads": 689,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "pytorch",
-        "wan",
-        "pruned",
-        "license:apache-2.0",
-        "diffusers:WalkyriePipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-04T07:45:07.000Z",
-      "lastModified": "2026-05-11T09:01:21.000Z"
-    },
-    {
-      "rank": 215,
-      "id": "MiniMaxAI/MiniMax-M2.7",
-      "author": "MiniMaxAI",
-      "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
-      "downloads": 635634,
-      "likes": 1128,
-      "trendingScore": 18,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "minimax_m2",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-04-09T03:37:12.000Z",
-      "lastModified": "2026-04-20T04:28:14.000Z"
-    },
-    {
-      "rank": 216,
-      "id": "baidu/ERNIE-Image",
-      "author": "baidu",
-      "url": "https://huggingface.co/baidu/ERNIE-Image",
-      "downloads": 13205,
-      "likes": 627,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "8B",
-        "license:apache-2.0",
-        "diffusers:ErnieImagePipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-04-07T07:26:56.000Z",
-      "lastModified": "2026-04-17T02:33:16.000Z"
-    },
-    {
-      "rank": 217,
-      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
-      "downloads": 5508,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "moe",
-        "mixture-of-experts",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-10T07:52:54.000Z",
-      "lastModified": "2026-05-10T08:57:13.000Z"
-    },
-    {
-      "rank": 218,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
       "downloads": 316422,
-      "likes": 850,
-      "trendingScore": 18,
+      "likes": 852,
+      "trendingScore": 19,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "nemo",
       "tags": [
@@ -6362,7 +6269,164 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
+      "rank": 215,
+      "id": "AesSedai/MiMo-V2.5-GGUF",
+      "author": "AesSedai",
+      "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
+      "downloads": 7035,
+      "likes": 31,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:XiaomiMiMo/MiMo-V2.5",
+        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-29T01:54:42.000Z",
+      "lastModified": "2026-05-07T10:17:59.000Z"
+    },
+    {
+      "rank": 216,
+      "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
+      "downloads": 41,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "audio-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "moss_music",
+        "music",
+        "music-understanding",
+        "audio",
+        "audio-language-model",
+        "moss",
+        "moss-music",
+        "lyrics-asr",
+        "music-captioning",
+        "chord-recognition",
+        "audio-text-to-text",
+        "custom_code",
+        "en",
+        "zh",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-21T09:25:53.000Z",
+      "lastModified": "2026-05-01T15:12:38.000Z"
+    },
+    {
+      "rank": 217,
+      "id": "kpsss34/Walkyrie-1.3B-v1.0",
+      "author": "kpsss34",
+      "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
+      "downloads": 689,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "pytorch",
+        "wan",
+        "pruned",
+        "license:apache-2.0",
+        "diffusers:WalkyriePipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-04T07:45:07.000Z",
+      "lastModified": "2026-05-11T09:01:21.000Z"
+    },
+    {
+      "rank": 218,
+      "id": "MiniMaxAI/MiniMax-M2.7",
+      "author": "MiniMaxAI",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
+      "downloads": 635634,
+      "likes": 1128,
+      "trendingScore": 18,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "minimax_m2",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-04-09T03:37:12.000Z",
+      "lastModified": "2026-04-20T04:28:14.000Z"
+    },
+    {
       "rank": 219,
+      "id": "baidu/ERNIE-Image",
+      "author": "baidu",
+      "url": "https://huggingface.co/baidu/ERNIE-Image",
+      "downloads": 13205,
+      "likes": 627,
+      "trendingScore": 18,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "8B",
+        "license:apache-2.0",
+        "diffusers:ErnieImagePipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-04-07T07:26:56.000Z",
+      "lastModified": "2026-04-17T02:33:16.000Z"
+    },
+    {
+      "rank": 220,
+      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
+      "downloads": 5508,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "moe",
+        "mixture-of-experts",
+        "qwen3.5",
+        "reasoning",
+        "chain-of-thought",
+        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-10T07:52:54.000Z",
+      "lastModified": "2026-05-10T08:57:13.000Z"
+    },
+    {
+      "rank": 221,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -6388,7 +6452,7 @@
       "lastModified": "2026-05-11T14:29:36.000Z"
     },
     {
-      "rank": 220,
+      "rank": 222,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -6405,7 +6469,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 221,
+      "rank": 223,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -6434,7 +6498,45 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 222,
+      "rank": 224,
+      "id": "fastino/gliner2-privacy-filter-PII-multi",
+      "author": "fastino",
+      "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
+      "downloads": 1730,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "token-classification",
+      "libraryName": "gliner2",
+      "tags": [
+        "gliner2",
+        "safetensors",
+        "extractor",
+        "pii",
+        "ner",
+        "privacy",
+        "redaction",
+        "gliner",
+        "information-extraction",
+        "span-extraction",
+        "token-classification",
+        "en",
+        "fr",
+        "es",
+        "de",
+        "it",
+        "pt",
+        "nl",
+        "dataset:synthetic",
+        "arxiv:2605.09973",
+        "arxiv:2604.09791",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-10T23:59:32.000Z",
+      "lastModified": "2026-05-14T18:18:54.000Z"
+    },
+    {
+      "rank": 225,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -6479,7 +6581,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 223,
+      "rank": 226,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -6508,7 +6610,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 224,
+      "rank": 227,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -6537,7 +6639,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 225,
+      "rank": 228,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -6582,7 +6684,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 226,
+      "rank": 229,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -6614,7 +6716,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 227,
+      "rank": 230,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -6644,7 +6746,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 228,
+      "rank": 231,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6665,7 +6767,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 229,
+      "rank": 232,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -6694,7 +6796,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 230,
+      "rank": 233,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -6715,7 +6817,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 231,
+      "rank": 234,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -6760,7 +6862,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 232,
+      "rank": 235,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -6789,7 +6891,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 233,
+      "rank": 236,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -6817,7 +6919,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 234,
+      "rank": 237,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -6839,7 +6941,7 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 235,
+      "rank": 238,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -6864,7 +6966,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 236,
+      "rank": 239,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -6887,12 +6989,12 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 237,
+      "rank": 240,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
       "downloads": 7771076,
-      "likes": 544,
+      "likes": 547,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -6914,7 +7016,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 238,
+      "rank": 241,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -6941,7 +7043,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 239,
+      "rank": 242,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -6967,45 +7069,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 240,
-      "id": "fastino/gliner2-privacy-filter-PII-multi",
-      "author": "fastino",
-      "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
-      "downloads": 1730,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": "token-classification",
-      "libraryName": "gliner2",
-      "tags": [
-        "gliner2",
-        "safetensors",
-        "extractor",
-        "pii",
-        "ner",
-        "privacy",
-        "redaction",
-        "gliner",
-        "information-extraction",
-        "span-extraction",
-        "token-classification",
-        "en",
-        "fr",
-        "es",
-        "de",
-        "it",
-        "pt",
-        "nl",
-        "dataset:synthetic",
-        "arxiv:2605.09973",
-        "arxiv:2604.09791",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-10T23:59:32.000Z",
-      "lastModified": "2026-05-14T18:18:54.000Z"
-    },
-    {
-      "rank": 241,
+      "rank": 243,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -7023,7 +7087,59 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 242,
+      "rank": 244,
+      "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
+      "downloads": 12477,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:quantized:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T12:44:22.000Z",
+      "lastModified": "2026-05-16T12:38:58.000Z"
+    },
+    {
+      "rank": 245,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-18T13:52:59.000Z"
+    },
+    {
+      "rank": 246,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -7048,7 +7164,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 243,
+      "rank": 247,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -7083,7 +7199,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 244,
+      "rank": 248,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -7128,7 +7244,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 245,
+      "rank": 249,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -7155,7 +7271,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 246,
+      "rank": 250,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -7184,7 +7300,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 247,
+      "rank": 251,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -7207,7 +7323,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 248,
+      "rank": 252,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -7251,7 +7367,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 249,
+      "rank": 253,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -7296,7 +7412,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 250,
+      "rank": 254,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -7314,7 +7430,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 251,
+      "rank": 255,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -7359,7 +7475,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 252,
+      "rank": 256,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -7377,34 +7493,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 253,
-      "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
-      "downloads": 12477,
-      "likes": 16,
-      "trendingScore": 16,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:quantized:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T12:44:22.000Z",
-      "lastModified": "2026-05-16T12:38:58.000Z"
-    },
-    {
-      "rank": 254,
+      "rank": 257,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -7430,7 +7519,140 @@
       "lastModified": "2026-05-18T08:01:35.000Z"
     },
     {
-      "rank": 255,
+      "rank": 258,
+      "id": "Datadog/Toto-2.0-313m",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
+      "downloads": 2709,
+      "likes": 17,
+      "trendingScore": 16,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T20:39:39.000Z",
+      "lastModified": "2026-05-14T14:23:31.000Z"
+    },
+    {
+      "rank": 259,
+      "id": "Comfy-Org/TRELLIS.2",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
+      "downloads": 0,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T00:59:09.000Z",
+      "lastModified": "2026-05-17T17:24:14.000Z"
+    },
+    {
+      "rank": 260,
+      "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+      "author": "DavidAU",
+      "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+      "downloads": 24,
+      "likes": 17,
+      "trendingScore": 16,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "unsloth",
+        "heretic",
+        "uncensored",
+        "abliterated",
+        "fine tune",
+        "creative",
+        "creative writing",
+        "fiction writing",
+        "plot generation",
+        "sub-plot generation",
+        "story generation",
+        "scene continue",
+        "storytelling",
+        "fiction story",
+        "science fiction",
+        "romance",
+        "all genres",
+        "story",
+        "writing",
+        "vivid prosing",
+        "vivid writing",
+        "fiction",
+        "roleplaying",
+        "bfloat16",
+        "all use cases",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T08:53:53.000Z",
+      "lastModified": "2026-05-18T07:56:29.000Z"
+    },
+    {
+      "rank": 261,
+      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "downloads": 0,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_5",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-18T05:48:32.000Z",
+      "lastModified": "2026-05-18T11:27:53.000Z"
+    },
+    {
+      "rank": 262,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -7457,7 +7679,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 256,
+      "rank": 263,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -7502,7 +7724,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 257,
+      "rank": 264,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -7532,7 +7754,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 258,
+      "rank": 265,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7561,7 +7783,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 259,
+      "rank": 266,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -7591,7 +7813,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 260,
+      "rank": 267,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -7636,7 +7858,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 261,
+      "rank": 268,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -7671,7 +7893,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 262,
+      "rank": 269,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -7699,7 +7921,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 263,
+      "rank": 270,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -7728,7 +7950,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 264,
+      "rank": 271,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -7753,7 +7975,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 265,
+      "rank": 272,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -7781,7 +8003,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 266,
+      "rank": 273,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -7809,7 +8031,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 267,
+      "rank": 274,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -7840,7 +8062,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 268,
+      "rank": 275,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -7885,7 +8107,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 269,
+      "rank": 276,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -7917,7 +8139,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 270,
+      "rank": 277,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -7944,7 +8166,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 271,
+      "rank": 278,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -7967,7 +8189,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 272,
+      "rank": 279,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -8000,7 +8222,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 273,
+      "rank": 280,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -8027,7 +8249,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 274,
+      "rank": 281,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -8046,7 +8268,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 275,
+      "rank": 282,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -8069,7 +8291,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 276,
+      "rank": 283,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -8095,7 +8317,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 277,
+      "rank": 284,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -8127,7 +8349,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 278,
+      "rank": 285,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -8157,7 +8379,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 279,
+      "rank": 286,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -8190,12 +8412,12 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 280,
+      "rank": 287,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
-      "downloads": 5556582,
-      "likes": 2317,
+      "downloads": 5537949,
+      "likes": 2321,
       "trendingScore": 15,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
@@ -8210,53 +8432,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 281,
-      "id": "Datadog/Toto-2.0-313m",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
-      "downloads": 2709,
-      "likes": 16,
-      "trendingScore": 15,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T20:39:39.000Z",
-      "lastModified": "2026-05-14T14:23:31.000Z"
-    },
-    {
-      "rank": 282,
-      "id": "Comfy-Org/TRELLIS.2",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
-      "downloads": 0,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T00:59:09.000Z",
-      "lastModified": "2026-05-17T17:24:14.000Z"
-    },
-    {
-      "rank": 283,
+      "rank": 288,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -8279,7 +8455,7 @@
       "lastModified": "2026-05-13T21:37:14.000Z"
     },
     {
-      "rank": 284,
+      "rank": 289,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -8317,52 +8493,94 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 285,
-      "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-      "author": "DavidAU",
-      "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-      "downloads": 24,
-      "likes": 16,
+      "rank": 290,
+      "id": "Simplified-Reasoning/SU-01",
+      "author": "Simplified-Reasoning",
+      "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
+      "downloads": 216,
+      "likes": 15,
       "trendingScore": 15,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "unsloth",
-        "heretic",
-        "uncensored",
-        "abliterated",
-        "fine tune",
-        "creative",
-        "creative writing",
-        "fiction writing",
-        "plot generation",
-        "sub-plot generation",
-        "story generation",
-        "scene continue",
-        "storytelling",
-        "fiction story",
-        "science fiction",
-        "romance",
-        "all genres",
-        "story",
-        "writing",
-        "vivid prosing",
-        "vivid writing",
-        "fiction",
-        "roleplaying",
-        "bfloat16",
-        "all use cases",
-        "conversational"
+        "qwen3_moe",
+        "text-generation",
+        "reasoning",
+        "olympiad",
+        "mathematics",
+        "science",
+        "reinforcement-learning",
+        "test-time-scaling",
+        "long-context",
+        "conversational",
+        "arxiv:2605.13301",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
       ],
-      "createdAt": "2026-05-15T08:53:53.000Z",
-      "lastModified": "2026-05-18T07:56:29.000Z"
+      "createdAt": "2026-05-12T22:20:39.000Z",
+      "lastModified": "2026-05-16T08:42:52.000Z"
     },
     {
-      "rank": 286,
+      "rank": 291,
+      "id": "GD-ML/DreamX-World-5B-Cam",
+      "author": "GD-ML",
+      "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
+      "downloads": 434,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "ti2v",
+        "world-model",
+        "video-generation",
+        "image-to-video",
+        "camera-control",
+        "interactive-generation",
+        "diffusion",
+        "transformer",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T09:08:54.000Z",
+      "lastModified": "2026-05-18T11:55:16.000Z"
+    },
+    {
+      "rank": 292,
+      "id": "chiennv/Orthrus-Qwen3-8B",
+      "author": "chiennv",
+      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
+      "downloads": 1535,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "diffusion",
+        "parallel-decoding",
+        "orthrus",
+        "conversational",
+        "custom_code",
+        "arxiv:2605.12825",
+        "license:cc-by-4.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T17:59:34.000Z",
+      "lastModified": "2026-05-16T22:44:53.000Z"
+    },
+    {
+      "rank": 293,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -8386,7 +8604,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 287,
+      "rank": 294,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -8413,7 +8631,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 288,
+      "rank": 295,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -8441,7 +8659,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 289,
+      "rank": 296,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -8469,7 +8687,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 290,
+      "rank": 297,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -8488,7 +8706,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 291,
+      "rank": 298,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -8520,7 +8738,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 292,
+      "rank": 299,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -8549,7 +8767,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 293,
+      "rank": 300,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -8576,7 +8794,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 294,
+      "rank": 301,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8600,7 +8818,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 295,
+      "rank": 302,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -8626,7 +8844,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 296,
+      "rank": 303,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -8657,7 +8875,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 297,
+      "rank": 304,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -8685,7 +8903,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 298,
+      "rank": 305,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -8708,7 +8926,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 299,
+      "rank": 306,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -8742,7 +8960,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 300,
+      "rank": 307,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -8768,7 +8986,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 301,
+      "rank": 308,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -8810,7 +9028,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 302,
+      "rank": 309,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -8848,7 +9066,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 303,
+      "rank": 310,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -8867,7 +9085,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 304,
+      "rank": 311,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -8887,7 +9105,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 305,
+      "rank": 312,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -8914,7 +9132,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 306,
+      "rank": 313,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -8940,65 +9158,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 307,
-      "id": "Simplified-Reasoning/SU-01",
-      "author": "Simplified-Reasoning",
-      "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
-      "downloads": 216,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_moe",
-        "text-generation",
-        "reasoning",
-        "olympiad",
-        "mathematics",
-        "science",
-        "reinforcement-learning",
-        "test-time-scaling",
-        "long-context",
-        "conversational",
-        "arxiv:2605.13301",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T22:20:39.000Z",
-      "lastModified": "2026-05-16T08:42:52.000Z"
-    },
-    {
-      "rank": 308,
-      "id": "GD-ML/DreamX-World-5B-Cam",
-      "author": "GD-ML",
-      "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
-      "downloads": 434,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "ti2v",
-        "world-model",
-        "video-generation",
-        "image-to-video",
-        "camera-control",
-        "interactive-generation",
-        "diffusion",
-        "transformer",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T09:08:54.000Z",
-      "lastModified": "2026-05-18T11:55:16.000Z"
-    },
-    {
-      "rank": 309,
+      "rank": 314,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9028,7 +9188,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 310,
+      "rank": 315,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -9057,7 +9217,7 @@
       "lastModified": "2026-05-16T06:48:11.000Z"
     },
     {
-      "rank": 311,
+      "rank": 316,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -9082,68 +9242,121 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 312,
-      "id": "chiennv/Orthrus-Qwen3-8B",
-      "author": "chiennv",
-      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
-      "downloads": 1535,
-      "likes": 14,
+      "rank": 317,
+      "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 226607,
+      "likes": 181,
       "trendingScore": 14,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "diffusion",
-        "parallel-decoding",
-        "orthrus",
-        "conversational",
-        "custom_code",
-        "arxiv:2605.12825",
-        "license:cc-by-4.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T17:59:34.000Z",
-      "lastModified": "2026-05-16T22:44:53.000Z"
-    },
-    {
-      "rank": 313,
-      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 12526,
-      "likes": 16,
-      "trendingScore": 14,
-      "pipelineTag": null,
+      "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
         "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "uncensored",
+        "gemma4",
+        "vision",
+        "multimodal",
+        "audio",
+        "abliterated",
+        "image-text-to-text",
+        "en",
+        "multilingual",
+        "license:gemma",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-02T23:25:00.000Z",
+      "lastModified": "2026-04-06T03:51:20.000Z"
+    },
+    {
+      "rank": 318,
+      "id": "Datadog/Toto-2.0-4m",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
+      "downloads": 1439,
+      "likes": 15,
+      "trendingScore": 14,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T20:21:36.000Z",
+      "lastModified": "2026-05-14T14:23:12.000Z"
+    },
+    {
+      "rank": 319,
+      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "downloads": 17011,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-122B-A10B",
+        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
+        "imatrix",
         "conversational"
       ],
-      "createdAt": "2026-05-16T19:11:26.000Z",
-      "lastModified": "2026-05-16T21:22:27.000Z"
+      "createdAt": "2026-05-15T19:03:18.000Z",
+      "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 314,
+      "rank": 320,
+      "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
+      "author": "perplexity-ai",
+      "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
+      "downloads": 4865,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "kernels",
+      "tags": [
+        "kernels",
+        "safetensors",
+        "bidirectional_pplx_qwen3",
+        "feature-extraction",
+        "custom_code",
+        "late-interaction",
+        "maxsim",
+        "pylate",
+        "base_model:perplexity-ai/pplx-embed-v1-0.6b",
+        "arxiv:2602.11151",
+        "base_model:finetune:perplexity-ai/pplx-embed-v1-0.6b",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-03-13T15:07:30.000Z",
+      "lastModified": "2026-05-18T17:03:49.000Z"
+    },
+    {
+      "rank": 321,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -9172,12 +9385,12 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 315,
+      "rank": 322,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
-      "downloads": 23347,
-      "likes": 1160,
+      "downloads": 31655,
+      "likes": 1175,
       "trendingScore": 13,
       "pipelineTag": "translation",
       "libraryName": "transformers",
@@ -9217,7 +9430,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 316,
+      "rank": 323,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -9262,7 +9475,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 317,
+      "rank": 324,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -9291,7 +9504,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 318,
+      "rank": 325,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -9318,7 +9531,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 319,
+      "rank": 326,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -9363,7 +9576,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 320,
+      "rank": 327,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -9390,7 +9603,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 321,
+      "rank": 328,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -9421,7 +9634,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 322,
+      "rank": 329,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9445,7 +9658,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 323,
+      "rank": 330,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -9469,37 +9682,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 324,
-      "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 308191,
-      "likes": 164,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "vision",
-        "multimodal",
-        "audio",
-        "abliterated",
-        "image-text-to-text",
-        "en",
-        "multilingual",
-        "license:gemma",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-02T23:25:00.000Z",
-      "lastModified": "2026-04-06T03:51:20.000Z"
-    },
-    {
-      "rank": 325,
+      "rank": 331,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -9544,7 +9727,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 326,
+      "rank": 332,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -9571,7 +9754,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 327,
+      "rank": 333,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -9607,7 +9790,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 328,
+      "rank": 334,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -9638,7 +9821,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 329,
+      "rank": 335,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -9669,7 +9852,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 330,
+      "rank": 336,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -9702,7 +9885,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 331,
+      "rank": 337,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -9731,7 +9914,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 332,
+      "rank": 338,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -9755,7 +9938,7 @@
       "lastModified": "2026-04-16T18:11:27.000Z"
     },
     {
-      "rank": 333,
+      "rank": 339,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -9781,7 +9964,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 334,
+      "rank": 340,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -9811,7 +9994,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 335,
+      "rank": 341,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -9829,7 +10012,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 336,
+      "rank": 342,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -9860,7 +10043,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 337,
+      "rank": 343,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -9881,7 +10064,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 338,
+      "rank": 344,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -9901,12 +10084,12 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 339,
+      "rank": 345,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
-      "downloads": 99942,
-      "likes": 66,
+      "downloads": 104503,
+      "likes": 70,
       "trendingScore": 13,
       "pipelineTag": "any-to-any",
       "libraryName": "transformers",
@@ -9932,7 +10115,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 340,
+      "rank": 346,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -9960,35 +10143,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 341,
-      "id": "Datadog/Toto-2.0-4m",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
-      "downloads": 1439,
-      "likes": 14,
-      "trendingScore": 13,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T20:21:36.000Z",
-      "lastModified": "2026-05-14T14:23:12.000Z"
-    },
-    {
-      "rank": 342,
+      "rank": 347,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -10015,7 +10170,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 343,
+      "rank": 348,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -10045,7 +10200,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 344,
+      "rank": 349,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -10062,77 +10217,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 345,
-      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "downloads": 0,
-      "likes": 13,
-      "trendingScore": 13,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_5",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "coder",
-        "text-generation",
-        "en",
-        "zh",
-        "ko",
-        "ru",
-        "ja",
-        "es",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-18T05:48:32.000Z",
-      "lastModified": "2026-05-18T11:27:53.000Z"
-    },
-    {
-      "rank": 346,
-      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "downloads": 17011,
-      "likes": 13,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-122B-A10B",
-        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T19:03:18.000Z",
-      "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 347,
+      "rank": 350,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10177,7 +10262,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 348,
+      "rank": 351,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -10204,7 +10289,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 349,
+      "rank": 352,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -10232,7 +10317,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 350,
+      "rank": 353,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -10265,7 +10350,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 351,
+      "rank": 354,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -10281,7 +10366,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 352,
+      "rank": 355,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -10304,7 +10389,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 353,
+      "rank": 356,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -10338,7 +10423,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 354,
+      "rank": 357,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -10358,7 +10443,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 355,
+      "rank": 358,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -10393,7 +10478,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 356,
+      "rank": 359,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -10423,7 +10508,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 357,
+      "rank": 360,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -10444,7 +10529,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 358,
+      "rank": 361,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -10473,7 +10558,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 359,
+      "rank": 362,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -10503,7 +10588,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 360,
+      "rank": 363,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -10531,7 +10616,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 361,
+      "rank": 364,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -10560,7 +10645,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 362,
+      "rank": 365,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -10592,7 +10677,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 363,
+      "rank": 366,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -10621,7 +10706,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 364,
+      "rank": 367,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -10656,7 +10741,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 365,
+      "rank": 368,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -10678,7 +10763,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 366,
+      "rank": 369,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -10716,7 +10801,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 367,
+      "rank": 370,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -10755,7 +10840,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 368,
+      "rank": 371,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -10792,7 +10877,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 369,
+      "rank": 372,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -10816,7 +10901,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 370,
+      "rank": 373,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -10843,7 +10928,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 371,
+      "rank": 374,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -10861,7 +10946,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 372,
+      "rank": 375,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -10880,7 +10965,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 373,
+      "rank": 376,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -10908,7 +10993,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 374,
+      "rank": 377,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -10935,7 +11020,70 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 375,
+      "rank": 378,
+      "id": "PaddlePaddle/PaddleOCR-VL-1.5",
+      "author": "PaddlePaddle",
+      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
+      "downloads": 36070,
+      "likes": 627,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "PaddleOCR",
+      "tags": [
+        "PaddleOCR",
+        "safetensors",
+        "paddleocr_vl",
+        "ERNIE4.5",
+        "PaddlePaddle",
+        "image-to-text",
+        "ocr",
+        "document-parse",
+        "layout",
+        "table",
+        "formula",
+        "chart",
+        "seal",
+        "spotting",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "zh",
+        "multilingual",
+        "arxiv:2601.21957",
+        "base_model:baidu/ERNIE-4.5-0.3B-Paddle",
+        "base_model:finetune:baidu/ERNIE-4.5-0.3B-Paddle",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-01-28T12:43:01.000Z",
+      "lastModified": "2026-04-30T09:36:47.000Z"
+    },
+    {
+      "rank": 379,
+      "id": "google/gemma-4-26B-A4B",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-26B-A4B",
+      "downloads": 227418,
+      "likes": 270,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-03-12T00:38:03.000Z",
+      "lastModified": "2026-04-02T16:13:38.000Z"
+    },
+    {
+      "rank": 380,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -10980,7 +11128,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 376,
+      "rank": 381,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -11022,7 +11170,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 377,
+      "rank": 382,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -11048,7 +11196,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 378,
+      "rank": 383,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -11073,7 +11221,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 379,
+      "rank": 384,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -11090,7 +11238,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 380,
+      "rank": 385,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -11118,7 +11266,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 381,
+      "rank": 386,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -11144,7 +11292,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 382,
+      "rank": 387,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -11171,7 +11319,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 383,
+      "rank": 388,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -11199,7 +11347,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 384,
+      "rank": 389,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -11232,7 +11380,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 385,
+      "rank": 390,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -11266,7 +11414,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 386,
+      "rank": 391,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -11295,7 +11443,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 387,
+      "rank": 392,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -11324,7 +11472,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 388,
+      "rank": 393,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -11357,7 +11505,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 389,
+      "rank": 394,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -11384,7 +11532,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 390,
+      "rank": 395,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -11414,7 +11562,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 391,
+      "rank": 396,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11437,7 +11585,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 392,
+      "rank": 397,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -11463,7 +11611,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 393,
+      "rank": 398,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -11487,7 +11635,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 394,
+      "rank": 399,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -11514,7 +11662,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 395,
+      "rank": 400,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -11544,7 +11692,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 396,
+      "rank": 401,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -11578,7 +11726,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 397,
+      "rank": 402,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -11594,7 +11742,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 398,
+      "rank": 403,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -11625,7 +11773,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 399,
+      "rank": 404,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -11647,7 +11795,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 400,
+      "rank": 405,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -11667,7 +11815,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 401,
+      "rank": 406,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -11689,7 +11837,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 402,
+      "rank": 407,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11720,7 +11868,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 403,
+      "rank": 408,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -11749,7 +11897,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 404,
+      "rank": 409,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -11786,7 +11934,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 405,
+      "rank": 410,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -11811,7 +11959,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 406,
+      "rank": 411,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -11836,7 +11984,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 407,
+      "rank": 412,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -11871,7 +12019,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 408,
+      "rank": 413,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -11895,12 +12043,12 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 409,
+      "rank": 414,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
-      "downloads": 3549428,
-      "likes": 471,
+      "downloads": 3550364,
+      "likes": 472,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -11923,7 +12071,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 410,
+      "rank": 415,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -11954,7 +12102,7 @@
       "lastModified": "2026-05-13T08:04:57.000Z"
     },
     {
-      "rank": 411,
+      "rank": 416,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -11986,7 +12134,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 412,
+      "rank": 417,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -12016,7 +12164,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 413,
+      "rank": 418,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -12043,48 +12191,91 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 414,
-      "id": "PaddlePaddle/PaddleOCR-VL-1.5",
-      "author": "PaddlePaddle",
-      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
-      "downloads": 36070,
-      "likes": 626,
+      "rank": 419,
+      "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 176644,
+      "likes": 342,
       "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "PaddleOCR",
+      "pipelineTag": null,
+      "libraryName": null,
       "tags": [
-        "PaddleOCR",
-        "safetensors",
-        "paddleocr_vl",
-        "ERNIE4.5",
-        "PaddlePaddle",
-        "image-to-text",
-        "ocr",
-        "document-parse",
-        "layout",
-        "table",
-        "formula",
-        "chart",
-        "seal",
-        "spotting",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
+        "gguf",
+        "uncensored",
+        "qwen3.5",
+        "qwen",
         "en",
         "zh",
         "multilingual",
-        "arxiv:2601.21957",
-        "base_model:baidu/ERNIE-4.5-0.3B-Paddle",
-        "base_model:finetune:baidu/ERNIE-4.5-0.3B-Paddle",
         "license:apache-2.0",
-        "eval-results",
-        "region:us"
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-01-28T12:43:01.000Z",
-      "lastModified": "2026-04-30T09:36:47.000Z"
+      "createdAt": "2026-03-03T12:16:35.000Z",
+      "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 415,
+      "rank": 420,
+      "id": "microsoft/GridSFM_Open",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/GridSFM_Open",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "graph-ml",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "graph-neural-network",
+        "power-systems",
+        "power-grid",
+        "ac-opf",
+        "optimal-power-flow",
+        "graph-attention-network",
+        "scientific-ml",
+        "research",
+        "graph-ml",
+        "en",
+        "dataset:microsoft/GridSFM_US_power_grid",
+        "arxiv:2406.07234",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T19:04:04.000Z",
+      "lastModified": "2026-05-13T13:45:10.000Z"
+    },
+    {
+      "rank": 421,
+      "id": "Datadog/Toto-2.0-1B",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
+      "downloads": 1038,
+      "likes": 13,
+      "trendingScore": 11,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T20:41:57.000Z",
+      "lastModified": "2026-05-14T14:23:39.000Z"
+    },
+    {
+      "rank": 422,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -12113,7 +12304,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 416,
+      "rank": 423,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -12147,7 +12338,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 417,
+      "rank": 424,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -12192,33 +12383,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 418,
-      "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 176644,
-      "likes": 341,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.5",
-        "qwen",
-        "en",
-        "zh",
-        "multilingual",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-03T12:16:35.000Z",
-      "lastModified": "2026-04-05T19:01:02.000Z"
-    },
-    {
-      "rank": 419,
+      "rank": 425,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -12247,7 +12412,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 420,
+      "rank": 426,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -12272,7 +12437,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 421,
+      "rank": 427,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -12307,7 +12472,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 422,
+      "rank": 428,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -12334,7 +12499,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 423,
+      "rank": 429,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -12379,7 +12544,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 424,
+      "rank": 430,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -12401,7 +12566,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 425,
+      "rank": 431,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -12433,7 +12598,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 426,
+      "rank": 432,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -12458,7 +12623,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 427,
+      "rank": 433,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -12482,7 +12647,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 428,
+      "rank": 434,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -12510,7 +12675,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 429,
+      "rank": 435,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -12553,7 +12718,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 430,
+      "rank": 436,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -12577,7 +12742,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 431,
+      "rank": 437,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -12622,7 +12787,7 @@
       "lastModified": "2026-04-07T16:23:12.000Z"
     },
     {
-      "rank": 432,
+      "rank": 438,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -12667,7 +12832,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 433,
+      "rank": 439,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -12696,7 +12861,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 434,
+      "rank": 440,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -12728,29 +12893,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 435,
-      "id": "google/gemma-4-26B-A4B",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-26B-A4B",
-      "downloads": 227418,
-      "likes": 268,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-12T00:38:03.000Z",
-      "lastModified": "2026-04-02T16:13:38.000Z"
-    },
-    {
-      "rank": 436,
+      "rank": 441,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -12774,7 +12917,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 437,
+      "rank": 442,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -12796,7 +12939,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 438,
+      "rank": 443,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -12821,7 +12964,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 439,
+      "rank": 444,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -12849,7 +12992,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 440,
+      "rank": 445,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -12873,7 +13016,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 441,
+      "rank": 446,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -12900,7 +13043,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 442,
+      "rank": 447,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -12925,7 +13068,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 443,
+      "rank": 448,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -12942,7 +13085,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 444,
+      "rank": 449,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -12966,7 +13109,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 445,
+      "rank": 450,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -12990,7 +13133,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 446,
+      "rank": 451,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -13023,7 +13166,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 447,
+      "rank": 452,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -13057,7 +13200,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 448,
+      "rank": 453,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -13079,7 +13222,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 449,
+      "rank": 454,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -13102,7 +13245,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 450,
+      "rank": 455,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -13122,7 +13265,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 451,
+      "rank": 456,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -13154,7 +13297,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 452,
+      "rank": 457,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -13193,7 +13336,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 453,
+      "rank": 458,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -13227,7 +13370,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 454,
+      "rank": 459,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -13251,7 +13394,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 455,
+      "rank": 460,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -13284,7 +13427,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 456,
+      "rank": 461,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -13304,7 +13447,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 457,
+      "rank": 462,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -13333,7 +13476,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 458,
+      "rank": 463,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -13355,7 +13498,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 459,
+      "rank": 464,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -13387,7 +13530,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 460,
+      "rank": 465,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -13414,7 +13557,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 461,
+      "rank": 466,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -13458,7 +13601,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 462,
+      "rank": 467,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -13476,7 +13619,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 463,
+      "rank": 468,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -13515,7 +13658,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 464,
+      "rank": 469,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -13554,7 +13697,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 465,
+      "rank": 470,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -13588,7 +13731,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 466,
+      "rank": 471,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -13616,7 +13759,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 467,
+      "rank": 472,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -13638,7 +13781,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 468,
+      "rank": 473,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -13666,12 +13809,12 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 469,
+      "rank": 474,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
       "downloads": 2746492,
-      "likes": 689,
+      "likes": 690,
       "trendingScore": 10,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
@@ -13684,65 +13827,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 470,
-      "id": "microsoft/GridSFM_Open",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/GridSFM_Open",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "graph-ml",
-      "libraryName": "pytorch",
-      "tags": [
-        "pytorch",
-        "graph-neural-network",
-        "power-systems",
-        "power-grid",
-        "ac-opf",
-        "optimal-power-flow",
-        "graph-attention-network",
-        "scientific-ml",
-        "research",
-        "graph-ml",
-        "en",
-        "dataset:microsoft/GridSFM_US_power_grid",
-        "arxiv:2406.07234",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T19:04:04.000Z",
-      "lastModified": "2026-05-13T13:45:10.000Z"
-    },
-    {
-      "rank": 471,
-      "id": "Datadog/Toto-2.0-1B",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
-      "downloads": 1038,
-      "likes": 12,
-      "trendingScore": 10,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T20:41:57.000Z",
-      "lastModified": "2026-05-14T14:23:39.000Z"
-    },
-    {
-      "rank": 472,
+      "rank": 475,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -13770,12 +13855,12 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 473,
+      "rank": 476,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
       "downloads": 5252488,
-      "likes": 1537,
+      "likes": 1538,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -13801,7 +13886,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 474,
+      "rank": 477,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -13826,7 +13911,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 475,
+      "rank": 478,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -13837,6 +13922,7 @@
       "libraryName": "transformers",
       "tags": [
         "transformers",
+        "gguf",
         "text-generation-inference",
         "unsloth",
         "gemma4",
@@ -13855,16 +13941,17 @@
         "en",
         "ja",
         "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "base_model:finetune:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "conversational"
       ],
       "createdAt": "2026-05-13T06:59:32.000Z",
-      "lastModified": "2026-05-18T19:47:57.000Z"
+      "lastModified": "2026-05-18T20:11:08.000Z"
     },
     {
-      "rank": 476,
+      "rank": 479,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -13890,7 +13977,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 477,
+      "rank": 480,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -13906,35 +13993,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 478,
-      "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
-      "author": "perplexity-ai",
-      "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
-      "downloads": 4865,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "kernels",
-      "tags": [
-        "kernels",
-        "safetensors",
-        "bidirectional_pplx_qwen3",
-        "feature-extraction",
-        "custom_code",
-        "late-interaction",
-        "maxsim",
-        "pylate",
-        "base_model:perplexity-ai/pplx-embed-v1-0.6b",
-        "arxiv:2602.11151",
-        "base_model:finetune:perplexity-ai/pplx-embed-v1-0.6b",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-03-13T15:07:30.000Z",
-      "lastModified": "2026-05-18T17:03:49.000Z"
-    },
-    {
-      "rank": 479,
+      "rank": 481,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -13961,7 +14020,58 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 480,
+      "rank": 482,
+      "id": "Datadog/Toto-2.0-22m",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
+      "downloads": 2786,
+      "likes": 11,
+      "trendingScore": 10,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T20:38:58.000Z",
+      "lastModified": "2026-05-14T14:23:21.000Z"
+    },
+    {
+      "rank": 483,
+      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "author": "vrgamedevgirl84",
+      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "downloads": 1722,
+      "likes": 13,
+      "trendingScore": 10,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ltx-video",
+        "text-to-video",
+        "safetensors",
+        "base_model:Lightricks/LTX-Video",
+        "base_model:adapter:Lightricks/LTX-Video",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T00:29:34.000Z",
+      "lastModified": "2026-04-24T02:26:47.000Z"
+    },
+    {
+      "rank": 484,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -13988,7 +14098,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 481,
+      "rank": 485,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -14014,7 +14124,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 482,
+      "rank": 486,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -14042,7 +14152,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 483,
+      "rank": 487,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -14068,7 +14178,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 484,
+      "rank": 488,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -14112,7 +14222,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 485,
+      "rank": 489,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -14152,7 +14262,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 486,
+      "rank": 490,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -14188,7 +14298,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 487,
+      "rank": 491,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -14232,7 +14342,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 488,
+      "rank": 492,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -14257,7 +14367,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 489,
+      "rank": 493,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -14302,7 +14412,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 490,
+      "rank": 494,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -14321,7 +14431,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 491,
+      "rank": 495,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -14346,7 +14456,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 492,
+      "rank": 496,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -14385,7 +14495,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 493,
+      "rank": 497,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -14402,7 +14512,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 494,
+      "rank": 498,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -14430,7 +14540,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 495,
+      "rank": 499,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -14459,7 +14569,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 496,
+      "rank": 500,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -14484,7 +14594,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 497,
+      "rank": 501,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -14519,7 +14629,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 498,
+      "rank": 502,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -14549,7 +14659,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 499,
+      "rank": 503,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -14585,7 +14695,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 500,
+      "rank": 504,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -14608,7 +14718,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 501,
+      "rank": 505,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -14625,7 +14735,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 502,
+      "rank": 506,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -14645,7 +14755,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 503,
+      "rank": 507,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -14672,7 +14782,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 504,
+      "rank": 508,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -14696,7 +14806,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 505,
+      "rank": 509,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -14718,7 +14828,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 506,
+      "rank": 510,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -14750,7 +14860,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 507,
+      "rank": 511,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -14778,7 +14888,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 508,
+      "rank": 512,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -14796,7 +14906,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 509,
+      "rank": 513,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -14821,7 +14931,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 510,
+      "rank": 514,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -14844,7 +14954,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 511,
+      "rank": 515,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -14862,7 +14972,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 512,
+      "rank": 516,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -14897,7 +15007,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 513,
+      "rank": 517,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -14925,7 +15035,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 514,
+      "rank": 518,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -14947,7 +15057,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 515,
+      "rank": 519,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -14974,7 +15084,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 516,
+      "rank": 520,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -14999,7 +15109,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 517,
+      "rank": 521,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -15033,30 +15143,34 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 518,
+      "rank": 522,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
       "downloads": 0,
-      "likes": 9,
+      "likes": 10,
       "trendingScore": 9,
       "pipelineTag": "any-to-any",
-      "libraryName": null,
+      "libraryName": "peft",
       "tags": [
+        "peft",
         "safetensors",
-        "T2AV,",
-        "RL",
+        "lora",
+        "reinforcement-learning",
+        "GRPO",
+        "T2AV",
         "any-to-any",
+        "arxiv:2605.12480",
         "base_model:Lightricks/LTX-2",
-        "base_model:finetune:Lightricks/LTX-2",
+        "base_model:adapter:Lightricks/LTX-2",
         "license:apache-2.0",
         "region:us"
       ],
       "createdAt": "2026-05-11T02:28:33.000Z",
-      "lastModified": "2026-05-11T03:49:52.000Z"
+      "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 519,
+      "rank": 523,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -15083,7 +15197,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 520,
+      "rank": 524,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -15110,7 +15224,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 521,
+      "rank": 525,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -15151,7 +15265,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 522,
+      "rank": 526,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -15181,7 +15295,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 523,
+      "rank": 527,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -15218,7 +15332,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 524,
+      "rank": 528,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -15250,7 +15364,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 525,
+      "rank": 529,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -15292,7 +15406,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 526,
+      "rank": 530,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -15322,7 +15436,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 527,
+      "rank": 531,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -15367,7 +15481,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 528,
+      "rank": 532,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -15394,7 +15508,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 529,
+      "rank": 533,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -15420,35 +15534,7 @@
       "lastModified": "2026-05-11T14:57:26.000Z"
     },
     {
-      "rank": 530,
-      "id": "Datadog/Toto-2.0-22m",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
-      "downloads": 2786,
-      "likes": 10,
-      "trendingScore": 9,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T20:38:58.000Z",
-      "lastModified": "2026-05-14T14:23:21.000Z"
-    },
-    {
-      "rank": 531,
+      "rank": 534,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -15482,7 +15568,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 532,
+      "rank": 535,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -15512,7 +15598,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 533,
+      "rank": 536,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -15537,7 +15623,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 534,
+      "rank": 537,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -15566,12 +15652,12 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 535,
+      "rank": 538,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
       "downloads": 1707896,
-      "likes": 2787,
+      "likes": 2788,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -15593,30 +15679,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 536,
-      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "author": "vrgamedevgirl84",
-      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "downloads": 1722,
-      "likes": 12,
-      "trendingScore": 9,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ltx-video",
-        "text-to-video",
-        "safetensors",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T00:29:34.000Z",
-      "lastModified": "2026-04-24T02:26:47.000Z"
-    },
-    {
-      "rank": 537,
+      "rank": 539,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -15642,7 +15705,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 538,
+      "rank": 540,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -15674,7 +15737,59 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 539,
+      "rank": 541,
+      "id": "unsloth/FLUX.2-klein-9B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
+      "downloads": 91217,
+      "likes": 205,
+      "trendingScore": 9,
+      "pipelineTag": "image-to-image",
+      "libraryName": "ggml",
+      "tags": [
+        "ggml",
+        "gguf",
+        "image-generation",
+        "unsloth",
+        "image-editing",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "base_model:black-forest-labs/FLUX.2-klein-9B",
+        "base_model:quantized:black-forest-labs/FLUX.2-klein-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-01-15T17:15:23.000Z",
+      "lastModified": "2026-01-16T15:48:16.000Z"
+    },
+    {
+      "rank": 542,
+      "id": "Alissonerdx/EditAnything",
+      "author": "Alissonerdx",
+      "url": "https://huggingface.co/Alissonerdx/EditAnything",
+      "downloads": 107,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "video",
+        "video-editing",
+        "ltx-2.3",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-01T08:12:57.000Z",
+      "lastModified": "2026-05-18T17:56:08.000Z"
+    },
+    {
+      "rank": 543,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -15701,7 +15816,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 540,
+      "rank": 544,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -15725,7 +15840,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 541,
+      "rank": 545,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -15745,7 +15860,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 542,
+      "rank": 546,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -15772,7 +15887,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 543,
+      "rank": 547,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -15791,7 +15906,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 544,
+      "rank": 548,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -15825,7 +15940,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 545,
+      "rank": 549,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -15857,7 +15972,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 546,
+      "rank": 550,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -15879,7 +15994,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 547,
+      "rank": 551,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -15924,7 +16039,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 548,
+      "rank": 552,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -15943,7 +16058,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 549,
+      "rank": 553,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -15977,7 +16092,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 550,
+      "rank": 554,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -16005,7 +16120,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 551,
+      "rank": 555,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -16033,7 +16148,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 552,
+      "rank": 556,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -16056,7 +16171,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 553,
+      "rank": 557,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -16083,7 +16198,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 554,
+      "rank": 558,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -16128,7 +16243,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 555,
+      "rank": 559,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -16164,7 +16279,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 556,
+      "rank": 560,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -16204,7 +16319,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 557,
+      "rank": 561,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -16233,7 +16348,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 558,
+      "rank": 562,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -16261,7 +16376,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 559,
+      "rank": 563,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -16280,7 +16395,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 560,
+      "rank": 564,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -16299,7 +16414,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 561,
+      "rank": 565,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -16331,7 +16446,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 562,
+      "rank": 566,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -16358,7 +16473,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 563,
+      "rank": 567,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -16380,7 +16495,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 564,
+      "rank": 568,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -16398,7 +16513,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 565,
+      "rank": 569,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -16427,12 +16542,12 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 566,
+      "rank": 570,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
-      "downloads": 13314,
-      "likes": 40,
+      "downloads": 10694,
+      "likes": 47,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -16472,7 +16587,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 567,
+      "rank": 571,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -16493,7 +16608,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 568,
+      "rank": 572,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -16521,7 +16636,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 569,
+      "rank": 573,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -16542,7 +16657,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 570,
+      "rank": 574,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -16578,7 +16693,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 571,
+      "rank": 575,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -16623,7 +16738,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 572,
+      "rank": 576,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -16649,7 +16764,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 573,
+      "rank": 577,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -16672,7 +16787,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 574,
+      "rank": 578,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -16697,7 +16812,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 575,
+      "rank": 579,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -16732,7 +16847,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 576,
+      "rank": 580,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -16777,7 +16892,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 577,
+      "rank": 581,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -16804,7 +16919,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 578,
+      "rank": 582,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -16833,7 +16948,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 579,
+      "rank": 583,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -16852,7 +16967,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 580,
+      "rank": 584,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -16873,7 +16988,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 581,
+      "rank": 585,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -16899,7 +17014,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 582,
+      "rank": 586,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -16925,7 +17040,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 583,
+      "rank": 587,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -16962,7 +17077,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 584,
+      "rank": 588,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -17007,7 +17122,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 585,
+      "rank": 589,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -17032,7 +17147,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 586,
+      "rank": 590,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -17049,7 +17164,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 587,
+      "rank": 591,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -17076,7 +17191,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 588,
+      "rank": 592,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -17094,7 +17209,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 589,
+      "rank": 593,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -17119,7 +17234,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 590,
+      "rank": 594,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -17151,7 +17266,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 591,
+      "rank": 595,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -17172,7 +17287,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 592,
+      "rank": 596,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -17191,7 +17306,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 593,
+      "rank": 597,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -17222,7 +17337,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 594,
+      "rank": 598,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -17245,12 +17360,12 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 595,
+      "rank": 599,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
       "downloads": 2393297,
-      "likes": 2133,
+      "likes": 2134,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -17283,35 +17398,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 596,
-      "id": "unsloth/FLUX.2-klein-9B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
-      "downloads": 91217,
-      "likes": 204,
-      "trendingScore": 8,
-      "pipelineTag": "image-to-image",
-      "libraryName": "ggml",
-      "tags": [
-        "ggml",
-        "gguf",
-        "image-generation",
-        "unsloth",
-        "image-editing",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "base_model:black-forest-labs/FLUX.2-klein-9B",
-        "base_model:quantized:black-forest-labs/FLUX.2-klein-9B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-01-15T17:15:23.000Z",
-      "lastModified": "2026-01-16T15:48:16.000Z"
-    },
-    {
-      "rank": 597,
+      "rank": 600,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -17328,7 +17415,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 598,
+      "rank": 601,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -17356,7 +17443,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 599,
+      "rank": 602,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -17383,7 +17470,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 600,
+      "rank": 603,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -17428,7 +17515,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 601,
+      "rank": 604,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -17445,7 +17532,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 602,
+      "rank": 605,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -17481,7 +17568,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 603,
+      "rank": 606,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -17511,7 +17598,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 604,
+      "rank": 607,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -17540,62 +17627,180 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 605,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
+      "rank": 608,
+      "id": "Jackrong/Qwopus3.5-9B-Coder",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
+      "downloads": 400,
       "likes": 8,
       "trendingScore": 8,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
+        "transformers",
         "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "agent",
+        "tool-use",
+        "function-calling",
+        "coder",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:lambda/hermes-agent-reasoning-traces",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
         "license:apache-2.0",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-18T13:52:59.000Z"
+      "createdAt": "2026-05-15T08:15:06.000Z",
+      "lastModified": "2026-05-17T01:57:40.000Z"
     },
     {
-      "rank": 606,
-      "id": "sapientinc/HRM-Text-1B",
-      "author": "sapientinc",
-      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 57,
+      "rank": 609,
+      "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
+      "author": "noctrex",
+      "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
+      "downloads": 2124,
       "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen",
+        "qwen3_5_moe",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Jackrong/Qwopus3.5-9B-Coder",
+        "base_model:quantized:Jackrong/Qwopus3.5-9B-Coder",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:52:39.000Z",
+      "lastModified": "2026-05-17T12:48:32.000Z"
+    },
+    {
+      "rank": 610,
+      "id": "meta-llama/Llama-3.2-1B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
+      "downloads": 7532787,
+      "likes": 1410,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "hrm_text",
+        "llama",
         "text-generation",
-        "hrm",
-        "hierarchical-reasoning",
-        "prefix-lm",
-        "pre-alignment",
-        "non-chat",
-        "non-instruction-tuned",
-        "custom_code",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
         "en",
-        "license:apache-2.0",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-17T15:13:02.000Z",
-      "lastModified": "2026-05-18T07:57:35.000Z"
+      "createdAt": "2024-09-18T15:12:47.000Z",
+      "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 607,
+      "rank": 611,
+      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
+      "author": "NousResearch",
+      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
+      "downloads": 217198,
+      "likes": 427,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "Llama-3",
+        "instruct",
+        "finetune",
+        "chatml",
+        "gpt4",
+        "synthetic data",
+        "distillation",
+        "function calling",
+        "json mode",
+        "axolotl",
+        "roleplaying",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2408.11857",
+        "base_model:meta-llama/Llama-3.1-8B",
+        "base_model:finetune:meta-llama/Llama-3.1-8B",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-07-28T06:00:57.000Z",
+      "lastModified": "2024-09-08T07:39:55.000Z"
+    },
+    {
+      "rank": 612,
+      "id": "Qwen/Qwen3.5-2B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
+      "downloads": 1955539,
+      "likes": 279,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.5-2B-Base",
+        "base_model:finetune:Qwen/Qwen3.5-2B-Base",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-02-28T23:56:16.000Z",
+      "lastModified": "2026-03-02T11:26:29.000Z"
+    },
+    {
+      "rank": 613,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -17621,7 +17826,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 608,
+      "rank": 614,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -17638,7 +17843,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 609,
+      "rank": 615,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -17661,7 +17866,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 610,
+      "rank": 616,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -17689,7 +17894,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 611,
+      "rank": 617,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -17732,7 +17937,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 612,
+      "rank": 618,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -17767,7 +17972,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 613,
+      "rank": 619,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -17792,7 +17997,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 614,
+      "rank": 620,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -17822,7 +18027,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 615,
+      "rank": 621,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -17851,7 +18056,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 616,
+      "rank": 622,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -17878,7 +18083,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 617,
+      "rank": 623,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -17904,7 +18109,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 618,
+      "rank": 624,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -17935,7 +18140,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 619,
+      "rank": 625,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -17953,7 +18158,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 620,
+      "rank": 626,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -17982,7 +18187,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 621,
+      "rank": 627,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -18005,7 +18210,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 622,
+      "rank": 628,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -18050,7 +18255,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 623,
+      "rank": 629,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -18076,7 +18281,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 624,
+      "rank": 630,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -18104,7 +18309,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 625,
+      "rank": 631,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -18142,7 +18347,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 626,
+      "rank": 632,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -18169,7 +18374,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 627,
+      "rank": 633,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -18195,7 +18400,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 628,
+      "rank": 634,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -18213,7 +18418,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 629,
+      "rank": 635,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -18239,7 +18444,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 630,
+      "rank": 636,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -18263,7 +18468,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 631,
+      "rank": 637,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -18304,7 +18509,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 632,
+      "rank": 638,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -18321,7 +18526,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 633,
+      "rank": 639,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -18354,7 +18559,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 634,
+      "rank": 640,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -18388,7 +18593,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 635,
+      "rank": 641,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -18427,7 +18632,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 636,
+      "rank": 642,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -18457,7 +18662,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 637,
+      "rank": 643,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -18493,7 +18698,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 638,
+      "rank": 644,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -18519,7 +18724,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 639,
+      "rank": 645,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -18555,7 +18760,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 640,
+      "rank": 646,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -18585,7 +18790,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 641,
+      "rank": 647,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -18623,7 +18828,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 642,
+      "rank": 648,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -18658,7 +18863,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 643,
+      "rank": 649,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -18683,7 +18888,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 644,
+      "rank": 650,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -18700,7 +18905,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 645,
+      "rank": 651,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -18742,7 +18947,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 646,
+      "rank": 652,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -18772,7 +18977,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 647,
+      "rank": 653,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -18797,7 +19002,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 648,
+      "rank": 654,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -18825,7 +19030,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 649,
+      "rank": 655,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -18842,7 +19047,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 650,
+      "rank": 656,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -18869,7 +19074,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 651,
+      "rank": 657,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -18912,7 +19117,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 652,
+      "rank": 658,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -18952,7 +19157,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 653,
+      "rank": 659,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -18976,7 +19181,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 654,
+      "rank": 660,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -19005,7 +19210,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 655,
+      "rank": 661,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -19031,7 +19236,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 656,
+      "rank": 662,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -19059,7 +19264,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 657,
+      "rank": 663,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -19098,7 +19303,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 658,
+      "rank": 664,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -19122,7 +19327,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 659,
+      "rank": 665,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -19150,7 +19355,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 660,
+      "rank": 666,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -19182,7 +19387,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 661,
+      "rank": 667,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -19212,7 +19417,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 662,
+      "rank": 668,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -19241,7 +19446,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 663,
+      "rank": 669,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -19269,7 +19474,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 664,
+      "rank": 670,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -19293,7 +19498,7 @@
       "lastModified": "2026-04-23T03:18:40.000Z"
     },
     {
-      "rank": 665,
+      "rank": 671,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -19326,7 +19531,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 666,
+      "rank": 672,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -19355,7 +19560,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 667,
+      "rank": 673,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -19375,7 +19580,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 668,
+      "rank": 674,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -19404,7 +19609,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 669,
+      "rank": 675,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -19428,7 +19633,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 670,
+      "rank": 676,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -19458,7 +19663,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 671,
+      "rank": 677,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -19488,7 +19693,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 672,
+      "rank": 678,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -19506,7 +19711,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 673,
+      "rank": 679,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -19523,7 +19728,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 674,
+      "rank": 680,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -19559,7 +19764,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 675,
+      "rank": 681,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -19590,7 +19795,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 676,
+      "rank": 682,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -19629,7 +19834,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 677,
+      "rank": 683,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -19660,7 +19865,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 678,
+      "rank": 684,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -19693,7 +19898,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 679,
+      "rank": 685,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -19721,7 +19926,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 680,
+      "rank": 686,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -19746,7 +19951,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 681,
+      "rank": 687,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -19769,7 +19974,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 682,
+      "rank": 688,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -19797,7 +20002,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 683,
+      "rank": 689,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -19830,7 +20035,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 684,
+      "rank": 690,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -19860,7 +20065,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 685,
+      "rank": 691,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -19895,7 +20100,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 686,
+      "rank": 692,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -19927,7 +20132,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 687,
+      "rank": 693,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -19952,7 +20157,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 688,
+      "rank": 694,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -19975,7 +20180,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 689,
+      "rank": 695,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -20002,7 +20207,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 690,
+      "rank": 696,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -20025,7 +20230,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 691,
+      "rank": 697,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -20050,7 +20255,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 692,
+      "rank": 698,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -20095,7 +20300,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 693,
+      "rank": 699,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -20127,7 +20332,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 694,
+      "rank": 700,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -20154,7 +20359,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 695,
+      "rank": 701,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -20180,12 +20385,12 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 696,
+      "rank": 702,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "downloads": 10632,
-      "likes": 12,
+      "likes": 13,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
       "libraryName": "llama.cpp",
@@ -20210,7 +20415,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 697,
+      "rank": 703,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -20242,7 +20447,7 @@
       "lastModified": "2026-04-17T20:15:06.000Z"
     },
     {
-      "rank": 698,
+      "rank": 704,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -20270,7 +20475,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 699,
+      "rank": 705,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -20299,7 +20504,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 700,
+      "rank": 706,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -20331,7 +20536,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 701,
+      "rank": 707,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -20361,7 +20566,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 702,
+      "rank": 708,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -20378,74 +20583,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 703,
-      "id": "Jackrong/Qwopus3.5-9B-Coder",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
-      "downloads": 400,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "agent",
-        "tool-use",
-        "function-calling",
-        "coder",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:lambda/hermes-agent-reasoning-traces",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:15:06.000Z",
-      "lastModified": "2026-05-17T01:57:40.000Z"
-    },
-    {
-      "rank": 704,
-      "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
-      "author": "noctrex",
-      "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
-      "downloads": 2124,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen",
-        "qwen3_5_moe",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Jackrong/Qwopus3.5-9B-Coder",
-        "base_model:quantized:Jackrong/Qwopus3.5-9B-Coder",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:52:39.000Z",
-      "lastModified": "2026-05-17T12:48:32.000Z"
-    },
-    {
-      "rank": 705,
+      "rank": 709,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -20465,7 +20603,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 706,
+      "rank": 710,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -20504,7 +20642,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 707,
+      "rank": 711,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -20542,7 +20680,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 708,
+      "rank": 712,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -20570,7 +20708,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 709,
+      "rank": 713,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -20595,7 +20733,7 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 710,
+      "rank": 714,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -20640,7 +20778,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 711,
+      "rank": 715,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -20676,7 +20814,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 712,
+      "rank": 716,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -20703,7 +20841,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 713,
+      "rank": 717,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -20736,45 +20874,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 714,
-      "id": "meta-llama/Llama-3.2-1B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 7532787,
-      "likes": 1409,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:12:47.000Z",
-      "lastModified": "2024-10-24T15:07:51.000Z"
-    },
-    {
-      "rank": 715,
+      "rank": 718,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -20798,7 +20898,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 716,
+      "rank": 719,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -20828,7 +20928,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 717,
+      "rank": 720,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -20855,31 +20955,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 718,
-      "id": "Alissonerdx/EditAnything",
-      "author": "Alissonerdx",
-      "url": "https://huggingface.co/Alissonerdx/EditAnything",
-      "downloads": 107,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "video",
-        "video-editing",
-        "ltx-2.3",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-01T08:12:57.000Z",
-      "lastModified": "2026-05-18T17:56:08.000Z"
-    },
-    {
-      "rank": 719,
+      "rank": 721,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -20906,7 +20982,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 720,
+      "rank": 722,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -20939,48 +21015,190 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 721,
-      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
-      "author": "NousResearch",
-      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 217198,
-      "likes": 425,
+      "rank": 723,
+      "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
+      "author": "YTan2000",
+      "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
+      "downloads": 1116,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "llama.cpp",
+        "qwen",
+        "qwen3.6",
+        "quantization",
+        "turboquant",
+        "tq3_4s",
+        "mtp",
+        "unsloth",
+        "vision",
+        "image-text-to-text",
+        "en",
+        "base_model:unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+        "base_model:quantized:unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T22:32:11.000Z",
+      "lastModified": "2026-05-17T20:41:40.000Z"
+    },
+    {
+      "rank": 724,
+      "id": "chiennv/Orthrus-Qwen3-1.7B",
+      "author": "chiennv",
+      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
+      "downloads": 464,
+      "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "llama",
+        "qwen3",
         "text-generation",
-        "Llama-3",
-        "instruct",
-        "finetune",
-        "chatml",
-        "gpt4",
-        "synthetic data",
-        "distillation",
-        "function calling",
-        "json mode",
-        "axolotl",
-        "roleplaying",
-        "chat",
+        "diffusion",
+        "parallel-decoding",
+        "orthrus",
         "conversational",
-        "en",
-        "arxiv:2408.11857",
-        "base_model:meta-llama/Llama-3.1-8B",
-        "base_model:finetune:meta-llama/Llama-3.1-8B",
-        "license:llama3",
+        "custom_code",
+        "arxiv:2605.12825",
+        "license:cc-by-4.0",
         "text-generation-inference",
         "endpoints_compatible",
-        "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2024-07-28T06:00:57.000Z",
-      "lastModified": "2024-09-08T07:39:55.000Z"
+      "createdAt": "2026-05-08T20:11:02.000Z",
+      "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 722,
+      "rank": 725,
+      "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
+      "downloads": 5483,
+      "likes": 12,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3.5",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "competitive-programming",
+        "trace-inversion",
+        "negentropy",
+        "distillation",
+        "claude-opus-4.7",
+        "qwen3",
+        "synthetic-data",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "ko",
+        "ja",
+        "ru",
+        "arxiv:2603.07267",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:adapter:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-07T17:15:51.000Z",
+      "lastModified": "2026-05-07T17:23:36.000Z"
+    },
+    {
+      "rank": 726,
+      "id": "chiennv/Orthrus-Qwen3-4B",
+      "author": "chiennv",
+      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
+      "downloads": 249,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "diffusion",
+        "parallel-decoding",
+        "orthrus",
+        "conversational",
+        "custom_code",
+        "arxiv:2605.12825",
+        "license:cc-by-4.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T18:04:31.000Z",
+      "lastModified": "2026-05-16T22:43:52.000Z"
+    },
+    {
+      "rank": 727,
+      "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "ggml-org",
+      "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 1482,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T11:20:53.000Z",
+      "lastModified": "2026-05-15T12:55:24.000Z"
+    },
+    {
+      "rank": 728,
+      "id": "GestaltLabs/BusyBeaver-50M",
+      "author": "GestaltLabs",
+      "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
+      "downloads": 0,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "busybeaver_qdelta",
+        "text-generation",
+        "busybeaver",
+        "tool-calling",
+        "agent-policy",
+        "json",
+        "local-agents",
+        "qdelta",
+        "50m",
+        "license:other",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T14:18:11.000Z",
+      "lastModified": "2026-05-19T00:07:41.000Z"
+    },
+    {
+      "rank": 729,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -21008,7 +21226,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 723,
+      "rank": 730,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -21047,7 +21265,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 724,
+      "rank": 731,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -21080,7 +21298,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 725,
+      "rank": 732,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -21109,7 +21327,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 726,
+      "rank": 733,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -21139,7 +21357,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 727,
+      "rank": 734,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -21184,7 +21402,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 728,
+      "rank": 735,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -21213,7 +21431,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 729,
+      "rank": 736,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -21258,7 +21476,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 730,
+      "rank": 737,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -21302,7 +21520,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 731,
+      "rank": 738,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -21328,7 +21546,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 732,
+      "rank": 739,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -21354,7 +21572,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 733,
+      "rank": 740,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -21386,7 +21604,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 734,
+      "rank": 741,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -21409,7 +21627,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 735,
+      "rank": 742,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -21452,7 +21670,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 736,
+      "rank": 743,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -21497,7 +21715,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 737,
+      "rank": 744,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -21542,7 +21760,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 738,
+      "rank": 745,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -21569,7 +21787,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 739,
+      "rank": 746,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -21596,7 +21814,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 740,
+      "rank": 747,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -21621,7 +21839,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 741,
+      "rank": 748,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -21660,7 +21878,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 742,
+      "rank": 749,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -21685,7 +21903,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 743,
+      "rank": 750,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -21713,7 +21931,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 744,
+      "rank": 751,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -21738,7 +21956,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 745,
+      "rank": 752,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -21754,7 +21972,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 746,
+      "rank": 753,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -21781,7 +21999,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 747,
+      "rank": 754,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -21813,7 +22031,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 748,
+      "rank": 755,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -21843,7 +22061,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 749,
+      "rank": 756,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -21875,7 +22093,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 750,
+      "rank": 757,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -21903,7 +22121,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 751,
+      "rank": 758,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -21929,7 +22147,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 752,
+      "rank": 759,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -21954,7 +22172,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 753,
+      "rank": 760,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -21983,7 +22201,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 754,
+      "rank": 761,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -22025,7 +22243,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 755,
+      "rank": 762,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -22052,7 +22270,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 756,
+      "rank": 763,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -22097,7 +22315,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 757,
+      "rank": 764,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -22123,7 +22341,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 758,
+      "rank": 765,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -22143,7 +22361,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 759,
+      "rank": 766,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -22170,7 +22388,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 760,
+      "rank": 767,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -22212,7 +22430,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 761,
+      "rank": 768,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -22239,7 +22457,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 762,
+      "rank": 769,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -22273,7 +22491,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 763,
+      "rank": 770,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -22302,7 +22520,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 764,
+      "rank": 771,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -22329,7 +22547,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 765,
+      "rank": 772,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -22356,7 +22574,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 766,
+      "rank": 773,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -22383,7 +22601,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 767,
+      "rank": 774,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -22411,7 +22629,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 768,
+      "rank": 775,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -22434,7 +22652,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 769,
+      "rank": 776,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -22465,7 +22683,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 770,
+      "rank": 777,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -22510,7 +22728,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 771,
+      "rank": 778,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -22532,7 +22750,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 772,
+      "rank": 779,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -22558,7 +22776,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 773,
+      "rank": 780,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -22584,7 +22802,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 774,
+      "rank": 781,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -22615,7 +22833,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 775,
+      "rank": 782,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -22638,7 +22856,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 776,
+      "rank": 783,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -22668,7 +22886,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 777,
+      "rank": 784,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -22700,7 +22918,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 778,
+      "rank": 785,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -22729,7 +22947,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 779,
+      "rank": 786,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -22761,7 +22979,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 780,
+      "rank": 787,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -22793,7 +23011,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 781,
+      "rank": 788,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -22824,7 +23042,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 782,
+      "rank": 789,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -22855,7 +23073,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 783,
+      "rank": 790,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -22878,7 +23096,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 784,
+      "rank": 791,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -22905,7 +23123,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 785,
+      "rank": 792,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -22950,7 +23168,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 786,
+      "rank": 793,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -22968,7 +23186,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 787,
+      "rank": 794,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -22991,7 +23209,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 788,
+      "rank": 795,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -23021,7 +23239,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 789,
+      "rank": 796,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -23060,7 +23278,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 790,
+      "rank": 797,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -23098,7 +23316,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 791,
+      "rank": 798,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -23143,7 +23361,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 792,
+      "rank": 799,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -23168,7 +23386,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 793,
+      "rank": 800,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -23202,7 +23420,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 794,
+      "rank": 801,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -23227,7 +23445,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 795,
+      "rank": 802,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -23260,7 +23478,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 796,
+      "rank": 803,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -23287,7 +23505,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 797,
+      "rank": 804,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -23317,7 +23535,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 798,
+      "rank": 805,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -23349,7 +23567,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 799,
+      "rank": 806,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -23382,7 +23600,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 800,
+      "rank": 807,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -23400,7 +23618,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 801,
+      "rank": 808,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -23423,7 +23641,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 802,
+      "rank": 809,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -23455,7 +23673,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 803,
+      "rank": 810,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -23500,7 +23718,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 804,
+      "rank": 811,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -23541,7 +23759,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 805,
+      "rank": 812,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -23580,7 +23798,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 806,
+      "rank": 813,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -23607,7 +23825,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 807,
+      "rank": 814,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -23644,7 +23862,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 808,
+      "rank": 815,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -23680,7 +23898,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 809,
+      "rank": 816,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -23698,7 +23916,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 810,
+      "rank": 817,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -23737,7 +23955,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 811,
+      "rank": 818,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -23766,7 +23984,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 812,
+      "rank": 819,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -23793,7 +24011,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 813,
+      "rank": 820,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -23820,7 +24038,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 814,
+      "rank": 821,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -23850,7 +24068,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 815,
+      "rank": 822,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -23877,7 +24095,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 816,
+      "rank": 823,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -23908,7 +24126,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 817,
+      "rank": 824,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -23926,7 +24144,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 818,
+      "rank": 825,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -23945,7 +24163,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 819,
+      "rank": 826,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -23972,7 +24190,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 820,
+      "rank": 827,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -23997,7 +24215,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 821,
+      "rank": 828,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -24027,34 +24245,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 822,
-      "id": "Qwen/Qwen3.5-2B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
-      "downloads": 1955539,
-      "likes": 277,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.5-2B-Base",
-        "base_model:finetune:Qwen/Qwen3.5-2B-Base",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-02-28T23:56:16.000Z",
-      "lastModified": "2026-03-02T11:26:29.000Z"
-    },
-    {
-      "rank": 823,
+      "rank": 829,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -24085,7 +24276,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 824,
+      "rank": 830,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -24107,12 +24298,12 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 825,
+      "rank": 831,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "downloads": 4272,
-      "likes": 6,
+      "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -24133,10 +24324,10 @@
         "conversational"
       ],
       "createdAt": "2026-05-14T14:13:15.000Z",
-      "lastModified": "2026-05-15T23:48:37.000Z"
+      "lastModified": "2026-05-18T22:20:53.000Z"
     },
     {
-      "rank": 826,
+      "rank": 832,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -24157,7 +24348,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 827,
+      "rank": 833,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -24193,7 +24384,7 @@
       "lastModified": "2026-04-22T14:03:41.000Z"
     },
     {
-      "rank": 828,
+      "rank": 834,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -24216,40 +24407,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 829,
-      "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
-      "author": "YTan2000",
-      "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
-      "downloads": 1116,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "llama.cpp",
-        "qwen",
-        "qwen3.6",
-        "quantization",
-        "turboquant",
-        "tq3_4s",
-        "mtp",
-        "unsloth",
-        "vision",
-        "image-text-to-text",
-        "en",
-        "base_model:unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-        "base_model:quantized:unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T22:32:11.000Z",
-      "lastModified": "2026-05-17T20:41:40.000Z"
-    },
-    {
-      "rank": 830,
+      "rank": 835,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -24294,7 +24452,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 831,
+      "rank": 836,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -24316,7 +24474,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 832,
+      "rank": 837,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -24346,7 +24504,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 833,
+      "rank": 838,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -24373,7 +24531,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 834,
+      "rank": 839,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -24398,7 +24556,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 835,
+      "rank": 840,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -24431,7 +24589,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 836,
+      "rank": 841,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -24454,36 +24612,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 837,
-      "id": "chiennv/Orthrus-Qwen3-1.7B",
-      "author": "chiennv",
-      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
-      "downloads": 464,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "diffusion",
-        "parallel-decoding",
-        "orthrus",
-        "conversational",
-        "custom_code",
-        "arxiv:2605.12825",
-        "license:cc-by-4.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T20:11:02.000Z",
-      "lastModified": "2026-05-16T22:43:28.000Z"
-    },
-    {
-      "rank": 838,
+      "rank": 842,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -24503,7 +24632,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 839,
+      "rank": 843,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -24548,7 +24677,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 840,
+      "rank": 844,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -24569,7 +24698,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 841,
+      "rank": 845,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -24602,7 +24731,7 @@
       "lastModified": "2026-05-18T05:10:11.000Z"
     },
     {
-      "rank": 842,
+      "rank": 846,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -24630,49 +24759,7 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 843,
-      "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
-      "downloads": 5483,
-      "likes": 11,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "competitive-programming",
-        "trace-inversion",
-        "negentropy",
-        "distillation",
-        "claude-opus-4.7",
-        "qwen3",
-        "synthetic-data",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "ko",
-        "ja",
-        "ru",
-        "arxiv:2603.07267",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:adapter:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-07T17:15:51.000Z",
-      "lastModified": "2026-05-07T17:23:36.000Z"
-    },
-    {
-      "rank": 844,
+      "rank": 847,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -24699,7 +24786,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 845,
+      "rank": 848,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -24744,7 +24831,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 846,
+      "rank": 849,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -24769,7 +24856,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 847,
+      "rank": 850,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -24787,7 +24874,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 848,
+      "rank": 851,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -24815,7 +24902,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 849,
+      "rank": 852,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -24843,7 +24930,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 850,
+      "rank": 853,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -24869,7 +24956,7 @@
       "lastModified": "2026-05-17T16:25:53.000Z"
     },
     {
-      "rank": 851,
+      "rank": 854,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -24894,12 +24981,12 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 852,
+      "rank": 855,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "downloads": 87,
-      "likes": 6,
+      "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
       "libraryName": "diffusers",
@@ -24917,12 +25004,12 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 853,
+      "rank": 856,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
       "downloads": 137974,
-      "likes": 122,
+      "likes": 123,
       "trendingScore": 6,
       "pipelineTag": "text-classification",
       "libraryName": "transformers",
@@ -24954,7 +25041,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 854,
+      "rank": 857,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -24985,57 +25072,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 855,
-      "id": "chiennv/Orthrus-Qwen3-4B",
-      "author": "chiennv",
-      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
-      "downloads": 249,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "diffusion",
-        "parallel-decoding",
-        "orthrus",
-        "conversational",
-        "custom_code",
-        "arxiv:2605.12825",
-        "license:cc-by-4.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T18:04:31.000Z",
-      "lastModified": "2026-05-16T22:43:52.000Z"
-    },
-    {
-      "rank": 856,
-      "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "ggml-org",
-      "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 1482,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T11:20:53.000Z",
-      "lastModified": "2026-05-15T12:55:24.000Z"
-    },
-    {
-      "rank": 857,
+      "rank": 858,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -25060,7 +25097,121 @@
       "lastModified": "2026-05-18T05:58:18.000Z"
     },
     {
-      "rank": 858,
+      "rank": 859,
+      "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
+      "author": "Minachist",
+      "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
+      "downloads": 11970,
+      "likes": 14,
+      "trendingScore": 6,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "compressed-tensors",
+        "qwen3_6",
+        "int8",
+        "autoround",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "8-bit",
+        "auto-round",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T01:36:06.000Z",
+      "lastModified": "2026-05-19T03:18:47.000Z"
+    },
+    {
+      "rank": 860,
+      "id": "infly/Infinity-Parser2-Pro",
+      "author": "infly",
+      "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
+      "downloads": 4722,
+      "likes": 38,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5_moe",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-04-08T12:28:55.000Z",
+      "lastModified": "2026-05-15T14:24:00.000Z"
+    },
+    {
+      "rank": 861,
+      "id": "SeeSee21/AniSee",
+      "author": "SeeSee21",
+      "url": "https://huggingface.co/SeeSee21/AniSee",
+      "downloads": 8,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "anisee",
+        "text-to-image",
+        "anime",
+        "anima",
+        "diffusion",
+        "comfyui",
+        "fine-tune",
+        "safetensors",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T16:28:42.000Z",
+      "lastModified": "2026-05-17T17:06:08.000Z"
+    },
+    {
+      "rank": 862,
+      "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
+      "downloads": 376,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "merge",
+        "mergekit",
+        "reasoning",
+        "non-reasoning",
+        "creative writing",
+        "roleplay",
+        "uncensored",
+        "31B",
+        "gemma-4",
+        "heretic",
+        "decensored",
+        "abliterated",
+        "ara",
+        "base_model:llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-18T00:52:41.000Z",
+      "lastModified": "2026-05-18T01:02:09.000Z"
+    },
+    {
+      "rank": 863,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -25087,7 +25238,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 859,
+      "rank": 864,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -25123,7 +25274,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 860,
+      "rank": 865,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -25168,7 +25319,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 861,
+      "rank": 866,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -25213,7 +25364,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 862,
+      "rank": 867,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -25243,12 +25394,12 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 863,
+      "rank": 868,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
       "downloads": 80546,
-      "likes": 223,
+      "likes": 224,
       "trendingScore": 5,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -25269,7 +25420,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 864,
+      "rank": 869,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -25304,7 +25455,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 865,
+      "rank": 870,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -25332,7 +25483,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 866,
+      "rank": 871,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -25358,7 +25509,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 867,
+      "rank": 872,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -25384,7 +25535,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 868,
+      "rank": 873,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -25410,7 +25561,7 @@
       "lastModified": "2026-05-06T20:09:03.000Z"
     },
     {
-      "rank": 869,
+      "rank": 874,
       "id": "TheDrummer/Skyfall-31B-v4.2",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
@@ -25430,7 +25581,7 @@
       "lastModified": "2026-04-03T20:52:19.000Z"
     },
     {
-      "rank": 870,
+      "rank": 875,
       "id": "LiquidAI/LFM2-24B-A2B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
@@ -25468,7 +25619,7 @@
       "lastModified": "2026-03-30T12:54:26.000Z"
     },
     {
-      "rank": 871,
+      "rank": 876,
       "id": "nvidia/GR00T-N1.7-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
@@ -25488,7 +25639,7 @@
       "lastModified": "2026-04-23T19:09:30.000Z"
     },
     {
-      "rank": 872,
+      "rank": 877,
       "id": "Aratako/Irodori-TTS-500M",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
@@ -25511,7 +25662,7 @@
       "lastModified": "2026-03-18T11:03:56.000Z"
     },
     {
-      "rank": 873,
+      "rank": 878,
       "id": "Qwen/Qwen3.5-0.8B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
@@ -25534,7 +25685,7 @@
       "lastModified": "2026-04-23T11:14:09.000Z"
     },
     {
-      "rank": 874,
+      "rank": 879,
       "id": "z-lab/Qwen3.5-9B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
@@ -25567,7 +25718,7 @@
       "lastModified": "2026-04-07T14:29:47.000Z"
     },
     {
-      "rank": 875,
+      "rank": 880,
       "id": "Winnougan/Must_Have_Klein_9b_loras",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
@@ -25589,7 +25740,7 @@
       "lastModified": "2026-03-26T22:03:08.000Z"
     },
     {
-      "rank": 876,
+      "rank": 881,
       "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
@@ -25616,7 +25767,7 @@
       "lastModified": "2026-04-05T16:05:28.000Z"
     },
     {
-      "rank": 877,
+      "rank": 882,
       "id": "100percentrobot/LTX-2.3-Audio-Reactive-LORA",
       "author": "100percentrobot",
       "url": "https://huggingface.co/100percentrobot/LTX-2.3-Audio-Reactive-LORA",
@@ -25640,7 +25791,7 @@
       "lastModified": "2026-04-10T15:12:18.000Z"
     },
     {
-      "rank": 878,
+      "rank": 883,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -25667,7 +25818,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 879,
+      "rank": 884,
       "id": "YJX-Xiaomi/ControlFoley",
       "author": "YJX-Xiaomi",
       "url": "https://huggingface.co/YJX-Xiaomi/ControlFoley",
@@ -25691,7 +25842,7 @@
       "lastModified": "2026-04-22T02:02:09.000Z"
     },
     {
-      "rank": 880,
+      "rank": 885,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -25731,7 +25882,7 @@
       "lastModified": "2026-04-19T00:19:49.000Z"
     },
     {
-      "rank": 881,
+      "rank": 886,
       "id": "lovis93/crt-animation-terminal-ltx-2.3-lora",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/crt-animation-terminal-ltx-2.3-lora",
@@ -25757,7 +25908,7 @@
       "lastModified": "2026-04-20T16:33:16.000Z"
     },
     {
-      "rank": 882,
+      "rank": 887,
       "id": "uva-cv-lab/OmniShotCut",
       "author": "uva-cv-lab",
       "url": "https://huggingface.co/uva-cv-lab/OmniShotCut",
@@ -25775,7 +25926,7 @@
       "lastModified": "2026-04-28T14:59:54.000Z"
     },
     {
-      "rank": 883,
+      "rank": 888,
       "id": "Yutian10/AnyRecon",
       "author": "Yutian10",
       "url": "https://huggingface.co/Yutian10/AnyRecon",
@@ -25793,7 +25944,7 @@
       "lastModified": "2026-04-27T02:17:02.000Z"
     },
     {
-      "rank": 884,
+      "rank": 889,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
@@ -25819,7 +25970,7 @@
       "lastModified": "2026-04-30T21:34:35.000Z"
     },
     {
-      "rank": 885,
+      "rank": 890,
       "id": "vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
@@ -25842,38 +25993,7 @@
       "lastModified": "2026-04-24T02:25:18.000Z"
     },
     {
-      "rank": 886,
-      "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
-      "author": "Minachist",
-      "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
-      "downloads": 11970,
-      "likes": 13,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "compressed-tensors",
-        "qwen3_6",
-        "int8",
-        "autoround",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "8-bit",
-        "auto-round",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T01:36:06.000Z",
-      "lastModified": "2026-05-06T21:03:47.000Z"
-    },
-    {
-      "rank": 887,
+      "rank": 891,
       "id": "Comfy-Org/void-model",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/void-model",
@@ -25891,7 +26011,7 @@
       "lastModified": "2026-05-07T10:17:55.000Z"
     },
     {
-      "rank": 888,
+      "rank": 892,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
@@ -25921,7 +26041,7 @@
       "lastModified": "2026-04-27T23:59:16.000Z"
     },
     {
-      "rank": 889,
+      "rank": 893,
       "id": "TheBurgstall/ltx-2.3-bodypositivity-lora",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/ltx-2.3-bodypositivity-lora",
@@ -25948,7 +26068,7 @@
       "lastModified": "2026-04-26T10:38:55.000Z"
     },
     {
-      "rank": 890,
+      "rank": 894,
       "id": "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
@@ -25978,7 +26098,7 @@
       "lastModified": "2026-05-05T17:25:56.000Z"
     },
     {
-      "rank": 891,
+      "rank": 895,
       "id": "GAi92/anima-loras",
       "author": "GAi92",
       "url": "https://huggingface.co/GAi92/anima-loras",
@@ -25999,7 +26119,7 @@
       "lastModified": "2026-05-08T23:44:33.000Z"
     },
     {
-      "rank": 892,
+      "rank": 896,
       "id": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
@@ -26026,7 +26146,7 @@
       "lastModified": "2026-05-06T05:56:30.000Z"
     },
     {
-      "rank": 893,
+      "rank": 897,
       "id": "XiaomiMiMo/MiMo-V2.5-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Base",
@@ -26055,7 +26175,7 @@
       "lastModified": "2026-05-08T10:25:24.000Z"
     },
     {
-      "rank": 894,
+      "rank": 898,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit",
@@ -26084,7 +26204,7 @@
       "lastModified": "2026-04-29T04:36:33.000Z"
     },
     {
-      "rank": 895,
+      "rank": 899,
       "id": "sokann/Qwen3.6-27B-GGUF-4.256bpw",
       "author": "sokann",
       "url": "https://huggingface.co/sokann/Qwen3.6-27B-GGUF-4.256bpw",
@@ -26108,7 +26228,7 @@
       "lastModified": "2026-04-30T05:52:10.000Z"
     },
     {
-      "rank": 896,
+      "rank": 900,
       "id": "Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
@@ -26153,7 +26273,7 @@
       "lastModified": "2026-04-30T00:55:51.000Z"
     },
     {
-      "rank": 897,
+      "rank": 901,
       "id": "mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
@@ -26198,7 +26318,7 @@
       "lastModified": "2026-04-30T08:28:27.000Z"
     },
     {
-      "rank": 898,
+      "rank": 902,
       "id": "OrobasVault/Geodesic-Phantom-12B",
       "author": "OrobasVault",
       "url": "https://huggingface.co/OrobasVault/Geodesic-Phantom-12B",
@@ -26239,7 +26359,7 @@
       "lastModified": "2026-05-01T03:53:12.000Z"
     },
     {
-      "rank": 899,
+      "rank": 903,
       "id": "Egor-3926/ToxicLord",
       "author": "Egor-3926",
       "url": "https://huggingface.co/Egor-3926/ToxicLord",
@@ -26269,7 +26389,7 @@
       "lastModified": "2026-04-30T20:07:44.000Z"
     },
     {
-      "rank": 900,
+      "rank": 904,
       "id": "Playtime-AI/LTX-2.3-Jenna_Coleman",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Jenna_Coleman",
@@ -26286,7 +26406,7 @@
       "lastModified": "2026-05-01T11:07:58.000Z"
     },
     {
-      "rank": 901,
+      "rank": 905,
       "id": "abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
       "author": "abhinand",
       "url": "https://huggingface.co/abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
@@ -26316,7 +26436,7 @@
       "lastModified": "2026-05-01T15:22:45.000Z"
     },
     {
-      "rank": 902,
+      "rank": 906,
       "id": "Naphula/Salamander-24B-v1",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/Salamander-24B-v1",
@@ -26361,7 +26481,7 @@
       "lastModified": "2026-05-02T10:32:50.000Z"
     },
     {
-      "rank": 903,
+      "rank": 907,
       "id": "Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
@@ -26378,7 +26498,7 @@
       "lastModified": "2026-05-04T13:20:35.000Z"
     },
     {
-      "rank": 904,
+      "rank": 908,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -26407,7 +26527,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 905,
+      "rank": 909,
       "id": "chromadb/context-1",
       "author": "chromadb",
       "url": "https://huggingface.co/chromadb/context-1",
@@ -26432,7 +26552,7 @@
       "lastModified": "2026-03-30T01:02:07.000Z"
     },
     {
-      "rank": 906,
+      "rank": 910,
       "id": "abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
       "author": "abovespec",
       "url": "https://huggingface.co/abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
@@ -26452,7 +26572,7 @@
       "lastModified": "2026-05-04T03:28:29.000Z"
     },
     {
-      "rank": 907,
+      "rank": 911,
       "id": "bond005/whisper-podlodka-turbo",
       "author": "bond005",
       "url": "https://huggingface.co/bond005/whisper-podlodka-turbo",
@@ -26487,7 +26607,7 @@
       "lastModified": "2026-01-29T10:12:53.000Z"
     },
     {
-      "rank": 908,
+      "rank": 912,
       "id": "nvidia/canary-qwen-2.5b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/canary-qwen-2.5b",
@@ -26532,7 +26652,7 @@
       "lastModified": "2026-04-21T12:31:18.000Z"
     },
     {
-      "rank": 909,
+      "rank": 913,
       "id": "lightx2v/Wan2.2-Distill-Loras",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-Distill-Loras",
@@ -26560,7 +26680,7 @@
       "lastModified": "2025-12-17T08:00:53.000Z"
     },
     {
-      "rank": 910,
+      "rank": 914,
       "id": "Qwen/Qwen3.5-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-27B",
@@ -26585,7 +26705,7 @@
       "lastModified": "2026-04-24T02:54:49.000Z"
     },
     {
-      "rank": 911,
+      "rank": 915,
       "id": "mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
@@ -26608,7 +26728,7 @@
       "lastModified": "2026-04-23T08:30:31.000Z"
     },
     {
-      "rank": 912,
+      "rank": 916,
       "id": "sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
@@ -26647,7 +26767,7 @@
       "lastModified": "2026-04-29T00:23:13.000Z"
     },
     {
-      "rank": 913,
+      "rank": 917,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit",
@@ -26675,7 +26795,7 @@
       "lastModified": "2026-04-29T06:58:31.000Z"
     },
     {
-      "rank": 914,
+      "rank": 918,
       "id": "Harley-ml/Tenete-8M",
       "author": "Harley-ml",
       "url": "https://huggingface.co/Harley-ml/Tenete-8M",
@@ -26705,7 +26825,7 @@
       "lastModified": "2026-05-05T14:34:26.000Z"
     },
     {
-      "rank": 915,
+      "rank": 919,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -26742,7 +26862,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 916,
+      "rank": 920,
       "id": "nvidia/omni-embed-nemotron-3b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/omni-embed-nemotron-3b",
@@ -26778,7 +26898,7 @@
       "lastModified": "2026-05-06T18:02:16.000Z"
     },
     {
-      "rank": 917,
+      "rank": 921,
       "id": "fal/flux-2-klein-4b-spritesheet-lora",
       "author": "fal",
       "url": "https://huggingface.co/fal/flux-2-klein-4b-spritesheet-lora",
@@ -26812,7 +26932,7 @@
       "lastModified": "2026-01-21T14:44:55.000Z"
     },
     {
-      "rank": 918,
+      "rank": 922,
       "id": "DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
@@ -26857,12 +26977,12 @@
       "lastModified": "2026-03-09T07:04:55.000Z"
     },
     {
-      "rank": 919,
+      "rank": 923,
       "id": "Comfy-Org/ltx-2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/ltx-2",
       "downloads": 0,
-      "likes": 118,
+      "likes": 123,
       "trendingScore": 5,
       "pipelineTag": null,
       "libraryName": null,
@@ -26874,7 +26994,7 @@
       "lastModified": "2026-03-08T17:36:30.000Z"
     },
     {
-      "rank": 920,
+      "rank": 924,
       "id": "silveroxides/LTX-2.3-Quants",
       "author": "silveroxides",
       "url": "https://huggingface.co/silveroxides/LTX-2.3-Quants",
@@ -26918,7 +27038,7 @@
       "lastModified": "2026-05-03T15:37:37.000Z"
     },
     {
-      "rank": 921,
+      "rank": 925,
       "id": "z-lab/Qwen3.5-35B-A3B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-35B-A3B-PARO",
@@ -26947,7 +27067,7 @@
       "lastModified": "2026-05-08T06:21:10.000Z"
     },
     {
-      "rank": 922,
+      "rank": 926,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -26982,7 +27102,7 @@
       "lastModified": "2026-04-06T02:19:40.000Z"
     },
     {
-      "rank": 923,
+      "rank": 927,
       "id": "OpenMed/privacy-filter-multilingual",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-multilingual",
@@ -27027,7 +27147,7 @@
       "lastModified": "2026-05-03T21:36:31.000Z"
     },
     {
-      "rank": 924,
+      "rank": 928,
       "id": "prism-ml/Bonsai-8B-mlx-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-mlx-1bit",
@@ -27058,7 +27178,7 @@
       "lastModified": "2026-04-18T20:44:19.000Z"
     },
     {
-      "rank": 925,
+      "rank": 929,
       "id": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
@@ -27103,7 +27223,7 @@
       "lastModified": "2025-12-22T10:16:55.000Z"
     },
     {
-      "rank": 926,
+      "rank": 930,
       "id": "zai-org/GLM-5",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5",
@@ -27130,7 +27250,7 @@
       "lastModified": "2026-04-05T07:48:51.000Z"
     },
     {
-      "rank": 927,
+      "rank": 931,
       "id": "Comfy-Org/Wan_2.1_ComfyUI_repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged",
@@ -27148,7 +27268,7 @@
       "lastModified": "2026-01-28T12:44:01.000Z"
     },
     {
-      "rank": 928,
+      "rank": 932,
       "id": "sequelbox/Qwen3.6-27B-Tachibana-Agent",
       "author": "sequelbox",
       "url": "https://huggingface.co/sequelbox/Qwen3.6-27B-Tachibana-Agent",
@@ -27193,7 +27313,7 @@
       "lastModified": "2026-05-07T02:13:23.000Z"
     },
     {
-      "rank": 929,
+      "rank": 933,
       "id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
@@ -27219,7 +27339,7 @@
       "lastModified": "2024-07-03T05:16:11.000Z"
     },
     {
-      "rank": 930,
+      "rank": 934,
       "id": "lynaNSFW/LTX2.3_NSFW_motion",
       "author": "lynaNSFW",
       "url": "https://huggingface.co/lynaNSFW/LTX2.3_NSFW_motion",
@@ -27241,7 +27361,7 @@
       "lastModified": "2026-03-25T12:45:24.000Z"
     },
     {
-      "rank": 931,
+      "rank": 935,
       "id": "mlx-community/DeepSeek-V4-Flash-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit",
@@ -27264,7 +27384,7 @@
       "lastModified": "2026-04-25T00:58:58.000Z"
     },
     {
-      "rank": 932,
+      "rank": 936,
       "id": "Qwen/Qwen3-ForcedAligner-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B",
@@ -27285,7 +27405,7 @@
       "lastModified": "2026-01-30T03:00:55.000Z"
     },
     {
-      "rank": 933,
+      "rank": 937,
       "id": "nvidia/Cosmos-Reason2-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Cosmos-Reason2-8B",
@@ -27314,7 +27434,7 @@
       "lastModified": "2026-04-30T03:16:12.000Z"
     },
     {
-      "rank": 934,
+      "rank": 938,
       "id": "Qwen/Qwen3-VL-4B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct",
@@ -27343,7 +27463,7 @@
       "lastModified": "2025-10-15T16:15:55.000Z"
     },
     {
-      "rank": 935,
+      "rank": 939,
       "id": "mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
@@ -27388,7 +27508,7 @@
       "lastModified": "2026-05-03T18:58:47.000Z"
     },
     {
-      "rank": 936,
+      "rank": 940,
       "id": "SWivid/F5-TTS",
       "author": "SWivid",
       "url": "https://huggingface.co/SWivid/F5-TTS",
@@ -27409,7 +27529,7 @@
       "lastModified": "2025-03-21T05:05:00.000Z"
     },
     {
-      "rank": 937,
+      "rank": 941,
       "id": "bartowski/google_gemma-4-E4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF",
@@ -27432,7 +27552,7 @@
       "lastModified": "2026-05-03T18:32:47.000Z"
     },
     {
-      "rank": 938,
+      "rank": 942,
       "id": "Ashen3/SNOFS",
       "author": "Ashen3",
       "url": "https://huggingface.co/Ashen3/SNOFS",
@@ -27452,7 +27572,7 @@
       "lastModified": "2026-02-21T20:02:14.000Z"
     },
     {
-      "rank": 939,
+      "rank": 943,
       "id": "Prior-Labs/tabpfn_2_6",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_2_6",
@@ -27476,7 +27596,7 @@
       "lastModified": "2026-04-02T10:00:43.000Z"
     },
     {
-      "rank": 940,
+      "rank": 944,
       "id": "Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
       "author": "Sikaworld1990",
       "url": "https://huggingface.co/Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
@@ -27505,7 +27625,7 @@
       "lastModified": "2026-03-11T17:20:00.000Z"
     },
     {
-      "rank": 941,
+      "rank": 945,
       "id": "google/medgemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-4b-it",
@@ -27549,7 +27669,7 @@
       "lastModified": "2025-10-28T17:24:49.000Z"
     },
     {
-      "rank": 942,
+      "rank": 946,
       "id": "nomic-ai/nomic-embed-text-v1.5-GGUF",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF",
@@ -27572,7 +27692,7 @@
       "lastModified": "2025-04-28T20:14:53.000Z"
     },
     {
-      "rank": 943,
+      "rank": 947,
       "id": "ponpoke/flux2-klein-4b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-4b-uncensored-text-encoder",
@@ -27605,7 +27725,7 @@
       "lastModified": "2026-05-02T11:35:01.000Z"
     },
     {
-      "rank": 944,
+      "rank": 948,
       "id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
       "author": "cardiffnlp",
       "url": "https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment-latest",
@@ -27632,7 +27752,7 @@
       "lastModified": "2025-08-04T07:58:29.000Z"
     },
     {
-      "rank": 945,
+      "rank": 949,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
@@ -27677,7 +27797,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 946,
+      "rank": 950,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
@@ -27707,7 +27827,7 @@
       "lastModified": "2026-05-04T02:04:15.000Z"
     },
     {
-      "rank": 947,
+      "rank": 951,
       "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
@@ -27732,7 +27852,7 @@
       "lastModified": "2025-02-24T03:31:45.000Z"
     },
     {
-      "rank": 948,
+      "rank": 952,
       "id": "microsoft/VibeVoice-Realtime-0.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-Realtime-0.5B",
@@ -27762,7 +27882,7 @@
       "lastModified": "2025-12-12T15:35:46.000Z"
     },
     {
-      "rank": 949,
+      "rank": 953,
       "id": "facebook/sam-audio-large",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam-audio-large",
@@ -27781,7 +27901,7 @@
       "lastModified": "2025-12-30T19:52:21.000Z"
     },
     {
-      "rank": 950,
+      "rank": 954,
       "id": "cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
       "author": "cognica",
       "url": "https://huggingface.co/cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
@@ -27808,7 +27928,7 @@
       "lastModified": "2026-05-16T07:11:10.000Z"
     },
     {
-      "rank": 951,
+      "rank": 955,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
@@ -27830,7 +27950,7 @@
       "lastModified": "2026-04-14T13:43:30.000Z"
     },
     {
-      "rank": 952,
+      "rank": 956,
       "id": "F16/z-image-turbo-flow-dpo",
       "author": "F16",
       "url": "https://huggingface.co/F16/z-image-turbo-flow-dpo",
@@ -27860,7 +27980,7 @@
       "lastModified": "2026-04-09T18:43:34.000Z"
     },
     {
-      "rank": 953,
+      "rank": 957,
       "id": "Jiunsong/supergemma4-e4b-abliterated",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-e4b-abliterated",
@@ -27891,7 +28011,7 @@
       "lastModified": "2026-04-17T13:20:56.000Z"
     },
     {
-      "rank": 954,
+      "rank": 958,
       "id": "deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
       "author": "deucebucket",
       "url": "https://huggingface.co/deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
@@ -27925,7 +28045,7 @@
       "lastModified": "2026-05-15T05:30:04.000Z"
     },
     {
-      "rank": 955,
+      "rank": 959,
       "id": "deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
       "author": "deepsweet",
       "url": "https://huggingface.co/deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
@@ -27951,7 +28071,7 @@
       "lastModified": "2026-05-10T15:18:41.000Z"
     },
     {
-      "rank": 956,
+      "rank": 960,
       "id": "Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Phil2Sat",
       "url": "https://huggingface.co/Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -27979,7 +28099,7 @@
       "lastModified": "2025-11-07T19:24:03.000Z"
     },
     {
-      "rank": 957,
+      "rank": 961,
       "id": "tencent/HunyuanVideo",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HunyuanVideo",
@@ -27999,7 +28119,7 @@
       "lastModified": "2025-03-06T15:39:29.000Z"
     },
     {
-      "rank": 958,
+      "rank": 962,
       "id": "mradermacher/Mistral-Nemo-2407-12B-Thinking-Claude-Gemini-GPT5.2-Uncensored-HERETIC-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Mistral-Nemo-2407-12B-Thinking-Claude-Gemini-GPT5.2-Uncensored-HERETIC-GGUF",
@@ -28044,7 +28164,7 @@
       "lastModified": "2026-01-10T03:19:10.000Z"
     },
     {
-      "rank": 959,
+      "rank": 963,
       "id": "KyleHessling1/Qwopus-GLM-18B-Merged-GGUF",
       "author": "KyleHessling1",
       "url": "https://huggingface.co/KyleHessling1/Qwopus-GLM-18B-Merged-GGUF",
@@ -28085,7 +28205,7 @@
       "lastModified": "2026-04-20T16:48:29.000Z"
     },
     {
-      "rank": 960,
+      "rank": 964,
       "id": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
@@ -28110,7 +28230,7 @@
       "lastModified": "2025-05-29T13:13:34.000Z"
     },
     {
-      "rank": 961,
+      "rank": 965,
       "id": "z-lab/Qwen3.5-4B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-4B-DFlash",
@@ -28143,7 +28263,7 @@
       "lastModified": "2026-04-07T14:29:28.000Z"
     },
     {
-      "rank": 962,
+      "rank": 966,
       "id": "ovi054/QIE-2511-Color-Grade-Transfer-LoRA",
       "author": "ovi054",
       "url": "https://huggingface.co/ovi054/QIE-2511-Color-Grade-Transfer-LoRA",
@@ -28164,7 +28284,7 @@
       "lastModified": "2026-05-06T18:12:57.000Z"
     },
     {
-      "rank": 963,
+      "rank": 967,
       "id": "Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound",
@@ -28187,7 +28307,7 @@
       "lastModified": "2026-05-01T13:20:17.000Z"
     },
     {
-      "rank": 964,
+      "rank": 968,
       "id": "RunDiffusion/Juggernaut-XI-v11",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XI-v11",
@@ -28221,7 +28341,7 @@
       "lastModified": "2026-05-08T17:23:19.000Z"
     },
     {
-      "rank": 965,
+      "rank": 969,
       "id": "Systran/faster-whisper-large-v3",
       "author": "Systran",
       "url": "https://huggingface.co/Systran/faster-whisper-large-v3",
@@ -28266,7 +28386,7 @@
       "lastModified": "2023-11-23T09:41:12.000Z"
     },
     {
-      "rank": 966,
+      "rank": 970,
       "id": "colbert-ir/colbertv2.0",
       "author": "colbert-ir",
       "url": "https://huggingface.co/colbert-ir/colbertv2.0",
@@ -28296,7 +28416,7 @@
       "lastModified": "2024-04-05T20:18:44.000Z"
     },
     {
-      "rank": 967,
+      "rank": 971,
       "id": "FacebookAI/xlm-roberta-base",
       "author": "FacebookAI",
       "url": "https://huggingface.co/FacebookAI/xlm-roberta-base",
@@ -28341,7 +28461,7 @@
       "lastModified": "2024-02-19T12:48:21.000Z"
     },
     {
-      "rank": 968,
+      "rank": 972,
       "id": "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
@@ -28359,7 +28479,7 @@
       "lastModified": "2026-02-26T07:46:49.000Z"
     },
     {
-      "rank": 969,
+      "rank": 973,
       "id": "oongaboongahacker/Gemini-Nano",
       "author": "oongaboongahacker",
       "url": "https://huggingface.co/oongaboongahacker/Gemini-Nano",
@@ -28375,7 +28495,7 @@
       "lastModified": "2024-06-25T08:45:00.000Z"
     },
     {
-      "rank": 970,
+      "rank": 974,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -28399,7 +28519,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 971,
+      "rank": 975,
       "id": "tarn59/pixel_art_style_lora_z_image_turbo",
       "author": "tarn59",
       "url": "https://huggingface.co/tarn59/pixel_art_style_lora_z_image_turbo",
@@ -28422,7 +28542,7 @@
       "lastModified": "2025-11-30T15:16:04.000Z"
     },
     {
-      "rank": 972,
+      "rank": 976,
       "id": "drbaph/OmniVoice-bf16",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/OmniVoice-bf16",
@@ -28467,7 +28587,7 @@
       "lastModified": "2026-04-02T20:50:23.000Z"
     },
     {
-      "rank": 973,
+      "rank": 977,
       "id": "zooeyy/Style-Transfer",
       "author": "zooeyy",
       "url": "https://huggingface.co/zooeyy/Style-Transfer",
@@ -28490,7 +28610,7 @@
       "lastModified": "2026-02-06T05:28:09.000Z"
     },
     {
-      "rank": 974,
+      "rank": 978,
       "id": "google/gemma-3-12b-it-qat-q4_0-unquantized",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized",
@@ -28535,7 +28655,7 @@
       "lastModified": "2025-04-15T21:07:07.000Z"
     },
     {
-      "rank": 975,
+      "rank": 979,
       "id": "Qwen/Qwen3-Reranker-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Reranker-0.6B",
@@ -28562,7 +28682,7 @@
       "lastModified": "2026-04-16T08:55:59.000Z"
     },
     {
-      "rank": 976,
+      "rank": 980,
       "id": "nvidia/parakeet-tdt-0.6b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2",
@@ -28601,7 +28721,7 @@
       "lastModified": "2026-04-13T13:49:50.000Z"
     },
     {
-      "rank": 977,
+      "rank": 981,
       "id": "apple/DepthPro-hf",
       "author": "apple",
       "url": "https://huggingface.co/apple/DepthPro-hf",
@@ -28625,7 +28745,7 @@
       "lastModified": "2025-02-28T18:31:40.000Z"
     },
     {
-      "rank": 978,
+      "rank": 982,
       "id": "Qwen/Qwen3-ASR-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-0.6B",
@@ -28648,7 +28768,7 @@
       "lastModified": "2026-01-30T03:00:21.000Z"
     },
     {
-      "rank": 979,
+      "rank": 983,
       "id": "cstr/qwen3-asr-1.7b-GGUF",
       "author": "cstr",
       "url": "https://huggingface.co/cstr/qwen3-asr-1.7b-GGUF",
@@ -28693,7 +28813,7 @@
       "lastModified": "2026-04-11T17:41:11.000Z"
     },
     {
-      "rank": 980,
+      "rank": 984,
       "id": "TheDrummer/Cydonia-24B-v4.3",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Cydonia-24B-v4.3",
@@ -28713,7 +28833,7 @@
       "lastModified": "2025-12-17T15:08:15.000Z"
     },
     {
-      "rank": 981,
+      "rank": 985,
       "id": "tencent/HY-OmniWeaving",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-OmniWeaving",
@@ -28739,7 +28859,7 @@
       "lastModified": "2026-05-06T10:16:28.000Z"
     },
     {
-      "rank": 982,
+      "rank": 986,
       "id": "google/paligemma-3b-pt-224",
       "author": "google",
       "url": "https://huggingface.co/google/paligemma-3b-pt-224",
@@ -28782,7 +28902,7 @@
       "lastModified": "2024-09-21T10:14:25.000Z"
     },
     {
-      "rank": 983,
+      "rank": 987,
       "id": "XRXRX/X-Voice",
       "author": "XRXRX",
       "url": "https://huggingface.co/XRXRX/X-Voice",
@@ -28802,7 +28922,7 @@
       "lastModified": "2026-05-05T08:15:34.000Z"
     },
     {
-      "rank": 984,
+      "rank": 988,
       "id": "lemonyins/Qwen3.6-27B-uncensored-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-uncensored-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -28833,7 +28953,7 @@
       "lastModified": "2026-05-07T10:29:03.000Z"
     },
     {
-      "rank": 985,
+      "rank": 989,
       "id": "unsloth/Qwen3.5-397B-A17B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF",
@@ -28859,7 +28979,7 @@
       "lastModified": "2026-03-07T04:33:56.000Z"
     },
     {
-      "rank": 986,
+      "rank": 990,
       "id": "dphn/Dolphin3.0-Llama3.1-8B-GGUF",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin3.0-Llama3.1-8B-GGUF",
@@ -28895,7 +29015,7 @@
       "lastModified": "2025-01-05T17:17:21.000Z"
     },
     {
-      "rank": 987,
+      "rank": 991,
       "id": "apple/Sharp",
       "author": "apple",
       "url": "https://huggingface.co/apple/Sharp",
@@ -28915,7 +29035,7 @@
       "lastModified": "2025-12-18T17:38:39.000Z"
     },
     {
-      "rank": 988,
+      "rank": 992,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1",
@@ -28944,7 +29064,7 @@
       "lastModified": "2026-01-31T17:47:55.000Z"
     },
     {
-      "rank": 989,
+      "rank": 993,
       "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
       "author": "Baraje",
       "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
@@ -28967,7 +29087,7 @@
       "lastModified": "2026-04-22T06:19:53.000Z"
     },
     {
-      "rank": 990,
+      "rank": 994,
       "id": "facebook/seamless-m4t-v2-large",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/seamless-m4t-v2-large",
@@ -29012,7 +29132,7 @@
       "lastModified": "2024-01-04T12:48:26.000Z"
     },
     {
-      "rank": 991,
+      "rank": 995,
       "id": "BAAI/bge-large-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-large-en-v1.5",
@@ -29049,7 +29169,7 @@
       "lastModified": "2024-02-21T02:51:44.000Z"
     },
     {
-      "rank": 992,
+      "rank": 996,
       "id": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
@@ -29094,7 +29214,7 @@
       "lastModified": "2025-12-31T06:30:55.000Z"
     },
     {
-      "rank": 993,
+      "rank": 997,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
@@ -29139,7 +29259,7 @@
       "lastModified": "2026-03-20T20:50:41.000Z"
     },
     {
-      "rank": 994,
+      "rank": 998,
       "id": "nvidia/gpt-oss-120b-Eagle3-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v3",
@@ -29166,7 +29286,7 @@
       "lastModified": "2026-05-08T16:33:12.000Z"
     },
     {
-      "rank": 995,
+      "rank": 999,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2",
@@ -29197,7 +29317,7 @@
       "lastModified": "2026-05-06T17:42:34.000Z"
     },
     {
-      "rank": 996,
+      "rank": 1000,
       "id": "Ardenzard/Qwen3.6-27B-DFlash-GGUF",
       "author": "Ardenzard",
       "url": "https://huggingface.co/Ardenzard/Qwen3.6-27B-DFlash-GGUF",
@@ -29227,136 +29347,6 @@
       ],
       "createdAt": "2026-04-28T16:05:52.000Z",
       "lastModified": "2026-04-28T17:48:00.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "localweights/Qwen3.6-35B-A3B-MTP-IQ4_XS-Q8nextn-GGUF",
-      "author": "localweights",
-      "url": "https://huggingface.co/localweights/Qwen3.6-35B-A3B-MTP-IQ4_XS-Q8nextn-GGUF",
-      "downloads": 1139,
-      "likes": 6,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen",
-        "qwen3.6",
-        "moe",
-        "llama.cpp",
-        "mtp",
-        "speculative-decoding",
-        "en",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-06T18:55:20.000Z",
-      "lastModified": "2026-05-07T16:32:28.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "OsaurusAI/ZAYA1-8B-MXFP4",
-      "author": "OsaurusAI",
-      "url": "https://huggingface.co/OsaurusAI/ZAYA1-8B-MXFP4",
-      "downloads": 3533,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "zaya",
-        "mixture-of-experts",
-        "hybrid-attention",
-        "cca-attention",
-        "apple-silicon",
-        "reasoning",
-        "tool-use",
-        "quantized",
-        "mxfp4",
-        "jang",
-        "osaurus",
-        "text-generation",
-        "conversational",
-        "base_model:Zyphra/ZAYA1-8B",
-        "base_model:quantized:Zyphra/ZAYA1-8B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T22:39:51.000Z",
-      "lastModified": "2026-05-10T08:32:01.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "nvidia/audio-flamingo-next-hf",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/audio-flamingo-next-hf",
-      "downloads": 7704,
-      "likes": 52,
-      "trendingScore": 5,
-      "pipelineTag": "audio-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "musicflamingo",
-        "text2text-generation",
-        "audio",
-        "speech",
-        "sound",
-        "music",
-        "reasoning",
-        "audio understanding",
-        "ASR",
-        "audio captioning",
-        "long-context",
-        "audio-language-model",
-        "long-audio",
-        "timestamp-grounding",
-        "instruction-tuned",
-        "audio-text-to-text",
-        "en",
-        "dataset:nvidia/LongAudio",
-        "dataset:nvidia/AF-Skills",
-        "dataset:nvidia/AF-Chat",
-        "dataset:nvidia/AF-Think",
-        "arxiv:2604.10905",
-        "license:other",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-05T22:22:34.000Z",
-      "lastModified": "2026-05-13T18:38:05.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
-      "author": "deepseek-ai",
-      "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
-      "downloads": 581625,
-      "likes": 1507,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "conversational",
-        "arxiv:2501.12948",
-        "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-01-20T09:04:18.000Z",
-      "lastModified": "2025-02-24T03:32:35.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26076390445

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.