### PR TITLE
fix(aiso): restore repo profile scans and Kimi briefs

### DIFF
--- a/.github/workflows/enrich-repo-profiles.yml
+++ b/.github/workflows/enrich-repo-profiles.yml
@@ -96,10 +96,12 @@ jobs:
             --queue data/profile-completion-queue.json
 
       - name: Compute commit timestamp
+        if: github.ref == 'refs/heads/main'
         id: ts
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Commit if changed
+        if: github.ref == 'refs/heads/main'
         timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
@@ -109,3 +111,8 @@ jobs:
           ignore-missing: "true"
           paths: |
             data/repo-profiles.json
+
+      - name: Skip data commit on non-main ref
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Skipping data commit because this run is on ${GITHUB_REF}; data PRs are only opened from main."


### PR DESCRIPTION
## Summary
- restores the scheduled repo-profile enrichment workflow that was deleted on 2026-05-16
- sends AISO scan attribution from repo-profile enrichment, drain queue, and self-scan paths
- adds Kimi expert trend briefs to persisted repo profiles and renders them on repo profile pages
- preserves existing `aisoScan` and `expertTrendBrief` in the worker so background refreshes do not wipe scan results back to `scan_pending`

## Validation
- `node --check scripts\enrich-repo-profiles.mjs`
- `npm run typecheck`
- `npm --prefix apps\trendingrepo-worker ci`
- `npm --prefix apps\trendingrepo-worker run typecheck`
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/api/__tests__/repo-profile.test.ts src/lib/pipeline/__tests__/canonical-profile-endpoint.test.ts src/lib/pipeline/__tests__/aiso-persist.test.ts src/lib/pipeline/__tests__/aiso-drain.test.ts`
- `npm run lint:guards`
- `git diff --check`
- `npm run lint`
- `npm run build`

## Operational note
The new workflow is not visible to GitHub Actions until this file exists on the default branch. After merge, run `enrich-repo-profiles.yml` with `mode=backfill`, a higher `limit`, and a controlled `max_scans` budget to recover stale repo profile website scans.