### PR TITLE
chore(data): promote unknown mentions 2026-05-19T08:02:46Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,27 @@
 {
-  "generatedAt": "2026-05-18T08:31:55.794Z",
-  "totalUnknownMentions": 191554,
-  "distinctRepos": 17625,
+  "generatedAt": "2026-05-19T08:02:44.716Z",
+  "totalUnknownMentions": 202946,
+  "distinctRepos": 18607,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
+      "fullName": "google-gemini/gemini-cli",
+      "totalCount": 74,
+      "sourceCount": 5,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+    },
+    {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 145,
+      "totalCount": 159,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -16,11 +30,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "vercel/next.js",
-      "totalCount": 143,
+      "totalCount": 151,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -29,11 +43,11 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "oven-sh/bun",
-      "totalCount": 124,
+      "totalCount": 137,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -42,7 +56,7 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "hmbown/deepseek-tui",
@@ -58,6 +72,19 @@
       "lastSeenAt": "2026-05-15T06:46:20.813Z"
     },
     {
+      "fullName": "vitejs/vite",
+      "totalCount": 83,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
       "fullName": "antirez/ds4",
       "totalCount": 82,
       "sourceCount": 4,
@@ -69,19 +96,6 @@
       ],
       "firstSeenAt": "2026-05-07T15:39:28.530Z",
       "lastSeenAt": "2026-05-18T03:31:51.517Z"
-    },
-    {
-      "fullName": "vitejs/vite",
-      "totalCount": 79,
-      "sourceCount": 4,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "facebook/react",
@@ -97,19 +111,6 @@
       "lastSeenAt": "2026-05-15T11:31:13.243Z"
     },
     {
-      "fullName": "google-gemini/gemini-cli",
-      "totalCount": 70,
-      "sourceCount": 4,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
-    },
-    {
       "fullName": "kolapsis/maintenant",
       "totalCount": 56,
       "sourceCount": 4,
@@ -123,8 +124,21 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
+      "fullName": "aattaran/deepclaude",
+      "totalCount": 8,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-03T23:05:44.779Z",
+      "lastSeenAt": "2026-05-18T19:48:27.935Z"
+    },
+    {
       "fullName": "onyks-os/transparenttorproxy",
-      "totalCount": 145,
+      "totalCount": 153,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -132,11 +146,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T11:34:16.788Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "microsoft/vscode",
-      "totalCount": 141,
+      "totalCount": 148,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -144,11 +158,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-17T17:48:32.737Z"
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "graemeg/blaise",
-      "totalCount": 124,
+      "totalCount": 132,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -156,7 +170,19 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-08T06:11:19.000Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "ninjahawk/hollow-agentos",
+      "totalCount": 111,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "minishlab/semble",
@@ -169,18 +195,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-18T04:41:26.919Z"
-    },
-    {
-      "fullName": "ninjahawk/hollow-agentos",
-      "totalCount": 103,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "scosman/cursed_browser",
@@ -207,6 +221,30 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
+      "fullName": "manojmallick/sigmap",
+      "totalCount": 101,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
+      "fullName": "leaningtech/browsercode",
+      "totalCount": 98,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
+    },
+    {
       "fullName": "anthropics/financial-services",
       "totalCount": 98,
       "sourceCount": 3,
@@ -229,30 +267,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
-    },
-    {
-      "fullName": "manojmallick/sigmap",
-      "totalCount": 97,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
-      "fullName": "leaningtech/browsercode",
-      "totalCount": 96,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "nvlabs/cuda-oxide",
@@ -291,20 +305,20 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "sifter-ai/sifter",
-      "totalCount": 84,
+      "fullName": "luce-org/lucebox-hub",
+      "totalCount": 88,
       "sourceCount": 3,
       "sources": [
-        "awesome-skills",
         "devto",
+        "hackernews",
         "reddit"
       ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+      "firstSeenAt": "2026-05-01T15:36:14.012Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
       "fullName": "reviewstage/stage-cli",
-      "totalCount": 84,
+      "totalCount": 88,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -312,7 +326,19 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T17:19:14.533Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
+      "fullName": "sifter-ai/sifter",
+      "totalCount": 85,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
     },
     {
       "fullName": "waybarrios/opencode-power-pack",
@@ -327,6 +353,30 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
+      "fullName": "higangssh/homebutler",
+      "totalCount": 80,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+    },
+    {
+      "fullName": "tanstack/router",
+      "totalCount": 80,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-02T04:02:25.023Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
       "fullName": "snyk/agent-scan",
       "totalCount": 79,
       "sourceCount": 3,
@@ -339,32 +389,8 @@
       "lastSeenAt": "2026-05-12T08:49:51.709Z"
     },
     {
-      "fullName": "tanstack/router",
-      "totalCount": 76,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T04:02:25.023Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 75,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
-    },
-    {
       "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 72,
+      "totalCount": 73,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -372,7 +398,31 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+    },
+    {
+      "fullName": "fsnotify/fsnotify",
+      "totalCount": 72,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T07:20:32.729Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
+      "fullName": "torrix-ai/install",
+      "totalCount": 67,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "sambigeara/pollen",
@@ -435,6 +485,42 @@
       "lastSeenAt": "2026-05-07T12:21:38.823Z"
     },
     {
+      "fullName": "jameslockman/griffin-powermate-driver",
+      "totalCount": 61,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-11T21:52:07.915Z",
+      "lastSeenAt": "2026-05-18T21:27:26.803Z"
+    },
+    {
+      "fullName": "genymobile/scrcpy",
+      "totalCount": 60,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T08:45:16.184Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "redis/redis",
+      "totalCount": 60,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T08:09:15.267Z",
+      "lastSeenAt": "2026-05-18T12:48:24.691Z"
+    },
+    {
       "fullName": "localsend/localsend",
       "totalCount": 60,
       "sourceCount": 3,
@@ -447,16 +533,16 @@
       "lastSeenAt": "2026-05-12T12:19:51.467Z"
     },
     {
-      "fullName": "redis/redis",
+      "fullName": "ollama/ollama",
       "totalCount": 59,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
-        "hackernews"
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-03T08:09:15.267Z",
-      "lastSeenAt": "2026-05-12T20:02:51.322Z"
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
       "fullName": "manankharwar/fusioncore",
@@ -471,44 +557,8 @@
       "lastSeenAt": "2026-05-07T21:45:14.561Z"
     },
     {
-      "fullName": "jameslockman/griffin-powermate-driver",
-      "totalCount": 57,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-11T21:52:07.915Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "torrix-ai/install",
-      "totalCount": 55,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "ollama/ollama",
-      "totalCount": 55,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
       "fullName": "uw-syfi/vibe-serve",
-      "totalCount": 54,
+      "totalCount": 56,
       "sourceCount": 3,
       "sources": [
         "arxiv",
@@ -516,7 +566,31 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-08T16:57:07.580Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
+    },
+    {
+      "fullName": "n8n-io/n8n",
+      "totalCount": 55,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "reddit",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
+      "fullName": "andyyyy64/whichllm",
+      "totalCount": 54,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T10:12:27.167Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "minio/minio",
@@ -531,28 +605,40 @@
       "lastSeenAt": "2026-05-09T08:04:55.501Z"
     },
     {
-      "fullName": "n8n-io/n8n",
-      "totalCount": 52,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "reddit",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
-      "fullName": "genymobile/scrcpy",
-      "totalCount": 50,
+      "fullName": "statewright/statewright",
+      "totalCount": 53,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-02T08:45:16.184Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "firstSeenAt": "2026-05-12T17:04:51.325Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "navid-m/flightsim",
+      "totalCount": 51,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
+      "fullName": "vercel/ai",
+      "totalCount": 51,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -565,6 +651,18 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-07T14:30:15.363Z"
+    },
+    {
+      "fullName": "jamesyc/timecapsulesmb",
+      "totalCount": 48,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-01T05:26:36.038Z",
+      "lastSeenAt": "2026-05-18T12:48:24.691Z"
     },
     {
       "fullName": "useknockout/api",
@@ -591,30 +689,6 @@
       "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
-      "fullName": "navid-m/flightsim",
-      "totalCount": 47,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
-      "fullName": "vercel/ai",
-      "totalCount": 47,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
       "fullName": "wrtnlabs/autobe",
       "totalCount": 47,
       "sourceCount": 3,
@@ -625,6 +699,18 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
+    },
+    {
+      "fullName": "vllm-project/vllm",
+      "totalCount": 46,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T19:21:26.285Z",
+      "lastSeenAt": "2026-05-18T19:48:27.935Z"
     },
     {
       "fullName": "nooga/let-go",
@@ -651,6 +737,18 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
+      "fullName": "v12-security/pocs",
+      "totalCount": 44,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
       "fullName": "simdjson/simdjson",
       "totalCount": 44,
       "sourceCount": 3,
@@ -663,20 +761,8 @@
       "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
-      "fullName": "vllm-project/vllm",
-      "totalCount": 44,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-13T08:53:46.257Z"
-    },
-    {
       "fullName": "0xmassi/webclaw",
-      "totalCount": 41,
+      "totalCount": 42,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -684,10 +770,10 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
     },
     {
-      "fullName": "statewright/statewright",
+      "fullName": "iliaal/fastchart",
       "totalCount": 41,
       "sourceCount": 3,
       "sources": [
@@ -695,12 +781,12 @@
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-12T17:04:51.325Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 37,
+      "totalCount": 40,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -708,7 +794,31 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+    },
+    {
+      "fullName": "junegunn/fzf",
+      "totalCount": 39,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
+      "fullName": "zed-industries/zed",
+      "totalCount": 37,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
     },
     {
       "fullName": "tidwall/btype",
@@ -723,80 +833,8 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "zed-industries/zed",
-      "totalCount": 36,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
-    },
-    {
-      "fullName": "v12-security/pocs",
-      "totalCount": 36,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "junegunn/fzf",
-      "totalCount": 35,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-18T05:12:55.510Z"
-    },
-    {
-      "fullName": "iliaal/fastchart",
-      "totalCount": 33,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "trycua/cua",
-      "totalCount": 29,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "hackernews",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
-    },
-    {
-      "fullName": "tabularisdb/tabularis",
-      "totalCount": 29,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
       "fullName": "rust-lang/rust",
-      "totalCount": 27,
+      "totalCount": 35,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -804,7 +842,55 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "tabularisdb/tabularis",
+      "totalCount": 33,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
+      "fullName": "trycua/cua",
+      "totalCount": 30,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "hackernews",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+    },
+    {
+      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
+      "totalCount": 30,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:43:54.808Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "open-webui/open-webui",
+      "totalCount": 27,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T04:53:38.982Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -817,30 +903,6 @@
       ],
       "firstSeenAt": "2026-05-07T19:50:24.370Z",
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
-    },
-    {
-      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
-      "totalCount": 21,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:43:54.808Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "open-webui/open-webui",
-      "totalCount": 19,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-07T04:53:38.982Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -868,7 +930,7 @@
     },
     {
       "fullName": "duriantaco/skylos",
-      "totalCount": 14,
+      "totalCount": 15,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -876,41 +938,41 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
     },
     {
-      "fullName": "aattaran/deepclaude",
-      "totalCount": 5,
+      "fullName": "anishathalye/ai-agent-security-lecture",
+      "totalCount": 12,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "hackernews",
-        "reddit"
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-03T23:05:44.779Z",
-      "lastSeenAt": "2026-05-07T07:40:15.618Z"
+      "firstSeenAt": "2026-05-18T16:34:28.470Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 141,
+      "totalCount": 147,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-18T08:18:07.070Z"
+      "lastSeenAt": "2026-05-19T08:00:24.394Z"
     },
     {
       "fullName": "wojtczyk/trust",
-      "totalCount": 136,
+      "totalCount": 138,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T07:40:15.618Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
       "fullName": "nexu-io/open-design",
@@ -925,14 +987,14 @@
     },
     {
       "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 123,
+      "totalCount": 125,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
       "fullName": "translate-tools/transly",
@@ -946,6 +1008,17 @@
       "lastSeenAt": "2026-05-09T16:11:39.536Z"
     },
     {
+      "fullName": "raiyanyahya/kit",
+      "totalCount": 116,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T09:05:56.174Z",
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
+    },
+    {
       "fullName": "ps5-linux/ps5-linux-loader",
       "totalCount": 116,
       "sourceCount": 2,
@@ -957,26 +1030,15 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
-      "fullName": "raiyanyahya/kit",
+      "fullName": "samplexbro/agentsmesh",
       "totalCount": 114,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-03T09:05:56.174Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "samplexbro/agentsmesh",
-      "totalCount": 110,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
       "fullName": "jossephus/chuchu",
@@ -990,6 +1052,17 @@
       "lastSeenAt": "2026-05-16T00:18:32.194Z"
     },
     {
+      "fullName": "raiyanyahya/how-to-train-your-gpt",
+      "totalCount": 105,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
       "fullName": "opensensenova/sensenova-u1",
       "totalCount": 105,
       "sourceCount": 2,
@@ -999,6 +1072,50 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
+    },
+    {
+      "fullName": "orhun/ratty",
+      "totalCount": 104,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "warwickwood-cell/gengeo-agent-registry",
+      "totalCount": 104,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "facebookresearch/tuna-2",
+      "totalCount": 102,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T23:09:58.018Z",
+      "lastSeenAt": "2026-05-19T01:56:00.808Z"
+    },
+    {
+      "fullName": "drcathicks/learning-opportunities",
+      "totalCount": 101,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "ifixai-ai/diagnostic",
@@ -1012,6 +1129,17 @@
       "lastSeenAt": "2026-05-11T23:22:32.173Z"
     },
     {
+      "fullName": "celestoai/smolvm",
+      "totalCount": 99,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
       "fullName": "mekickdemons-creator/mnemara",
       "totalCount": 98,
       "sourceCount": 2,
@@ -1023,48 +1151,15 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
-      "fullName": "warwickwood-cell/gengeo-agent-registry",
-      "totalCount": 96,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "facebookresearch/tuna-2",
-      "totalCount": 95,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T23:09:58.018Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "celestoai/smolvm",
-      "totalCount": 95,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
-      "fullName": "orhun/ratty",
+      "fullName": "avarok-cybersecurity/atlas",
       "totalCount": 94,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
       "fullName": "openmoss/moss-audio",
@@ -1078,28 +1173,6 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "drcathicks/learning-opportunities",
-      "totalCount": 93,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "avarok-cybersecurity/atlas",
-      "totalCount": 92,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
       "fullName": "facebook/pyrefly",
       "totalCount": 92,
       "sourceCount": 2,
@@ -1109,6 +1182,17 @@
       ],
       "firstSeenAt": "2026-05-02T17:16:19.580Z",
       "lastSeenAt": "2026-05-17T23:08:31.913Z"
+    },
+    {
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 91,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-19T04:33:47.216Z"
     },
     {
       "fullName": "emad-elsaid/xlog",
@@ -1166,17 +1250,6 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 87,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-18T00:10:02.617Z"
-    },
-    {
       "fullName": "cubiczan/consensus-hardening-protocol",
       "totalCount": 87,
       "sourceCount": 2,
@@ -1186,17 +1259,6 @@
       ],
       "firstSeenAt": "2026-05-01T21:16:46.793Z",
       "lastSeenAt": "2026-05-08T19:48:01.671Z"
-    },
-    {
-      "fullName": "luce-org/lucebox-hub",
-      "totalCount": 87,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T15:36:14.012Z",
-      "lastSeenAt": "2026-05-08T11:33:06.098Z"
     },
     {
       "fullName": "regent-vcs/re_gent",
@@ -1219,6 +1281,17 @@
       ],
       "firstSeenAt": "2026-05-02T03:28:11.836Z",
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
+    },
+    {
+      "fullName": "narghev/askdiff",
+      "totalCount": 83,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
       "fullName": "v4bel/dirtyfrag",
@@ -1265,6 +1338,17 @@
       "lastSeenAt": "2026-05-09T18:44:58.134Z"
     },
     {
+      "fullName": "harnexa/nexa-gauge",
+      "totalCount": 82,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T01:29:16.934Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
       "fullName": "dmarshaltu/coord",
       "totalCount": 82,
       "sourceCount": 2,
@@ -1309,15 +1393,15 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "narghev/askdiff",
+      "fullName": "naver/lispe",
       "totalCount": 79,
       "sourceCount": 2,
       "sources": [
-        "devto",
-        "hackernews"
+        "hackernews",
+        "lobsters"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
+      "lastSeenAt": "2026-05-19T04:45:29.398Z"
     },
     {
       "fullName": "bep/grrep",
@@ -1362,6 +1446,17 @@
       ],
       "firstSeenAt": "2026-05-03T10:34:44.583Z",
       "lastSeenAt": "2026-05-10T10:08:57.038Z"
+    },
+    {
+      "fullName": "tsirysndr/rockbox-zig",
+      "totalCount": 78,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T15:17:55.542Z",
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
       "fullName": "dventimisupabase/pg_flight_recorder",
@@ -1430,6 +1525,17 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
+      "fullName": "jher7/tokenyst",
+      "totalCount": 77,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T20:33:23.845Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+    },
+    {
       "fullName": "wiaahmarketplace/typerion-oss",
       "totalCount": 77,
       "sourceCount": 2,
@@ -1450,17 +1556,6 @@
       ],
       "firstSeenAt": "2026-05-03T10:34:44.583Z",
       "lastSeenAt": "2026-05-11T11:39:37.103Z"
-    },
-    {
-      "fullName": "tsirysndr/rockbox-zig",
-      "totalCount": 76,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T15:17:55.542Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "datadog/java-reggie",
@@ -1527,17 +1622,6 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "harnexa/nexa-gauge",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T01:29:16.934Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
       "fullName": "autoloops/upskill",
@@ -1626,6 +1710,28 @@
       ],
       "firstSeenAt": "2026-05-02T21:01:52.519Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "arriemeijer-creator/aerojax",
+      "totalCount": 72,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "heymrun/heym",
+      "totalCount": 72,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-18T15:38:08.835Z"
     },
     {
       "fullName": "penthertz/luksbox",
@@ -1749,26 +1855,15 @@
       "lastSeenAt": "2026-05-08T17:55:29.602Z"
     },
     {
-      "fullName": "jher7/tokenyst",
-      "totalCount": 71,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T20:33:23.845Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "fsnotify/fsnotify",
+      "fullName": "pion/rtwatch",
       "totalCount": 71,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-16T10:40:06.669Z"
+      "firstSeenAt": "2026-05-09T14:44:37.003Z",
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
       "fullName": "cloudflare/workers-sdk",
@@ -1791,17 +1886,6 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-12T19:09:34.978Z"
-    },
-    {
-      "fullName": "heymrun/heym",
-      "totalCount": 70,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
     },
     {
       "fullName": "webstonehq/tuxedo",
@@ -1837,15 +1921,15 @@
       "lastSeenAt": "2026-05-12T14:51:56.628Z"
     },
     {
-      "fullName": "pion/rtwatch",
+      "fullName": "enmanuelmag/heimdall-mcp",
       "totalCount": 69,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-09T14:44:37.003Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
       "fullName": "sudarshan8417/tfdrift",
@@ -2013,6 +2097,17 @@
       "lastSeenAt": "2026-05-09T21:15:18.927Z"
     },
     {
+      "fullName": "eleutherai/lm-evaluation-harness",
+      "totalCount": 66,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
       "fullName": "intel/auto-round",
       "totalCount": 66,
       "sourceCount": 2,
@@ -2055,6 +2150,17 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-08T16:28:40.683Z"
+    },
+    {
+      "fullName": "chojs23/concord",
+      "totalCount": 64,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
       "fullName": "advisories/ghsa-vp62-r36r-9xqp",
@@ -2101,15 +2207,48 @@
       "lastSeenAt": "2026-05-09T01:29:16.934Z"
     },
     {
-      "fullName": "enmanuelmag/heimdall-mcp",
+      "fullName": "c2sp/wycheproof",
+      "totalCount": 63,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T10:30:24.305Z",
+      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+    },
+    {
+      "fullName": "mozilla/standards-positions",
+      "totalCount": 63,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-18T16:34:28.470Z"
+    },
+    {
+      "fullName": "liamromanis101/cve-2026-31431-copy-fail---vulnerability-detection-script",
       "totalCount": 63,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
+      "firstSeenAt": "2026-05-08T15:06:30.276Z",
+      "lastSeenAt": "2026-05-18T15:38:08.835Z"
+    },
+    {
+      "fullName": "perufitlife/supabase-security-skill",
+      "totalCount": 63,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T13:30:06.157Z",
+      "lastSeenAt": "2026-05-18T10:09:50.074Z"
     },
     {
       "fullName": "merkoba/meltdown",
@@ -2154,138 +2293,6 @@
       ],
       "firstSeenAt": "2026-05-03T11:59:33.442Z",
       "lastSeenAt": "2026-05-10T10:08:57.038Z"
-    },
-    {
-      "fullName": "leox255/loopsy",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-08T09:54:31.486Z"
-    },
-    {
-      "fullName": "chojs23/concord",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "perufitlife/supabase-security-skill",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T13:30:06.157Z",
-      "lastSeenAt": "2026-05-18T03:53:09.241Z"
-    },
-    {
-      "fullName": "argoproj/argo-cd",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-16T04:05:02.808Z"
-    },
-    {
-      "fullName": "crosspoint-reader/crosspoint-reader",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-16T00:10:04.548Z"
-    },
-    {
-      "fullName": "mozilla/standards-positions",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-15T15:22:15.429Z"
-    },
-    {
-      "fullName": "chrislgarry/apollo-11",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-12T00:21:52.545Z"
-    },
-    {
-      "fullName": "benhatsor/rollup-dts-bundler",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T13:58:12.542Z",
-      "lastSeenAt": "2026-05-09T11:12:04.879Z"
-    },
-    {
-      "fullName": "openmixerproject/openx32",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-09T01:29:16.934Z"
-    },
-    {
-      "fullName": "troglobit/uget",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T00:15:48.713Z",
-      "lastSeenAt": "2026-05-08T23:44:54.468Z"
-    },
-    {
-      "fullName": "pilcrowonpaper/basic-example.auth.pilcrowonpaper.com",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T14:05:07.423Z",
-      "lastSeenAt": "2026-05-08T11:33:06.098Z"
-    },
-    {
-      "fullName": "gc-victor/supersimple",
-      "totalCount": 62,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-01T07:51:01.444Z",
-      "lastSeenAt": "2026-05-08T06:27:42.545Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26084371941

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.