### PR TITLE
chore(data): refresh huggingface signals 2026-05-19T10:09:00Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-19T04:34:50.639Z",
+  "ts": "2026-05-19T10:09:00.249Z",
   "count": 1,
-  "durationMs": 7545,
+  "durationMs": 7968,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T04:34:43.096Z",
+  "fetchedAt": "2026-05-19T10:08:52.281Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -157,9 +157,9 @@
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic-3",
-      "downloads": 24031,
-      "likes": 425,
-      "trendingScore": 320,
+      "downloads": 28681,
+      "likes": 441,
+      "trendingScore": 325,
       "pipelineTag": "text-to-speech",
       "libraryName": "supertonic",
       "tags": [
@@ -230,8 +230,8 @@
       "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 237613,
-      "likes": 250,
+      "downloads": 296380,
+      "likes": 255,
       "trendingScore": 229,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -335,6 +335,25 @@
     },
     {
       "rank": 13,
+      "id": "circlestone-labs/Anima",
+      "author": "circlestone-labs",
+      "url": "https://huggingface.co/circlestone-labs/Anima",
+      "downloads": 558113,
+      "likes": 1416,
+      "trendingScore": 184,
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
+      "tags": [
+        "diffusion-single-file",
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-01-29T21:17:57.000Z",
+      "lastModified": "2026-05-14T17:13:39.000Z"
+    },
+    {
+      "rank": 14,
       "id": "TenStrip/LTX2.3-10Eros",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
@@ -352,32 +371,13 @@
       "lastModified": "2026-05-07T01:24:09.000Z"
     },
     {
-      "rank": 14,
-      "id": "circlestone-labs/Anima",
-      "author": "circlestone-labs",
-      "url": "https://huggingface.co/circlestone-labs/Anima",
-      "downloads": 545205,
-      "likes": 1413,
-      "trendingScore": 181,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
-      "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-01-29T21:17:57.000Z",
-      "lastModified": "2026-05-14T17:13:39.000Z"
-    },
-    {
       "rank": 15,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/Dramabox",
-      "downloads": 1001,
-      "likes": 164,
-      "trendingScore": 162,
+      "downloads": 1118,
+      "likes": 167,
+      "trendingScore": 164,
       "pipelineTag": "text-to-speech",
       "libraryName": "ltx-audio-tts",
       "tags": [
@@ -405,8 +405,8 @@
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
       "downloads": 0,
-      "likes": 297,
-      "trendingScore": 146,
+      "likes": 301,
+      "trendingScore": 148,
       "pipelineTag": null,
       "libraryName": "mlx",
       "tags": [
@@ -547,6 +547,34 @@
     },
     {
       "rank": 21,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/bytedance-research/Lance",
+      "downloads": 171,
+      "likes": 121,
+      "trendingScore": 120,
+      "pipelineTag": "any-to-any",
+      "libraryName": "Lance",
+      "tags": [
+        "Lance",
+        "safetensors",
+        "multimodal",
+        "image-generation",
+        "video-generation",
+        "image-editing",
+        "video-understanding",
+        "any-to-any",
+        "arxiv:2605.18678",
+        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T08:05:57.000Z",
+      "lastModified": "2026-05-19T07:43:27.000Z"
+    },
+    {
+      "rank": 22,
       "id": "Qwen/Qwen3.6-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
@@ -571,7 +599,7 @@
       "lastModified": "2026-04-24T02:53:42.000Z"
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "google/gemma-4-26B-A4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-assistant",
@@ -594,7 +622,7 @@
       "lastModified": "2026-05-11T07:50:08.000Z"
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -636,7 +664,7 @@
       "lastModified": "2026-05-07T02:39:32.000Z"
     },
     {
-      "rank": 24,
+      "rank": 25,
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
@@ -669,7 +697,7 @@
       "lastModified": "2026-04-12T13:42:43.000Z"
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -695,7 +723,50 @@
       "lastModified": "2026-05-06T04:18:09.000Z"
     },
     {
-      "rank": 26,
+      "rank": 27,
+      "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
+      "downloads": 12117,
+      "likes": 105,
+      "trendingScore": 104,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_5",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "agent",
+        "tool-use",
+        "function-calling",
+        "coder",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:lambda/hermes-agent-reasoning-traces",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T12:53:59.000Z",
+      "lastModified": "2026-05-19T08:46:19.000Z"
+    },
+    {
+      "rank": 28,
       "id": "sensenova/SenseNova-U1-8B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
@@ -723,48 +794,7 @@
       "lastModified": "2026-05-07T08:00:27.000Z"
     },
     {
-      "rank": 27,
-      "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
-      "downloads": 6462,
-      "likes": 102,
-      "trendingScore": 101,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_5",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "agent",
-        "tool-use",
-        "function-calling",
-        "coder",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:lambda/hermes-agent-reasoning-traces",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T12:53:59.000Z",
-      "lastModified": "2026-05-17T01:57:24.000Z"
-    },
-    {
-      "rank": 28,
+      "rank": 29,
       "id": "jackxinning/Leanly_AI",
       "author": "jackxinning",
       "url": "https://huggingface.co/jackxinning/Leanly_AI",
@@ -788,7 +818,7 @@
       "lastModified": "2026-05-04T07:50:46.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
@@ -812,7 +842,7 @@
       "lastModified": "2026-05-15T10:40:24.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "google/gemma-4-31B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B-it",
@@ -839,7 +869,7 @@
       "lastModified": "2026-05-07T07:39:17.000Z"
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "ScenemaAI/scenema-audio",
       "author": "ScenemaAI",
       "url": "https://huggingface.co/ScenemaAI/scenema-audio",
@@ -878,7 +908,7 @@
       "lastModified": "2026-05-14T03:19:58.000Z"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -907,7 +937,7 @@
       "lastModified": "2026-05-05T12:57:20.000Z"
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
@@ -933,7 +963,7 @@
       "lastModified": "2026-04-25T21:33:07.000Z"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "unsloth/Qwen3.6-27B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
@@ -961,7 +991,32 @@
       "lastModified": "2026-04-22T16:01:39.000Z"
     },
     {
-      "rank": 35,
+      "rank": 36,
+      "id": "Cactus-Compute/needle",
+      "author": "Cactus-Compute",
+      "url": "https://huggingface.co/Cactus-Compute/needle",
+      "downloads": 268,
+      "likes": 87,
+      "trendingScore": 86,
+      "pipelineTag": null,
+      "libraryName": "jax",
+      "tags": [
+        "jax",
+        "custom",
+        "function-calling",
+        "tool-use",
+        "encoder-decoder",
+        "edge",
+        "on-device",
+        "flax",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-03-16T04:01:31.000Z",
+      "lastModified": "2026-05-13T09:32:17.000Z"
+    },
+    {
+      "rank": 37,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/k2-fsa/OmniVoice",
@@ -1006,7 +1061,7 @@
       "lastModified": "2026-05-07T15:45:07.000Z"
     },
     {
-      "rank": 36,
+      "rank": 38,
       "id": "havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
@@ -1033,41 +1088,13 @@
       "lastModified": "2026-05-10T15:43:51.000Z"
     },
     {
-      "rank": 37,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 0,
-      "likes": 84,
-      "trendingScore": 84,
-      "pipelineTag": "any-to-any",
-      "libraryName": "Lance",
-      "tags": [
-        "Lance",
-        "safetensors",
-        "multimodal",
-        "image-generation",
-        "video-generation",
-        "image-editing",
-        "video-understanding",
-        "any-to-any",
-        "arxiv:2605.18678",
-        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-19T03:14:47.000Z"
-    },
-    {
-      "rank": 38,
+      "rank": 39,
       "id": "microsoft/Fara-7B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Fara-7B",
-      "downloads": 16011,
-      "likes": 578,
-      "trendingScore": 83,
+      "downloads": 14464,
+      "likes": 579,
+      "trendingScore": 84,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1086,31 +1113,6 @@
       ],
       "createdAt": "2025-10-30T18:56:59.000Z",
       "lastModified": "2025-12-11T22:11:43.000Z"
-    },
-    {
-      "rank": 39,
-      "id": "Cactus-Compute/needle",
-      "author": "Cactus-Compute",
-      "url": "https://huggingface.co/Cactus-Compute/needle",
-      "downloads": 241,
-      "likes": 84,
-      "trendingScore": 83,
-      "pipelineTag": null,
-      "libraryName": "jax",
-      "tags": [
-        "jax",
-        "custom",
-        "function-calling",
-        "tool-use",
-        "encoder-decoder",
-        "edge",
-        "on-device",
-        "flax",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-03-16T04:01:31.000Z",
-      "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
       "rank": 40,
@@ -1267,9 +1269,9 @@
       "id": "inclusionAI/Ring-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
-      "downloads": 2406,
-      "likes": 77,
-      "trendingScore": 76,
+      "downloads": 3038,
+      "likes": 79,
+      "trendingScore": 78,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1292,9 +1294,9 @@
       "id": "internlm/Intern-S2-Preview",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview",
-      "downloads": 1168,
-      "likes": 76,
-      "trendingScore": 76,
+      "downloads": 1842,
+      "likes": 77,
+      "trendingScore": 77,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1309,7 +1311,7 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T03:49:25.000Z",
-      "lastModified": "2026-05-18T08:00:41.000Z"
+      "lastModified": "2026-05-19T08:01:07.000Z"
     },
     {
       "rank": 47,
@@ -1411,35 +1413,12 @@
     },
     {
       "rank": 50,
-      "id": "google/gemma-4-E4B-it-assistant",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
-      "downloads": 51766,
-      "likes": 70,
-      "trendingScore": 69,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4_assistant",
-        "text-generation",
-        "any-to-any",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T18:44:33.000Z",
-      "lastModified": "2026-05-11T07:50:40.000Z"
-    },
-    {
-      "rank": 51,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
-      "downloads": 18203,
-      "likes": 92,
-      "trendingScore": 68,
+      "downloads": 18458,
+      "likes": 99,
+      "trendingScore": 70,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1464,6 +1443,29 @@
       ],
       "createdAt": "2026-05-13T10:53:22.000Z",
       "lastModified": "2026-05-17T19:46:30.000Z"
+    },
+    {
+      "rank": 51,
+      "id": "google/gemma-4-E4B-it-assistant",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
+      "downloads": 51766,
+      "likes": 70,
+      "trendingScore": 69,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4_assistant",
+        "text-generation",
+        "any-to-any",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T18:44:33.000Z",
+      "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
       "rank": 52,
@@ -1569,6 +1571,36 @@
     },
     {
       "rank": 55,
+      "id": "sapientinc/HRM-Text-1B",
+      "author": "sapientinc",
+      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
+      "downloads": 884,
+      "likes": 66,
+      "trendingScore": 65,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hrm_text",
+        "text-generation",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T15:13:02.000Z",
+      "lastModified": "2026-05-18T07:57:35.000Z"
+    },
+    {
+      "rank": 56,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -1595,7 +1627,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 56,
+      "rank": 57,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -1628,7 +1660,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 57,
+      "rank": 58,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -1660,7 +1692,7 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 58,
+      "rank": 59,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -1689,7 +1721,32 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 59,
+      "rank": 60,
+      "id": "AIDC-AI/Ovis2.6-80B-A3B",
+      "author": "AIDC-AI",
+      "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
+      "downloads": 87,
+      "likes": 59,
+      "trendingScore": 59,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "ovis2_6_next",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "arxiv:2508.11737",
+        "arxiv:2405.20797",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T07:57:36.000Z",
+      "lastModified": "2026-05-14T08:44:07.000Z"
+    },
+    {
+      "rank": 61,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -1717,7 +1774,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 60,
+      "rank": 62,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -1744,7 +1801,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 61,
+      "rank": 63,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -1771,32 +1828,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 62,
-      "id": "AIDC-AI/Ovis2.6-80B-A3B",
-      "author": "AIDC-AI",
-      "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
-      "downloads": 73,
-      "likes": 58,
-      "trendingScore": 58,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "ovis2_6_next",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "arxiv:2508.11737",
-        "arxiv:2405.20797",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T07:57:36.000Z",
-      "lastModified": "2026-05-14T08:44:07.000Z"
-    },
-    {
-      "rank": 63,
+      "rank": 64,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -1819,11 +1851,11 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 64,
+      "rank": 65,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
-      "downloads": 2071,
+      "downloads": 2485,
       "likes": 58,
       "trendingScore": 57,
       "pipelineTag": "text-classification",
@@ -1850,7 +1882,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 65,
+      "rank": 66,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -1880,7 +1912,7 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 66,
+      "rank": 67,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -1924,7 +1956,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 67,
+      "rank": 68,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -1942,7 +1974,39 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 68,
+      "rank": 69,
+      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "downloads": 53662,
+      "likes": 57,
+      "trendingScore": 54,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "gemma4",
+        "moe",
+        "vision",
+        "multimodal",
+        "agentic",
+        "coding",
+        "image-text-to-text",
+        "en",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-14T16:24:48.000Z",
+      "lastModified": "2026-05-14T17:07:52.000Z"
+    },
+    {
+      "rank": 70,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -1969,7 +2033,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 69,
+      "rank": 71,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2002,44 +2066,12 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 70,
-      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "downloads": 40301,
-      "likes": 56,
-      "trendingScore": 53,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "moe",
-        "vision",
-        "multimodal",
-        "agentic",
-        "coding",
-        "image-text-to-text",
-        "en",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-14T16:24:48.000Z",
-      "lastModified": "2026-05-14T17:07:52.000Z"
-    },
-    {
-      "rank": 71,
+      "rank": 72,
       "id": "facebook/VGGT-Omega",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/VGGT-Omega",
       "downloads": 0,
-      "likes": 55,
+      "likes": 56,
       "trendingScore": 53,
       "pipelineTag": null,
       "libraryName": null,
@@ -2054,7 +2086,7 @@
       "lastModified": "2026-05-14T21:23:21.000Z"
     },
     {
-      "rank": 72,
+      "rank": 73,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2099,7 +2131,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 73,
+      "rank": 74,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2126,7 +2158,7 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 74,
+      "rank": 75,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2154,7 +2186,34 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 75,
+      "rank": 76,
+      "id": "Lakonik/AsymFLUX.2-klein-9B",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
+      "downloads": 1803,
+      "likes": 50,
+      "trendingScore": 50,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "flow-matching",
+        "pixel-diffusion",
+        "pixel-generation",
+        "flux2",
+        "text-to-image",
+        "arxiv:2605.12964",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T20:19:24.000Z",
+      "lastModified": "2026-05-14T02:37:15.000Z"
+    },
+    {
+      "rank": 77,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2188,34 +2247,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 76,
-      "id": "Lakonik/AsymFLUX.2-klein-9B",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
-      "downloads": 1608,
-      "likes": 49,
-      "trendingScore": 49,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "flow-matching",
-        "pixel-diffusion",
-        "pixel-generation",
-        "flux2",
-        "text-to-image",
-        "arxiv:2605.12964",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T20:19:24.000Z",
-      "lastModified": "2026-05-14T02:37:15.000Z"
-    },
-    {
-      "rank": 77,
+      "rank": 78,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2245,7 +2277,7 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 78,
+      "rank": 79,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -2276,7 +2308,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 79,
+      "rank": 80,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -2301,11 +2333,11 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 80,
+      "rank": 81,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
-      "downloads": 247,
+      "downloads": 261,
       "likes": 49,
       "trendingScore": 47,
       "pipelineTag": "text-to-image",
@@ -2321,7 +2353,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 81,
+      "rank": 82,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -2358,12 +2390,12 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 82,
+      "rank": 83,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
-      "downloads": 28917,
-      "likes": 52,
+      "downloads": 29883,
+      "likes": 53,
       "trendingScore": 47,
       "pipelineTag": "feature-extraction",
       "libraryName": "transformers",
@@ -2395,7 +2427,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 83,
+      "rank": 84,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -2423,7 +2455,7 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 84,
+      "rank": 85,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -2446,7 +2478,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 85,
+      "rank": 86,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -2479,7 +2511,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -2510,7 +2542,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -2526,13 +2558,13 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 88,
+      "rank": 89,
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "downloads": 495,
-      "likes": 41,
-      "trendingScore": 41,
+      "downloads": 618,
+      "likes": 42,
+      "trendingScore": 42,
       "pipelineTag": "image-text-to-image",
       "libraryName": "transformers",
       "tags": [
@@ -2550,7 +2582,7 @@
       "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 89,
+      "rank": 90,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -2567,36 +2599,6 @@
       ],
       "createdAt": "2026-05-05T23:12:08.000Z",
       "lastModified": "2026-05-08T23:21:12.000Z"
-    },
-    {
-      "rank": 90,
-      "id": "sapientinc/HRM-Text-1B",
-      "author": "sapientinc",
-      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 57,
-      "likes": 39,
-      "trendingScore": 39,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hrm_text",
-        "text-generation",
-        "hrm",
-        "hierarchical-reasoning",
-        "prefix-lm",
-        "pre-alignment",
-        "non-chat",
-        "non-instruction-tuned",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T15:13:02.000Z",
-      "lastModified": "2026-05-18T07:57:35.000Z"
     },
     {
       "rank": 91,
@@ -2654,6 +2656,39 @@
     },
     {
       "rank": 93,
+      "id": "Alissonerdx/BFS-Best-Face-Swap",
+      "author": "Alissonerdx",
+      "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+      "downloads": 94621,
+      "likes": 552,
+      "trendingScore": 36,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "qwen-image-edit",
+        "face-swap",
+        "head-swap",
+        "image-editing",
+        "ai-generated",
+        "comfyui",
+        "bfs",
+        "flux 2",
+        "flux",
+        "klein",
+        "image-to-image",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T09:50:28.000Z",
+      "lastModified": "2026-03-08T12:54:54.000Z"
+    },
+    {
+      "rank": 94,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -2685,7 +2720,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -2708,7 +2743,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 95,
+      "rank": 96,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -2734,7 +2769,7 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 96,
+      "rank": 97,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -2758,7 +2793,34 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 97,
+      "rank": 98,
+      "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
+      "downloads": 41558,
+      "likes": 36,
+      "trendingScore": 35,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-9B",
+        "base_model:quantized:Qwen/Qwen3.5-9B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T13:34:47.000Z",
+      "lastModified": "2026-05-16T12:39:00.000Z"
+    },
+    {
+      "rank": 99,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -2782,7 +2844,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 98,
+      "rank": 100,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -2799,7 +2861,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 99,
+      "rank": 101,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -2823,7 +2885,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 100,
+      "rank": 102,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -2849,7 +2911,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 101,
+      "rank": 103,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -2865,7 +2927,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 102,
+      "rank": 104,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -2892,7 +2954,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 103,
+      "rank": 105,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -2921,34 +2983,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 104,
-      "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
-      "downloads": 24211,
-      "likes": 35,
-      "trendingScore": 34,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-9B",
-        "base_model:quantized:Qwen/Qwen3.5-9B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T13:34:47.000Z",
-      "lastModified": "2026-05-16T12:39:00.000Z"
-    },
-    {
-      "rank": 105,
+      "rank": 106,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -2993,7 +3028,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 106,
+      "rank": 107,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -3038,7 +3073,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 107,
+      "rank": 108,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -3082,7 +3117,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 108,
+      "rank": 109,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3122,7 +3157,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 109,
+      "rank": 110,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3141,7 +3176,7 @@
       "lastModified": "2026-05-01T16:08:38.000Z"
     },
     {
-      "rank": 110,
+      "rank": 111,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -3185,7 +3220,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 111,
+      "rank": 112,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3210,7 +3245,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 112,
+      "rank": 113,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -3255,11 +3290,11 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 113,
+      "rank": 114,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
-      "downloads": 179,
+      "downloads": 188,
       "likes": 114,
       "trendingScore": 32,
       "pipelineTag": null,
@@ -3281,7 +3316,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 114,
+      "rank": 115,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -3314,7 +3349,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 115,
+      "rank": 116,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -3338,7 +3373,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -3365,7 +3400,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3396,7 +3431,7 @@
       "lastModified": "2026-05-07T19:24:05.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -3438,7 +3473,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 119,
+      "rank": 120,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -3466,7 +3501,35 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 120,
+      "rank": 121,
+      "id": "Datadog/Toto-2.0-2.5B",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
+      "downloads": 1691,
+      "likes": 36,
+      "trendingScore": 31,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-17T16:56:02.000Z",
+      "lastModified": "2026-05-14T14:23:46.000Z"
+    },
+    {
+      "rank": 122,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -3492,7 +3555,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 121,
+      "rank": 123,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -3524,7 +3587,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 122,
+      "rank": 124,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -3551,7 +3614,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 123,
+      "rank": 125,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -3585,40 +3648,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 124,
-      "id": "Alissonerdx/BFS-Best-Face-Swap",
-      "author": "Alissonerdx",
-      "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
-      "downloads": 93163,
-      "likes": 546,
-      "trendingScore": 30,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "qwen-image-edit",
-        "face-swap",
-        "head-swap",
-        "image-editing",
-        "ai-generated",
-        "comfyui",
-        "bfs",
-        "flux 2",
-        "flux",
-        "klein",
-        "image-to-image",
-        "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2025-11-07T09:50:28.000Z",
-      "lastModified": "2026-03-08T12:54:54.000Z"
-    },
-    {
-      "rank": 125,
+      "rank": 126,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -3649,7 +3679,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 126,
+      "rank": 127,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -3674,7 +3704,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 127,
+      "rank": 128,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -3697,7 +3727,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 128,
+      "rank": 129,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -3724,7 +3754,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 129,
+      "rank": 130,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -3753,34 +3783,6 @@
       ],
       "createdAt": "2026-05-09T01:03:31.000Z",
       "lastModified": "2026-05-10T01:13:14.000Z"
-    },
-    {
-      "rank": 130,
-      "id": "Datadog/Toto-2.0-2.5B",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
-      "downloads": 1372,
-      "likes": 34,
-      "trendingScore": 29,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T16:56:02.000Z",
-      "lastModified": "2026-05-14T14:23:46.000Z"
     },
     {
       "rank": 131,
@@ -3901,8 +3903,8 @@
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
-      "downloads": 4818342,
-      "likes": 5705,
+      "downloads": 4891216,
+      "likes": 5707,
       "trendingScore": 28,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
@@ -4130,7 +4132,7 @@
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
-      "downloads": 410,
+      "downloads": 450,
       "likes": 27,
       "trendingScore": 27,
       "pipelineTag": null,
@@ -4333,7 +4335,7 @@
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
-      "downloads": 982,
+      "downloads": 1361,
       "likes": 26,
       "trendingScore": 26,
       "pipelineTag": "sentence-similarity",
@@ -5080,8 +5082,8 @@
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
-      "downloads": 26601814,
-      "likes": 3011,
+      "downloads": 27202170,
+      "likes": 3013,
       "trendingScore": 23,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -5109,6 +5111,38 @@
     },
     {
       "rank": 177,
+      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "downloads": 14895,
+      "likes": 25,
+      "trendingScore": 23,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:11:26.000Z",
+      "lastModified": "2026-05-16T21:22:27.000Z"
+    },
+    {
+      "rank": 178,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -5139,7 +5173,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 178,
+      "rank": 179,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -5168,7 +5202,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 179,
+      "rank": 180,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -5213,7 +5247,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 180,
+      "rank": 181,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -5240,7 +5274,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 181,
+      "rank": 182,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5266,7 +5300,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 182,
+      "rank": 183,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -5290,7 +5324,62 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 183,
+      "rank": 184,
+      "id": "ByteDance-Seed/Cola-DLM",
+      "author": "ByteDance-Seed",
+      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
+      "downloads": 0,
+      "likes": 22,
+      "trendingScore": 22,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "text-generation",
+        "language-model",
+        "diffusion",
+        "latent-diffusion",
+        "flow-matching",
+        "text-vae",
+        "pytorch",
+        "research",
+        "en",
+        "arxiv:2605.06548",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T07:55:26.000Z",
+      "lastModified": "2026-05-15T09:38:05.000Z"
+    },
+    {
+      "rank": 185,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 22,
+      "trendingScore": 22,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
+    },
+    {
+      "rank": 186,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -5335,11 +5424,11 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 184,
+      "rank": 187,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
-      "downloads": 1134317,
+      "downloads": 1107944,
       "likes": 430,
       "trendingScore": 21,
       "pipelineTag": "image-text-to-text",
@@ -5363,7 +5452,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 185,
+      "rank": 188,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -5390,7 +5479,7 @@
       "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 186,
+      "rank": 189,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -5426,69 +5515,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 187,
-      "id": "ByteDance-Seed/Cola-DLM",
-      "author": "ByteDance-Seed",
-      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
-      "downloads": 0,
-      "likes": 21,
-      "trendingScore": 21,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "text-generation",
-        "language-model",
-        "diffusion",
-        "latent-diffusion",
-        "flow-matching",
-        "text-vae",
-        "pytorch",
-        "research",
-        "en",
-        "arxiv:2605.06548",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T07:55:26.000Z",
-      "lastModified": "2026-05-15T09:38:05.000Z"
-    },
-    {
-      "rank": 188,
-      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 12526,
-      "likes": 23,
-      "trendingScore": 21,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:11:26.000Z",
-      "lastModified": "2026-05-16T21:22:27.000Z"
-    },
-    {
-      "rank": 189,
+      "rank": 190,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -5516,7 +5543,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 190,
+      "rank": 191,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -5549,7 +5576,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 191,
+      "rank": 192,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -5574,7 +5601,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 192,
+      "rank": 193,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -5611,7 +5638,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 193,
+      "rank": 194,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -5654,7 +5681,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -5678,7 +5705,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 195,
+      "rank": 196,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -5702,7 +5729,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5734,7 +5761,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -5763,7 +5790,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 198,
+      "rank": 199,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -5794,11 +5821,11 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 199,
+      "rank": 200,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
-      "downloads": 36700,
+      "downloads": 49730,
       "likes": 20,
       "trendingScore": 20,
       "pipelineTag": "text-generation",
@@ -5826,7 +5853,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 200,
+      "rank": 201,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -5871,7 +5898,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 201,
+      "rank": 202,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -5904,7 +5931,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 202,
+      "rank": 203,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -5926,7 +5953,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 203,
+      "rank": 204,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -5953,7 +5980,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 204,
+      "rank": 205,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -5969,7 +5996,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 205,
+      "rank": 206,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -5986,7 +6013,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 206,
+      "rank": 207,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -6009,7 +6036,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 207,
+      "rank": 208,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -6034,7 +6061,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 208,
+      "rank": 209,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -6070,7 +6097,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 209,
+      "rank": 210,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -6099,7 +6126,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 210,
+      "rank": 211,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -6129,7 +6156,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 211,
+      "rank": 212,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -6147,11 +6174,11 @@
       "lastModified": "2026-05-15T10:14:24.000Z"
     },
     {
-      "rank": 212,
+      "rank": 213,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
-      "downloads": 139,
+      "downloads": 202,
       "likes": 22,
       "trendingScore": 19,
       "pipelineTag": "text-generation",
@@ -6192,7 +6219,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 213,
+      "rank": 214,
       "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
       "author": "fal",
       "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
@@ -6224,7 +6251,7 @@
       "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
-      "rank": 214,
+      "rank": 215,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -6269,7 +6296,96 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 215,
+      "rank": 216,
+      "id": "Qwen/Qwen3.5-4B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
+      "downloads": 7935232,
+      "likes": 549,
+      "trendingScore": 19,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.5-4B-Base",
+        "base_model:finetune:Qwen/Qwen3.5-4B-Base",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-02-27T14:45:03.000Z",
+      "lastModified": "2026-03-02T00:52:52.000Z"
+    },
+    {
+      "rank": 217,
+      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "downloads": 54,
+      "likes": 20,
+      "trendingScore": 19,
+      "pipelineTag": null,
+      "libraryName": "nemo",
+      "tags": [
+        "nemo",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T21:52:25.000Z",
+      "lastModified": "2026-05-16T05:35:07.000Z"
+    },
+    {
+      "rank": 218,
+      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "downloads": 2160,
+      "likes": 20,
+      "trendingScore": 19,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_5",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-18T05:48:32.000Z",
+      "lastModified": "2026-05-19T08:47:21.000Z"
+    },
+    {
+      "rank": 219,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -6291,7 +6407,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 216,
+      "rank": 220,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -6325,7 +6441,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 217,
+      "rank": 221,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -6349,7 +6465,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 218,
+      "rank": 222,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -6375,7 +6491,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 219,
+      "rank": 223,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -6397,7 +6513,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 220,
+      "rank": 224,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -6426,7 +6542,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 221,
+      "rank": 225,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -6452,7 +6568,7 @@
       "lastModified": "2026-05-11T14:29:36.000Z"
     },
     {
-      "rank": 222,
+      "rank": 226,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -6469,7 +6585,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 223,
+      "rank": 227,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -6498,11 +6614,11 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 224,
+      "rank": 228,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
-      "downloads": 1730,
+      "downloads": 2786,
       "likes": 18,
       "trendingScore": 18,
       "pipelineTag": "token-classification",
@@ -6536,7 +6652,76 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 225,
+      "rank": 229,
+      "id": "facebook/sam3.1",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3.1",
+      "downloads": 294517,
+      "likes": 265,
+      "trendingScore": 18,
+      "pipelineTag": "mask-generation",
+      "libraryName": "checkpoint",
+      "tags": [
+        "checkpoint",
+        "sam3_video",
+        "sam3.1",
+        "mask-generation",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T01:25:54.000Z",
+      "lastModified": "2026-03-27T17:40:55.000Z"
+    },
+    {
+      "rank": 230,
+      "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
+      "author": "BigDannyPt",
+      "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
+      "downloads": 36366,
+      "likes": 84,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-11-02T10:51:30.000Z",
+      "lastModified": "2026-03-30T16:27:22.000Z"
+    },
+    {
+      "rank": 231,
+      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "author": "sensenova",
+      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "downloads": 396,
+      "likes": 25,
+      "trendingScore": 18,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "neo_chat",
+        "feature-extraction",
+        "multimodal",
+        "text-to-image",
+        "image-to-text",
+        "image-editing",
+        "interleaved-generation",
+        "custom_code",
+        "any-to-any",
+        "arxiv:2502.01522",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T09:54:29.000Z",
+      "lastModified": "2026-05-16T06:48:11.000Z"
+    },
+    {
+      "rank": 232,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -6581,7 +6766,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 226,
+      "rank": 233,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -6610,7 +6795,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 227,
+      "rank": 234,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -6639,12 +6824,12 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 228,
+      "rank": 235,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
-      "downloads": 294512,
-      "likes": 383,
+      "downloads": 270765,
+      "likes": 400,
       "trendingScore": 17,
       "pipelineTag": "image-to-video",
       "libraryName": "ggml",
@@ -6684,7 +6869,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 229,
+      "rank": 236,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -6716,7 +6901,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 230,
+      "rank": 237,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -6746,7 +6931,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 231,
+      "rank": 238,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6767,7 +6952,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 232,
+      "rank": 239,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -6796,7 +6981,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 233,
+      "rank": 240,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -6817,7 +7002,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 234,
+      "rank": 241,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -6862,7 +7047,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 235,
+      "rank": 242,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -6891,7 +7076,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 236,
+      "rank": 243,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -6919,29 +7104,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 237,
-      "id": "facebook/sam3.1",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 291552,
-      "likes": 263,
-      "trendingScore": 17,
-      "pipelineTag": "mask-generation",
-      "libraryName": "checkpoint",
-      "tags": [
-        "checkpoint",
-        "sam3_video",
-        "sam3.1",
-        "mask-generation",
-        "en",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T01:25:54.000Z",
-      "lastModified": "2026-03-27T17:40:55.000Z"
-    },
-    {
-      "rank": 238,
+      "rank": 244,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -6966,7 +7129,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 239,
+      "rank": 245,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -6989,34 +7152,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 240,
-      "id": "Qwen/Qwen3.5-4B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
-      "downloads": 7771076,
-      "likes": 547,
-      "trendingScore": 17,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.5-4B-Base",
-        "base_model:finetune:Qwen/Qwen3.5-4B-Base",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-02-27T14:45:03.000Z",
-      "lastModified": "2026-03-02T00:52:52.000Z"
-    },
-    {
-      "rank": 241,
+      "rank": 246,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -7043,7 +7179,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 242,
+      "rank": 247,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -7069,29 +7205,11 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 243,
-      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "downloads": 34,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": null,
-      "libraryName": "nemo",
-      "tags": [
-        "nemo",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T21:52:25.000Z",
-      "lastModified": "2026-05-16T05:35:07.000Z"
-    },
-    {
-      "rank": 244,
+      "rank": 248,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
-      "downloads": 12477,
+      "downloads": 16335,
       "likes": 17,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
@@ -7114,32 +7232,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 245,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-18T13:52:59.000Z"
-    },
-    {
-      "rank": 246,
+      "rank": 249,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -7164,7 +7257,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 247,
+      "rank": 250,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -7199,7 +7292,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 248,
+      "rank": 251,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -7244,7 +7337,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 249,
+      "rank": 252,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -7271,7 +7364,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 250,
+      "rank": 253,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -7300,7 +7393,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 251,
+      "rank": 254,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -7323,7 +7416,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 252,
+      "rank": 255,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -7367,7 +7460,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 253,
+      "rank": 256,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -7412,7 +7505,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 254,
+      "rank": 257,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -7430,7 +7523,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 255,
+      "rank": 258,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -7475,29 +7568,11 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 256,
-      "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
-      "author": "BigDannyPt",
-      "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
-      "downloads": 36160,
-      "likes": 82,
-      "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-11-02T10:51:30.000Z",
-      "lastModified": "2026-03-30T16:27:22.000Z"
-    },
-    {
-      "rank": 257,
+      "rank": 259,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
-      "downloads": 1305,
+      "downloads": 1341,
       "likes": 16,
       "trendingScore": 16,
       "pipelineTag": "image-text-to-text",
@@ -7516,14 +7591,14 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T03:51:55.000Z",
-      "lastModified": "2026-05-18T08:01:35.000Z"
+      "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 258,
+      "rank": 260,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
-      "downloads": 2709,
+      "downloads": 2789,
       "likes": 17,
       "trendingScore": 16,
       "pipelineTag": "time-series-forecasting",
@@ -7547,7 +7622,7 @@
       "lastModified": "2026-05-14T14:23:31.000Z"
     },
     {
-      "rank": 259,
+      "rank": 261,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -7565,11 +7640,11 @@
       "lastModified": "2026-05-17T17:24:14.000Z"
     },
     {
-      "rank": 260,
+      "rank": 262,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-      "downloads": 24,
+      "downloads": 61,
       "likes": 17,
       "trendingScore": 16,
       "pipelineTag": "image-text-to-text",
@@ -7610,49 +7685,45 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 261,
-      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "downloads": 0,
-      "likes": 16,
+      "rank": 263,
+      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
+      "downloads": 17503,
+      "likes": 85,
       "trendingScore": 16,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_5",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "coder",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
         "text-generation",
+        "reasoning",
+        "distillation",
+        "chain-of-thought",
+        "qwen",
+        "qwen3.6",
+        "mixture-of-experts",
+        "moe",
+        "lora",
+        "unsloth",
+        "abliterated",
+        "uncensored",
+        "conversational",
         "en",
-        "zh",
-        "ko",
-        "ru",
-        "ja",
-        "es",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "base_model:adapter:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "region:us"
       ],
-      "createdAt": "2026-05-18T05:48:32.000Z",
-      "lastModified": "2026-05-18T11:27:53.000Z"
+      "createdAt": "2026-04-21T09:07:29.000Z",
+      "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 262,
+      "rank": 264,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -7679,7 +7750,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 263,
+      "rank": 265,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -7724,7 +7795,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 264,
+      "rank": 266,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -7754,7 +7825,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 265,
+      "rank": 267,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7783,7 +7854,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 266,
+      "rank": 268,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -7813,7 +7884,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 267,
+      "rank": 269,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -7858,7 +7929,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 268,
+      "rank": 270,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -7893,7 +7964,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 269,
+      "rank": 271,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -7921,7 +7992,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 270,
+      "rank": 272,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -7950,7 +8021,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 271,
+      "rank": 273,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -7975,7 +8046,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 272,
+      "rank": 274,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -8003,7 +8074,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 273,
+      "rank": 275,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -8031,7 +8102,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 274,
+      "rank": 276,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -8062,7 +8133,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 275,
+      "rank": 277,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -8107,7 +8178,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 276,
+      "rank": 278,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -8139,7 +8210,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 277,
+      "rank": 279,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -8166,7 +8237,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 278,
+      "rank": 280,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -8189,7 +8260,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 279,
+      "rank": 281,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -8222,7 +8293,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 280,
+      "rank": 282,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -8249,12 +8320,12 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 281,
+      "rank": 283,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
-      "downloads": 8566608,
-      "likes": 3548,
+      "downloads": 8597894,
+      "likes": 3549,
       "trendingScore": 15,
       "pipelineTag": "text-to-speech",
       "libraryName": "coqui",
@@ -8268,7 +8339,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 282,
+      "rank": 284,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -8291,7 +8362,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 283,
+      "rank": 285,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -8317,11 +8388,11 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 284,
+      "rank": 286,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
-      "downloads": 652,
+      "downloads": 724,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -8349,7 +8420,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 285,
+      "rank": 287,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -8379,11 +8450,11 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 286,
+      "rank": 288,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
-      "downloads": 159,
+      "downloads": 212,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -8412,11 +8483,11 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 287,
+      "rank": 289,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
-      "downloads": 5537949,
+      "downloads": 5500897,
       "likes": 2321,
       "trendingScore": 15,
       "pipelineTag": null,
@@ -8432,11 +8503,11 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 288,
+      "rank": 290,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
-      "downloads": 85,
+      "downloads": 90,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "text-to-video",
@@ -8455,49 +8526,11 @@
       "lastModified": "2026-05-13T21:37:14.000Z"
     },
     {
-      "rank": 289,
-      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
-      "downloads": 16122,
-      "likes": 84,
-      "trendingScore": 15,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "text-generation",
-        "reasoning",
-        "distillation",
-        "chain-of-thought",
-        "qwen",
-        "qwen3.6",
-        "mixture-of-experts",
-        "moe",
-        "lora",
-        "unsloth",
-        "abliterated",
-        "uncensored",
-        "conversational",
-        "en",
-        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "base_model:adapter:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-21T09:07:29.000Z",
-      "lastModified": "2026-04-21T14:40:49.000Z"
-    },
-    {
-      "rank": 290,
+      "rank": 291,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
-      "downloads": 216,
+      "downloads": 265,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -8524,11 +8557,11 @@
       "lastModified": "2026-05-16T08:42:52.000Z"
     },
     {
-      "rank": 291,
+      "rank": 292,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
-      "downloads": 434,
+      "downloads": 466,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "image-to-video",
@@ -8551,11 +8584,11 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 292,
+      "rank": 293,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
-      "downloads": 1535,
+      "downloads": 1720,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -8580,7 +8613,63 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 293,
+      "rank": 294,
+      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "downloads": 19598,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-122B-A10B",
+        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T19:03:18.000Z",
+      "lastModified": "2026-05-18T03:29:50.000Z"
+    },
+    {
+      "rank": 295,
+      "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
+      "author": "perplexity-ai",
+      "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
+      "downloads": 4865,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "kernels",
+      "tags": [
+        "kernels",
+        "safetensors",
+        "bidirectional_pplx_qwen3",
+        "feature-extraction",
+        "custom_code",
+        "late-interaction",
+        "maxsim",
+        "pylate",
+        "base_model:perplexity-ai/pplx-embed-v1-0.6b",
+        "arxiv:2602.11151",
+        "base_model:finetune:perplexity-ai/pplx-embed-v1-0.6b",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-03-13T15:07:30.000Z",
+      "lastModified": "2026-05-18T17:03:49.000Z"
+    },
+    {
+      "rank": 296,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -8604,7 +8693,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 294,
+      "rank": 297,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -8631,7 +8720,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 295,
+      "rank": 298,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -8659,7 +8748,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 296,
+      "rank": 299,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -8687,7 +8776,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 297,
+      "rank": 300,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -8706,7 +8795,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 298,
+      "rank": 301,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -8738,7 +8827,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 299,
+      "rank": 302,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -8767,7 +8856,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 300,
+      "rank": 303,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -8794,7 +8883,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 301,
+      "rank": 304,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8818,7 +8907,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 302,
+      "rank": 305,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -8844,7 +8933,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 303,
+      "rank": 306,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -8875,7 +8964,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 304,
+      "rank": 307,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -8903,7 +8992,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 305,
+      "rank": 308,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -8926,7 +9015,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 306,
+      "rank": 309,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -8960,7 +9049,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 307,
+      "rank": 310,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -8986,7 +9075,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 308,
+      "rank": 311,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -9028,12 +9117,12 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 309,
+      "rank": 312,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
-      "downloads": 1538,
-      "likes": 14,
+      "downloads": 43424,
+      "likes": 25,
       "trendingScore": 14,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -9066,7 +9155,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 310,
+      "rank": 313,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -9085,7 +9174,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 311,
+      "rank": 314,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -9105,7 +9194,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 312,
+      "rank": 315,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -9132,7 +9221,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 313,
+      "rank": 316,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -9158,11 +9247,11 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 314,
+      "rank": 317,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
-      "downloads": 5063,
+      "downloads": 6278,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": null,
@@ -9188,36 +9277,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 315,
-      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "author": "sensenova",
-      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "downloads": 382,
-      "likes": 15,
-      "trendingScore": 14,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "neo_chat",
-        "feature-extraction",
-        "multimodal",
-        "text-to-image",
-        "image-to-text",
-        "image-editing",
-        "interleaved-generation",
-        "custom_code",
-        "any-to-any",
-        "arxiv:2502.01522",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T09:54:29.000Z",
-      "lastModified": "2026-05-16T06:48:11.000Z"
-    },
-    {
-      "rank": 316,
+      "rank": 318,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -9242,12 +9302,12 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 317,
+      "rank": 319,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 226607,
-      "likes": 181,
+      "downloads": 215966,
+      "likes": 182,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -9272,11 +9332,11 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
-      "downloads": 1439,
+      "downloads": 1523,
       "likes": 15,
       "trendingScore": 14,
       "pipelineTag": "time-series-forecasting",
@@ -9300,98 +9360,13 @@
       "lastModified": "2026-05-14T14:23:12.000Z"
     },
     {
-      "rank": 319,
-      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "downloads": 17011,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-122B-A10B",
-        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T19:03:18.000Z",
-      "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 320,
-      "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
-      "author": "perplexity-ai",
-      "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
-      "downloads": 4865,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "kernels",
-      "tags": [
-        "kernels",
-        "safetensors",
-        "bidirectional_pplx_qwen3",
-        "feature-extraction",
-        "custom_code",
-        "late-interaction",
-        "maxsim",
-        "pylate",
-        "base_model:perplexity-ai/pplx-embed-v1-0.6b",
-        "arxiv:2602.11151",
-        "base_model:finetune:perplexity-ai/pplx-embed-v1-0.6b",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-03-13T15:07:30.000Z",
-      "lastModified": "2026-05-18T17:03:49.000Z"
-    },
-    {
       "rank": 321,
-      "id": "amazon/chronos-2",
-      "author": "amazon",
-      "url": "https://huggingface.co/amazon/chronos-2",
-      "downloads": 15614579,
-      "likes": 284,
-      "trendingScore": 13,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": "chronos-forecasting",
-      "tags": [
-        "chronos-forecasting",
-        "safetensors",
-        "t5",
-        "time series",
-        "forecasting",
-        "foundation models",
-        "pretrained models",
-        "time-series-forecasting",
-        "dataset:autogluon/chronos_datasets",
-        "dataset:Salesforce/GiftEvalPretrain",
-        "arxiv:2403.07815",
-        "arxiv:2510.15821",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-10-30T14:54:39.000Z",
-      "lastModified": "2026-01-06T09:44:02.000Z"
-    },
-    {
-      "rank": 322,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
-      "downloads": 31655,
-      "likes": 1175,
-      "trendingScore": 13,
+      "downloads": 31572,
+      "likes": 1177,
+      "trendingScore": 14,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -9428,6 +9403,35 @@
       ],
       "createdAt": "2025-12-25T10:41:05.000Z",
       "lastModified": "2026-01-01T02:35:18.000Z"
+    },
+    {
+      "rank": 322,
+      "id": "amazon/chronos-2",
+      "author": "amazon",
+      "url": "https://huggingface.co/amazon/chronos-2",
+      "downloads": 15614579,
+      "likes": 284,
+      "trendingScore": 13,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": "chronos-forecasting",
+      "tags": [
+        "chronos-forecasting",
+        "safetensors",
+        "t5",
+        "time series",
+        "forecasting",
+        "foundation models",
+        "pretrained models",
+        "time-series-forecasting",
+        "dataset:autogluon/chronos_datasets",
+        "dataset:Salesforce/GiftEvalPretrain",
+        "arxiv:2403.07815",
+        "arxiv:2510.15821",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-10-30T14:54:39.000Z",
+      "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
       "rank": 323,
@@ -10218,6 +10222,56 @@
     },
     {
       "rank": 350,
+      "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
+      "author": "FrontiersMind",
+      "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
+      "downloads": 136,
+      "likes": 16,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nandi",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "en",
+        "hi",
+        "base_model:FrontiersMind/Nandi-Mini-150M",
+        "base_model:finetune:FrontiersMind/Nandi-Mini-150M",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T16:25:02.000Z",
+      "lastModified": "2026-05-18T17:32:55.000Z"
+    },
+    {
+      "rank": 351,
+      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "author": "vrgamedevgirl84",
+      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "downloads": 1893,
+      "likes": 16,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ltx-video",
+        "text-to-video",
+        "safetensors",
+        "base_model:Lightricks/LTX-Video",
+        "base_model:adapter:Lightricks/LTX-Video",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T00:29:34.000Z",
+      "lastModified": "2026-04-24T02:26:47.000Z"
+    },
+    {
+      "rank": 352,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10262,7 +10316,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 351,
+      "rank": 353,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -10289,7 +10343,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 352,
+      "rank": 354,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -10317,7 +10371,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 353,
+      "rank": 355,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -10350,7 +10404,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 354,
+      "rank": 356,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -10366,7 +10420,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 355,
+      "rank": 357,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -10389,7 +10443,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 356,
+      "rank": 358,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -10423,7 +10477,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 357,
+      "rank": 359,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -10443,7 +10497,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 358,
+      "rank": 360,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -10478,7 +10532,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 359,
+      "rank": 361,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -10508,7 +10562,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 360,
+      "rank": 362,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -10529,7 +10583,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 361,
+      "rank": 363,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -10558,7 +10612,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 362,
+      "rank": 364,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -10588,7 +10642,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 363,
+      "rank": 365,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -10616,7 +10670,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 364,
+      "rank": 366,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -10645,7 +10699,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 365,
+      "rank": 367,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -10677,7 +10731,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 366,
+      "rank": 368,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -10706,7 +10760,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 367,
+      "rank": 369,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -10741,7 +10795,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 368,
+      "rank": 370,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -10763,7 +10817,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 369,
+      "rank": 371,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -10801,7 +10855,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 370,
+      "rank": 372,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -10840,7 +10894,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 371,
+      "rank": 373,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -10877,7 +10931,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 372,
+      "rank": 374,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -10901,11 +10955,11 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 373,
+      "rank": 375,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
-      "downloads": 1641,
+      "downloads": 1916,
       "likes": 41,
       "trendingScore": 12,
       "pipelineTag": null,
@@ -10928,7 +10982,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 374,
+      "rank": 376,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -10946,7 +11000,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 375,
+      "rank": 377,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -10965,7 +11019,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 376,
+      "rank": 378,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -10993,38 +11047,11 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 377,
-      "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
-      "author": "FrontiersMind",
-      "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
-      "downloads": 0,
-      "likes": 15,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nandi",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "en",
-        "hi",
-        "base_model:FrontiersMind/Nandi-Mini-150M",
-        "base_model:finetune:FrontiersMind/Nandi-Mini-150M",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T16:25:02.000Z",
-      "lastModified": "2026-05-18T17:32:55.000Z"
-    },
-    {
-      "rank": 378,
+      "rank": 379,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
-      "downloads": 36070,
+      "downloads": 36169,
       "likes": 627,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -11061,11 +11088,11 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 379,
+      "rank": 380,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
-      "downloads": 227418,
+      "downloads": 221885,
       "likes": 270,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -11083,7 +11110,165 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 380,
+      "rank": 381,
+      "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 661953,
+      "likes": 1389,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.5",
+        "moe",
+        "vision",
+        "multimodal",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "multilingual",
+        "base_model:Qwen/Qwen3.5-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.5-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-03-10T19:36:57.000Z",
+      "lastModified": "2026-04-05T19:00:54.000Z"
+    },
+    {
+      "rank": 382,
+      "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+      "author": "OsaurusAI",
+      "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+      "downloads": 5987,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "deepseek_v4",
+        "jang",
+        "jangtq",
+        "jangtq2",
+        "jangtq-prestack",
+        "mxtq",
+        "deepseek",
+        "deepseek-v4",
+        "deepseek-v4-flash",
+        "moe",
+        "mla",
+        "hash-layers",
+        "mtp",
+        "apple-silicon",
+        "osaurus",
+        "text-generation",
+        "base_model:deepseek-ai/DeepSeek-V4-Flash",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T13:08:35.000Z",
+      "lastModified": "2026-05-12T13:09:29.000Z"
+    },
+    {
+      "rank": 383,
+      "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
+      "downloads": 4549,
+      "likes": 15,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.5",
+        "reasoning",
+        "chain-of-thought",
+        "evolutionary-merge",
+        "darwin",
+        "base_model:FINAL-Bench/Darwin-36B-Opus",
+        "base_model:quantized:FINAL-Bench/Darwin-36B-Opus",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T09:29:30.000Z",
+      "lastModified": "2026-05-15T12:12:22.000Z"
+    },
+    {
+      "rank": 384,
+      "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
+      "author": "treadon",
+      "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
+      "downloads": 4918,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "minicpmv4_6",
+        "image-text-to-text",
+        "abliteration",
+        "disinhibition",
+        "minicpm-v",
+        "mechanistic-interpretability",
+        "conversational",
+        "base_model:openbmb/MiniCPM-V-4.6",
+        "base_model:quantized:openbmb/MiniCPM-V-4.6",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T21:34:24.000Z",
+      "lastModified": "2026-05-12T02:18:15.000Z"
+    },
+    {
+      "rank": 385,
+      "id": "Datadog/Toto-2.0-1B",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
+      "downloads": 1076,
+      "likes": 14,
+      "trendingScore": 12,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T20:41:57.000Z",
+      "lastModified": "2026-05-14T14:23:39.000Z"
+    },
+    {
+      "rank": 386,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -11128,7 +11313,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 381,
+      "rank": 387,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -11170,7 +11355,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 382,
+      "rank": 388,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -11196,7 +11381,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 383,
+      "rank": 389,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -11221,7 +11406,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 384,
+      "rank": 390,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -11238,7 +11423,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 385,
+      "rank": 391,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -11266,7 +11451,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 386,
+      "rank": 392,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -11292,7 +11477,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 387,
+      "rank": 393,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -11319,7 +11504,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 388,
+      "rank": 394,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -11347,7 +11532,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 389,
+      "rank": 395,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -11380,7 +11565,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 390,
+      "rank": 396,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -11414,7 +11599,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 391,
+      "rank": 397,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -11443,7 +11628,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 392,
+      "rank": 398,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -11472,7 +11657,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 393,
+      "rank": 399,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -11505,7 +11690,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 394,
+      "rank": 400,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -11532,7 +11717,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 395,
+      "rank": 401,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -11562,7 +11747,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 396,
+      "rank": 402,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11585,7 +11770,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 397,
+      "rank": 403,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -11611,7 +11796,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 398,
+      "rank": 404,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -11635,7 +11820,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 399,
+      "rank": 405,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -11662,7 +11847,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 400,
+      "rank": 406,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -11692,7 +11877,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 401,
+      "rank": 407,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -11726,7 +11911,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 402,
+      "rank": 408,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -11742,7 +11927,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 403,
+      "rank": 409,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -11773,7 +11958,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 404,
+      "rank": 410,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -11795,7 +11980,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 405,
+      "rank": 411,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -11815,7 +12000,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 406,
+      "rank": 412,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -11837,38 +12022,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 407,
-      "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 738481,
-      "likes": 1388,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.5",
-        "moe",
-        "vision",
-        "multimodal",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "multilingual",
-        "base_model:Qwen/Qwen3.5-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.5-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-10T19:36:57.000Z",
-      "lastModified": "2026-04-05T19:00:54.000Z"
-    },
-    {
-      "rank": 408,
+      "rank": 413,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -11897,44 +12051,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 409,
-      "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-      "author": "OsaurusAI",
-      "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-      "downloads": 5454,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "deepseek_v4",
-        "jang",
-        "jangtq",
-        "jangtq2",
-        "jangtq-prestack",
-        "mxtq",
-        "deepseek",
-        "deepseek-v4",
-        "deepseek-v4-flash",
-        "moe",
-        "mla",
-        "hash-layers",
-        "mtp",
-        "apple-silicon",
-        "osaurus",
-        "text-generation",
-        "base_model:deepseek-ai/DeepSeek-V4-Flash",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T13:08:35.000Z",
-      "lastModified": "2026-05-12T13:09:29.000Z"
-    },
-    {
-      "rank": 410,
+      "rank": 414,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -11959,7 +12076,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 411,
+      "rank": 415,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -11984,7 +12101,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 412,
+      "rank": 416,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -12019,11 +12136,11 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 413,
+      "rank": 417,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
-      "downloads": 6707,
+      "downloads": 8867,
       "likes": 51,
       "trendingScore": 11,
       "pipelineTag": "text-to-image",
@@ -12043,11 +12160,11 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 414,
+      "rank": 418,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
-      "downloads": 3550364,
+      "downloads": 3588521,
       "likes": 472,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -12071,7 +12188,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 415,
+      "rank": 419,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -12102,74 +12219,12 @@
       "lastModified": "2026-05-13T08:04:57.000Z"
     },
     {
-      "rank": 416,
-      "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
-      "downloads": 4262,
-      "likes": 13,
-      "trendingScore": 11,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "evolutionary-merge",
-        "darwin",
-        "base_model:FINAL-Bench/Darwin-36B-Opus",
-        "base_model:quantized:FINAL-Bench/Darwin-36B-Opus",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T09:29:30.000Z",
-      "lastModified": "2026-05-15T12:12:22.000Z"
-    },
-    {
-      "rank": 417,
-      "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
-      "author": "treadon",
-      "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
-      "downloads": 4425,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "minicpmv4_6",
-        "image-text-to-text",
-        "abliteration",
-        "disinhibition",
-        "minicpm-v",
-        "mechanistic-interpretability",
-        "conversational",
-        "base_model:openbmb/MiniCPM-V-4.6",
-        "base_model:quantized:openbmb/MiniCPM-V-4.6",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T21:34:24.000Z",
-      "lastModified": "2026-05-12T02:18:15.000Z"
-    },
-    {
-      "rank": 418,
+      "rank": 420,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
-      "downloads": 149996,
-      "likes": 474,
+      "downloads": 148442,
+      "likes": 476,
       "trendingScore": 11,
       "pipelineTag": "image-to-image",
       "libraryName": null,
@@ -12191,11 +12246,11 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 419,
+      "rank": 421,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 176644,
+      "downloads": 173171,
       "likes": 342,
       "trendingScore": 11,
       "pipelineTag": null,
@@ -12217,7 +12272,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 420,
+      "rank": 422,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -12247,35 +12302,73 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 421,
-      "id": "Datadog/Toto-2.0-1B",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
-      "downloads": 1038,
-      "likes": 13,
+      "rank": 423,
+      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "downloads": 9719,
+      "likes": 11,
       "trendingScore": 11,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "gemma4",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "creative writing",
+        "translation",
+        "visual novels",
+        "finetune",
+        "roleplay",
+        "rp",
+        "image-text-to-text",
+        "en",
+        "ja",
+        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
         "license:apache-2.0",
-        "model-index",
-        "region:us"
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-04-14T20:41:57.000Z",
-      "lastModified": "2026-05-14T14:23:39.000Z"
+      "createdAt": "2026-05-13T06:59:32.000Z",
+      "lastModified": "2026-05-18T20:11:08.000Z"
     },
     {
-      "rank": 422,
+      "rank": 424,
+      "id": "Abiray/ZAYA1-8B-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
+      "downloads": 2728,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "text-generation",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "zaya",
+        "moe",
+        "zyphra",
+        "text-generation",
+        "reasoning",
+        "base_model:Zyphra/ZAYA1-8B",
+        "base_model:quantized:Zyphra/ZAYA1-8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T13:23:12.000Z",
+      "lastModified": "2026-05-16T14:23:36.000Z"
+    },
+    {
+      "rank": 425,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -12304,7 +12397,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 423,
+      "rank": 426,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -12338,7 +12431,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 424,
+      "rank": 427,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -12383,7 +12476,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 425,
+      "rank": 428,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -12412,7 +12505,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -12437,7 +12530,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -12472,7 +12565,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -12499,7 +12592,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -12544,7 +12637,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -12566,7 +12659,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 431,
+      "rank": 434,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -12598,7 +12691,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 432,
+      "rank": 435,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -12623,7 +12716,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 433,
+      "rank": 436,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -12647,7 +12740,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 434,
+      "rank": 437,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -12675,7 +12768,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 435,
+      "rank": 438,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -12718,7 +12811,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 436,
+      "rank": 439,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -12742,7 +12835,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 437,
+      "rank": 440,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -12787,7 +12880,7 @@
       "lastModified": "2026-04-07T16:23:12.000Z"
     },
     {
-      "rank": 438,
+      "rank": 441,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -12832,7 +12925,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 439,
+      "rank": 442,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -12861,7 +12954,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 440,
+      "rank": 443,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -12893,7 +12986,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 441,
+      "rank": 444,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -12917,7 +13010,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 442,
+      "rank": 445,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -12939,7 +13032,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 443,
+      "rank": 446,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -12964,7 +13057,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 444,
+      "rank": 447,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -12992,7 +13085,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 445,
+      "rank": 448,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -13016,7 +13109,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 446,
+      "rank": 449,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -13043,7 +13136,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 447,
+      "rank": 450,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -13068,7 +13161,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 448,
+      "rank": 451,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -13085,7 +13178,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 449,
+      "rank": 452,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -13109,7 +13202,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 450,
+      "rank": 453,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -13133,7 +13226,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 451,
+      "rank": 454,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -13166,7 +13259,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 452,
+      "rank": 455,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -13200,7 +13293,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 453,
+      "rank": 456,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -13222,7 +13315,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 454,
+      "rank": 457,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -13245,7 +13338,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 455,
+      "rank": 458,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -13265,7 +13358,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 456,
+      "rank": 459,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -13297,7 +13390,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 457,
+      "rank": 460,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -13336,7 +13429,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 458,
+      "rank": 461,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -13370,7 +13463,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 459,
+      "rank": 462,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -13394,7 +13487,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 460,
+      "rank": 463,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -13427,7 +13520,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 461,
+      "rank": 464,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -13447,7 +13540,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 462,
+      "rank": 465,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -13476,7 +13569,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 463,
+      "rank": 466,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -13498,7 +13591,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 464,
+      "rank": 467,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -13530,7 +13623,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 465,
+      "rank": 468,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -13557,7 +13650,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 466,
+      "rank": 469,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -13601,7 +13694,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 467,
+      "rank": 470,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -13619,7 +13712,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 468,
+      "rank": 471,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -13658,7 +13751,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 469,
+      "rank": 472,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -13697,11 +13790,11 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 470,
+      "rank": 473,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
-      "downloads": 697,
+      "downloads": 976,
       "likes": 11,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -13731,7 +13824,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 471,
+      "rank": 474,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -13759,7 +13852,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 472,
+      "rank": 475,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -13781,11 +13874,11 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 473,
+      "rank": 476,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
-      "downloads": 75,
+      "downloads": 81,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "text-to-video",
@@ -13809,11 +13902,11 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 474,
+      "rank": 477,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
-      "downloads": 2746492,
+      "downloads": 2748620,
       "likes": 690,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -13827,7 +13920,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 475,
+      "rank": 478,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -13855,11 +13948,11 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 476,
+      "rank": 479,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
-      "downloads": 5252488,
+      "downloads": 4569750,
       "likes": 1538,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -13886,11 +13979,11 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 477,
+      "rank": 480,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
-      "downloads": 623699,
+      "downloads": 632706,
       "likes": 252,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -13911,73 +14004,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 478,
-      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "downloads": 7214,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "gemma4",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "creative writing",
-        "translation",
-        "visual novels",
-        "finetune",
-        "roleplay",
-        "rp",
-        "image-text-to-text",
-        "en",
-        "ja",
-        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T06:59:32.000Z",
-      "lastModified": "2026-05-18T20:11:08.000Z"
-    },
-    {
-      "rank": 479,
-      "id": "Abiray/ZAYA1-8B-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
-      "downloads": 1720,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "zaya",
-        "moe",
-        "zyphra",
-        "text-generation",
-        "reasoning",
-        "base_model:Zyphra/ZAYA1-8B",
-        "base_model:quantized:Zyphra/ZAYA1-8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T13:23:12.000Z",
-      "lastModified": "2026-05-16T14:23:36.000Z"
-    },
-    {
-      "rank": 480,
+      "rank": 481,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -13993,11 +14020,11 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 481,
+      "rank": 482,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
-      "downloads": 0,
+      "downloads": 53,
       "likes": 13,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -14020,11 +14047,11 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 482,
+      "rank": 483,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
-      "downloads": 2786,
+      "downloads": 3029,
       "likes": 11,
       "trendingScore": 10,
       "pipelineTag": "time-series-forecasting",
@@ -14048,30 +14075,86 @@
       "lastModified": "2026-05-14T14:23:21.000Z"
     },
     {
-      "rank": 483,
-      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "author": "vrgamedevgirl84",
-      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "downloads": 1722,
-      "likes": 13,
+      "rank": 484,
+      "id": "zghhui/OmniNFT",
+      "author": "zghhui",
+      "url": "https://huggingface.co/zghhui/OmniNFT",
+      "downloads": 49,
+      "likes": 11,
       "trendingScore": 10,
-      "pipelineTag": "text-to-video",
+      "pipelineTag": "any-to-any",
+      "libraryName": "peft",
+      "tags": [
+        "peft",
+        "safetensors",
+        "lora",
+        "reinforcement-learning",
+        "GRPO",
+        "T2AV",
+        "any-to-any",
+        "arxiv:2605.12480",
+        "base_model:Lightricks/LTX-2",
+        "base_model:adapter:Lightricks/LTX-2",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T02:28:33.000Z",
+      "lastModified": "2026-05-19T03:47:56.000Z"
+    },
+    {
+      "rank": 485,
+      "id": "unsloth/FLUX.2-klein-9B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
+      "downloads": 91765,
+      "likes": 206,
+      "trendingScore": 10,
+      "pipelineTag": "image-to-image",
+      "libraryName": "ggml",
+      "tags": [
+        "ggml",
+        "gguf",
+        "image-generation",
+        "unsloth",
+        "image-editing",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "base_model:black-forest-labs/FLUX.2-klein-9B",
+        "base_model:quantized:black-forest-labs/FLUX.2-klein-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-01-15T17:15:23.000Z",
+      "lastModified": "2026-01-16T15:48:16.000Z"
+    },
+    {
+      "rank": 486,
+      "id": "Alissonerdx/EditAnything",
+      "author": "Alissonerdx",
+      "url": "https://huggingface.co/Alissonerdx/EditAnything",
+      "downloads": 727,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": null,
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
         "lora",
-        "ltx-video",
-        "text-to-video",
-        "safetensors",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
+        "video",
+        "video-editing",
+        "ltx-2.3",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-04-23T00:29:34.000Z",
-      "lastModified": "2026-04-24T02:26:47.000Z"
+      "createdAt": "2026-05-01T08:12:57.000Z",
+      "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 484,
+      "rank": 487,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -14098,7 +14181,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 485,
+      "rank": 488,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -14124,7 +14207,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 486,
+      "rank": 489,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -14152,7 +14235,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 487,
+      "rank": 490,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -14178,7 +14261,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 488,
+      "rank": 491,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -14222,7 +14305,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 489,
+      "rank": 492,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -14262,7 +14345,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 490,
+      "rank": 493,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -14298,7 +14381,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 491,
+      "rank": 494,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -14342,7 +14425,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 492,
+      "rank": 495,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -14367,7 +14450,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 493,
+      "rank": 496,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -14412,7 +14495,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 494,
+      "rank": 497,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -14431,7 +14514,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 495,
+      "rank": 498,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -14456,7 +14539,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 496,
+      "rank": 499,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -14495,7 +14578,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 497,
+      "rank": 500,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -14512,7 +14595,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 498,
+      "rank": 501,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -14540,7 +14623,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 499,
+      "rank": 502,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -14569,7 +14652,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 500,
+      "rank": 503,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -14594,7 +14677,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 501,
+      "rank": 504,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -14629,7 +14712,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 502,
+      "rank": 505,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -14659,7 +14742,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 503,
+      "rank": 506,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -14695,7 +14778,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 504,
+      "rank": 507,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -14718,7 +14801,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 505,
+      "rank": 508,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -14735,7 +14818,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 506,
+      "rank": 509,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -14755,7 +14838,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 507,
+      "rank": 510,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -14782,7 +14865,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 508,
+      "rank": 511,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -14806,7 +14889,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 509,
+      "rank": 512,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -14828,7 +14911,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 510,
+      "rank": 513,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -14860,7 +14943,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 511,
+      "rank": 514,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -14888,7 +14971,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 512,
+      "rank": 515,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -14906,7 +14989,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 513,
+      "rank": 516,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -14931,7 +15014,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 514,
+      "rank": 517,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -14954,7 +15037,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 515,
+      "rank": 518,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -14972,7 +15055,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 516,
+      "rank": 519,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -15007,7 +15090,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 517,
+      "rank": 520,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -15035,7 +15118,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 518,
+      "rank": 521,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -15057,7 +15140,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 519,
+      "rank": 522,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -15084,7 +15167,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 520,
+      "rank": 523,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -15109,7 +15192,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 521,
+      "rank": 524,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -15143,34 +15226,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 522,
-      "id": "zghhui/OmniNFT",
-      "author": "zghhui",
-      "url": "https://huggingface.co/zghhui/OmniNFT",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 9,
-      "pipelineTag": "any-to-any",
-      "libraryName": "peft",
-      "tags": [
-        "peft",
-        "safetensors",
-        "lora",
-        "reinforcement-learning",
-        "GRPO",
-        "T2AV",
-        "any-to-any",
-        "arxiv:2605.12480",
-        "base_model:Lightricks/LTX-2",
-        "base_model:adapter:Lightricks/LTX-2",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T02:28:33.000Z",
-      "lastModified": "2026-05-19T03:47:56.000Z"
-    },
-    {
-      "rank": 523,
+      "rank": 525,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -15197,7 +15253,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 524,
+      "rank": 526,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -15224,7 +15280,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 525,
+      "rank": 527,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -15265,7 +15321,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 526,
+      "rank": 528,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -15295,7 +15351,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 527,
+      "rank": 529,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -15332,7 +15388,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 528,
+      "rank": 530,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -15364,7 +15420,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 529,
+      "rank": 531,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -15406,7 +15462,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 530,
+      "rank": 532,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -15436,7 +15492,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 531,
+      "rank": 533,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -15481,7 +15537,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 532,
+      "rank": 534,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -15508,7 +15564,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 533,
+      "rank": 535,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -15534,7 +15590,7 @@
       "lastModified": "2026-05-11T14:57:26.000Z"
     },
     {
-      "rank": 534,
+      "rank": 536,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -15568,7 +15624,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 535,
+      "rank": 537,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -15598,7 +15654,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 536,
+      "rank": 538,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -15623,7 +15679,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 537,
+      "rank": 539,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -15652,11 +15708,11 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 538,
+      "rank": 540,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
-      "downloads": 1707896,
+      "downloads": 1668130,
       "likes": 2788,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -15679,11 +15735,11 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 539,
+      "rank": 541,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
-      "downloads": 79376,
+      "downloads": 79298,
       "likes": 2624,
       "trendingScore": 9,
       "pipelineTag": "image-to-image",
@@ -15705,7 +15761,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 540,
+      "rank": 542,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -15737,59 +15793,78 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 541,
-      "id": "unsloth/FLUX.2-klein-9B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
-      "downloads": 91217,
-      "likes": 205,
+      "rank": 543,
+      "id": "FINAL-Bench/Darwin-36B-Opus",
+      "author": "FINAL-Bench",
+      "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
+      "downloads": 3042,
+      "likes": 65,
       "trendingScore": 9,
-      "pipelineTag": "image-to-image",
-      "libraryName": "ggml",
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "ggml",
-        "gguf",
-        "image-generation",
-        "unsloth",
-        "image-editing",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe_text",
+        "text-generation",
+        "darwin",
+        "darwin-v7",
+        "evolutionary-merge",
+        "reasoning",
+        "advanced-reasoning",
+        "chain-of-thought",
+        "thinking",
+        "qwen3.6",
+        "qwen",
+        "moe",
+        "mixture-of-experts",
+        "claude-opus",
+        "distillation",
+        "multilingual",
+        "gpqa",
+        "benchmark",
+        "open-source",
+        "apache-2.0",
+        "hybrid-vigor",
+        "proto-agi",
+        "vidraft",
+        "eval-results",
+        "conversational",
         "en",
-        "base_model:black-forest-labs/FLUX.2-klein-9B",
-        "base_model:quantized:black-forest-labs/FLUX.2-klein-9B",
-        "license:other",
-        "region:us"
+        "zh",
+        "ko"
       ],
-      "createdAt": "2026-01-15T17:15:23.000Z",
-      "lastModified": "2026-01-16T15:48:16.000Z"
+      "createdAt": "2026-04-22T07:14:53.000Z",
+      "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 542,
-      "id": "Alissonerdx/EditAnything",
-      "author": "Alissonerdx",
-      "url": "https://huggingface.co/Alissonerdx/EditAnything",
-      "downloads": 107,
+      "rank": 544,
+      "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
+      "author": "noctrex",
+      "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
+      "downloads": 2876,
       "likes": 9,
       "trendingScore": 9,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
       "tags": [
-        "diffusers",
-        "lora",
-        "video",
-        "video-editing",
-        "ltx-2.3",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
+        "gguf",
+        "qwen",
+        "qwen3_5_moe",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Jackrong/Qwopus3.5-9B-Coder",
+        "base_model:quantized:Jackrong/Qwopus3.5-9B-Coder",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-01T08:12:57.000Z",
-      "lastModified": "2026-05-18T17:56:08.000Z"
+      "createdAt": "2026-05-16T19:52:39.000Z",
+      "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 543,
+      "rank": 545,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -15816,7 +15891,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 544,
+      "rank": 546,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -15840,7 +15915,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 545,
+      "rank": 547,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -15860,7 +15935,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 546,
+      "rank": 548,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -15887,7 +15962,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 547,
+      "rank": 549,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -15906,7 +15981,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 548,
+      "rank": 550,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -15940,7 +16015,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 549,
+      "rank": 551,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -15972,7 +16047,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 550,
+      "rank": 552,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -15994,7 +16069,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 551,
+      "rank": 553,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -16039,7 +16114,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 552,
+      "rank": 554,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -16058,7 +16133,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 553,
+      "rank": 555,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -16092,7 +16167,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 554,
+      "rank": 556,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -16120,7 +16195,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 555,
+      "rank": 557,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -16148,7 +16223,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 556,
+      "rank": 558,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -16171,7 +16246,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 557,
+      "rank": 559,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -16198,7 +16273,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 558,
+      "rank": 560,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -16243,7 +16318,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 559,
+      "rank": 561,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -16279,7 +16354,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 560,
+      "rank": 562,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -16319,7 +16394,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 561,
+      "rank": 563,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -16348,7 +16423,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 562,
+      "rank": 564,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -16376,7 +16451,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 563,
+      "rank": 565,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -16395,7 +16470,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 564,
+      "rank": 566,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -16414,7 +16489,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 565,
+      "rank": 567,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -16446,7 +16521,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 566,
+      "rank": 568,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -16473,7 +16548,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 567,
+      "rank": 569,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -16495,7 +16570,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 568,
+      "rank": 570,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -16513,7 +16588,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 569,
+      "rank": 571,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -16542,11 +16617,11 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 570,
+      "rank": 572,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
-      "downloads": 10694,
+      "downloads": 10384,
       "likes": 47,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -16587,7 +16662,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 571,
+      "rank": 573,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -16608,7 +16683,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 572,
+      "rank": 574,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -16636,7 +16711,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 573,
+      "rank": 575,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -16657,7 +16732,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 574,
+      "rank": 576,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -16693,7 +16768,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 575,
+      "rank": 577,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -16738,7 +16813,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 576,
+      "rank": 578,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -16764,7 +16839,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 577,
+      "rank": 579,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -16787,7 +16862,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 578,
+      "rank": 580,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -16812,7 +16887,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 579,
+      "rank": 581,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -16847,7 +16922,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 580,
+      "rank": 582,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -16892,7 +16967,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 581,
+      "rank": 583,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -16919,7 +16994,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 582,
+      "rank": 584,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -16948,7 +17023,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 583,
+      "rank": 585,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -16967,7 +17042,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 584,
+      "rank": 586,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -16988,7 +17063,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 585,
+      "rank": 587,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -17014,12 +17089,12 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 586,
+      "rank": 588,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
-      "downloads": 652984,
-      "likes": 840,
+      "downloads": 606448,
+      "likes": 843,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -17040,7 +17115,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 587,
+      "rank": 589,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -17077,7 +17152,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 588,
+      "rank": 590,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -17122,7 +17197,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 589,
+      "rank": 591,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -17147,7 +17222,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 590,
+      "rank": 592,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -17164,7 +17239,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 591,
+      "rank": 593,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -17191,7 +17266,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 592,
+      "rank": 594,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -17209,7 +17284,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 593,
+      "rank": 595,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -17234,7 +17309,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 594,
+      "rank": 596,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -17266,7 +17341,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 595,
+      "rank": 597,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -17287,7 +17362,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 596,
+      "rank": 598,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -17306,7 +17381,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 597,
+      "rank": 599,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -17337,7 +17412,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 598,
+      "rank": 600,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -17360,7 +17435,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 599,
+      "rank": 601,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -17398,7 +17473,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 600,
+      "rank": 602,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -17415,7 +17490,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 601,
+      "rank": 603,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -17443,11 +17518,11 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 602,
+      "rank": 604,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
-      "downloads": 8664,
+      "downloads": 10504,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -17470,52 +17545,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 603,
-      "id": "FINAL-Bench/Darwin-36B-Opus",
-      "author": "FINAL-Bench",
-      "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
-      "downloads": 2973,
-      "likes": 63,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe_text",
-        "text-generation",
-        "darwin",
-        "darwin-v7",
-        "evolutionary-merge",
-        "reasoning",
-        "advanced-reasoning",
-        "chain-of-thought",
-        "thinking",
-        "qwen3.6",
-        "qwen",
-        "moe",
-        "mixture-of-experts",
-        "claude-opus",
-        "distillation",
-        "multilingual",
-        "gpqa",
-        "benchmark",
-        "open-source",
-        "apache-2.0",
-        "hybrid-vigor",
-        "proto-agi",
-        "vidraft",
-        "eval-results",
-        "conversational",
-        "en",
-        "zh",
-        "ko"
-      ],
-      "createdAt": "2026-04-22T07:14:53.000Z",
-      "lastModified": "2026-05-15T04:06:39.000Z"
-    },
-    {
-      "rank": 604,
+      "rank": 605,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -17532,7 +17562,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 605,
+      "rank": 606,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -17568,11 +17598,11 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 606,
+      "rank": 607,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
-      "downloads": 42664,
+      "downloads": 42379,
       "likes": 32,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -17598,11 +17628,11 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 607,
+      "rank": 608,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
-      "downloads": 140,
+      "downloads": 233,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -17627,11 +17657,11 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 608,
+      "rank": 609,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
-      "downloads": 400,
+      "downloads": 823,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -17658,6 +17688,8 @@
         "ru",
         "ja",
         "dataset:lambda/hermes-agent-reasoning-traces",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
         "base_model:Jackrong/Qwopus3.5-9B-v3.5",
         "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
         "license:apache-2.0",
@@ -17665,40 +17697,14 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T08:15:06.000Z",
-      "lastModified": "2026-05-17T01:57:40.000Z"
-    },
-    {
-      "rank": 609,
-      "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
-      "author": "noctrex",
-      "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
-      "downloads": 2124,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen",
-        "qwen3_5_moe",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Jackrong/Qwopus3.5-9B-Coder",
-        "base_model:quantized:Jackrong/Qwopus3.5-9B-Coder",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:52:39.000Z",
-      "lastModified": "2026-05-17T12:48:32.000Z"
+      "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
       "rank": 610,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 7532787,
+      "downloads": 7743597,
       "likes": 1410,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -17736,7 +17742,7 @@
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 217198,
+      "downloads": 217037,
       "likes": 427,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -17801,6 +17807,141 @@
     },
     {
       "rank": 613,
+      "id": "Lightricks/LTX-Video",
+      "author": "Lightricks",
+      "url": "https://huggingface.co/Lightricks/LTX-Video",
+      "downloads": 400023,
+      "likes": 2183,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "ltx-video",
+        "image-to-video",
+        "en",
+        "license:other",
+        "diffusers:LTXPipeline",
+        "region:us"
+      ],
+      "createdAt": "2024-10-31T12:36:00.000Z",
+      "lastModified": "2025-07-16T14:32:35.000Z"
+    },
+    {
+      "rank": 614,
+      "id": "mistralai/Mistral-7B-Instruct-v0.2",
+      "author": "mistralai",
+      "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
+      "downloads": 3274617,
+      "likes": 3142,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "safetensors",
+        "mistral",
+        "text-generation",
+        "finetuned",
+        "mistral-common",
+        "conversational",
+        "arxiv:2310.06825",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "region:us",
+        "deploy:azure"
+      ],
+      "createdAt": "2023-12-11T13:18:44.000Z",
+      "lastModified": "2025-07-24T16:57:21.000Z"
+    },
+    {
+      "rank": 615,
+      "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
+      "author": "mlx-community",
+      "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
+      "downloads": 49457,
+      "likes": 197,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "qwen3_5",
+        "reasoning",
+        "distilled",
+        "qwen",
+        "qwen3.5",
+        "apple-silicon",
+        "chain-of-thought",
+        "claude-4.6-opus",
+        "mlx-community",
+        "en",
+        "zh",
+        "base_model:Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
+        "base_model:quantized:Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
+        "license:apache-2.0",
+        "4-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-03-04T02:02:20.000Z",
+      "lastModified": "2026-03-06T02:44:20.000Z"
+    },
+    {
+      "rank": 616,
+      "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "ggml-org",
+      "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 2114,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T11:20:53.000Z",
+      "lastModified": "2026-05-19T09:20:22.000Z"
+    },
+    {
+      "rank": 617,
+      "id": "Qwen/Qwen3-VL-Embedding-2B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
+      "downloads": 1697458,
+      "likes": 408,
+      "trendingScore": 8,
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "transformers",
+        "multimodal embedding",
+        "qwen",
+        "embedding",
+        "sentence-similarity",
+        "arxiv:2601.04720",
+        "base_model:Qwen/Qwen3-VL-2B-Instruct",
+        "base_model:finetune:Qwen/Qwen3-VL-2B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T03:03:25.000Z",
+      "lastModified": "2026-04-16T08:54:25.000Z"
+    },
+    {
+      "rank": 618,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -17826,7 +17967,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 614,
+      "rank": 619,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -17843,30 +17984,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 615,
-      "id": "Lightricks/LTX-Video",
-      "author": "Lightricks",
-      "url": "https://huggingface.co/Lightricks/LTX-Video",
-      "downloads": 395345,
-      "likes": 2171,
-      "trendingScore": 7,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "ltx-video",
-        "image-to-video",
-        "en",
-        "license:other",
-        "diffusers:LTXPipeline",
-        "region:us"
-      ],
-      "createdAt": "2024-10-31T12:36:00.000Z",
-      "lastModified": "2025-07-16T14:32:35.000Z"
-    },
-    {
-      "rank": 616,
+      "rank": 620,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -17894,7 +18012,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 617,
+      "rank": 621,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -17937,7 +18055,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 618,
+      "rank": 622,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -17972,7 +18090,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 619,
+      "rank": 623,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -17997,7 +18115,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 620,
+      "rank": 624,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -18027,7 +18145,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 621,
+      "rank": 625,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -18056,7 +18174,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 622,
+      "rank": 626,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -18083,7 +18201,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 623,
+      "rank": 627,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -18109,7 +18227,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 624,
+      "rank": 628,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -18140,7 +18258,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 625,
+      "rank": 629,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -18158,7 +18276,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 626,
+      "rank": 630,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -18187,7 +18305,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 627,
+      "rank": 631,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -18210,7 +18328,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 628,
+      "rank": 632,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -18255,7 +18373,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 629,
+      "rank": 633,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -18281,7 +18399,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 630,
+      "rank": 634,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -18309,7 +18427,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 631,
+      "rank": 635,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -18347,7 +18465,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 632,
+      "rank": 636,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -18374,7 +18492,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 633,
+      "rank": 637,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -18400,7 +18518,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 634,
+      "rank": 638,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -18418,7 +18536,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 635,
+      "rank": 639,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -18444,7 +18562,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 636,
+      "rank": 640,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -18468,7 +18586,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 637,
+      "rank": 641,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -18509,7 +18627,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 638,
+      "rank": 642,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -18526,7 +18644,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 639,
+      "rank": 643,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -18559,7 +18677,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 640,
+      "rank": 644,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -18593,7 +18711,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 641,
+      "rank": 645,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -18632,7 +18750,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 642,
+      "rank": 646,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -18662,7 +18780,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 643,
+      "rank": 647,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -18698,7 +18816,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 644,
+      "rank": 648,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -18724,7 +18842,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 645,
+      "rank": 649,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -18760,7 +18878,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 646,
+      "rank": 650,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -18790,7 +18908,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 647,
+      "rank": 651,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -18828,7 +18946,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 648,
+      "rank": 652,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -18863,7 +18981,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 649,
+      "rank": 653,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -18888,7 +19006,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 650,
+      "rank": 654,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -18905,7 +19023,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 651,
+      "rank": 655,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -18947,7 +19065,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 652,
+      "rank": 656,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -18977,7 +19095,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 653,
+      "rank": 657,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -19002,7 +19120,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 654,
+      "rank": 658,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -19030,7 +19148,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 655,
+      "rank": 659,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -19047,7 +19165,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 656,
+      "rank": 660,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -19074,7 +19192,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 657,
+      "rank": 661,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -19117,7 +19235,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 658,
+      "rank": 662,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -19157,7 +19275,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 659,
+      "rank": 663,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -19181,7 +19299,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 660,
+      "rank": 664,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -19210,7 +19328,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 661,
+      "rank": 665,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -19236,7 +19354,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 662,
+      "rank": 666,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -19264,7 +19382,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 663,
+      "rank": 667,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -19303,7 +19421,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 664,
+      "rank": 668,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -19327,7 +19445,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 665,
+      "rank": 669,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -19355,7 +19473,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 666,
+      "rank": 670,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -19387,7 +19505,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 667,
+      "rank": 671,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -19417,7 +19535,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 668,
+      "rank": 672,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -19446,7 +19564,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 669,
+      "rank": 673,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -19474,7 +19592,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 670,
+      "rank": 674,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -19498,7 +19616,7 @@
       "lastModified": "2026-04-23T03:18:40.000Z"
     },
     {
-      "rank": 671,
+      "rank": 675,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -19531,7 +19649,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 672,
+      "rank": 676,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -19560,7 +19678,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 673,
+      "rank": 677,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -19580,7 +19698,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 674,
+      "rank": 678,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -19609,7 +19727,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 675,
+      "rank": 679,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -19633,7 +19751,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 676,
+      "rank": 680,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -19663,7 +19781,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 677,
+      "rank": 681,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -19693,7 +19811,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 678,
+      "rank": 682,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -19711,7 +19829,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 679,
+      "rank": 683,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -19728,7 +19846,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 680,
+      "rank": 684,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -19764,7 +19882,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 681,
+      "rank": 685,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -19795,7 +19913,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 682,
+      "rank": 686,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -19834,7 +19952,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 683,
+      "rank": 687,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -19865,7 +19983,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 684,
+      "rank": 688,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -19898,7 +20016,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 685,
+      "rank": 689,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -19926,7 +20044,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 686,
+      "rank": 690,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -19951,7 +20069,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 687,
+      "rank": 691,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -19974,7 +20092,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 688,
+      "rank": 692,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -20002,7 +20120,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 689,
+      "rank": 693,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -20035,7 +20153,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 690,
+      "rank": 694,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -20065,7 +20183,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 691,
+      "rank": 695,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -20100,7 +20218,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 692,
+      "rank": 696,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -20132,7 +20250,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 693,
+      "rank": 697,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -20157,7 +20275,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 694,
+      "rank": 698,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -20180,7 +20298,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 695,
+      "rank": 699,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -20207,7 +20325,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 696,
+      "rank": 700,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -20230,11 +20348,11 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 697,
+      "rank": 701,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
-      "downloads": 133,
+      "downloads": 149,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -20255,7 +20373,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 698,
+      "rank": 702,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -20300,7 +20418,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 699,
+      "rank": 703,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -20332,11 +20450,11 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 700,
+      "rank": 704,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
-      "downloads": 157,
+      "downloads": 212,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -20359,7 +20477,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 701,
+      "rank": 705,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -20385,11 +20503,11 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 702,
+      "rank": 706,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
-      "downloads": 10632,
+      "downloads": 11528,
       "likes": 13,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -20415,11 +20533,11 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 703,
+      "rank": 707,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
-      "downloads": 156259,
+      "downloads": 159901,
       "likes": 76,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -20447,35 +20565,7 @@
       "lastModified": "2026-04-17T20:15:06.000Z"
     },
     {
-      "rank": 704,
-      "id": "mistralai/Mistral-7B-Instruct-v0.2",
-      "author": "mistralai",
-      "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
-      "downloads": 3268730,
-      "likes": 3141,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "safetensors",
-        "mistral",
-        "text-generation",
-        "finetuned",
-        "mistral-common",
-        "conversational",
-        "arxiv:2310.06825",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2023-12-11T13:18:44.000Z",
-      "lastModified": "2025-07-24T16:57:21.000Z"
-    },
-    {
-      "rank": 705,
+      "rank": 708,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -20504,7 +20594,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 706,
+      "rank": 709,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -20536,7 +20626,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 707,
+      "rank": 710,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -20566,11 +20656,11 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 708,
+      "rank": 711,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
-      "downloads": 43067,
+      "downloads": 44135,
       "likes": 1085,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -20583,11 +20673,11 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 709,
+      "rank": 712,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
-      "downloads": 813,
+      "downloads": 827,
       "likes": 80,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -20603,7 +20693,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 710,
+      "rank": 713,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -20642,7 +20732,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 711,
+      "rank": 714,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -20680,7 +20770,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 712,
+      "rank": 715,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -20708,11 +20798,11 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 713,
+      "rank": 716,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
-      "downloads": 3055,
+      "downloads": 3124,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
@@ -20733,11 +20823,11 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 714,
+      "rank": 717,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
-      "downloads": 24,
+      "downloads": 33,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -20778,11 +20868,11 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 715,
+      "rank": 718,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
-      "downloads": 3131,
+      "downloads": 3448,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -20814,7 +20904,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 716,
+      "rank": 719,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -20841,40 +20931,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 717,
-      "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
-      "author": "mlx-community",
-      "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
-      "downloads": 50929,
-      "likes": 196,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5",
-        "reasoning",
-        "distilled",
-        "qwen",
-        "qwen3.5",
-        "apple-silicon",
-        "chain-of-thought",
-        "claude-4.6-opus",
-        "mlx-community",
-        "en",
-        "zh",
-        "base_model:Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
-        "base_model:quantized:Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
-        "license:apache-2.0",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-03-04T02:02:20.000Z",
-      "lastModified": "2026-03-06T02:44:20.000Z"
-    },
-    {
-      "rank": 718,
+      "rank": 720,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -20898,11 +20955,11 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 719,
+      "rank": 721,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
-      "downloads": 69,
+      "downloads": 89,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-to-video",
@@ -20928,11 +20985,11 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 720,
+      "rank": 722,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
-      "downloads": 23079,
+      "downloads": 23311,
       "likes": 138,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -20955,11 +21012,11 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 721,
+      "rank": 723,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
-      "downloads": 90,
+      "downloads": 92,
       "likes": 51,
       "trendingScore": 7,
       "pipelineTag": "any-to-any",
@@ -20982,11 +21039,11 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 722,
+      "rank": 724,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
-      "downloads": 56,
+      "downloads": 98,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21015,11 +21072,11 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 723,
+      "rank": 725,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
-      "downloads": 1116,
+      "downloads": 1265,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -21045,14 +21102,14 @@
         "conversational"
       ],
       "createdAt": "2026-05-15T22:32:11.000Z",
-      "lastModified": "2026-05-17T20:41:40.000Z"
+      "lastModified": "2026-05-19T08:00:47.000Z"
     },
     {
-      "rank": 724,
+      "rank": 726,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
-      "downloads": 464,
+      "downloads": 543,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21077,7 +21134,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 725,
+      "rank": 727,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -21119,11 +21176,11 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 726,
+      "rank": 728,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
-      "downloads": 249,
+      "downloads": 300,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21148,32 +21205,11 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 727,
-      "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "ggml-org",
-      "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 1482,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T11:20:53.000Z",
-      "lastModified": "2026-05-15T12:55:24.000Z"
-    },
-    {
-      "rank": 728,
+      "rank": 729,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
-      "downloads": 0,
+      "downloads": 168,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21198,7 +21234,110 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 729,
+      "rank": 730,
+      "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
+      "author": "noctrex",
+      "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
+      "downloads": 1964,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen",
+        "qwen3_5_moe",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Jackrong/Qwopus3.6-27B-v1-preview",
+        "base_model:quantized:Jackrong/Qwopus3.6-27B-v1-preview",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T21:42:10.000Z",
+      "lastModified": "2026-05-17T16:25:53.000Z"
+    },
+    {
+      "rank": 731,
+      "id": "minishlab/potion-code-16M",
+      "author": "minishlab",
+      "url": "https://huggingface.co/minishlab/potion-code-16M",
+      "downloads": 6219,
+      "likes": 17,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": "model2vec",
+      "tags": [
+        "model2vec",
+        "safetensors",
+        "embeddings",
+        "code",
+        "retrieval",
+        "static-embeddings",
+        "dataset:minishlab/tokenlearn-cornstack-queries-coderankembed",
+        "dataset:minishlab/tokenlearn-cornstack-docs-coderankembed",
+        "dataset:nomic-ai/cornstack-python-v1",
+        "dataset:nomic-ai/cornstack-java-v1",
+        "dataset:nomic-ai/cornstack-php-v1",
+        "dataset:nomic-ai/cornstack-go-v1",
+        "dataset:nomic-ai/cornstack-javascript-v1",
+        "dataset:nomic-ai/cornstack-ruby-v1",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-02T14:21:30.000Z",
+      "lastModified": "2026-04-27T05:13:51.000Z"
+    },
+    {
+      "rank": 732,
+      "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
+      "author": "ggml-org",
+      "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
+      "downloads": 1679,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T11:20:11.000Z",
+      "lastModified": "2026-05-19T09:05:17.000Z"
+    },
+    {
+      "rank": 733,
+      "id": "Efficient-Large-Model/LongLive-2.0-5B",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
+      "downloads": 0,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "text-to-video",
+        "multi-shot",
+        "video-generation",
+        "diffusion",
+        "long-video",
+        "longlive2",
+        "arxiv:2605.18739",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:10:14.000Z",
+      "lastModified": "2026-05-19T02:54:48.000Z"
+    },
+    {
+      "rank": 734,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -21226,7 +21365,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 730,
+      "rank": 735,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -21265,7 +21404,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 731,
+      "rank": 736,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -21298,7 +21437,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 732,
+      "rank": 737,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -21327,7 +21466,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 733,
+      "rank": 738,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -21357,11 +21496,11 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 734,
+      "rank": 739,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
-      "downloads": 538114,
+      "downloads": 517986,
       "likes": 684,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -21402,7 +21541,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 735,
+      "rank": 740,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -21431,7 +21570,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 736,
+      "rank": 741,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -21476,11 +21615,11 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 737,
+      "rank": 742,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
-      "downloads": 1828232,
+      "downloads": 1832194,
       "likes": 101,
       "trendingScore": 6,
       "pipelineTag": "image-to-video",
@@ -21520,7 +21659,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 738,
+      "rank": 743,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -21546,7 +21685,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 739,
+      "rank": 744,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -21572,7 +21711,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 740,
+      "rank": 745,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -21604,7 +21743,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 741,
+      "rank": 746,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -21627,7 +21766,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 742,
+      "rank": 747,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -21670,7 +21809,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 743,
+      "rank": 748,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -21715,7 +21854,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 744,
+      "rank": 749,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -21760,7 +21899,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 745,
+      "rank": 750,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -21787,7 +21926,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 746,
+      "rank": 751,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -21814,7 +21953,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 747,
+      "rank": 752,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -21839,7 +21978,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 748,
+      "rank": 753,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -21878,7 +22017,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 749,
+      "rank": 754,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -21903,7 +22042,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 750,
+      "rank": 755,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -21931,7 +22070,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 751,
+      "rank": 756,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -21956,7 +22095,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 752,
+      "rank": 757,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -21972,7 +22111,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 753,
+      "rank": 758,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -21999,7 +22138,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 754,
+      "rank": 759,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -22031,7 +22170,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 755,
+      "rank": 760,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -22061,7 +22200,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 756,
+      "rank": 761,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -22093,7 +22232,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 757,
+      "rank": 762,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -22121,7 +22260,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 758,
+      "rank": 763,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -22147,7 +22286,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 759,
+      "rank": 764,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -22172,7 +22311,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 760,
+      "rank": 765,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -22201,7 +22340,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 761,
+      "rank": 766,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -22243,7 +22382,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 762,
+      "rank": 767,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -22270,7 +22409,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 763,
+      "rank": 768,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -22315,7 +22454,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 764,
+      "rank": 769,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -22341,7 +22480,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 765,
+      "rank": 770,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -22361,7 +22500,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 766,
+      "rank": 771,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -22388,7 +22527,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 767,
+      "rank": 772,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -22430,7 +22569,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 768,
+      "rank": 773,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -22457,7 +22596,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 769,
+      "rank": 774,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -22491,7 +22630,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 770,
+      "rank": 775,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -22520,7 +22659,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 771,
+      "rank": 776,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -22547,7 +22686,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 772,
+      "rank": 777,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -22574,7 +22713,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 773,
+      "rank": 778,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -22601,7 +22740,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 774,
+      "rank": 779,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -22629,7 +22768,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 775,
+      "rank": 780,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -22652,7 +22791,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 776,
+      "rank": 781,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -22683,7 +22822,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 777,
+      "rank": 782,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -22728,7 +22867,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 778,
+      "rank": 783,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -22750,7 +22889,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 779,
+      "rank": 784,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -22776,7 +22915,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 780,
+      "rank": 785,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -22802,7 +22941,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 781,
+      "rank": 786,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -22833,7 +22972,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 782,
+      "rank": 787,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -22856,7 +22995,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 783,
+      "rank": 788,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -22886,7 +23025,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 784,
+      "rank": 789,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -22918,7 +23057,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 785,
+      "rank": 790,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -22947,7 +23086,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 786,
+      "rank": 791,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -22979,7 +23118,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 787,
+      "rank": 792,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -23011,7 +23150,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 788,
+      "rank": 793,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -23042,7 +23181,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 789,
+      "rank": 794,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -23073,7 +23212,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 790,
+      "rank": 795,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -23096,7 +23235,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 791,
+      "rank": 796,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -23123,7 +23262,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 792,
+      "rank": 797,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -23168,7 +23307,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 793,
+      "rank": 798,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -23186,7 +23325,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 794,
+      "rank": 799,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -23209,7 +23348,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 795,
+      "rank": 800,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -23239,7 +23378,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 796,
+      "rank": 801,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -23278,7 +23417,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 797,
+      "rank": 802,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -23316,7 +23455,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 798,
+      "rank": 803,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -23361,7 +23500,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 799,
+      "rank": 804,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -23386,7 +23525,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 800,
+      "rank": 805,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -23420,7 +23559,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 801,
+      "rank": 806,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -23445,7 +23584,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 802,
+      "rank": 807,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -23478,7 +23617,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 803,
+      "rank": 808,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -23505,7 +23644,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 804,
+      "rank": 809,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -23535,7 +23674,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 805,
+      "rank": 810,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -23567,7 +23706,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 806,
+      "rank": 811,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -23600,7 +23739,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 807,
+      "rank": 812,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -23618,7 +23757,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 808,
+      "rank": 813,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -23641,7 +23780,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 809,
+      "rank": 814,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -23673,7 +23812,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 810,
+      "rank": 815,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -23718,7 +23857,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 811,
+      "rank": 816,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -23759,7 +23898,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 812,
+      "rank": 817,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -23798,7 +23937,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 813,
+      "rank": 818,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -23825,7 +23964,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 814,
+      "rank": 819,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -23862,7 +24001,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 815,
+      "rank": 820,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -23898,7 +24037,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 816,
+      "rank": 821,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -23916,7 +24055,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 817,
+      "rank": 822,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -23955,7 +24094,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 818,
+      "rank": 823,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -23984,7 +24123,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 819,
+      "rank": 824,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -24011,7 +24150,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 820,
+      "rank": 825,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -24038,11 +24177,11 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 821,
+      "rank": 826,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
-      "downloads": 21097,
+      "downloads": 20950,
       "likes": 37,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -24068,7 +24207,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 822,
+      "rank": 827,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -24095,7 +24234,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 823,
+      "rank": 828,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -24126,7 +24265,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 824,
+      "rank": 829,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -24144,7 +24283,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 825,
+      "rank": 830,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -24163,7 +24302,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 826,
+      "rank": 831,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -24190,7 +24329,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 827,
+      "rank": 832,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -24215,11 +24354,11 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 828,
+      "rank": 833,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
-      "downloads": 42,
+      "downloads": 57,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -24245,11 +24384,11 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 829,
+      "rank": 834,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
-      "downloads": 70,
+      "downloads": 183,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "translation",
@@ -24276,7 +24415,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 830,
+      "rank": 835,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -24298,11 +24437,11 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 831,
+      "rank": 836,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
-      "downloads": 4272,
+      "downloads": 4985,
       "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -24327,7 +24466,7 @@
       "lastModified": "2026-05-18T22:20:53.000Z"
     },
     {
-      "rank": 832,
+      "rank": 837,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -24348,12 +24487,12 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 833,
+      "rank": 838,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
-      "downloads": 30002,
-      "likes": 54,
+      "downloads": 29770,
+      "likes": 55,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -24381,10 +24520,10 @@
         "region:us"
       ],
       "createdAt": "2026-04-13T18:07:47.000Z",
-      "lastModified": "2026-04-22T14:03:41.000Z"
+      "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 834,
+      "rank": 839,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -24407,7 +24546,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 835,
+      "rank": 840,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -24452,7 +24591,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 836,
+      "rank": 841,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -24474,7 +24613,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 837,
+      "rank": 842,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -24504,11 +24643,11 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 838,
+      "rank": 843,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
-      "downloads": 58,
+      "downloads": 62,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -24531,7 +24670,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 839,
+      "rank": 844,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -24556,11 +24695,11 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 840,
+      "rank": 845,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
-      "downloads": 23244,
+      "downloads": 29106,
       "likes": 140,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -24589,12 +24728,12 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 841,
+      "rank": 846,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
-      "downloads": 1253501,
-      "likes": 155,
+      "downloads": 1264622,
+      "likes": 156,
       "trendingScore": 6,
       "pipelineTag": "time-series-forecasting",
       "libraryName": null,
@@ -24612,7 +24751,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 842,
+      "rank": 847,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -24632,7 +24771,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 843,
+      "rank": 848,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -24677,7 +24816,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 844,
+      "rank": 849,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -24698,11 +24837,11 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 845,
+      "rank": 850,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
-      "downloads": 243,
+      "downloads": 347,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -24731,7 +24870,7 @@
       "lastModified": "2026-05-18T05:10:11.000Z"
     },
     {
-      "rank": 846,
+      "rank": 851,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -24759,11 +24898,11 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 847,
+      "rank": 852,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
-      "downloads": 7273,
+      "downloads": 9409,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -24786,7 +24925,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 848,
+      "rank": 853,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -24831,7 +24970,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 849,
+      "rank": 854,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -24856,11 +24995,11 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 850,
+      "rank": 855,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
-      "downloads": 169340,
+      "downloads": 173234,
       "likes": 230,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -24874,11 +25013,11 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 851,
+      "rank": 856,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
-      "downloads": 44,
+      "downloads": 54,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -24902,11 +25041,11 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 852,
+      "rank": 857,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
-      "downloads": 10980,
+      "downloads": 13616,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -24930,33 +25069,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 853,
-      "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
-      "author": "noctrex",
-      "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
-      "downloads": 1543,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen",
-        "qwen3_5_moe",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Jackrong/Qwopus3.6-27B-v1-preview",
-        "base_model:quantized:Jackrong/Qwopus3.6-27B-v1-preview",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T21:42:10.000Z",
-      "lastModified": "2026-05-17T16:25:53.000Z"
-    },
-    {
-      "rank": 854,
+      "rank": 858,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -24981,11 +25094,11 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 855,
+      "rank": 859,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
-      "downloads": 87,
+      "downloads": 96,
       "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -25004,11 +25117,11 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 856,
+      "rank": 860,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
-      "downloads": 137974,
+      "downloads": 139905,
       "likes": 123,
       "trendingScore": 6,
       "pipelineTag": "text-classification",
@@ -25041,38 +25154,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 857,
-      "id": "minishlab/potion-code-16M",
-      "author": "minishlab",
-      "url": "https://huggingface.co/minishlab/potion-code-16M",
-      "downloads": 4383,
-      "likes": 16,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": "model2vec",
-      "tags": [
-        "model2vec",
-        "safetensors",
-        "embeddings",
-        "code",
-        "retrieval",
-        "static-embeddings",
-        "dataset:minishlab/tokenlearn-cornstack-queries-coderankembed",
-        "dataset:minishlab/tokenlearn-cornstack-docs-coderankembed",
-        "dataset:nomic-ai/cornstack-python-v1",
-        "dataset:nomic-ai/cornstack-java-v1",
-        "dataset:nomic-ai/cornstack-php-v1",
-        "dataset:nomic-ai/cornstack-go-v1",
-        "dataset:nomic-ai/cornstack-javascript-v1",
-        "dataset:nomic-ai/cornstack-ruby-v1",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-02T14:21:30.000Z",
-      "lastModified": "2026-04-27T05:13:51.000Z"
-    },
-    {
-      "rank": 858,
+      "rank": 861,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -25097,11 +25179,11 @@
       "lastModified": "2026-05-18T05:58:18.000Z"
     },
     {
-      "rank": 859,
+      "rank": 862,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
-      "downloads": 11970,
+      "downloads": 12914,
       "likes": 14,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -25128,11 +25210,11 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 860,
+      "rank": 863,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
-      "downloads": 4722,
+      "downloads": 4797,
       "likes": 38,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -25147,11 +25229,11 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 861,
+      "rank": 864,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
-      "downloads": 8,
+      "downloads": 20,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-image",
@@ -25176,11 +25258,11 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 862,
+      "rank": 865,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
-      "downloads": 376,
+      "downloads": 2046,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -25211,7 +25293,267 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 863,
+      "rank": 866,
+      "id": "black-forest-labs/FLUX.2-klein-base-9B",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
+      "downloads": 80667,
+      "likes": 225,
+      "trendingScore": 6,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-generation",
+        "image-editing",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "license:other",
+        "diffusers:Flux2KleinPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-01-14T13:40:35.000Z",
+      "lastModified": "2026-02-24T00:19:46.000Z"
+    },
+    {
+      "rank": 867,
+      "id": "xai-org/grok-1",
+      "author": "xai-org",
+      "url": "https://huggingface.co/xai-org/grok-1",
+      "downloads": 508,
+      "likes": 2409,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "grok",
+      "tags": [
+        "grok",
+        "grok-1",
+        "text-generation",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2024-03-17T05:47:21.000Z",
+      "lastModified": "2024-03-28T16:25:32.000Z"
+    },
+    {
+      "rank": 868,
+      "id": "Qwen/Qwen2.5-0.5B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
+      "downloads": 2461463,
+      "likes": 407,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "en",
+        "arxiv:2407.10671",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-09-15T12:15:39.000Z",
+      "lastModified": "2024-09-25T12:32:36.000Z"
+    },
+    {
+      "rank": 869,
+      "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
+      "downloads": 102780,
+      "likes": 203,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "code",
+        "codeqwen",
+        "chat",
+        "qwen",
+        "qwen-coder",
+        "text-generation",
+        "en",
+        "arxiv:2409.12186",
+        "arxiv:2407.10671",
+        "base_model:Qwen/Qwen2.5-Coder-32B-Instruct",
+        "base_model:quantized:Qwen/Qwen2.5-Coder-32B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2024-11-09T12:45:18.000Z",
+      "lastModified": "2025-01-12T02:08:48.000Z"
+    },
+    {
+      "rank": 870,
+      "id": "Wan-AI/Wan2.2-TI2V-5B",
+      "author": "Wan-AI",
+      "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
+      "downloads": 8769,
+      "likes": 593,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "diffusers",
+        "safetensors",
+        "ti2v",
+        "text-to-video",
+        "en",
+        "zh",
+        "arxiv:2503.20314",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-07-18T09:35:44.000Z",
+      "lastModified": "2025-08-07T10:22:24.000Z"
+    },
+    {
+      "rank": 871,
+      "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
+      "downloads": 11908,
+      "likes": 27,
+      "trendingScore": 6,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3_5",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "image-text-to-text",
+        "base_model:llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2",
+        "base_model:quantized:llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-03-30T16:40:50.000Z",
+      "lastModified": "2026-03-30T22:38:36.000Z"
+    },
+    {
+      "rank": 872,
+      "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
+      "author": "cyankiwi",
+      "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
+      "downloads": 1564525,
+      "likes": 44,
+      "trendingScore": 6,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "conversational",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:quantized:google/gemma-4-31B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "compressed-tensors",
+        "region:us"
+      ],
+      "createdAt": "2026-04-02T20:03:40.000Z",
+      "lastModified": "2026-04-30T21:52:07.000Z"
+    },
+    {
+      "rank": 873,
+      "id": "bytedance-research/GRN",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/bytedance-research/GRN",
+      "downloads": 0,
+      "likes": 14,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "arxiv:2604.13030",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-16T09:01:34.000Z",
+      "lastModified": "2026-05-13T08:40:50.000Z"
+    },
+    {
+      "rank": 874,
+      "id": "MLXBits/sulphur-2-distill-mlx-q4",
+      "author": "MLXBits",
+      "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
+      "downloads": 622,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "image-text-to-video",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "AudioVideo",
+        "quantized",
+        "4bit",
+        "q4",
+        "image-text-to-video",
+        "base_model:SulphurAI/Sulphur-2-base",
+        "base_model:quantized:SulphurAI/Sulphur-2-base",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T18:23:21.000Z",
+      "lastModified": "2026-05-12T20:32:15.000Z"
+    },
+    {
+      "rank": 875,
+      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "downloads": 5734,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T13:16:15.000Z",
+      "lastModified": "2026-05-17T15:23:22.000Z"
+    },
+    {
+      "rank": 876,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -25238,7 +25580,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 864,
+      "rank": 877,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -25274,7 +25616,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 865,
+      "rank": 878,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -25319,7 +25661,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 866,
+      "rank": 879,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -25364,7 +25706,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 867,
+      "rank": 880,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -25394,33 +25736,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 868,
-      "id": "black-forest-labs/FLUX.2-klein-base-9B",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
-      "downloads": 80546,
-      "likes": 224,
-      "trendingScore": 5,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-generation",
-        "image-editing",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "license:other",
-        "diffusers:Flux2KleinPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-01-14T13:40:35.000Z",
-      "lastModified": "2026-02-24T00:19:46.000Z"
-    },
-    {
-      "rank": 869,
+      "rank": 881,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -25455,7 +25771,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 870,
+      "rank": 882,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -25483,7 +25799,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 871,
+      "rank": 883,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -25509,7 +25825,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 872,
+      "rank": 884,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -25535,7 +25851,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 873,
+      "rank": 885,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -25561,7 +25877,7 @@
       "lastModified": "2026-05-06T20:09:03.000Z"
     },
     {
-      "rank": 874,
+      "rank": 886,
       "id": "TheDrummer/Skyfall-31B-v4.2",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
@@ -25581,7 +25897,7 @@
       "lastModified": "2026-04-03T20:52:19.000Z"
     },
     {
-      "rank": 875,
+      "rank": 887,
       "id": "LiquidAI/LFM2-24B-A2B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
@@ -25619,7 +25935,7 @@
       "lastModified": "2026-03-30T12:54:26.000Z"
     },
     {
-      "rank": 876,
+      "rank": 888,
       "id": "nvidia/GR00T-N1.7-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
@@ -25639,7 +25955,7 @@
       "lastModified": "2026-04-23T19:09:30.000Z"
     },
     {
-      "rank": 877,
+      "rank": 889,
       "id": "Aratako/Irodori-TTS-500M",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
@@ -25662,7 +25978,7 @@
       "lastModified": "2026-03-18T11:03:56.000Z"
     },
     {
-      "rank": 878,
+      "rank": 890,
       "id": "Qwen/Qwen3.5-0.8B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
@@ -25685,7 +26001,7 @@
       "lastModified": "2026-04-23T11:14:09.000Z"
     },
     {
-      "rank": 879,
+      "rank": 891,
       "id": "z-lab/Qwen3.5-9B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
@@ -25718,7 +26034,7 @@
       "lastModified": "2026-04-07T14:29:47.000Z"
     },
     {
-      "rank": 880,
+      "rank": 892,
       "id": "Winnougan/Must_Have_Klein_9b_loras",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
@@ -25740,7 +26056,7 @@
       "lastModified": "2026-03-26T22:03:08.000Z"
     },
     {
-      "rank": 881,
+      "rank": 893,
       "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
@@ -25767,7 +26083,7 @@
       "lastModified": "2026-04-05T16:05:28.000Z"
     },
     {
-      "rank": 882,
+      "rank": 894,
       "id": "100percentrobot/LTX-2.3-Audio-Reactive-LORA",
       "author": "100percentrobot",
       "url": "https://huggingface.co/100percentrobot/LTX-2.3-Audio-Reactive-LORA",
@@ -25791,7 +26107,7 @@
       "lastModified": "2026-04-10T15:12:18.000Z"
     },
     {
-      "rank": 883,
+      "rank": 895,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -25818,7 +26134,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 884,
+      "rank": 896,
       "id": "YJX-Xiaomi/ControlFoley",
       "author": "YJX-Xiaomi",
       "url": "https://huggingface.co/YJX-Xiaomi/ControlFoley",
@@ -25842,7 +26158,7 @@
       "lastModified": "2026-04-22T02:02:09.000Z"
     },
     {
-      "rank": 885,
+      "rank": 897,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -25882,7 +26198,7 @@
       "lastModified": "2026-04-19T00:19:49.000Z"
     },
     {
-      "rank": 886,
+      "rank": 898,
       "id": "lovis93/crt-animation-terminal-ltx-2.3-lora",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/crt-animation-terminal-ltx-2.3-lora",
@@ -25908,7 +26224,7 @@
       "lastModified": "2026-04-20T16:33:16.000Z"
     },
     {
-      "rank": 887,
+      "rank": 899,
       "id": "uva-cv-lab/OmniShotCut",
       "author": "uva-cv-lab",
       "url": "https://huggingface.co/uva-cv-lab/OmniShotCut",
@@ -25926,7 +26242,7 @@
       "lastModified": "2026-04-28T14:59:54.000Z"
     },
     {
-      "rank": 888,
+      "rank": 900,
       "id": "Yutian10/AnyRecon",
       "author": "Yutian10",
       "url": "https://huggingface.co/Yutian10/AnyRecon",
@@ -25944,11 +26260,11 @@
       "lastModified": "2026-04-27T02:17:02.000Z"
     },
     {
-      "rank": 889,
+      "rank": 901,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
-      "downloads": 259513,
+      "downloads": 276426,
       "likes": 29,
       "trendingScore": 5,
       "pipelineTag": "image-text-to-text",
@@ -25970,7 +26286,7 @@
       "lastModified": "2026-04-30T21:34:35.000Z"
     },
     {
-      "rank": 890,
+      "rank": 902,
       "id": "vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
@@ -25993,7 +26309,7 @@
       "lastModified": "2026-04-24T02:25:18.000Z"
     },
     {
-      "rank": 891,
+      "rank": 903,
       "id": "Comfy-Org/void-model",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/void-model",
@@ -26011,7 +26327,7 @@
       "lastModified": "2026-05-07T10:17:55.000Z"
     },
     {
-      "rank": 892,
+      "rank": 904,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
@@ -26041,7 +26357,7 @@
       "lastModified": "2026-04-27T23:59:16.000Z"
     },
     {
-      "rank": 893,
+      "rank": 905,
       "id": "TheBurgstall/ltx-2.3-bodypositivity-lora",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/ltx-2.3-bodypositivity-lora",
@@ -26068,7 +26384,7 @@
       "lastModified": "2026-04-26T10:38:55.000Z"
     },
     {
-      "rank": 894,
+      "rank": 906,
       "id": "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
@@ -26098,7 +26414,7 @@
       "lastModified": "2026-05-05T17:25:56.000Z"
     },
     {
-      "rank": 895,
+      "rank": 907,
       "id": "GAi92/anima-loras",
       "author": "GAi92",
       "url": "https://huggingface.co/GAi92/anima-loras",
@@ -26119,7 +26435,7 @@
       "lastModified": "2026-05-08T23:44:33.000Z"
     },
     {
-      "rank": 896,
+      "rank": 908,
       "id": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
@@ -26146,7 +26462,7 @@
       "lastModified": "2026-05-06T05:56:30.000Z"
     },
     {
-      "rank": 897,
+      "rank": 909,
       "id": "XiaomiMiMo/MiMo-V2.5-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Base",
@@ -26175,7 +26491,7 @@
       "lastModified": "2026-05-08T10:25:24.000Z"
     },
     {
-      "rank": 898,
+      "rank": 910,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit",
@@ -26204,7 +26520,7 @@
       "lastModified": "2026-04-29T04:36:33.000Z"
     },
     {
-      "rank": 899,
+      "rank": 911,
       "id": "sokann/Qwen3.6-27B-GGUF-4.256bpw",
       "author": "sokann",
       "url": "https://huggingface.co/sokann/Qwen3.6-27B-GGUF-4.256bpw",
@@ -26228,7 +26544,7 @@
       "lastModified": "2026-04-30T05:52:10.000Z"
     },
     {
-      "rank": 900,
+      "rank": 912,
       "id": "Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
@@ -26273,7 +26589,7 @@
       "lastModified": "2026-04-30T00:55:51.000Z"
     },
     {
-      "rank": 901,
+      "rank": 913,
       "id": "mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
@@ -26318,7 +26634,7 @@
       "lastModified": "2026-04-30T08:28:27.000Z"
     },
     {
-      "rank": 902,
+      "rank": 914,
       "id": "OrobasVault/Geodesic-Phantom-12B",
       "author": "OrobasVault",
       "url": "https://huggingface.co/OrobasVault/Geodesic-Phantom-12B",
@@ -26359,7 +26675,7 @@
       "lastModified": "2026-05-01T03:53:12.000Z"
     },
     {
-      "rank": 903,
+      "rank": 915,
       "id": "Egor-3926/ToxicLord",
       "author": "Egor-3926",
       "url": "https://huggingface.co/Egor-3926/ToxicLord",
@@ -26389,7 +26705,7 @@
       "lastModified": "2026-04-30T20:07:44.000Z"
     },
     {
-      "rank": 904,
+      "rank": 916,
       "id": "Playtime-AI/LTX-2.3-Jenna_Coleman",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Jenna_Coleman",
@@ -26406,7 +26722,7 @@
       "lastModified": "2026-05-01T11:07:58.000Z"
     },
     {
-      "rank": 905,
+      "rank": 917,
       "id": "abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
       "author": "abhinand",
       "url": "https://huggingface.co/abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
@@ -26436,7 +26752,7 @@
       "lastModified": "2026-05-01T15:22:45.000Z"
     },
     {
-      "rank": 906,
+      "rank": 918,
       "id": "Naphula/Salamander-24B-v1",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/Salamander-24B-v1",
@@ -26481,7 +26797,7 @@
       "lastModified": "2026-05-02T10:32:50.000Z"
     },
     {
-      "rank": 907,
+      "rank": 919,
       "id": "Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
@@ -26498,7 +26814,7 @@
       "lastModified": "2026-05-04T13:20:35.000Z"
     },
     {
-      "rank": 908,
+      "rank": 920,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -26527,7 +26843,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 909,
+      "rank": 921,
       "id": "chromadb/context-1",
       "author": "chromadb",
       "url": "https://huggingface.co/chromadb/context-1",
@@ -26552,7 +26868,7 @@
       "lastModified": "2026-03-30T01:02:07.000Z"
     },
     {
-      "rank": 910,
+      "rank": 922,
       "id": "abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
       "author": "abovespec",
       "url": "https://huggingface.co/abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
@@ -26572,7 +26888,7 @@
       "lastModified": "2026-05-04T03:28:29.000Z"
     },
     {
-      "rank": 911,
+      "rank": 923,
       "id": "bond005/whisper-podlodka-turbo",
       "author": "bond005",
       "url": "https://huggingface.co/bond005/whisper-podlodka-turbo",
@@ -26607,7 +26923,7 @@
       "lastModified": "2026-01-29T10:12:53.000Z"
     },
     {
-      "rank": 912,
+      "rank": 924,
       "id": "nvidia/canary-qwen-2.5b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/canary-qwen-2.5b",
@@ -26652,7 +26968,7 @@
       "lastModified": "2026-04-21T12:31:18.000Z"
     },
     {
-      "rank": 913,
+      "rank": 925,
       "id": "lightx2v/Wan2.2-Distill-Loras",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-Distill-Loras",
@@ -26680,7 +26996,7 @@
       "lastModified": "2025-12-17T08:00:53.000Z"
     },
     {
-      "rank": 914,
+      "rank": 926,
       "id": "Qwen/Qwen3.5-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-27B",
@@ -26705,7 +27021,7 @@
       "lastModified": "2026-04-24T02:54:49.000Z"
     },
     {
-      "rank": 915,
+      "rank": 927,
       "id": "mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
@@ -26728,7 +27044,7 @@
       "lastModified": "2026-04-23T08:30:31.000Z"
     },
     {
-      "rank": 916,
+      "rank": 928,
       "id": "sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
@@ -26767,7 +27083,7 @@
       "lastModified": "2026-04-29T00:23:13.000Z"
     },
     {
-      "rank": 917,
+      "rank": 929,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit",
@@ -26795,7 +27111,7 @@
       "lastModified": "2026-04-29T06:58:31.000Z"
     },
     {
-      "rank": 918,
+      "rank": 930,
       "id": "Harley-ml/Tenete-8M",
       "author": "Harley-ml",
       "url": "https://huggingface.co/Harley-ml/Tenete-8M",
@@ -26825,11 +27141,11 @@
       "lastModified": "2026-05-05T14:34:26.000Z"
     },
     {
-      "rank": 919,
+      "rank": 931,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
-      "downloads": 1208271,
+      "downloads": 1211359,
       "likes": 780,
       "trendingScore": 5,
       "pipelineTag": "text-generation",
@@ -26862,7 +27178,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 920,
+      "rank": 932,
       "id": "nvidia/omni-embed-nemotron-3b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/omni-embed-nemotron-3b",
@@ -26898,7 +27214,7 @@
       "lastModified": "2026-05-06T18:02:16.000Z"
     },
     {
-      "rank": 921,
+      "rank": 933,
       "id": "fal/flux-2-klein-4b-spritesheet-lora",
       "author": "fal",
       "url": "https://huggingface.co/fal/flux-2-klein-4b-spritesheet-lora",
@@ -26932,7 +27248,7 @@
       "lastModified": "2026-01-21T14:44:55.000Z"
     },
     {
-      "rank": 922,
+      "rank": 934,
       "id": "DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
@@ -26977,7 +27293,7 @@
       "lastModified": "2026-03-09T07:04:55.000Z"
     },
     {
-      "rank": 923,
+      "rank": 935,
       "id": "Comfy-Org/ltx-2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/ltx-2",
@@ -26994,7 +27310,7 @@
       "lastModified": "2026-03-08T17:36:30.000Z"
     },
     {
-      "rank": 924,
+      "rank": 936,
       "id": "silveroxides/LTX-2.3-Quants",
       "author": "silveroxides",
       "url": "https://huggingface.co/silveroxides/LTX-2.3-Quants",
@@ -27038,7 +27354,7 @@
       "lastModified": "2026-05-03T15:37:37.000Z"
     },
     {
-      "rank": 925,
+      "rank": 937,
       "id": "z-lab/Qwen3.5-35B-A3B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-35B-A3B-PARO",
@@ -27067,7 +27383,7 @@
       "lastModified": "2026-05-08T06:21:10.000Z"
     },
     {
-      "rank": 926,
+      "rank": 938,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -27102,7 +27418,7 @@
       "lastModified": "2026-04-06T02:19:40.000Z"
     },
     {
-      "rank": 927,
+      "rank": 939,
       "id": "OpenMed/privacy-filter-multilingual",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-multilingual",
@@ -27147,7 +27463,7 @@
       "lastModified": "2026-05-03T21:36:31.000Z"
     },
     {
-      "rank": 928,
+      "rank": 940,
       "id": "prism-ml/Bonsai-8B-mlx-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-mlx-1bit",
@@ -27178,7 +27494,7 @@
       "lastModified": "2026-04-18T20:44:19.000Z"
     },
     {
-      "rank": 929,
+      "rank": 941,
       "id": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
@@ -27223,7 +27539,7 @@
       "lastModified": "2025-12-22T10:16:55.000Z"
     },
     {
-      "rank": 930,
+      "rank": 942,
       "id": "zai-org/GLM-5",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5",
@@ -27250,7 +27566,7 @@
       "lastModified": "2026-04-05T07:48:51.000Z"
     },
     {
-      "rank": 931,
+      "rank": 943,
       "id": "Comfy-Org/Wan_2.1_ComfyUI_repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged",
@@ -27268,7 +27584,7 @@
       "lastModified": "2026-01-28T12:44:01.000Z"
     },
     {
-      "rank": 932,
+      "rank": 944,
       "id": "sequelbox/Qwen3.6-27B-Tachibana-Agent",
       "author": "sequelbox",
       "url": "https://huggingface.co/sequelbox/Qwen3.6-27B-Tachibana-Agent",
@@ -27313,7 +27629,7 @@
       "lastModified": "2026-05-07T02:13:23.000Z"
     },
     {
-      "rank": 933,
+      "rank": 945,
       "id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
@@ -27339,7 +27655,7 @@
       "lastModified": "2024-07-03T05:16:11.000Z"
     },
     {
-      "rank": 934,
+      "rank": 946,
       "id": "lynaNSFW/LTX2.3_NSFW_motion",
       "author": "lynaNSFW",
       "url": "https://huggingface.co/lynaNSFW/LTX2.3_NSFW_motion",
@@ -27361,7 +27677,7 @@
       "lastModified": "2026-03-25T12:45:24.000Z"
     },
     {
-      "rank": 935,
+      "rank": 947,
       "id": "mlx-community/DeepSeek-V4-Flash-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit",
@@ -27384,7 +27700,7 @@
       "lastModified": "2026-04-25T00:58:58.000Z"
     },
     {
-      "rank": 936,
+      "rank": 948,
       "id": "Qwen/Qwen3-ForcedAligner-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B",
@@ -27405,7 +27721,7 @@
       "lastModified": "2026-01-30T03:00:55.000Z"
     },
     {
-      "rank": 937,
+      "rank": 949,
       "id": "nvidia/Cosmos-Reason2-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Cosmos-Reason2-8B",
@@ -27434,7 +27750,7 @@
       "lastModified": "2026-04-30T03:16:12.000Z"
     },
     {
-      "rank": 938,
+      "rank": 950,
       "id": "Qwen/Qwen3-VL-4B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct",
@@ -27463,7 +27779,7 @@
       "lastModified": "2025-10-15T16:15:55.000Z"
     },
     {
-      "rank": 939,
+      "rank": 951,
       "id": "mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
@@ -27508,7 +27824,7 @@
       "lastModified": "2026-05-03T18:58:47.000Z"
     },
     {
-      "rank": 940,
+      "rank": 952,
       "id": "SWivid/F5-TTS",
       "author": "SWivid",
       "url": "https://huggingface.co/SWivid/F5-TTS",
@@ -27529,7 +27845,7 @@
       "lastModified": "2025-03-21T05:05:00.000Z"
     },
     {
-      "rank": 941,
+      "rank": 953,
       "id": "bartowski/google_gemma-4-E4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF",
@@ -27552,7 +27868,7 @@
       "lastModified": "2026-05-03T18:32:47.000Z"
     },
     {
-      "rank": 942,
+      "rank": 954,
       "id": "Ashen3/SNOFS",
       "author": "Ashen3",
       "url": "https://huggingface.co/Ashen3/SNOFS",
@@ -27572,7 +27888,7 @@
       "lastModified": "2026-02-21T20:02:14.000Z"
     },
     {
-      "rank": 943,
+      "rank": 955,
       "id": "Prior-Labs/tabpfn_2_6",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_2_6",
@@ -27596,7 +27912,7 @@
       "lastModified": "2026-04-02T10:00:43.000Z"
     },
     {
-      "rank": 944,
+      "rank": 956,
       "id": "Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
       "author": "Sikaworld1990",
       "url": "https://huggingface.co/Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
@@ -27625,7 +27941,7 @@
       "lastModified": "2026-03-11T17:20:00.000Z"
     },
     {
-      "rank": 945,
+      "rank": 957,
       "id": "google/medgemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-4b-it",
@@ -27669,7 +27985,7 @@
       "lastModified": "2025-10-28T17:24:49.000Z"
     },
     {
-      "rank": 946,
+      "rank": 958,
       "id": "nomic-ai/nomic-embed-text-v1.5-GGUF",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF",
@@ -27692,7 +28008,7 @@
       "lastModified": "2025-04-28T20:14:53.000Z"
     },
     {
-      "rank": 947,
+      "rank": 959,
       "id": "ponpoke/flux2-klein-4b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-4b-uncensored-text-encoder",
@@ -27725,7 +28041,7 @@
       "lastModified": "2026-05-02T11:35:01.000Z"
     },
     {
-      "rank": 948,
+      "rank": 960,
       "id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
       "author": "cardiffnlp",
       "url": "https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment-latest",
@@ -27752,7 +28068,7 @@
       "lastModified": "2025-08-04T07:58:29.000Z"
     },
     {
-      "rank": 949,
+      "rank": 961,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
@@ -27797,7 +28113,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 950,
+      "rank": 962,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
@@ -27827,7 +28143,7 @@
       "lastModified": "2026-05-04T02:04:15.000Z"
     },
     {
-      "rank": 951,
+      "rank": 963,
       "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
@@ -27852,7 +28168,7 @@
       "lastModified": "2025-02-24T03:31:45.000Z"
     },
     {
-      "rank": 952,
+      "rank": 964,
       "id": "microsoft/VibeVoice-Realtime-0.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-Realtime-0.5B",
@@ -27882,7 +28198,7 @@
       "lastModified": "2025-12-12T15:35:46.000Z"
     },
     {
-      "rank": 953,
+      "rank": 965,
       "id": "facebook/sam-audio-large",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam-audio-large",
@@ -27901,7 +28217,7 @@
       "lastModified": "2025-12-30T19:52:21.000Z"
     },
     {
-      "rank": 954,
+      "rank": 966,
       "id": "cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
       "author": "cognica",
       "url": "https://huggingface.co/cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
@@ -27928,7 +28244,7 @@
       "lastModified": "2026-05-16T07:11:10.000Z"
     },
     {
-      "rank": 955,
+      "rank": 967,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
@@ -27950,7 +28266,7 @@
       "lastModified": "2026-04-14T13:43:30.000Z"
     },
     {
-      "rank": 956,
+      "rank": 968,
       "id": "F16/z-image-turbo-flow-dpo",
       "author": "F16",
       "url": "https://huggingface.co/F16/z-image-turbo-flow-dpo",
@@ -27980,7 +28296,7 @@
       "lastModified": "2026-04-09T18:43:34.000Z"
     },
     {
-      "rank": 957,
+      "rank": 969,
       "id": "Jiunsong/supergemma4-e4b-abliterated",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-e4b-abliterated",
@@ -28011,7 +28327,7 @@
       "lastModified": "2026-04-17T13:20:56.000Z"
     },
     {
-      "rank": 958,
+      "rank": 970,
       "id": "deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
       "author": "deucebucket",
       "url": "https://huggingface.co/deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
@@ -28045,7 +28361,7 @@
       "lastModified": "2026-05-15T05:30:04.000Z"
     },
     {
-      "rank": 959,
+      "rank": 971,
       "id": "deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
       "author": "deepsweet",
       "url": "https://huggingface.co/deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
@@ -28071,7 +28387,7 @@
       "lastModified": "2026-05-10T15:18:41.000Z"
     },
     {
-      "rank": 960,
+      "rank": 972,
       "id": "Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Phil2Sat",
       "url": "https://huggingface.co/Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -28099,7 +28415,7 @@
       "lastModified": "2025-11-07T19:24:03.000Z"
     },
     {
-      "rank": 961,
+      "rank": 973,
       "id": "tencent/HunyuanVideo",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HunyuanVideo",
@@ -28119,7 +28435,7 @@
       "lastModified": "2025-03-06T15:39:29.000Z"
     },
     {
-      "rank": 962,
+      "rank": 974,
       "id": "mradermacher/Mistral-Nemo-2407-12B-Thinking-Claude-Gemini-GPT5.2-Uncensored-HERETIC-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Mistral-Nemo-2407-12B-Thinking-Claude-Gemini-GPT5.2-Uncensored-HERETIC-GGUF",
@@ -28164,7 +28480,7 @@
       "lastModified": "2026-01-10T03:19:10.000Z"
     },
     {
-      "rank": 963,
+      "rank": 975,
       "id": "KyleHessling1/Qwopus-GLM-18B-Merged-GGUF",
       "author": "KyleHessling1",
       "url": "https://huggingface.co/KyleHessling1/Qwopus-GLM-18B-Merged-GGUF",
@@ -28205,7 +28521,7 @@
       "lastModified": "2026-04-20T16:48:29.000Z"
     },
     {
-      "rank": 964,
+      "rank": 976,
       "id": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
@@ -28230,7 +28546,7 @@
       "lastModified": "2025-05-29T13:13:34.000Z"
     },
     {
-      "rank": 965,
+      "rank": 977,
       "id": "z-lab/Qwen3.5-4B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-4B-DFlash",
@@ -28263,7 +28579,7 @@
       "lastModified": "2026-04-07T14:29:28.000Z"
     },
     {
-      "rank": 966,
+      "rank": 978,
       "id": "ovi054/QIE-2511-Color-Grade-Transfer-LoRA",
       "author": "ovi054",
       "url": "https://huggingface.co/ovi054/QIE-2511-Color-Grade-Transfer-LoRA",
@@ -28284,7 +28600,7 @@
       "lastModified": "2026-05-06T18:12:57.000Z"
     },
     {
-      "rank": 967,
+      "rank": 979,
       "id": "Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound",
@@ -28307,7 +28623,7 @@
       "lastModified": "2026-05-01T13:20:17.000Z"
     },
     {
-      "rank": 968,
+      "rank": 980,
       "id": "RunDiffusion/Juggernaut-XI-v11",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XI-v11",
@@ -28341,7 +28657,7 @@
       "lastModified": "2026-05-08T17:23:19.000Z"
     },
     {
-      "rank": 969,
+      "rank": 981,
       "id": "Systran/faster-whisper-large-v3",
       "author": "Systran",
       "url": "https://huggingface.co/Systran/faster-whisper-large-v3",
@@ -28386,7 +28702,7 @@
       "lastModified": "2023-11-23T09:41:12.000Z"
     },
     {
-      "rank": 970,
+      "rank": 982,
       "id": "colbert-ir/colbertv2.0",
       "author": "colbert-ir",
       "url": "https://huggingface.co/colbert-ir/colbertv2.0",
@@ -28416,7 +28732,7 @@
       "lastModified": "2024-04-05T20:18:44.000Z"
     },
     {
-      "rank": 971,
+      "rank": 983,
       "id": "FacebookAI/xlm-roberta-base",
       "author": "FacebookAI",
       "url": "https://huggingface.co/FacebookAI/xlm-roberta-base",
@@ -28461,7 +28777,7 @@
       "lastModified": "2024-02-19T12:48:21.000Z"
     },
     {
-      "rank": 972,
+      "rank": 984,
       "id": "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
@@ -28479,7 +28795,7 @@
       "lastModified": "2026-02-26T07:46:49.000Z"
     },
     {
-      "rank": 973,
+      "rank": 985,
       "id": "oongaboongahacker/Gemini-Nano",
       "author": "oongaboongahacker",
       "url": "https://huggingface.co/oongaboongahacker/Gemini-Nano",
@@ -28495,7 +28811,7 @@
       "lastModified": "2024-06-25T08:45:00.000Z"
     },
     {
-      "rank": 974,
+      "rank": 986,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -28519,7 +28835,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 975,
+      "rank": 987,
       "id": "tarn59/pixel_art_style_lora_z_image_turbo",
       "author": "tarn59",
       "url": "https://huggingface.co/tarn59/pixel_art_style_lora_z_image_turbo",
@@ -28542,7 +28858,7 @@
       "lastModified": "2025-11-30T15:16:04.000Z"
     },
     {
-      "rank": 976,
+      "rank": 988,
       "id": "drbaph/OmniVoice-bf16",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/OmniVoice-bf16",
@@ -28587,7 +28903,7 @@
       "lastModified": "2026-04-02T20:50:23.000Z"
     },
     {
-      "rank": 977,
+      "rank": 989,
       "id": "zooeyy/Style-Transfer",
       "author": "zooeyy",
       "url": "https://huggingface.co/zooeyy/Style-Transfer",
@@ -28610,7 +28926,7 @@
       "lastModified": "2026-02-06T05:28:09.000Z"
     },
     {
-      "rank": 978,
+      "rank": 990,
       "id": "google/gemma-3-12b-it-qat-q4_0-unquantized",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized",
@@ -28655,7 +28971,7 @@
       "lastModified": "2025-04-15T21:07:07.000Z"
     },
     {
-      "rank": 979,
+      "rank": 991,
       "id": "Qwen/Qwen3-Reranker-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Reranker-0.6B",
@@ -28682,7 +28998,7 @@
       "lastModified": "2026-04-16T08:55:59.000Z"
     },
     {
-      "rank": 980,
+      "rank": 992,
       "id": "nvidia/parakeet-tdt-0.6b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2",
@@ -28721,7 +29037,7 @@
       "lastModified": "2026-04-13T13:49:50.000Z"
     },
     {
-      "rank": 981,
+      "rank": 993,
       "id": "apple/DepthPro-hf",
       "author": "apple",
       "url": "https://huggingface.co/apple/DepthPro-hf",
@@ -28745,7 +29061,7 @@
       "lastModified": "2025-02-28T18:31:40.000Z"
     },
     {
-      "rank": 982,
+      "rank": 994,
       "id": "Qwen/Qwen3-ASR-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-0.6B",
@@ -28768,7 +29084,7 @@
       "lastModified": "2026-01-30T03:00:21.000Z"
     },
     {
-      "rank": 983,
+      "rank": 995,
       "id": "cstr/qwen3-asr-1.7b-GGUF",
       "author": "cstr",
       "url": "https://huggingface.co/cstr/qwen3-asr-1.7b-GGUF",
@@ -28813,7 +29129,7 @@
       "lastModified": "2026-04-11T17:41:11.000Z"
     },
     {
-      "rank": 984,
+      "rank": 996,
       "id": "TheDrummer/Cydonia-24B-v4.3",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Cydonia-24B-v4.3",
@@ -28833,7 +29149,7 @@
       "lastModified": "2025-12-17T15:08:15.000Z"
     },
     {
-      "rank": 985,
+      "rank": 997,
       "id": "tencent/HY-OmniWeaving",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-OmniWeaving",
@@ -28859,7 +29175,7 @@
       "lastModified": "2026-05-06T10:16:28.000Z"
     },
     {
-      "rank": 986,
+      "rank": 998,
       "id": "google/paligemma-3b-pt-224",
       "author": "google",
       "url": "https://huggingface.co/google/paligemma-3b-pt-224",
@@ -28902,7 +29218,7 @@
       "lastModified": "2024-09-21T10:14:25.000Z"
     },
     {
-      "rank": 987,
+      "rank": 999,
       "id": "XRXRX/X-Voice",
       "author": "XRXRX",
       "url": "https://huggingface.co/XRXRX/X-Voice",
@@ -28922,7 +29238,7 @@
       "lastModified": "2026-05-05T08:15:34.000Z"
     },
     {
-      "rank": 988,
+      "rank": 1000,
       "id": "lemonyins/Qwen3.6-27B-uncensored-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-uncensored-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -28951,402 +29267,6 @@
       ],
       "createdAt": "2026-05-06T11:19:50.000Z",
       "lastModified": "2026-05-07T10:29:03.000Z"
-    },
-    {
-      "rank": 989,
-      "id": "unsloth/Qwen3.5-397B-A17B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF",
-      "downloads": 57508,
-      "likes": 245,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "unsloth",
-        "base_model:Qwen/Qwen3.5-397B-A17B",
-        "base_model:quantized:Qwen/Qwen3.5-397B-A17B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-02-16T04:59:50.000Z",
-      "lastModified": "2026-03-07T04:33:56.000Z"
-    },
-    {
-      "rank": 990,
-      "id": "dphn/Dolphin3.0-Llama3.1-8B-GGUF",
-      "author": "dphn",
-      "url": "https://huggingface.co/dphn/Dolphin3.0-Llama3.1-8B-GGUF",
-      "downloads": 51594,
-      "likes": 173,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "en",
-        "dataset:OpenCoder-LLM/opc-sft-stage1",
-        "dataset:OpenCoder-LLM/opc-sft-stage2",
-        "dataset:microsoft/orca-agentinstruct-1M-v1",
-        "dataset:microsoft/orca-math-word-problems-200k",
-        "dataset:NousResearch/hermes-function-calling-v1",
-        "dataset:AI-MO/NuminaMath-CoT",
-        "dataset:AI-MO/NuminaMath-TIR",
-        "dataset:allenai/tulu-3-sft-mixture",
-        "dataset:cognitivecomputations/dolphin-coder",
-        "dataset:HuggingFaceTB/smoltalk",
-        "dataset:cognitivecomputations/samantha-data",
-        "dataset:m-a-p/CodeFeedback-Filtered-Instruction",
-        "dataset:m-a-p/Code-Feedback",
-        "base_model:meta-llama/Llama-3.1-8B",
-        "base_model:quantized:meta-llama/Llama-3.1-8B",
-        "license:llama3.1",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2025-01-02T22:11:05.000Z",
-      "lastModified": "2025-01-05T17:17:21.000Z"
-    },
-    {
-      "rank": 991,
-      "id": "apple/Sharp",
-      "author": "apple",
-      "url": "https://huggingface.co/apple/Sharp",
-      "downloads": 9160,
-      "likes": 374,
-      "trendingScore": 5,
-      "pipelineTag": "image-to-3d",
-      "libraryName": "ml-sharp",
-      "tags": [
-        "ml-sharp",
-        "image-to-3d",
-        "arxiv:2512.10685",
-        "license:apple-amlr",
-        "region:us"
-      ],
-      "createdAt": "2025-12-12T08:53:39.000Z",
-      "lastModified": "2025-12-18T17:38:39.000Z"
-    },
-    {
-      "rank": 992,
-      "id": "BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1",
-      "author": "BennyDaBall",
-      "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Turbo-AbliteratedV1",
-      "downloads": 25585,
-      "likes": 64,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gguf",
-        "qwen3",
-        "abliterated",
-        "heretic",
-        "z-image",
-        "qwen",
-        "censorship-removal",
-        "base_model:Tongyi-MAI/Z-Image-Turbo",
-        "base_model:quantized:Tongyi-MAI/Z-Image-Turbo",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-01-28T01:40:20.000Z",
-      "lastModified": "2026-01-31T17:47:55.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
-      "author": "Baraje",
-      "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
-      "downloads": 19877,
-      "likes": 7,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "text-to-image",
-        "lora",
-        "template:diffusion-lora",
-        "base_model:Qwen/Qwen-Image",
-        "base_model:adapter:Qwen/Qwen-Image",
-        "license:artistic-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T06:19:31.000Z",
-      "lastModified": "2026-04-22T06:19:53.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "facebook/seamless-m4t-v2-large",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/seamless-m4t-v2-large",
-      "downloads": 81612,
-      "likes": 982,
-      "trendingScore": 5,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "seamless_m4t_v2",
-        "feature-extraction",
-        "audio-to-audio",
-        "text-to-speech",
-        "seamless_communication",
-        "automatic-speech-recognition",
-        "af",
-        "am",
-        "ar",
-        "as",
-        "az",
-        "be",
-        "bn",
-        "bs",
-        "bg",
-        "ca",
-        "cs",
-        "zh",
-        "cy",
-        "da",
-        "de",
-        "el",
-        "en",
-        "et",
-        "fi",
-        "fr",
-        "or",
-        "om"
-      ],
-      "createdAt": "2023-11-29T14:37:04.000Z",
-      "lastModified": "2024-01-04T12:48:26.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "BAAI/bge-large-en-v1.5",
-      "author": "BAAI",
-      "url": "https://huggingface.co/BAAI/bge-large-en-v1.5",
-      "downloads": 15515158,
-      "likes": 662,
-      "trendingScore": 5,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "pytorch",
-        "onnx",
-        "safetensors",
-        "bert",
-        "feature-extraction",
-        "sentence-similarity",
-        "transformers",
-        "mteb",
-        "en",
-        "arxiv:2401.03462",
-        "arxiv:2312.15503",
-        "arxiv:2311.13534",
-        "arxiv:2310.07554",
-        "arxiv:2309.07597",
-        "license:mit",
-        "model-index",
-        "eval-results",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2023-09-12T05:20:08.000Z",
-      "lastModified": "2024-02-21T02:51:44.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
-      "downloads": 87377,
-      "likes": 305,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "nvidia",
-        "unsloth",
-        "text-generation",
-        "en",
-        "es",
-        "fr",
-        "de",
-        "ja",
-        "it",
-        "dataset:nvidia/Nemotron-Pretraining-Code-v1",
-        "dataset:nvidia/Nemotron-CC-v2",
-        "dataset:nvidia/Nemotron-Pretraining-SFT-v1",
-        "dataset:nvidia/Nemotron-CC-Math-v1",
-        "dataset:nvidia/Nemotron-Pretraining-Code-v2",
-        "dataset:nvidia/Nemotron-Pretraining-Specialized-v1",
-        "dataset:nvidia/Nemotron-CC-v2.1",
-        "dataset:nvidia/Nemotron-CC-Code-v1",
-        "dataset:nvidia/Nemotron-Pretraining-Dataset-sample",
-        "dataset:nvidia/Nemotron-Competitive-Programming-v1",
-        "dataset:nvidia/Nemotron-Math-v2",
-        "dataset:nvidia/Nemotron-Agentic-v1",
-        "dataset:nvidia/Nemotron-Math-Proofs-v1",
-        "dataset:nvidia/Nemotron-Instruction-Following-Chat-v1",
-        "dataset:nvidia/Nemotron-Science-v1",
-        "dataset:nvidia/Nemotron-3-Nano-RL-Training-Blend",
-        "base_model:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "base_model:quantized:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "license:other"
-      ],
-      "createdAt": "2025-12-15T11:42:58.000Z",
-      "lastModified": "2025-12-31T06:30:55.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
-      "downloads": 99068,
-      "likes": 85,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_h",
-        "text-generation",
-        "nvidia",
-        "pytorch",
-        "conversational",
-        "custom_code",
-        "en",
-        "dataset:nvidia/Nemotron-CC-v2",
-        "dataset:nvidia/Nemotron-Post-Training-Dataset-v2",
-        "dataset:nvidia/Nemotron-Science-v1",
-        "dataset:nvidia/Nemotron-Instruction-Following-Chat-v1",
-        "dataset:nvidia/Nemotron-Agentic-v1",
-        "dataset:nvidia/Nemotron-Competitive-Programming-v1",
-        "dataset:nvidia/Nemotron-Math-Proofs-v1",
-        "dataset:nvidia/Nemotron-RL-Agentic-Conversational-Tool-Use-Pivot-v1",
-        "dataset:nvidia/Nemotron-RL-instruction_following",
-        "dataset:nvidia/Nemotron-RL-agent-calendar_scheduling",
-        "dataset:nvidia/Nemotron-RL-instruction_following-structured_outputs",
-        "arxiv:2511.16664",
-        "arxiv:2504.03624",
-        "arxiv:2512.20856",
-        "arxiv:2512.20848",
-        "arxiv:2412.02595",
-        "base_model:nvidia/NVIDIA-Nemotron-Nano-9B-v2",
-        "base_model:finetune:nvidia/NVIDIA-Nemotron-Nano-9B-v2",
-        "license:other",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-07T01:23:35.000Z",
-      "lastModified": "2026-03-20T20:50:41.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "nvidia/gpt-oss-120b-Eagle3-v3",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v3",
-      "downloads": 4344,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "llama",
-        "nvidia",
-        "ModelOpt",
-        "gpt-oss-120b",
-        "Eagle3",
-        "text-generation",
-        "base_model:openai/gpt-oss-120b",
-        "base_model:finetune:openai/gpt-oss-120b",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-28T03:59:50.000Z",
-      "lastModified": "2026-05-08T16:33:12.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2",
-      "author": "TeichAI",
-      "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2",
-      "downloads": 1322,
-      "likes": 12,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "reasoning",
-        "conversational",
-        "dataset:TeichAI/Claude-Opus-4.6-Reasoning-887x",
-        "dataset:TeichAI/claude-4.5-opus-high-reasoning-250x",
-        "dataset:Crownelius/Opus-4.6-Reasoning-2100x-formatted",
-        "base_model:unsloth/gemma-4-31B-it",
-        "base_model:finetune:unsloth/gemma-4-31B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-12T01:25:17.000Z",
-      "lastModified": "2026-05-06T17:42:34.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "Ardenzard/Qwen3.6-27B-DFlash-GGUF",
-      "author": "Ardenzard",
-      "url": "https://huggingface.co/Ardenzard/Qwen3.6-27B-DFlash-GGUF",
-      "downloads": 6960,
-      "likes": 7,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "qwen",
-        "qwen3",
-        "qwen3.6",
-        "dflash",
-        "speculative-decoding",
-        "llama.cpp",
-        "buun-llama-cpp",
-        "draft-model",
-        "text-generation",
-        "arxiv:2602.06036",
-        "base_model:z-lab/Qwen3.6-27B-DFlash",
-        "base_model:quantized:z-lab/Qwen3.6-27B-DFlash",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-28T16:05:52.000Z",
-      "lastModified": "2026-04-28T17:48:00.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26090481455

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.