### PR TITLE
chore(data): refresh repo profiles 2026-05-19T09:13:10Z

### DIFF
--- a/.github/workflows/aiso-self-scan.yml
+++ b/.github/workflows/aiso-self-scan.yml
@@ -47,7 +47,7 @@ jobs:
           resp=$(curl -s -w "\n__HTTP__%{http_code}" --max-time 30 \
             -X POST "https://aiso.tools/api/scan" \
             -H "Content-Type: application/json" \
-            -d '{"url":"https://aiso.tools","mode":"homepage"}')
+            -d '{"url":"https://aiso.tools","mode":"homepage","source":"api","projectName":"TrendingRepo self-scan","projectUrl":"https://trendingrepo.com"}')
           end=$(date +%s%3N)
           latency=$((end - start))
 

--- a/.github/workflows/enrich-repo-profiles.yml
+++ b/.github/workflows/enrich-repo-profiles.yml
@@ -1,0 +1,111 @@
+name: Refresh repo profiles
+
+# Restores the scheduled repo-profile enrichment lane. The worker fetcher
+# resolves fast surfaces and queues profiles, but this workflow is the lane
+# that submits real website scans to AISO and writes the persisted expert
+# trend brief used by /repo/[owner]/[name].
+
+on:
+  schedule:
+    - cron: "41 * * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "profile enrichment mode"
+        required: false
+        default: "incremental"
+        type: choice
+        options:
+          - top
+          - incremental
+          - catchup
+      limit:
+        description: "candidate limit"
+        required: false
+        default: "75"
+        type: string
+      max_scans:
+        description: "new AISO scans allowed this run"
+        required: false
+        default: "3"
+        type: string
+      kimi_max_repos:
+        description: "Kimi expert briefs allowed this run"
+        required: false
+        default: "3"
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: repo-profile-refresh
+  cancel-in-progress: false
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Enrich repo profiles
+        env:
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA: ${{ github.sha }}
+          PROFILE_ENRICH_AISO_BASE_URL: https://aiso.tools
+          PROFILE_ENRICH_AISO_SOURCE: api
+          PROFILE_ENRICH_AISO_PROJECT: TrendingRepo repo profile enrichment
+          PROFILE_ENRICH_AISO_PROJECT_URL: https://trendingrepo.com
+          PROFILE_ENRICH_AISO_PROMOTION_SECRET: ${{ secrets.AISO_TRENDINGREPO_SECRET }}
+          PROFILE_ENRICH_AISO_BILLING_TIER: ${{ vars.PROFILE_ENRICH_AISO_BILLING_TIER || 'free' }}
+          PROFILE_ENRICH_AISO_PROFILE: ${{ vars.PROFILE_ENRICH_AISO_PROFILE || '' }}
+          PROFILE_ENRICH_AISO_DAILY_SCAN_BUDGET: ${{ vars.PROFILE_ENRICH_AISO_DAILY_SCAN_BUDGET || '30' }}
+          PROFILE_ENRICH_KIMI: ${{ vars.PROFILE_ENRICH_KIMI || 'true' }}
+          PROFILE_ENRICH_KIMI_MAX_REPOS: ${{ github.event.inputs.kimi_max_repos || vars.PROFILE_ENRICH_KIMI_MAX_REPOS || '3' }}
+          PROFILE_ENRICH_KIMI_TIMEOUT_MS: ${{ vars.PROFILE_ENRICH_KIMI_TIMEOUT_MS || '45000' }}
+          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+          KIMI_BASE_URL: ${{ vars.KIMI_BASE_URL || 'https://api.kimi.com/coding/v1' }}
+          KIMI_MODEL: ${{ vars.KIMI_MODEL || 'kimi-for-coding' }}
+        run: |
+          MODE="${{ github.event.inputs.mode || 'incremental' }}"
+          LIMIT="${{ github.event.inputs.limit || vars.PROFILE_ENRICH_LIMIT || '75' }}"
+          MAX_SCANS="${{ github.event.inputs.max_scans || vars.PROFILE_ENRICH_MAX_SCANS || '3' }}"
+          node scripts/enrich-repo-profiles.mjs \
+            --mode "$MODE" \
+            --limit "$LIMIT" \
+            --max-scans "$MAX_SCANS" \
+            --queue data/profile-completion-queue.json
+
+      - name: Compute commit timestamp
+        id: ts
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit if changed
+        timeout-minutes: 5
+        uses: ./.github/actions/git-commit-data
+        with:
+          gh-token: ${{ secrets.DATA_BOT_TOKEN }}
+          actor-email: "bot@trendingrepo.com"
+          message: "chore(data): refresh repo profiles ${{ steps.ts.outputs.value }}"
+          ignore-missing: "true"
+          paths: |
+            data/repo-profiles.json

--- a/apps/trendingrepo-worker/src/fetchers/repo-profiles/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/repo-profiles/index.ts
@@ -64,10 +64,10 @@ interface PhLaunchesPayload {
 interface RepoProfile {
   fullName: string;
   rank: number | null;
-  selectedFrom: 'manual_include' | 'trending_top_24h';
+  selectedFrom: string;
   websiteUrl: string | null;
   websiteSource: 'producthunt' | 'github_homepage' | 'npm_homepage' | null;
-  status: 'no_website' | 'scan_pending';
+  status: 'scanned' | 'scan_pending' | 'scan_running' | 'scan_failed' | 'rate_limited' | 'no_website';
   lastProfiledAt: string;
   nextScanAfter: string | null;
   surfaces: {
@@ -76,7 +76,17 @@ interface RepoProfile {
     npmPackages: string[];
     productHuntLaunchId: string | number | null;
   };
-  aisoScan: null;
+  aisoScan: unknown | null;
+  expertTrendBrief?: {
+    provider: 'kimi';
+    model: string;
+    generatedAt: string;
+    headline: string;
+    summary: string;
+    drivers: string[];
+    evidence: string[];
+    caveats: string[];
+  } | null;
   error: string | null;
 }
 
@@ -86,10 +96,11 @@ interface RepoProfilesPayload {
   selection: {
     source: 'top';
     limit: number;
-    scanned: 0;
+    scanned: number;
     queued: number;
     noWebsite: number;
-    failed: 0;
+    failed: number;
+    expertBriefs?: number;
   };
   profiles: RepoProfile[];
 }
@@ -151,12 +162,14 @@ const fetcher: Fetcher = {
       'repo-metadata',
       'npm-packages',
       'producthunt-launches',
+      'repo-profiles',
     ] as const;
     const reads = await Promise.allSettled([
       readDataStore<TrendingPayload>('trending'),
       readDataStore<RepoMetadataPayload>('repo-metadata'),
       readDataStore<NpmPackagesPayload>('npm-packages'),
       readDataStore<PhLaunchesPayload>('producthunt-launches'),
+      readDataStore<RepoProfilesPayload>('repo-profiles'),
     ]);
     const readFailures: Array<{ key: string; err: string }> = [];
     const values = reads.map((r, i) => {
@@ -173,11 +186,12 @@ const fetcher: Fetcher = {
         'repo-profiles: some reads failed; degrading those sources to null',
       );
     }
-    const [trending, repoMetadata, npmPackages, phLaunches] = values as [
+    const [trending, repoMetadata, npmPackages, phLaunches, existingProfiles] = values as [
       TrendingPayload | null,
       RepoMetadataPayload | null,
       NpmPackagesPayload | null,
       PhLaunchesPayload | null,
+      RepoProfilesPayload | null,
     ];
 
     const metadataByRepo = new Map<string, RepoMetadataItem>();
@@ -205,6 +219,10 @@ const fetcher: Fetcher = {
     }
 
     const rankMap = buildTrendingRankMap(trending);
+    const existingByRepo = new Map<string, RepoProfile>();
+    for (const profile of existingProfiles?.profiles ?? []) {
+      if (profile?.fullName) existingByRepo.set(normalizeRepoKey(profile.fullName), profile);
+    }
     const candidates: Array<{ fullName: string; rank: number | null; key: string }> = [];
     for (const [key, rank] of rankMap.entries()) {
       if (candidates.length >= TOP_LIMIT) break;
@@ -216,8 +234,10 @@ const fetcher: Fetcher = {
     }
 
     const now = new Date().toISOString();
+    let scanned = 0;
     let queued = 0;
     let noWebsite = 0;
+    let failed = 0;
     const profiles: RepoProfile[] = [];
 
     for (const candidate of candidates) {
@@ -253,26 +273,38 @@ const fetcher: Fetcher = {
         npmPkgs
           .map((pkg) => cleanUrl(pkg.homepage))
           .find((url) => url && /docs|documentation|readme/i.test(url)) ?? null;
+      const existing = existingByRepo.get(candidate.key) ?? null;
+      const preserveExistingEnrichment = Boolean(
+        existing && existing.websiteUrl === websiteUrl,
+      );
+      const status = preserveExistingEnrichment && existing
+        ? existing.status
+        : websiteUrl
+          ? 'scan_pending'
+          : 'no_website';
       const profile: RepoProfile = {
         fullName: meta?.fullName ?? candidate.fullName,
         rank: candidate.rank,
         selectedFrom: 'trending_top_24h',
         websiteUrl,
         websiteSource,
-        status: websiteUrl ? 'scan_pending' : 'no_website',
+        status,
         lastProfiledAt: now,
-        nextScanAfter: null,
+        nextScanAfter: preserveExistingEnrichment ? existing?.nextScanAfter ?? null : null,
         surfaces: {
           githubUrl,
           docsUrl,
           npmPackages: npmPkgs.map((pkg) => pkg.name),
           productHuntLaunchId: phLaunch?.id ?? null,
         },
-        aisoScan: null,
-        error: null,
+        aisoScan: preserveExistingEnrichment ? existing?.aisoScan ?? null : null,
+        expertTrendBrief: existing?.expertTrendBrief ?? null,
+        error: preserveExistingEnrichment ? existing?.error ?? null : null,
       };
       profiles.push(profile);
-      if (websiteUrl) queued += 1;
+      if (profile.status === 'scanned') scanned += 1;
+      else if (profile.status === 'scan_failed') failed += 1;
+      else if (websiteUrl) queued += 1;
       else noWebsite += 1;
     }
 
@@ -282,10 +314,10 @@ const fetcher: Fetcher = {
       selection: {
         source: 'top',
         limit: TOP_LIMIT,
-        scanned: 0,
+        scanned,
         queued,
         noWebsite,
-        failed: 0,
+        failed,
       },
       profiles,
     };

--- a/scripts/enrich-repo-profiles.mjs
+++ b/scripts/enrich-repo-profiles.mjs
@@ -42,6 +42,32 @@ const GITHUB_DELAY_MS = optionInt("github-delay-ms", "PROFILE_ENRICH_GITHUB_DELA
 const AISO_SCAN_DELAY_MS = optionInt("aiso-delay-ms", "PROFILE_ENRICH_AISO_DELAY_MS", 1_000, 0, 60_000);
 const AISO_WAIT_MS = optionInt("aiso-wait-ms", "PROFILE_ENRICH_AISO_WAIT_MS", 90_000, 5_000, 600_000);
 const AISO_POLL_MS = optionInt("aiso-poll-ms", "PROFILE_ENRICH_AISO_POLL_MS", 2_000, 500, 30_000);
+const AISO_DAILY_SCAN_BUDGET = optionInt("aiso-daily-budget", "PROFILE_ENRICH_AISO_DAILY_SCAN_BUDGET", 30, 0, 1_000);
+const AISO_SOURCE = optionString("aiso-source", "PROFILE_ENRICH_AISO_SOURCE", "api");
+const AISO_PROJECT_NAME = optionString("aiso-project", "PROFILE_ENRICH_AISO_PROJECT", "TrendingRepo repo profile enrichment");
+const AISO_PROJECT_URL = optionString("aiso-project-url", "PROFILE_ENRICH_AISO_PROJECT_URL", "https://trendingrepo.com");
+const AISO_PROMOTION_SECRET = optionString(
+  "aiso-promotion-secret",
+  "PROFILE_ENRICH_AISO_PROMOTION_SECRET",
+  process.env.AISO_TRENDINGREPO_SECRET ?? "",
+);
+const AISO_BILLING_TIER = optionString("aiso-billing-tier", "PROFILE_ENRICH_AISO_BILLING_TIER", "free");
+const AISO_PROFILE = optionString("aiso-profile", "PROFILE_ENRICH_AISO_PROFILE", "");
+const KIMI_API_KEY = optionString("kimi-api-key", "KIMI_API_KEY", "");
+const KIMI_ENABLED = optionBool("kimi", "PROFILE_ENRICH_KIMI", Boolean(KIMI_API_KEY));
+const KIMI_BASE_URL = optionString("kimi-base-url", "KIMI_BASE_URL", "https://api.kimi.com/coding/v1").replace(/\/+$/, "");
+const KIMI_MODEL = optionString("kimi-model", "KIMI_MODEL", "kimi-for-coding");
+const KIMI_MAX_REPOS = optionInt(
+  "kimi-max-repos",
+  "PROFILE_ENRICH_KIMI_MAX_REPOS",
+  Math.min(LIMIT, MAX_SCANS > 0 ? MAX_SCANS : 3),
+  0,
+  1_000,
+);
+const KIMI_TTL_DAYS = optionInt("kimi-ttl-days", "PROFILE_ENRICH_KIMI_TTL_DAYS", 1, 1, 30);
+const KIMI_TIMEOUT_MS = optionInt("kimi-timeout-ms", "PROFILE_ENRICH_KIMI_TIMEOUT_MS", 45_000, 5_000, 120_000);
+const KIMI_MAX_TOKENS = optionInt("kimi-max-tokens", "PROFILE_ENRICH_KIMI_MAX_TOKENS", 520, 120, 2_000);
+const KIMI_DELAY_MS = optionInt("kimi-delay-ms", "PROFILE_ENRICH_KIMI_DELAY_MS", 500, 0, 30_000);
 
 function clampInt(raw, fallback, min, max) {
   const parsed = Number.parseInt(String(raw ?? ""), 10);
@@ -206,8 +232,33 @@ function truncateError(error) {
   return String(error?.message ?? error).replace(/\s+/g, " ").trim().slice(0, 500);
 }
 
+function truncateText(value, maxLength) {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
 function normalizeRepoKey(fullName) {
   return String(fullName ?? "").toLowerCase();
+}
+
+function repoProfileUrl(fullName) {
+  const [owner, name] = String(fullName ?? "").split("/");
+  if (!owner || !name) return AISO_PROJECT_URL;
+  return `https://trendingrepo.com/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
+function aisoProjectName(fullName) {
+  const suffix = String(fullName ?? "").trim();
+  return truncateText(suffix ? `TrendingRepo: ${suffix}` : AISO_PROJECT_NAME, 80);
+}
+
+function isFreshIso(iso, days) {
+  const ts = Date.parse(iso ?? "");
+  if (!Number.isFinite(ts)) return false;
+  const ageMs = Date.now() - ts;
+  return ageMs >= 0 && ageMs <= days * 86_400_000;
 }
 
 function buildMetadataIndex(metadataFile) {
@@ -526,11 +577,38 @@ function existingScanIsFresh(existing, websiteUrl) {
   return Date.now() - profiledAt < RESCAN_DAYS * 86_400_000;
 }
 
-async function submitAisoScan(baseUrl, websiteUrl) {
+function countRecentAisoSubmissions(profilesByRepo) {
+  let count = 0;
+  for (const profile of profilesByRepo.values()) {
+    if (!profile?.aisoScan?.scanId) continue;
+    const scanAt = profile.aisoScan.completedAt ?? profile.lastProfiledAt;
+    if (isFreshIso(scanAt, 1)) count += 1;
+  }
+  return count;
+}
+
+async function submitAisoScan(baseUrl, websiteUrl, candidate) {
+  const headers = {
+    "content-type": "application/json",
+    "x-aiso-source": AISO_SOURCE,
+    "x-aiso-project": aisoProjectName(candidate?.fullName),
+    "x-aiso-project-url": repoProfileUrl(candidate?.fullName),
+  };
+  if (AISO_PROMOTION_SECRET) {
+    headers["x-aiso-promotion-secret"] = AISO_PROMOTION_SECRET;
+  }
+  const body = {
+    url: websiteUrl,
+    source: AISO_SOURCE,
+    projectName: aisoProjectName(candidate?.fullName),
+    projectUrl: repoProfileUrl(candidate?.fullName),
+    billingTier: AISO_BILLING_TIER,
+  };
+  if (AISO_PROFILE) body.profile = AISO_PROFILE;
   return fetchJsonWithRetry(`${baseUrl}/api/scan`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ url: websiteUrl }),
+    headers,
+    body: JSON.stringify(body),
     attempts: 1,
     timeoutMs: 20_000,
   });
@@ -545,7 +623,7 @@ async function fetchAisoScan(baseUrl, scanId) {
   });
 }
 
-async function runAisoScan({ baseUrl, websiteUrl, existing, scanIdOverride = null }) {
+async function runAisoScan({ baseUrl, websiteUrl, existing, candidate, scanIdOverride = null }) {
   if (!AISO_ENABLED) {
     return {
       status: existing?.aisoScan ? "scanned" : "scan_pending",
@@ -569,7 +647,7 @@ async function runAisoScan({ baseUrl, websiteUrl, existing, scanIdOverride = nul
     : null;
   if (!submitted) {
     try {
-      submitted = await submitAisoScan(baseUrl, websiteUrl);
+      submitted = await submitAisoScan(baseUrl, websiteUrl, candidate);
     } catch (err) {
       const status = err instanceof HttpStatusError && err.status === 429
         ? "rate_limited"
@@ -643,6 +721,219 @@ async function runAisoScan({ baseUrl, websiteUrl, existing, scanIdOverride = nul
   };
 }
 
+function existingBriefIsFresh(existing) {
+  return Boolean(
+    existing?.expertTrendBrief?.provider === "kimi" &&
+      existing.expertTrendBrief.summary &&
+      isFreshIso(existing.expertTrendBrief.generatedAt, KIMI_TTL_DAYS),
+  );
+}
+
+function parseKimiJson(text) {
+  const trimmed = String(text ?? "").trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const firstBrace = trimmed.indexOf("{");
+    const lastBrace = trimmed.lastIndexOf("}");
+    if (firstBrace === -1 || lastBrace <= firstBrace) return null;
+    try {
+      return JSON.parse(trimmed.slice(firstBrace, lastBrace + 1));
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function readKimiStream(response) {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const chunk = JSON.parse(payload);
+        const delta = chunk?.choices?.[0]?.delta;
+        if (typeof delta?.content === "string") text += delta.content;
+      } catch {
+        // Ignore malformed keepalive or proxy lines; the final JSON validator
+        // below decides whether the accumulated model output is usable.
+      }
+    }
+  }
+  return text;
+}
+
+async function callKimiJson({ systemPrompt, userMessage }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), KIMI_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${KIMI_BASE_URL}/chat/completions`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        authorization: `Bearer ${KIMI_API_KEY}`,
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        "user-agent": "claude-cli/1.0",
+      },
+      body: JSON.stringify({
+        model: KIMI_MODEL,
+        max_tokens: KIMI_MAX_TOKENS,
+        temperature: 0.25,
+        stream: true,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userMessage },
+        ],
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`Kimi ${response.status}: ${truncateText(body, 240)}`);
+    }
+    return parseKimiJson(await readKimiStream(response));
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function safeStringArray(value, maxItems, maxLength) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => truncateText(item, maxLength))
+    .filter(Boolean)
+    .slice(0, maxItems);
+}
+
+function normalizeExpertTrendBrief(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const headline = truncateText(raw.headline, 120);
+  const summary = truncateText(raw.summary, 600);
+  if (!headline || !summary) return null;
+  return {
+    provider: "kimi",
+    model: KIMI_MODEL,
+    generatedAt: new Date().toISOString(),
+    headline,
+    summary,
+    drivers: safeStringArray(raw.drivers, 4, 180),
+    evidence: safeStringArray(raw.evidence, 4, 180),
+    caveats: safeStringArray(raw.caveats, 3, 180),
+  };
+}
+
+function buildKimiFacts({ candidate, baseProfile, scanResult, phLaunch, npmPackages }) {
+  const metadata = candidate.metadata ?? {};
+  const scan = scanResult?.aisoScan ?? baseProfile.aisoScan ?? null;
+  return {
+    repo: {
+      fullName: baseProfile.fullName,
+      rank24h: candidate.rank,
+      selectedFrom: candidate.selectedFrom,
+      githubUrl: baseProfile.surfaces.githubUrl,
+      description: truncateText(metadata.description, 320),
+      language: metadata.language ?? null,
+      topics: Array.isArray(metadata.topics) ? metadata.topics.slice(0, 12) : [],
+      stars: metadata.stars ?? null,
+      forks: metadata.forks ?? null,
+      openIssues: metadata.openIssues ?? null,
+      createdAt: metadata.createdAt ?? null,
+      pushedAt: metadata.pushedAt ?? null,
+    },
+    surfaces: {
+      websiteUrl: baseProfile.websiteUrl,
+      websiteSource: baseProfile.websiteSource,
+      docsUrl: baseProfile.surfaces.docsUrl,
+      npmPackages: npmPackages.slice(0, 5).map((pkg) => ({
+        name: pkg.name,
+        homepage: pkg.homepage ?? null,
+        downloads7d: pkg.downloads7d ?? null,
+        weeklyDownloads: pkg.discovery?.weeklyDownloads ?? null,
+      })),
+      productHunt: phLaunch
+        ? {
+            id: phLaunch.id ?? null,
+            name: phLaunch.name ?? null,
+            tagline: phLaunch.tagline ?? null,
+            votesCount: phLaunch.votesCount ?? null,
+            commentsCount: phLaunch.commentsCount ?? null,
+            website: phLaunch.website ?? null,
+          }
+        : null,
+    },
+    aiso: scan
+      ? {
+          status: scan.status,
+          score: scan.score ?? null,
+          tier: scan.tier ?? null,
+          runtimeVisibility: scan.runtimeVisibility ?? null,
+          completedAt: scan.completedAt ?? null,
+          topDimensions: (scan.dimensions ?? [])
+            .slice()
+            .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+            .slice(0, 5)
+            .map((dimension) => ({
+              key: dimension.key,
+              label: dimension.label,
+              score: dimension.score,
+              status: dimension.status,
+              issuesCount: dimension.issuesCount,
+            })),
+          topIssues: (scan.issues ?? []).slice(0, 5).map((issue) => ({
+            severity: issue.severity,
+            title: issue.title,
+            fix: issue.fix,
+          })),
+        }
+      : null,
+  };
+}
+
+async function buildExpertTrendBrief(context) {
+  if (!KIMI_ENABLED || !KIMI_API_KEY) {
+    return context.existing?.expertTrendBrief ?? null;
+  }
+  if (existingBriefIsFresh(context.existing)) {
+    return context.existing.expertTrendBrief;
+  }
+
+  const facts = buildKimiFacts(context);
+  const systemPrompt = [
+    "You are an expert open-source trend analyst for TrendingRepo.",
+    "Use only the supplied facts. Do not invent adoption, revenue, customers, or benchmarks.",
+    "Explain why the repository is trending now and how its website/AISO surface affects AI discoverability.",
+    "Return strict JSON only with keys: headline, summary, drivers, evidence, caveats.",
+  ].join(" ");
+  const userMessage = JSON.stringify(
+    {
+      task:
+        "Write a concise expert trend brief for a repo profile page. Keep summary under 110 words. drivers/evidence/caveats are short bullet strings.",
+      facts,
+    },
+    null,
+    2,
+  );
+
+  const parsed = await callKimiJson({ systemPrompt, userMessage });
+  const brief = normalizeExpertTrendBrief(parsed);
+  if (!brief) throw new Error("Kimi returned unusable JSON");
+  return brief;
+}
+
 async function writeProfilesFile(profilesByRepo, selection, { mirrorToStore = false } = {}) {
   const profiles = Array.from(profilesByRepo.values()).sort((a, b) => {
     const ar = a.rank ?? Number.MAX_SAFE_INTEGER;
@@ -713,17 +1004,21 @@ async function main() {
     source: MODE,
     limit: LIMIT,
     maxScans: MAX_SCANS,
+    dailyScanBudget: AISO_DAILY_SCAN_BUDGET,
     fromQueue: queueRepos.length,
     scanned: 0,
     queued: 0,
     noWebsite: 0,
     failed: 0,
+    expertBriefs: 0,
   };
   let scansStarted = 0;
+  let kimiStarted = 0;
+  const recentAisoSubmissions = countRecentAisoSubmissions(profilesByRepo);
   let aisoRateLimited = false;
 
   console.log(
-    `repo profiles: mode=${MODE} candidates=${candidates.length} fromQueue=${queueRepos.length} maxScans=${MAX_SCANS} aiso=${AISO_ENABLED ? aisoBaseUrl : "disabled"}`,
+    `repo profiles: mode=${MODE} candidates=${candidates.length} fromQueue=${queueRepos.length} maxScans=${MAX_SCANS} dailyBudget=${AISO_DAILY_SCAN_BUDGET} recent24h=${recentAisoSubmissions} aiso=${AISO_ENABLED ? aisoBaseUrl : "disabled"} kimi=${KIMI_ENABLED && KIMI_API_KEY ? `${KIMI_MODEL} max=${KIMI_MAX_REPOS}` : "disabled"}`,
   );
 
   for (const candidate of candidates) {
@@ -755,10 +1050,31 @@ async function main() {
         productHuntLaunchId: phLaunch?.id ?? null,
       },
       aisoScan: existing?.aisoScan ?? null,
+      expertTrendBrief: existing?.expertTrendBrief ?? null,
       error: null,
     };
 
     if (!websiteUrl) {
+      if (KIMI_ENABLED && KIMI_API_KEY && kimiStarted < KIMI_MAX_REPOS && !existingBriefIsFresh(existing)) {
+        try {
+          baseProfile.expertTrendBrief = await buildExpertTrendBrief({
+            candidate,
+            baseProfile,
+            existing,
+            scanResult: null,
+            phLaunch,
+            npmPackages,
+          });
+          if (baseProfile.expertTrendBrief !== existing?.expertTrendBrief) {
+            selection.expertBriefs += 1;
+          }
+        } catch (err) {
+          console.warn(`kimi skipped ${candidate.fullName}: ${truncateError(err)}`);
+        } finally {
+          kimiStarted += 1;
+          if (KIMI_DELAY_MS > 0) await sleep(KIMI_DELAY_MS);
+        }
+      }
       selection.noWebsite += 1;
       profilesByRepo.set(key, baseProfile);
       console.log(`skip no website: ${candidate.fullName}`);
@@ -781,8 +1097,14 @@ async function main() {
         websiteUrl,
         existing,
         scanIdOverride,
+        candidate,
       });
-    } else if (aisoRateLimited || scansStarted >= MAX_SCANS) {
+    } else if (
+      aisoRateLimited ||
+      scansStarted >= MAX_SCANS ||
+      (AISO_DAILY_SCAN_BUDGET > 0 &&
+        recentAisoSubmissions + scansStarted >= AISO_DAILY_SCAN_BUDGET)
+    ) {
       scanResult = {
         status: "scan_pending",
         aisoScan: existing?.aisoScan ?? null,
@@ -794,6 +1116,7 @@ async function main() {
         baseUrl: aisoBaseUrl,
         websiteUrl,
         existing,
+        candidate,
       });
       if (scanResult.countedAsScan) {
         scansStarted += 1;
@@ -811,11 +1134,34 @@ async function main() {
       selection.queued += 1;
     }
 
+    let expertTrendBrief = baseProfile.expertTrendBrief;
+    if (KIMI_ENABLED && KIMI_API_KEY && kimiStarted < KIMI_MAX_REPOS && !existingBriefIsFresh(existing)) {
+      try {
+        expertTrendBrief = await buildExpertTrendBrief({
+          candidate,
+          baseProfile,
+          existing,
+          scanResult,
+          phLaunch,
+          npmPackages,
+        });
+        if (expertTrendBrief !== existing?.expertTrendBrief) {
+          selection.expertBriefs += 1;
+        }
+      } catch (err) {
+        console.warn(`kimi skipped ${candidate.fullName}: ${truncateError(err)}`);
+      } finally {
+        kimiStarted += 1;
+        if (KIMI_DELAY_MS > 0) await sleep(KIMI_DELAY_MS);
+      }
+    }
+
     profilesByRepo.set(key, {
       ...baseProfile,
       status: scanResult.status,
       nextScanAfter: scanResult.status === "scanned" ? futureIso(RESCAN_DAYS) : null,
       aisoScan: scanResult.aisoScan,
+      expertTrendBrief,
       error: scanResult.error,
     });
     console.log(`${scanResult.status}: ${candidate.fullName} -> ${websiteUrl}`);
@@ -826,7 +1172,7 @@ async function main() {
     mirrorToStore: true,
   });
   console.log(
-    `repo profiles wrote ${OUT_FILE} scanned=${selection.scanned} queued=${selection.queued} noWebsite=${selection.noWebsite} failed=${selection.failed} [redis: ${redisResult?.source ?? "skipped"}]`,
+    `repo profiles wrote ${OUT_FILE} scanned=${selection.scanned} queued=${selection.queued} noWebsite=${selection.noWebsite} failed=${selection.failed} expertBriefs=${selection.expertBriefs} [redis: ${redisResult?.source ?? "skipped"}]`,
   );
 }
 

--- a/src/app/api/cron/aiso-drain/route.ts
+++ b/src/app/api/cron/aiso-drain/route.ts
@@ -93,8 +93,15 @@ const POST_CACHE_HEADERS = {
 // in production reads these hooks.
 
 export interface AisoDrainTestOverrides {
-  /** Replacement for `getAisoToolsScan(url)`. */
-  scanner?: (url: string | null) => Promise<AisoToolsScan | null>;
+  /** Replacement for `getAisoToolsScan(url, attribution)`. */
+  scanner?: (
+    url: string | null,
+    options?: {
+      source?: string | null;
+      projectName?: string | null;
+      projectUrl?: string | null;
+    },
+  ) => Promise<AisoToolsScan | null>;
   /**
    * Replacement for the 3s inter-call gap. Tests pass 0 to avoid dragging
    * test runtime.
@@ -139,6 +146,16 @@ function parseLimit(raw: unknown): number {
   }
   const clamped = Math.min(Math.floor(raw), MAX_LIMIT);
   return Math.max(1, clamped);
+}
+
+function repoProfileUrl(fullName: string): string {
+  const [owner, name] = fullName.split("/");
+  if (!owner || !name) return "https://trendingrepo.com";
+  return `https://trendingrepo.com/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+}
+
+function projectName(fullName: string): string {
+  return `TrendingRepo: ${fullName}`.slice(0, 80);
 }
 
 // Body parsing routed through @/lib/api/parse-body (canonical helper)
@@ -258,7 +275,11 @@ async function runDrain(
     }
 
     try {
-      const scan = await scanner(row.websiteUrl);
+      const scan = await scanner(row.websiteUrl, {
+        source: `trendingrepo-aiso-drain:${row.source ?? "unknown"}`.slice(0, 80),
+        projectName: projectName(row.repoFullName),
+        projectUrl: repoProfileUrl(row.repoFullName),
+      });
       // Persist the scan (even null) into data/repo-profiles.json so the
       // result outlives the in-process memoryCache. A persist throw is
       // treated as a row failure — we'd rather retry than silently drop

--- a/src/app/repo/[owner]/[name]/page.tsx
+++ b/src/app/repo/[owner]/[name]/page.tsx
@@ -94,6 +94,7 @@ import { getWhyNarrative } from "@/lib/why-narrative";
 import { FundingPanel } from "@/components/repo-detail/FundingPanel";
 import { RelatedReposPanel } from "@/components/repo-detail/RelatedReposPanel";
 import { RelatedIdeasPanel } from "@/components/repo-detail/RelatedIdeasPanel";
+import { WhyTrendingNarrative } from "@/components/repo-detail/WhyTrendingNarrative";
 
 // ISR over force-dynamic: the 12+ refresh hooks above each share the
 // data-store's 30s rate-limit + dedupe, so calling them on every request
@@ -436,6 +437,7 @@ export default async function RepoDetailPage({ params }: PageProps) {
         <div className="repo-profile-topline">
           <CompletenessStrip repo={repo} />
           <WhyBadge narrative={whyNarrative} variant="full" />
+          <WhyTrendingNarrative repo={repo} profile={profile} />
           <RepoSignalSnapshot
             repo={repo}
             mentions={mentions}

--- a/src/components/repo-detail/WhyTrendingNarrative.tsx
+++ b/src/components/repo-detail/WhyTrendingNarrative.tsx
@@ -34,11 +34,135 @@ function getTopSignalSource(
   return max > 0 ? { platform: topPlatform, count: max } : null;
 }
 
+const eyebrowStyle = {
+  margin: "0 0 6px",
+  fontFamily: "var(--v4-mono, ui-monospace, monospace)",
+  fontSize: 10,
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  color: "var(--v4-ink-400, var(--v3-ink-400))",
+} as const;
+
+const listStyle = {
+  margin: 0,
+  paddingLeft: 18,
+  lineHeight: 1.45,
+  fontSize: 12,
+  color: "var(--v4-ink-200, var(--v3-ink-200))",
+} as const;
+
 export function WhyTrendingNarrative({
   repo,
   profile,
 }: WhyTrendingNarrativeProps) {
   if (!repo) return null;
+
+  const expertBrief = profile.expertTrendBrief;
+  if (expertBrief?.headline && expertBrief.summary) {
+    const drivers = expertBrief.drivers?.filter(Boolean).slice(0, 4) ?? [];
+    const evidence = expertBrief.evidence?.filter(Boolean).slice(0, 4) ?? [];
+    const caveats = expertBrief.caveats?.filter(Boolean).slice(0, 2) ?? [];
+
+    return (
+      <section
+        className="repo-narrative repo-narrative--expert"
+        aria-label="Expert trend brief"
+        style={{
+          padding: "14px 16px",
+          margin: "0.75rem 0",
+          border: "1px solid var(--v4-line-100, rgba(255,255,255,0.1))",
+          borderLeft: "3px solid var(--v4-acc, var(--v3-acc, #ff5e1a))",
+          background: "var(--v4-bg-100, var(--v3-bg-100, transparent))",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: 12,
+            marginBottom: 8,
+          }}
+        >
+          <h2
+            style={{
+              margin: 0,
+              fontSize: 15,
+              lineHeight: 1.3,
+              color: "var(--v4-ink-100, var(--v3-ink-100))",
+            }}
+          >
+            {expertBrief.headline}
+          </h2>
+          <span
+            style={{
+              flexShrink: 0,
+              fontFamily: "var(--v4-mono, ui-monospace, monospace)",
+              fontSize: 10,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--v4-ink-400, var(--v3-ink-400))",
+            }}
+          >
+            {expertBrief.provider} / {expertBrief.model}
+          </span>
+        </div>
+        <p
+          style={{
+            margin: 0,
+            lineHeight: 1.55,
+            fontSize: 14,
+            color: "var(--v4-ink-100, var(--v3-ink-100))",
+          }}
+        >
+          {expertBrief.summary}
+        </p>
+        {drivers.length > 0 || evidence.length > 0 ? (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(240px, 100%), 1fr))",
+              gap: 12,
+              marginTop: 12,
+            }}
+          >
+            {drivers.length > 0 ? (
+              <div>
+                <p style={eyebrowStyle}>Drivers</p>
+                <ul style={listStyle}>
+                  {drivers.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            {evidence.length > 0 ? (
+              <div>
+                <p style={eyebrowStyle}>Evidence</p>
+                <ul style={listStyle}>
+                  {evidence.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        {caveats.length > 0 ? (
+          <p
+            style={{
+              margin: "10px 0 0",
+              lineHeight: 1.45,
+              fontSize: 12,
+              color: "var(--v4-ink-300, var(--v3-ink-300))",
+            }}
+          >
+            {caveats.join(" ")}
+          </p>
+        ) : null}
+      </section>
+    );
+  }
 
   const sentences: string[] = [];
 

--- a/src/lib/aiso-persist.ts
+++ b/src/lib/aiso-persist.ts
@@ -186,6 +186,7 @@ function makeMinimalProfile(
       productHuntLaunchId: null,
     },
     aisoScan: scan,
+    expertTrendBrief: null,
     error: null,
   };
 }

--- a/src/lib/aiso-tools.ts
+++ b/src/lib/aiso-tools.ts
@@ -51,6 +51,12 @@ interface ScanSubmitResponse {
   status: AisoScanStatus;
 }
 
+interface AisoScanSubmitOptions {
+  source?: string | null;
+  projectName?: string | null;
+  projectUrl?: string | null;
+}
+
 interface ScanPayload {
   scanId: string;
   url: string;
@@ -160,11 +166,22 @@ async function fetchJson<T>(
 async function submitScan(
   baseUrl: string,
   targetUrl: string,
+  options: AisoScanSubmitOptions = {},
 ): Promise<ScanSubmitResponse | null> {
   return fetchJson<ScanSubmitResponse>(`${baseUrl}/api/scan`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ url: targetUrl }),
+    headers: {
+      "content-type": "application/json",
+      ...(options.source ? { "x-aiso-source": options.source } : {}),
+      ...(options.projectName ? { "x-aiso-project": options.projectName } : {}),
+      ...(options.projectUrl ? { "x-aiso-project-url": options.projectUrl } : {}),
+    },
+    body: JSON.stringify({
+      url: targetUrl,
+      ...(options.source ? { source: options.source } : {}),
+      ...(options.projectName ? { projectName: options.projectName } : {}),
+      ...(options.projectUrl ? { projectUrl: options.projectUrl } : {}),
+    }),
   });
 }
 
@@ -239,6 +256,7 @@ async function pollScan(
 
 export async function getAisoToolsScan(
   targetUrl: string | null,
+  options: AisoScanSubmitOptions = {},
 ): Promise<AisoToolsScan | null> {
   if (!targetUrl) return null;
 
@@ -262,7 +280,7 @@ export async function getAisoToolsScan(
     return cached.value;
   }
 
-  const submitted = await submitScan(baseUrl, targetUrl);
+  const submitted = await submitScan(baseUrl, targetUrl, options);
   if (!submitted?.scanId) {
     memoryCache.set(cacheKey, {
       expiresAt: Date.now() + FAILED_CACHE_TTL_MS,

--- a/src/lib/api/repo-profile.ts
+++ b/src/lib/api/repo-profile.ts
@@ -61,7 +61,11 @@ import {
   getTrustmrrClaimOverlay,
   refreshRevenueOverlaysFromStore,
 } from "@/lib/revenue-overlays";
-import { refreshRepoProfilesFromStore } from "@/lib/repo-profiles";
+import {
+  getRepoProfile,
+  refreshRepoProfilesFromStore,
+  type RepoExpertTrendBrief,
+} from "@/lib/repo-profiles";
 import {
   getFundingEventsForRepo,
   type RepoFundingEvent,
@@ -122,6 +126,7 @@ export interface CanonicalRepoProfile {
   twitter: TwitterRepoPanel | null;
   npm: CanonicalRepoProfileNpm;
   productHunt: Launch | null;
+  expertTrendBrief: RepoExpertTrendBrief | null;
   revenue: CanonicalRepoProfileRevenue;
   funding: RepoFundingEvent[];
   related: RelatedRepoItem[];
@@ -506,6 +511,7 @@ export async function buildCanonicalRepoProfile(
 
   // --- Synchronous loaders (all are mtime/memo cached internally) ---------
   const reasons = getRepoReasons(repo.fullName);
+  const persistedRepoProfile = getRepoProfile(repo.fullName);
   const freshness = getFreshnessSnapshot();
   const related = getRelatedReposFor(repo.fullName);
   const productHunt = getLaunchForRepo(repo.fullName);
@@ -611,6 +617,7 @@ export async function buildCanonicalRepoProfile(
       dependents: npmDependents,
     },
     productHunt,
+    expertTrendBrief: persistedRepoProfile?.expertTrendBrief ?? null,
     revenue: {
       verified: verifiedRevenue,
       selfReported: selfReportedRevenue,

--- a/src/lib/pipeline/__tests__/canonical-profile-endpoint.test.ts
+++ b/src/lib/pipeline/__tests__/canonical-profile-endpoint.test.ts
@@ -151,6 +151,7 @@ test("v=2 returns canonical shape with all top-level keys", async () => {
     "twitter",
     "npm",
     "productHunt",
+    "expertTrendBrief",
     "revenue",
     "funding",
     "related",

--- a/src/lib/repo-profiles.ts
+++ b/src/lib/repo-profiles.ts
@@ -30,6 +30,17 @@ export interface RepoProfileSurface {
   productHuntLaunchId: string | null;
 }
 
+export interface RepoExpertTrendBrief {
+  provider: "kimi";
+  model: string;
+  generatedAt: string;
+  headline: string;
+  summary: string;
+  drivers: string[];
+  evidence: string[];
+  caveats: string[];
+}
+
 export interface RepoProfile {
   fullName: string;
   rank: number | null;
@@ -41,6 +52,7 @@ export interface RepoProfile {
   nextScanAfter: string | null;
   surfaces: RepoProfileSurface;
   aisoScan: AisoToolsScan | null;
+  expertTrendBrief?: RepoExpertTrendBrief | null;
   error: string | null;
 }
 
@@ -51,10 +63,12 @@ export interface RepoProfilesFile {
     source: string;
     limit: number;
     maxScans: number;
+    dailyScanBudget?: number;
     scanned: number;
     queued: number;
     noWebsite: number;
     failed: number;
+    expertBriefs?: number;
   };
   profiles: RepoProfile[];
 }


### PR DESCRIPTION
Automated data refresh from `Refresh repo profiles`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26087735370

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.