### PR TITLE
chore(data): refresh lobsters signals 2026-05-19T08:45:21Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-19T04:45:30.664Z",
+  "ts": "2026-05-19T08:45:21.246Z",
   "count": 1,
-  "durationMs": 5742,
+  "durationMs": 8710,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T04:45:24.936Z",
+  "fetchedAt": "2026-05-19T08:45:12.548Z",
   "windowDays": 7,
-  "scannedStories": 80,
+  "scannedStories": 83,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T04:45:24.936Z",
+  "fetchedAt": "2026-05-19T08:45:12.548Z",
   "windowHours": 72,
-  "scannedTotal": 80,
+  "scannedTotal": 83,
   "stories": [
     {
       "shortId": "29pm2f",

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -203199,3 +203199,7 @@
 {"source":"bluesky","fullName":"goreleaser/goreleaser","observedAt":"2026-05-19T08:39:05.009Z"}
 {"source":"bluesky","fullName":"filebrowser/filebrowser","observedAt":"2026-05-19T08:39:05.009Z"}
 {"source":"bluesky","fullName":"satheez/laravel-package-doctor","observedAt":"2026-05-19T08:39:05.009Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-19T08:45:19.811Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-19T08:45:19.811Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-19T08:45:19.811Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-19T08:45:19.811Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26086372889

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.