### PR TITLE
chore(data): refresh lobsters signals 2026-05-19T04:45:30Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-18T23:40:21.721Z",
+  "ts": "2026-05-19T04:45:30.664Z",
   "count": 1,
-  "durationMs": 8772,
+  "durationMs": 5742,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T23:40:12.962Z",
+  "fetchedAt": "2026-05-19T04:45:24.936Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-18T23:40:12.962Z",
+  "fetchedAt": "2026-05-19T04:45:24.936Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -309,6 +309,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "cjwt5c",
+      "title": "Comprehensive Response to Bambu's AGPLv3 Violations",
+      "url": "https://sfconservancy.org/news/2026/may/18/bambu-studio-3d-printer-agpl-violation-response/",
+      "commentsUrl": "https://lobste.rs/s/cjwt5c/comprehensive_response_bambu_s_agplv3",
+      "by": "",
+      "score": 31,
+      "commentCount": 0,
+      "createdUtc": 1779143049,
+      "ageHours": 6.354166666666667,
+      "trendingScore": 1.2838284364741332,
+      "tags": [
+        "law"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "ynxkj6",
       "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
       "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
@@ -508,23 +525,6 @@
         "graphics",
         "historical",
         "video"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "cjwt5c",
-      "title": "Comprehensive Response to Bambu's AGPLv3 Violations",
-      "url": "https://sfconservancy.org/news/2026/may/18/bambu-studio-3d-printer-agpl-violation-response/",
-      "commentsUrl": "https://lobste.rs/s/cjwt5c/comprehensive_response_bambu_s_agplv3",
-      "by": "",
-      "score": 6,
-      "commentCount": 0,
-      "createdUtc": 1779143049,
-      "ageHours": 1.2675,
-      "trendingScore": 1.015845955901289,
-      "tags": [
-        "law"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -199734,3 +199734,7 @@
 {"source":"bluesky","fullName":"tencentcloud-sdk-php/cwp","observedAt":"2026-05-19T04:33:47.216Z"}
 {"source":"bluesky","fullName":"tencentcloud-sdk-php/mna","observedAt":"2026-05-19T04:33:47.216Z"}
 {"source":"bluesky","fullName":"tencentcloud-sdk-php/dataagent","observedAt":"2026-05-19T04:33:47.216Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-19T04:45:29.398Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-19T04:45:29.398Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-19T04:45:29.398Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-19T04:45:29.398Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26076722844

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.