### PR TITLE
chore(data): refresh staleness report 2026-05-19T06:12:28Z

### DIFF
--- a/data/staleness-report.json
+++ b/data/staleness-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-18T06:18:48.597Z",
+  "generatedAt": "2026-05-19T06:12:26.881Z",
   "sources": [
     {
       "slug": "trending",


### PR DESCRIPTION
Automated data refresh from `Sweep staleness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26079718725

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.