### PR TITLE
chore(data): refresh ai rss signals 2026-05-19T04:40:34Z

### DIFF
--- a/data/_meta/claude-rss.json
+++ b/data/_meta/claude-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "claude-rss",
   "reason": "ok",
-  "ts": "2026-05-18T20:11:20.224Z",
+  "ts": "2026-05-19T04:40:32.088Z",
   "count": 1,
-  "durationMs": 5402,
+  "durationMs": 4398,
   "extra": {}
 }

--- a/data/_meta/openai-rss.json
+++ b/data/_meta/openai-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "openai-rss",
   "reason": "ok",
-  "ts": "2026-05-18T20:11:23.035Z",
+  "ts": "2026-05-19T04:40:34.856Z",
   "count": 1,
-  "durationMs": 2655,
+  "durationMs": 2613,
   "extra": {}
 }

--- a/data/claude-rss.json
+++ b/data/claude-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T20:11:14.826Z",
+  "fetchedAt": "2026-05-19T04:40:27.695Z",
   "source": "claude",
   "feedUrl": "https://www.anthropic.com/news",
   "error": null,

--- a/data/openai-rss.json
+++ b/data/openai-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T20:11:20.385Z",
+  "fetchedAt": "2026-05-19T04:40:32.248Z",
   "source": "openai",
   "feedUrl": "https://openai.com/news/rss.xml",
   "error": null,


### PR DESCRIPTION
Automated data refresh from `Refresh AI RSS signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26076569906

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.