### PR TITLE
fix(aiso): redact Kimi error bodies

### DIFF
--- a/scripts/enrich-repo-profiles.mjs
+++ b/scripts/enrich-repo-profiles.mjs
@@ -802,8 +802,8 @@ async function callKimiJson({ systemPrompt, userMessage }) {
       }),
     });
     if (!response.ok) {
-      const body = await response.text().catch(() => "");
-      throw new Error(`Kimi ${response.status}: ${truncateText(body, 240)}`);
+      await response.arrayBuffer().catch(() => null);
+      throw new Error(`Kimi ${response.status} ${response.statusText || "request failed"}`);
     }
     return parseKimiJson(await readKimiStream(response));
   } finally {


### PR DESCRIPTION
## Summary
- stops logging upstream Kimi response bodies when the expert-brief API returns non-2xx
- keeps the response drained before throwing a concise status/statusText error

## Validation
- `node --check scripts\enrich-repo-profiles.mjs`
- `git diff --check`

## Context
The hosted `KIMI_API_KEY` is now configured, but the canary run returned a provider quota 403, so no expert briefs were generated yet. This patch keeps future quota/auth failures from copying provider payloads into workflow logs.