### PR TITLE
chore(data): refresh huggingface space signals 2026-05-19T04:45:44Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-18T20:18:07.163Z",
+  "ts": "2026-05-19T04:45:44.358Z",
   "count": 1,
-  "durationMs": 5244,
+  "durationMs": 6218,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T20:18:01.921Z",
+  "fetchedAt": "2026-05-19T04:45:38.142Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -25,8 +25,8 @@
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/spaces/TencentARC/Pixal3D",
-      "likes": 164,
-      "trendingScore": 151,
+      "likes": 177,
+      "trendingScore": 153,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -246,8 +246,8 @@
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 60,
-      "trendingScore": 60,
+      "likes": 61,
+      "trendingScore": 61,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -262,8 +262,8 @@
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 64,
-      "trendingScore": 57,
+      "likes": 66,
+      "trendingScore": 58,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -522,6 +522,23 @@
     },
     {
       "rank": 32,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 40,
+      "trendingScore": 30,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 33,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -538,7 +555,7 @@
       "models": []
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -551,23 +568,6 @@
       ],
       "createdAt": "2026-01-02T00:31:44.000Z",
       "lastModified": "2026-05-17T07:08:19.000Z",
-      "models": []
-    },
-    {
-      "rank": 34,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 39,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -642,6 +642,38 @@
     },
     {
       "rank": 39,
+      "id": "Lakonik/AsymFLUX.2-klein",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
+      "likes": 23,
+      "trendingScore": 23,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:06:55.000Z",
+      "lastModified": "2026-05-19T00:50:26.000Z",
+      "models": []
+    },
+    {
+      "rank": 40,
+      "id": "linoyts/Flux2-Klein-Face-Swap",
+      "author": "linoyts",
+      "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
+      "likes": 386,
+      "trendingScore": 22,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-02-03T14:43:29.000Z",
+      "lastModified": "2026-03-10T10:33:23.000Z",
+      "models": []
+    },
+    {
+      "rank": 41,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -654,38 +686,6 @@
       ],
       "createdAt": "2026-05-06T17:25:59.000Z",
       "lastModified": "2026-05-07T18:52:54.000Z",
-      "models": []
-    },
-    {
-      "rank": 40,
-      "id": "Lakonik/AsymFLUX.2-klein",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
-      "likes": 22,
-      "trendingScore": 22,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:06:55.000Z",
-      "lastModified": "2026-05-14T02:05:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 41,
-      "id": "linoyts/Flux2-Klein-Face-Swap",
-      "author": "linoyts",
-      "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
-      "likes": 382,
-      "trendingScore": 21,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-02-03T14:43:29.000Z",
-      "lastModified": "2026-03-10T10:33:23.000Z",
       "models": []
     },
     {
@@ -726,6 +726,23 @@
     },
     {
       "rank": 44,
+      "id": "huggingface/physics-intern",
+      "author": "huggingface",
+      "url": "https://huggingface.co/spaces/huggingface/physics-intern",
+      "likes": 23,
+      "trendingScore": 21,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "research-article-template",
+        "region:us"
+      ],
+      "createdAt": "2026-04-09T06:56:52.000Z",
+      "lastModified": "2026-05-12T14:59:53.000Z",
+      "models": []
+    },
+    {
+      "rank": 45,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -742,7 +759,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
       "author": "BoobyBoobs",
       "url": "https://huggingface.co/spaces/BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
@@ -758,7 +775,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "NucleusAI/nucleus-image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/spaces/NucleusAI/nucleus-image",
@@ -771,23 +788,6 @@
       ],
       "createdAt": "2026-04-15T22:24:04.000Z",
       "lastModified": "2026-04-30T12:41:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 47,
-      "id": "huggingface/physics-intern",
-      "author": "huggingface",
-      "url": "https://huggingface.co/spaces/huggingface/physics-intern",
-      "likes": 22,
-      "trendingScore": 20,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "research-article-template",
-        "region:us"
-      ],
-      "createdAt": "2026-04-09T06:56:52.000Z",
-      "lastModified": "2026-05-12T14:59:53.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26076732154

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.