### PR TITLE
chore(data): refresh scoring shadow report 2026-05-19T05:58:28Z

### DIFF
--- a/data/scoring-shadow-report.json
+++ b/data/scoring-shadow-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-18T06:03:38.261Z",
+  "generatedAt": "2026-05-19T05:58:26.628Z",
   "reports": [
     {
       "domainKey": "skill",
@@ -8,301 +8,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.595,
+          "momentum": 9.594,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 9.073,
+          "momentum": 8.923,
           "rank": 2
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.828,
-          "rank": 3
-        },
-        {
-          "id": "agents365-ai-drawio-skill",
-          "title": "drawio-skill",
-          "momentum": 7.768,
-          "rank": 4
-        },
-        {
-          "id": "glitternetwork-pinme",
-          "title": "pinme",
-          "momentum": 7.593,
-          "rank": 5
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 7.535,
-          "rank": 6
+          "momentum": 8.688,
+          "rank": 3
         },
         {
-          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
-          "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.356,
-          "rank": 7
+          "id": "agricidaniel-claude-ads",
+          "title": "claude-ads",
+          "momentum": 8.46,
+          "rank": 4
+        },
+        {
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.7,
+          "rank": 5
+        },
+        {
+          "id": "agents365-ai-drawio-skill",
+          "title": "drawio-skill",
+          "momentum": 7.655,
+          "rank": 6
         },
         {
           "id": "eugeniughelbur-obsidian-second-brain",
           "title": "obsidian-second-brain",
-          "momentum": 7.198,
+          "momentum": 7.557,
+          "rank": 7
+        },
+        {
+          "id": "glitternetwork-pinme",
+          "title": "pinme",
+          "momentum": 7.464,
           "rank": 8
+        },
+        {
+          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
+          "title": "nano-banana-pro-prompts-recommend-skill",
+          "momentum": 7.31,
+          "rank": 9
         },
         {
           "id": "alexgreensh-token-optimizer",
           "title": "token-optimizer",
-          "momentum": 6.791,
-          "rank": 9
+          "momentum": 6.843,
+          "rank": 10
         },
         {
           "id": "htdt-godogen",
           "title": "godogen",
-          "momentum": 6.762,
-          "rank": 10
-        },
-        {
-          "id": "denissergeevitch-agents-best-practices",
-          "title": "agents-best-practices",
-          "momentum": 6.26,
+          "momentum": 6.647,
           "rank": 11
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.236,
-          "rank": 12
-        },
-        {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 6.234,
-          "rank": 13
         },
         {
           "id": "agricidaniel-claude-blog",
           "title": "claude-blog",
-          "momentum": 6.171,
-          "rank": 14
-        },
-        {
-          "id": "wuyoscar-gpt-image-2-skill",
-          "title": "gpt_image_2_skill",
-          "momentum": 6.154,
-          "rank": 15
+          "momentum": 6.569,
+          "rank": 12
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.093,
-          "rank": 16
-        },
-        {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 6.02,
-          "rank": 17
-        },
-        {
-          "id": "avdlee-rocketsimapp",
-          "title": "RocketSimApp",
-          "momentum": 5.937,
-          "rank": 18
+          "momentum": 6.439,
+          "rank": 13
         },
         {
           "id": "juneyaooo-gpt-image2-ppt-skills",
           "title": "gpt-image2-ppt-skills",
-          "momentum": 5.853,
+          "momentum": 6.343,
+          "rank": 14
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.268,
+          "rank": 15
+        },
+        {
+          "id": "denissergeevitch-agents-best-practices",
+          "title": "agents-best-practices",
+          "momentum": 6.25,
+          "rank": 16
+        },
+        {
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.127,
+          "rank": 17
+        },
+        {
+          "id": "wuyoscar-gpt-image-2-skill",
+          "title": "gpt_image_2_skill",
+          "momentum": 6.056,
+          "rank": 18
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 5.925,
           "rank": 19
+        },
+        {
+          "id": "alirezarezvani-claudeforge",
+          "title": "ClaudeForge",
+          "momentum": 5.91,
+          "rank": 20
+        },
+        {
+          "id": "avdlee-rocketsimapp",
+          "title": "RocketSimApp",
+          "momentum": 5.837,
+          "rank": 21
+        },
+        {
+          "id": "alirezarezvani-claude-code-aso-skill",
+          "title": "claude-code-aso-skill",
+          "momentum": 5.833,
+          "rank": 22
         },
         {
           "id": "mrgediao-shuorenhua",
           "title": "shuorenhua",
-          "momentum": 5.768,
-          "rank": 20
+          "momentum": 5.672,
+          "rank": 23
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.715,
-          "rank": 21
+          "momentum": 5.624,
+          "rank": 24
         },
         {
           "id": "bharathkumarsuresh-claude-design-system-hooks",
           "title": "claude-design-system-hooks",
-          "momentum": 5.596,
-          "rank": 22
-        },
-        {
-          "id": "aspegio-nelson",
-          "title": "nelson",
-          "momentum": 5.56,
-          "rank": 23
-        },
-        {
-          "id": "pegasi-ai-reins",
-          "title": "reins",
-          "momentum": 5.437,
-          "rank": 24
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.404,
+          "momentum": 5.502,
           "rank": 25
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 5.145,
-          "rank": 26
-        },
-        {
-          "id": "bitwize-music-studio-claude-ai-music-skills",
-          "title": "claude-ai-music-skills",
-          "momentum": 5.104,
-          "rank": 27
-        },
-        {
-          "id": "memtensor-skills-vote",
-          "title": "skills-vote",
-          "momentum": 5.075,
-          "rank": 28
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.057,
+          "momentum": 5.486,
+          "rank": 26
+        },
+        {
+          "id": "aspegio-nelson",
+          "title": "nelson",
+          "momentum": 5.47,
+          "rank": 27
+        },
+        {
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.364,
+          "rank": 28
+        },
+        {
+          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
+          "title": "Claude-Mythos-AI-Anthropic-App",
+          "momentum": 5.354,
           "rank": 29
         },
         {
-          "id": "agents365-ai-asta-skill",
-          "title": "asta-skill",
-          "momentum": 5.023,
+          "id": "pegasi-ai-reins",
+          "title": "reins",
+          "momentum": 5.344,
           "rank": 30
         },
         {
           "id": "vast-ai-vast-cli",
           "title": "vast-cli",
-          "momentum": 5.008,
+          "momentum": 5.239,
           "rank": 31
+        },
+        {
+          "id": "memtensor-skills-vote",
+          "title": "skills-vote",
+          "momentum": 5.237,
+          "rank": 32
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 5.064,
+          "rank": 33
+        },
+        {
+          "id": "bitwize-music-studio-claude-ai-music-skills",
+          "title": "claude-ai-music-skills",
+          "momentum": 5.027,
+          "rank": 34
+        },
+        {
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 4.945,
+          "rank": 35
         },
         {
           "id": "agents365-ai-paper-fetch",
           "title": "paper-fetch",
-          "momentum": 4.963,
-          "rank": 32
-        },
-        {
-          "id": "agricidaniel-claude-ads",
-          "title": "claude-ads",
-          "momentum": 4.958,
-          "rank": 33
+          "momentum": 4.886,
+          "rank": 36
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 4.927,
-          "rank": 34
-        },
-        {
-          "id": "keerthanapranesh-claude-code-swarm-toolkit",
-          "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.841,
-          "rank": 35
+          "momentum": 4.846,
+          "rank": 37
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.823,
-          "rank": 36
+          "momentum": 4.822,
+          "rank": 38
+        },
+        {
+          "id": "keerthanapranesh-claude-code-swarm-toolkit",
+          "title": "Claude-Code-Swarm-Toolkit",
+          "momentum": 4.758,
+          "rank": 39
         },
         {
           "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.777,
-          "rank": 37
+          "momentum": 4.695,
+          "rank": 40
         },
         {
           "id": "jeecgboot-skills",
           "title": "skills",
-          "momentum": 4.753,
-          "rank": 38
-        },
-        {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.664,
-          "rank": 39
+          "momentum": 4.679,
+          "rank": 41
         },
         {
           "id": "luoling8192-technical-writing",
           "title": "technical-writing",
-          "momentum": 4.645,
-          "rank": 40
+          "momentum": 4.669,
+          "rank": 42
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.592,
+          "rank": 43
         },
         {
           "id": "likaku-mck-ppt-design-skill",
           "title": "Mck-ppt-design-skill",
-          "momentum": 4.636,
-          "rank": 41
+          "momentum": 4.577,
+          "rank": 44
         },
         {
           "id": "secondsky-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.595,
-          "rank": 42
+          "momentum": 4.528,
+          "rank": 45
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.56,
-          "rank": 43
-        },
-        {
-          "id": "ylsssq926-relic-skill",
-          "title": "relic.skill",
-          "momentum": 4.523,
-          "rank": 44
-        },
-        {
-          "id": "agents365-ai-excalidraw-skill",
-          "title": "excalidraw-skill",
-          "momentum": 4.495,
-          "rank": 45
+          "momentum": 4.49,
+          "rank": 46
         },
         {
           "id": "xquik-dev-x-twitter-scraper",
           "title": "x-twitter-scraper",
-          "momentum": 4.404,
-          "rank": 46
-        },
-        {
-          "id": "tonylofgren-aurora-smart-home",
-          "title": "aurora-smart-home",
-          "momentum": 4.374,
+          "momentum": 4.468,
           "rank": 47
         },
         {
-          "id": "aldefy-compose-skill",
-          "title": "compose-skill",
-          "momentum": 4.359,
+          "id": "agents365-ai-excalidraw-skill",
+          "title": "excalidraw-skill",
+          "momentum": 4.459,
           "rank": 48
         },
         {
-          "id": "agricidaniel-claude-shorts",
-          "title": "claude-shorts",
-          "momentum": 4.324,
+          "id": "ylsssq926-relic-skill",
+          "title": "relic.skill",
+          "momentum": 4.439,
           "rank": 49
         },
         {
-          "id": "codeaashu-claude-code",
-          "title": "claude-code",
-          "momentum": 4.323,
+          "id": "hao0321-claude-skill-social-post",
+          "title": "claude-skill-social-post",
+          "momentum": 4.338,
           "rank": 50
         }
       ],
@@ -310,301 +310,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.595,
+          "momentum": 9.594,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 9.073,
+          "momentum": 8.923,
           "rank": 2
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.828,
-          "rank": 3
-        },
-        {
-          "id": "agents365-ai-drawio-skill",
-          "title": "drawio-skill",
-          "momentum": 7.768,
-          "rank": 4
-        },
-        {
-          "id": "glitternetwork-pinme",
-          "title": "pinme",
-          "momentum": 7.593,
-          "rank": 5
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 7.535,
-          "rank": 6
+          "momentum": 8.688,
+          "rank": 3
         },
         {
-          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
-          "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.356,
-          "rank": 7
+          "id": "agricidaniel-claude-ads",
+          "title": "claude-ads",
+          "momentum": 8.46,
+          "rank": 4
+        },
+        {
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.7,
+          "rank": 5
+        },
+        {
+          "id": "agents365-ai-drawio-skill",
+          "title": "drawio-skill",
+          "momentum": 7.655,
+          "rank": 6
         },
         {
           "id": "eugeniughelbur-obsidian-second-brain",
           "title": "obsidian-second-brain",
-          "momentum": 7.198,
+          "momentum": 7.557,
+          "rank": 7
+        },
+        {
+          "id": "glitternetwork-pinme",
+          "title": "pinme",
+          "momentum": 7.464,
           "rank": 8
+        },
+        {
+          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
+          "title": "nano-banana-pro-prompts-recommend-skill",
+          "momentum": 7.31,
+          "rank": 9
         },
         {
           "id": "alexgreensh-token-optimizer",
           "title": "token-optimizer",
-          "momentum": 6.791,
-          "rank": 9
+          "momentum": 6.843,
+          "rank": 10
         },
         {
           "id": "htdt-godogen",
           "title": "godogen",
-          "momentum": 6.762,
-          "rank": 10
-        },
-        {
-          "id": "denissergeevitch-agents-best-practices",
-          "title": "agents-best-practices",
-          "momentum": 6.26,
+          "momentum": 6.647,
           "rank": 11
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.236,
-          "rank": 12
-        },
-        {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 6.234,
-          "rank": 13
         },
         {
           "id": "agricidaniel-claude-blog",
           "title": "claude-blog",
-          "momentum": 6.171,
-          "rank": 14
-        },
-        {
-          "id": "wuyoscar-gpt-image-2-skill",
-          "title": "gpt_image_2_skill",
-          "momentum": 6.154,
-          "rank": 15
+          "momentum": 6.569,
+          "rank": 12
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.093,
-          "rank": 16
-        },
-        {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 6.02,
-          "rank": 17
-        },
-        {
-          "id": "avdlee-rocketsimapp",
-          "title": "RocketSimApp",
-          "momentum": 5.937,
-          "rank": 18
+          "momentum": 6.439,
+          "rank": 13
         },
         {
           "id": "juneyaooo-gpt-image2-ppt-skills",
           "title": "gpt-image2-ppt-skills",
-          "momentum": 5.853,
+          "momentum": 6.343,
+          "rank": 14
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.268,
+          "rank": 15
+        },
+        {
+          "id": "denissergeevitch-agents-best-practices",
+          "title": "agents-best-practices",
+          "momentum": 6.25,
+          "rank": 16
+        },
+        {
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.127,
+          "rank": 17
+        },
+        {
+          "id": "wuyoscar-gpt-image-2-skill",
+          "title": "gpt_image_2_skill",
+          "momentum": 6.056,
+          "rank": 18
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 5.925,
           "rank": 19
+        },
+        {
+          "id": "alirezarezvani-claudeforge",
+          "title": "ClaudeForge",
+          "momentum": 5.91,
+          "rank": 20
+        },
+        {
+          "id": "avdlee-rocketsimapp",
+          "title": "RocketSimApp",
+          "momentum": 5.837,
+          "rank": 21
+        },
+        {
+          "id": "alirezarezvani-claude-code-aso-skill",
+          "title": "claude-code-aso-skill",
+          "momentum": 5.833,
+          "rank": 22
         },
         {
           "id": "mrgediao-shuorenhua",
           "title": "shuorenhua",
-          "momentum": 5.768,
-          "rank": 20
+          "momentum": 5.672,
+          "rank": 23
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.715,
-          "rank": 21
+          "momentum": 5.624,
+          "rank": 24
         },
         {
           "id": "bharathkumarsuresh-claude-design-system-hooks",
           "title": "claude-design-system-hooks",
-          "momentum": 5.596,
-          "rank": 22
-        },
-        {
-          "id": "aspegio-nelson",
-          "title": "nelson",
-          "momentum": 5.56,
-          "rank": 23
-        },
-        {
-          "id": "pegasi-ai-reins",
-          "title": "reins",
-          "momentum": 5.437,
-          "rank": 24
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.404,
+          "momentum": 5.502,
           "rank": 25
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 5.145,
-          "rank": 26
-        },
-        {
-          "id": "bitwize-music-studio-claude-ai-music-skills",
-          "title": "claude-ai-music-skills",
-          "momentum": 5.104,
-          "rank": 27
-        },
-        {
-          "id": "memtensor-skills-vote",
-          "title": "skills-vote",
-          "momentum": 5.075,
-          "rank": 28
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.057,
+          "momentum": 5.486,
+          "rank": 26
+        },
+        {
+          "id": "aspegio-nelson",
+          "title": "nelson",
+          "momentum": 5.47,
+          "rank": 27
+        },
+        {
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.364,
+          "rank": 28
+        },
+        {
+          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
+          "title": "Claude-Mythos-AI-Anthropic-App",
+          "momentum": 5.354,
           "rank": 29
         },
         {
-          "id": "agents365-ai-asta-skill",
-          "title": "asta-skill",
-          "momentum": 5.023,
+          "id": "pegasi-ai-reins",
+          "title": "reins",
+          "momentum": 5.344,
           "rank": 30
         },
         {
           "id": "vast-ai-vast-cli",
           "title": "vast-cli",
-          "momentum": 5.008,
+          "momentum": 5.239,
           "rank": 31
+        },
+        {
+          "id": "memtensor-skills-vote",
+          "title": "skills-vote",
+          "momentum": 5.237,
+          "rank": 32
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 5.064,
+          "rank": 33
+        },
+        {
+          "id": "bitwize-music-studio-claude-ai-music-skills",
+          "title": "claude-ai-music-skills",
+          "momentum": 5.027,
+          "rank": 34
+        },
+        {
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 4.945,
+          "rank": 35
         },
         {
           "id": "agents365-ai-paper-fetch",
           "title": "paper-fetch",
-          "momentum": 4.963,
-          "rank": 32
-        },
-        {
-          "id": "agricidaniel-claude-ads",
-          "title": "claude-ads",
-          "momentum": 4.958,
-          "rank": 33
+          "momentum": 4.886,
+          "rank": 36
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 4.927,
-          "rank": 34
-        },
-        {
-          "id": "keerthanapranesh-claude-code-swarm-toolkit",
-          "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.841,
-          "rank": 35
+          "momentum": 4.846,
+          "rank": 37
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.823,
-          "rank": 36
+          "momentum": 4.822,
+          "rank": 38
+        },
+        {
+          "id": "keerthanapranesh-claude-code-swarm-toolkit",
+          "title": "Claude-Code-Swarm-Toolkit",
+          "momentum": 4.758,
+          "rank": 39
         },
         {
           "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.777,
-          "rank": 37
+          "momentum": 4.695,
+          "rank": 40
         },
         {
           "id": "jeecgboot-skills",
           "title": "skills",
-          "momentum": 4.753,
-          "rank": 38
-        },
-        {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.664,
-          "rank": 39
+          "momentum": 4.679,
+          "rank": 41
         },
         {
           "id": "luoling8192-technical-writing",
           "title": "technical-writing",
-          "momentum": 4.645,
-          "rank": 40
+          "momentum": 4.669,
+          "rank": 42
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.592,
+          "rank": 43
         },
         {
           "id": "likaku-mck-ppt-design-skill",
           "title": "Mck-ppt-design-skill",
-          "momentum": 4.636,
-          "rank": 41
+          "momentum": 4.577,
+          "rank": 44
         },
         {
           "id": "secondsky-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.595,
-          "rank": 42
+          "momentum": 4.528,
+          "rank": 45
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.56,
-          "rank": 43
-        },
-        {
-          "id": "ylsssq926-relic-skill",
-          "title": "relic.skill",
-          "momentum": 4.523,
-          "rank": 44
-        },
-        {
-          "id": "agents365-ai-excalidraw-skill",
-          "title": "excalidraw-skill",
-          "momentum": 4.495,
-          "rank": 45
+          "momentum": 4.49,
+          "rank": 46
         },
         {
           "id": "xquik-dev-x-twitter-scraper",
           "title": "x-twitter-scraper",
-          "momentum": 4.404,
-          "rank": 46
-        },
-        {
-          "id": "tonylofgren-aurora-smart-home",
-          "title": "aurora-smart-home",
-          "momentum": 4.374,
+          "momentum": 4.468,
           "rank": 47
         },
         {
-          "id": "aldefy-compose-skill",
-          "title": "compose-skill",
-          "momentum": 4.359,
+          "id": "agents365-ai-excalidraw-skill",
+          "title": "excalidraw-skill",
+          "momentum": 4.459,
           "rank": 48
         },
         {
-          "id": "agricidaniel-claude-shorts",
-          "title": "claude-shorts",
-          "momentum": 4.324,
+          "id": "ylsssq926-relic-skill",
+          "title": "relic.skill",
+          "momentum": 4.439,
           "rank": 49
         },
         {
-          "id": "codeaashu-claude-code",
-          "title": "claude-code",
-          "momentum": 4.323,
+          "id": "hao0321-claude-skill-social-post",
+          "title": "claude-skill-social-post",
+          "momentum": 4.338,
           "rank": 50
         }
       ],
@@ -613,7 +613,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-18T06:03:36.687Z",
+      "generatedAt": "2026-05-19T05:58:25.040Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     },
@@ -1229,7 +1229,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-18T06:03:37.454Z",
+      "generatedAt": "2026-05-19T05:58:25.819Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     }


### PR DESCRIPTION
Automated data refresh from `Run shadow scoring`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26079194625

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.