### PR TITLE
chore(data): refresh mcp liveness 2026-05-19T04:48:46Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-18T20:20:30.841Z",
+  "fetchedAt": "2026-05-19T04:48:42.139Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -1830,6 +1830,50 @@
       "livenessInferred": true
     },
     "mohamadalhusseinie/openmembrain": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "calame-tech/calame": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "crsxmd/rewindex": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sunix/jdtls-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yubinkim444/ai-first-scraper-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yubinkim444/repo-memory": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bperezpereira/wasabil": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sudomichael/gizmo analytics": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "patdolitse/engram": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "vighriday/veris": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "andysalvo/supership-scan": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kajolchawla98/google docs + gmail mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3954,50 +3998,6 @@
       "livenessInferred": true
     },
     "sonaiengine/graph-tool-call": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "0xzcov/mcp-omnifun": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "gregario/mtg-oracle": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "i-can-hack/pdf-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dan24ou-cpu/palate-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "transparentlyok/mcp context manager": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "davidsimoes/digisign-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "amcharts/amcharts 5 mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "feedoracle/feedoracle compliance mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "stackbilt-dev/stackbilt": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "markgregg/low-code ui mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "smart-mcp-proxy/mcpproxy-go": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26076836777

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.