### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-19T10:11:05Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-19T04:37:44.210Z",
+  "ts": "2026-05-19T10:11:05.352Z",
   "count": 1,
-  "durationMs": 2676,
+  "durationMs": 3026,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T04:37:41.536Z",
+  "fetchedAt": "2026-05-19T10:11:02.328Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -40,9 +40,9 @@
       "id": "PsiBotAI/SynData",
       "author": "PsiBotAI",
       "url": "https://huggingface.co/datasets/PsiBotAI/SynData",
-      "downloads": 33959,
-      "likes": 140,
-      "trendingScore": 93,
+      "downloads": 35727,
+      "likes": 143,
+      "trendingScore": 95,
       "tags": [
         "language:en",
         "license:cc-by-4.0",
@@ -61,6 +61,34 @@
     },
     {
       "rank": 3,
+      "id": "AlienKevin/SWE-ZERO-12M-trajectories",
+      "author": "AlienKevin",
+      "url": "https://huggingface.co/datasets/AlienKevin/SWE-ZERO-12M-trajectories",
+      "downloads": 7573,
+      "likes": 76,
+      "trendingScore": 73,
+      "tags": [
+        "task_categories:text-generation",
+        "language:en",
+        "license:apache-2.0",
+        "size_categories:10M<n<100M",
+        "format:parquet",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "region:us",
+        "swe-zero",
+        "code",
+        "agentic",
+        "pre-training"
+      ],
+      "createdAt": "2026-04-16T07:19:37.000Z",
+      "lastModified": "2026-05-14T23:54:23.000Z"
+    },
+    {
+      "rank": 4,
       "id": "ADSKAILab/Zero-To-CAD-1m",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/datasets/ADSKAILab/Zero-To-CAD-1m",
@@ -96,12 +124,12 @@
       "lastModified": "2026-05-03T14:11:21.000Z"
     },
     {
-      "rank": 4,
+      "rank": 5,
       "id": "angrygiraffe/claude-opus-4.6-4.7-reasoning-8.7k",
       "author": "angrygiraffe",
       "url": "https://huggingface.co/datasets/angrygiraffe/claude-opus-4.6-4.7-reasoning-8.7k",
-      "downloads": 2923,
-      "likes": 136,
+      "downloads": 3170,
+      "likes": 137,
       "trendingScore": 69,
       "tags": [
         "task_categories:text-generation",
@@ -129,34 +157,6 @@
       ],
       "createdAt": "2026-05-01T05:06:53.000Z",
       "lastModified": "2026-05-01T17:11:41.000Z"
-    },
-    {
-      "rank": 5,
-      "id": "AlienKevin/SWE-ZERO-12M-trajectories",
-      "author": "AlienKevin",
-      "url": "https://huggingface.co/datasets/AlienKevin/SWE-ZERO-12M-trajectories",
-      "downloads": 7083,
-      "likes": 70,
-      "trendingScore": 67,
-      "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "license:apache-2.0",
-        "size_categories:10M<n<100M",
-        "format:parquet",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "region:us",
-        "swe-zero",
-        "code",
-        "agentic",
-        "pre-training"
-      ],
-      "createdAt": "2026-04-16T07:19:37.000Z",
-      "lastModified": "2026-05-14T23:54:23.000Z"
     },
     {
       "rank": 6,
@@ -257,6 +257,37 @@
     },
     {
       "rank": 9,
+      "id": "5CD-AI/Viet-Handwriting-OCR-v2",
+      "author": "5CD-AI",
+      "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
+      "downloads": 171,
+      "likes": 37,
+      "trendingScore": 34,
+      "tags": [
+        "task_categories:image-to-text",
+        "language:vi",
+        "size_categories:10K<n<100K",
+        "format:parquet",
+        "format:optimized-parquet",
+        "modality:image",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2408.12480",
+        "region:us",
+        "ocr",
+        "text-recognition",
+        "handwriting",
+        "handwriting-recognition",
+        "vietnamese"
+      ],
+      "createdAt": "2026-05-10T22:38:24.000Z",
+      "lastModified": "2026-05-18T17:14:55.000Z"
+    },
+    {
+      "rank": 10,
       "id": "Jackrong/DeepSeek-V4-Distill-8000x",
       "author": "Jackrong",
       "url": "https://huggingface.co/datasets/Jackrong/DeepSeek-V4-Distill-8000x",
@@ -284,37 +315,6 @@
       ],
       "createdAt": "2026-04-24T07:17:06.000Z",
       "lastModified": "2026-04-24T08:32:56.000Z"
-    },
-    {
-      "rank": 10,
-      "id": "5CD-AI/Viet-Handwriting-OCR-v2",
-      "author": "5CD-AI",
-      "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
-      "downloads": 78,
-      "likes": 34,
-      "trendingScore": 31,
-      "tags": [
-        "task_categories:image-to-text",
-        "language:vi",
-        "size_categories:10K<n<100K",
-        "format:parquet",
-        "format:optimized-parquet",
-        "modality:image",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "arxiv:2408.12480",
-        "region:us",
-        "ocr",
-        "text-recognition",
-        "handwriting",
-        "handwriting-recognition",
-        "vietnamese"
-      ],
-      "createdAt": "2026-05-10T22:38:24.000Z",
-      "lastModified": "2026-05-18T17:14:55.000Z"
     },
     {
       "rank": 11,
@@ -454,6 +454,43 @@
     },
     {
       "rank": 16,
+      "id": "Qwen/WebWorldData",
+      "author": "Qwen",
+      "url": "https://huggingface.co/datasets/Qwen/WebWorldData",
+      "downloads": 604,
+      "likes": 37,
+      "trendingScore": 25,
+      "tags": [
+        "task_categories:text-generation",
+        "language:en",
+        "language:zh",
+        "license:apache-2.0",
+        "size_categories:100K<n<1M",
+        "format:json",
+        "modality:text",
+        "library:datasets",
+        "library:pandas",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2602.14721",
+        "region:us",
+        "WebWorld",
+        "world-model",
+        "web-agent",
+        "browser-simulation",
+        "a11y",
+        "html",
+        "xml",
+        "markdown",
+        "trajectories",
+        "agent-training",
+        "synthetic-data"
+      ],
+      "createdAt": "2026-02-13T14:14:24.000Z",
+      "lastModified": "2026-05-08T12:12:49.000Z"
+    },
+    {
+      "rank": 17,
       "id": "nvidia/Nemotron-Image-Training-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/datasets/nvidia/Nemotron-Image-Training-v3",
@@ -477,7 +514,7 @@
       "lastModified": "2026-04-28T08:35:01.000Z"
     },
     {
-      "rank": 17,
+      "rank": 18,
       "id": "apptek-com/apptek_callcenter_dialogues",
       "author": "apptek-com",
       "url": "https://huggingface.co/datasets/apptek-com/apptek_callcenter_dialogues",
@@ -511,7 +548,7 @@
       "lastModified": "2026-05-08T22:49:17.000Z"
     },
     {
-      "rank": 18,
+      "rank": 19,
       "id": "iletisim/dezenformasyon-bultenleri",
       "author": "iletisim",
       "url": "https://huggingface.co/datasets/iletisim/dezenformasyon-bultenleri",
@@ -546,48 +583,11 @@
       "lastModified": "2026-05-03T09:10:37.000Z"
     },
     {
-      "rank": 19,
-      "id": "Qwen/WebWorldData",
-      "author": "Qwen",
-      "url": "https://huggingface.co/datasets/Qwen/WebWorldData",
-      "downloads": 576,
-      "likes": 35,
-      "trendingScore": 24,
-      "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "language:zh",
-        "license:apache-2.0",
-        "size_categories:100K<n<1M",
-        "format:json",
-        "modality:text",
-        "library:datasets",
-        "library:pandas",
-        "library:polars",
-        "library:mlcroissant",
-        "arxiv:2602.14721",
-        "region:us",
-        "WebWorld",
-        "world-model",
-        "web-agent",
-        "browser-simulation",
-        "a11y",
-        "html",
-        "xml",
-        "markdown",
-        "trajectories",
-        "agent-training",
-        "synthetic-data"
-      ],
-      "createdAt": "2026-02-13T14:14:24.000Z",
-      "lastModified": "2026-05-08T12:12:49.000Z"
-    },
-    {
       "rank": 20,
       "id": "alibaba-multimodal-industrial-ai/IndustryBench",
       "author": "alibaba-multimodal-industrial-ai",
       "url": "https://huggingface.co/datasets/alibaba-multimodal-industrial-ai/IndustryBench",
-      "downloads": 143,
+      "downloads": 162,
       "likes": 25,
       "trendingScore": 24,
       "tags": [
@@ -613,6 +613,38 @@
     },
     {
       "rank": 21,
+      "id": "openai/gsm8k",
+      "author": "openai",
+      "url": "https://huggingface.co/datasets/openai/gsm8k",
+      "downloads": 933210,
+      "likes": 1322,
+      "trendingScore": 22,
+      "tags": [
+        "benchmark:official",
+        "benchmark:eval-yaml",
+        "task_categories:text-generation",
+        "annotations_creators:crowdsourced",
+        "language_creators:crowdsourced",
+        "multilinguality:monolingual",
+        "source_datasets:original",
+        "language:en",
+        "license:mit",
+        "size_categories:10K<n<100K",
+        "format:parquet",
+        "modality:text",
+        "library:datasets",
+        "library:pandas",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2110.14168",
+        "region:us",
+        "math-word-problems"
+      ],
+      "createdAt": "2022-04-12T10:22:10.000Z",
+      "lastModified": "2026-03-23T10:18:13.000Z"
+    },
+    {
+      "rank": 22,
       "id": "Modotte/CodeX-2M-Thinking",
       "author": "Modotte",
       "url": "https://huggingface.co/datasets/Modotte/CodeX-2M-Thinking",
@@ -651,11 +683,11 @@
       "lastModified": "2026-02-10T07:23:38.000Z"
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "blanchon/opencs2_dataset",
       "author": "blanchon",
       "url": "https://huggingface.co/datasets/blanchon/opencs2_dataset",
-      "downloads": 21088,
+      "downloads": 21674,
       "likes": 21,
       "trendingScore": 21,
       "tags": [
@@ -686,7 +718,7 @@
       "lastModified": "2026-05-04T15:38:59.000Z"
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "SALT-NLP/SWE-chat",
       "author": "SALT-NLP",
       "url": "https://huggingface.co/datasets/SALT-NLP/SWE-chat",
@@ -719,7 +751,7 @@
       "lastModified": "2026-04-29T15:05:22.000Z"
     },
     {
-      "rank": 24,
+      "rank": 25,
       "id": "r0b0tlab/deepseek-hermes-reasoning-traces",
       "author": "r0b0tlab",
       "url": "https://huggingface.co/datasets/r0b0tlab/deepseek-hermes-reasoning-traces",
@@ -752,38 +784,6 @@
       ],
       "createdAt": "2026-05-03T14:43:24.000Z",
       "lastModified": "2026-05-04T00:18:27.000Z"
-    },
-    {
-      "rank": 25,
-      "id": "openai/gsm8k",
-      "author": "openai",
-      "url": "https://huggingface.co/datasets/openai/gsm8k",
-      "downloads": 923053,
-      "likes": 1320,
-      "trendingScore": 20,
-      "tags": [
-        "benchmark:official",
-        "benchmark:eval-yaml",
-        "task_categories:text-generation",
-        "annotations_creators:crowdsourced",
-        "language_creators:crowdsourced",
-        "multilinguality:monolingual",
-        "source_datasets:original",
-        "language:en",
-        "license:mit",
-        "size_categories:10K<n<100K",
-        "format:parquet",
-        "modality:text",
-        "library:datasets",
-        "library:pandas",
-        "library:polars",
-        "library:mlcroissant",
-        "arxiv:2110.14168",
-        "region:us",
-        "math-word-problems"
-      ],
-      "createdAt": "2022-04-12T10:22:10.000Z",
-      "lastModified": "2026-03-23T10:18:13.000Z"
     },
     {
       "rank": 26,
@@ -1106,7 +1106,7 @@
       "id": "camvsl/Articraft-10K",
       "author": "camvsl",
       "url": "https://huggingface.co/datasets/camvsl/Articraft-10K",
-      "downloads": 1598,
+      "downloads": 12386,
       "likes": 16,
       "trendingScore": 15,
       "tags": [
@@ -1118,6 +1118,36 @@
     },
     {
       "rank": 37,
+      "id": "Exgentic/agent-llm-traces",
+      "author": "Exgentic",
+      "url": "https://huggingface.co/datasets/Exgentic/agent-llm-traces",
+      "downloads": 1482,
+      "likes": 15,
+      "trendingScore": 15,
+      "tags": [
+        "task_categories:text-generation",
+        "language:en",
+        "license:cdla-permissive-2.0",
+        "size_categories:1K<n<10K",
+        "format:parquet",
+        "modality:tabular",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "region:us",
+        "llm",
+        "traces",
+        "opentelemetry",
+        "benchmarks",
+        "agents"
+      ],
+      "createdAt": "2026-05-07T13:59:42.000Z",
+      "lastModified": "2026-05-14T18:50:50.000Z"
+    },
+    {
+      "rank": 38,
       "id": "OwnedByDanes/Usenet-Corpus-1980-2013",
       "author": "OwnedByDanes",
       "url": "https://huggingface.co/datasets/OwnedByDanes/Usenet-Corpus-1980-2013",
@@ -1158,7 +1188,7 @@
       "lastModified": "2026-05-05T16:17:39.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "badlogicgames/pi-mono",
       "author": "badlogicgames",
       "url": "https://huggingface.co/datasets/badlogicgames/pi-mono",
@@ -1188,7 +1218,7 @@
       "lastModified": "2026-04-06T13:10:36.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
       "author": "sequelbox",
       "url": "https://huggingface.co/datasets/sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
@@ -1231,7 +1261,7 @@
       "lastModified": "2026-04-30T17:12:47.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "Inferact/codex_swebenchpro_traces",
       "author": "Inferact",
       "url": "https://huggingface.co/datasets/Inferact/codex_swebenchpro_traces",
@@ -1253,7 +1283,7 @@
       "lastModified": "2026-05-07T01:13:21.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "5551z/VisCoR_Contrast",
       "author": "5551z",
       "url": "https://huggingface.co/datasets/5551z/VisCoR_Contrast",
@@ -1276,7 +1306,7 @@
       "lastModified": "2026-04-30T01:37:13.000Z"
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "llm-jp/Jagle",
       "author": "llm-jp",
       "url": "https://huggingface.co/datasets/llm-jp/Jagle",
@@ -1292,36 +1322,6 @@
       ],
       "createdAt": "2026-04-11T08:56:17.000Z",
       "lastModified": "2026-05-12T00:53:55.000Z"
-    },
-    {
-      "rank": 43,
-      "id": "Exgentic/agent-llm-traces",
-      "author": "Exgentic",
-      "url": "https://huggingface.co/datasets/Exgentic/agent-llm-traces",
-      "downloads": 1386,
-      "likes": 14,
-      "trendingScore": 14,
-      "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "license:cdla-permissive-2.0",
-        "size_categories:1K<n<10K",
-        "format:parquet",
-        "modality:tabular",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "region:us",
-        "llm",
-        "traces",
-        "opentelemetry",
-        "benchmarks",
-        "agents"
-      ],
-      "createdAt": "2026-05-07T13:59:42.000Z",
-      "lastModified": "2026-05-14T18:50:50.000Z"
     },
     {
       "rank": 44,
@@ -1379,6 +1379,27 @@
     },
     {
       "rank": 46,
+      "id": "LukaDev13/Liminal-Dreamcore-1K",
+      "author": "LukaDev13",
+      "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
+      "downloads": 1860,
+      "likes": 13,
+      "trendingScore": 12,
+      "tags": [
+        "license:mit",
+        "modality:image",
+        "region:us",
+        "ai-generated",
+        "dreamcore",
+        "aesthetic",
+        "image-collection",
+        "gpt-image"
+      ],
+      "createdAt": "2026-05-16T12:14:28.000Z",
+      "lastModified": "2026-05-18T22:03:11.000Z"
+    },
+    {
+      "rank": 47,
       "id": "NodeLinker/deepseek-ai-Thinking-with-Visual-Primitives-deleted-repo",
       "author": "NodeLinker",
       "url": "https://huggingface.co/datasets/NodeLinker/deepseek-ai-Thinking-with-Visual-Primitives-deleted-repo",
@@ -1393,7 +1414,7 @@
       "lastModified": "2026-05-01T19:27:38.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "microsoft/synthetic-computers-at-scale",
       "author": "microsoft",
       "url": "https://huggingface.co/datasets/microsoft/synthetic-computers-at-scale",
@@ -1423,7 +1444,7 @@
       "lastModified": "2026-05-01T06:30:14.000Z"
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "clem/ml-intern-sessions",
       "author": "clem",
       "url": "https://huggingface.co/datasets/clem/ml-intern-sessions",
@@ -1455,7 +1476,7 @@
       "lastModified": "2026-05-05T18:26:42.000Z"
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "bigcode/the-stack-v2",
       "author": "bigcode",
       "url": "https://huggingface.co/datasets/bigcode/the-stack-v2",
@@ -1484,27 +1505,6 @@
       ],
       "createdAt": "2024-02-26T04:26:48.000Z",
       "lastModified": "2024-04-23T15:52:32.000Z"
-    },
-    {
-      "rank": 50,
-      "id": "LukaDev13/Liminal-Dreamcore-1K",
-      "author": "LukaDev13",
-      "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
-      "downloads": 351,
-      "likes": 12,
-      "trendingScore": 11,
-      "tags": [
-        "license:mit",
-        "modality:image",
-        "region:us",
-        "ai-generated",
-        "dreamcore",
-        "aesthetic",
-        "image-collection",
-        "gpt-image"
-      ],
-      "createdAt": "2026-05-16T12:14:28.000Z",
-      "lastModified": "2026-05-18T22:03:11.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26090581238

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.