### PR TITLE
chore(data): refresh mcp liveness 2026-05-19T10:28:38Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T04:48:42.139Z",
+  "fetchedAt": "2026-05-19T10:28:34.071Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -17,11 +17,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "reddit": {
+    "exa": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "exa": {
+    "reddit": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -29,19 +29,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aniruddha-adhikary/gahmen-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rashforddamion/rivalsearch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "hamid-vakilzadeh/mcpsemanticscholar": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "martin111ma-za5d/swiss-truth-mcp": {
+    "aniruddha-adhikary/gahmen-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -49,23 +41,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aryankeluskar/polymarket-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "standardaccounting/public-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "agentmail": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "heather-macavelia/ai-agent-index": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fabsforward2-zhoi/sbb-mcp": {
+    "aryankeluskar/polymarket-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -77,10 +57,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "settlegrid/settlegrid-discovery": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "re-rank/uiux-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -89,19 +65,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "martin111ma-za5d/swiss-truth-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "zwldarren/akshare-one-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sincetomorrow/cultural-intelligence": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "microsoft/learn_mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bh-rat/context-awesome": {
+    "fabsforward2-zhoi/sbb-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -113,19 +85,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "icons8community/icons8mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ayni-protocol/ayni": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "upstash/context7-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "titansneaker/paper-search-mcp-openai-v2": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -133,11 +93,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "quantoracle/quantoracle": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bitpoort/on-chain-data": {
+    "titansneaker/paper-search-mcp-openai-v2": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -153,11 +109,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "cloud101.kr/cloud101kr": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "do-droid/seoul-essentials": {
+    "rashforddamion/rivalsearch": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -165,11 +117,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "antvis/mcp-server-chart": {
+    "supabase": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "supabase": {
+    "icons8community/icons8mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -177,7 +129,71 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "enji/ai-marketing-agent": {
+    "microsoft/learn_mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "octomil/octomil": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bh-rat/context-awesome": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "vdineshk/ai-compliance-monitor": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "slack": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "oevortex/ddg_search": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cloud101.kr/cloud101kr": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "instagram": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "standardaccounting/public-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "quantoracle/quantoracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "heather-macavelia/ai-agent-index": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "garasegae/aiskillstore": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sincetomorrow/cultural-intelligence": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "do-droid/seoul-essentials": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "googledrive": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "settlegrid/settlegrid-discovery": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tbakerx/instant-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -185,11 +201,47 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aguskenari86-8bo7/cryptoiz-mcp": {
+    "waldzellai/clear-thought": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "octomil/octomil": {
+    "info-g03l/catalunya-2022": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "isdaniel/mcp_weather_server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "code-rabi/littlesis-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "integsec/turbopentest": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "alexandria-shai-eden/caselaw": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jon-ag46/troystack": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ayni-protocol/ayni": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bitpoort/on-chain-data": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ucpchecker/ucp-checker": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "linxule/mcp-music-studio": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -201,126 +253,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "slack": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "isdaniel/mcp_weather_server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vdineshk/ai-compliance-monitor": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "oevortex/ddg_search": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "davidcho/ca-building-code-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "info-g03l/catalunya-2022": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "instagram": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alexandria-shai-eden/caselaw": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "linxule/mcp-music-studio": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "strale-io/strale": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "waldzellai/clear-thought": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "theconstructionstandard/the-construction-standard": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "garasegae/aiskillstore": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hola-ps65/siil-ostomy-store": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "googledrive": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tbakerx/instant-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "labsofuniverse/legacy-mcp-analyzer": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "code-rabi/littlesis-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "imviky-zzzr/tickerr-live-status": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hellokitty-v/smithery-mcp-servers": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "integsec/turbopentest": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "modellix/modellix-docs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "maximumsats/maximumsats": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jon-ag46/troystack": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "chuhuoyuan/cloudflare": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ucpchecker/ucp-checker": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arizeai/docs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "artvepa80/hefestoai": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "janmacher02-xl8y/czech-vat-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "strale/agent-tools": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "exa-labs/websets-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
@@ -329,7 +261,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "jarvis-stark1985/superhero-mcp-server": {
+    "apogeoapi/apogeoapi-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "theconstructionstandard/the-construction-standard": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -337,15 +273,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "apogeoapi/apogeoapi-mcp": {
+    "labsofuniverse/legacy-mcp-analyzer": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "nekzus/npm-sentinel-mcp": {
+    "enji/ai-marketing-agent": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "namewhisper/ens-tools": {
+    "github": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "modellix/modellix-docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -353,23 +293,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "bartek-ywte/gaproll": {
+    "davidcho/ca-building-code-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sfiorini/youtube-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jina": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "blake365/macrostrat-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "nexgendata-apify/developer-tools-mcp-server": {
+    "chuhuoyuan/cloudflare": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -377,31 +305,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "pinkpixel-dev/web-scout-mcp": {
+    "nexgendata-apify/developer-tools-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "parallel/search": {
+    "blake365/macrostrat-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kkjdaniel/bgg-mcp": {
+    "strale-io/strale": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "agonzalez/prueba-mcp-seeker": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "synthetic-ci/vibe-marketing": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "linxule/lotus-wisdom-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bopmarket/marketplace": {
+    "jina": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -409,19 +325,79 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "pinkpixel-dev/web-scout-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "maximumsats/maximumsats": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "parallel/search": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "arizeai/docs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kkjdaniel/bgg-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hola-ps65/siil-ostomy-store": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "artvepa80/hefestoai": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "antvis/mcp-server-chart": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aguskenari86-8bo7/cryptoiz-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "youtube": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "linxule/lotus-wisdom-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "smithery-ai/national-weather-service": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "linell/grimoire-mcp": {
+    "imviky-zzzr/tickerr-live-status": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "seahbk1006/seahboonkeong-chat-opendosm": {
+    "nekzus/npm-sentinel-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jarvis-stark1985/superhero-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hellokitty-v/smithery-mcp-servers": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bartek-ywte/gaproll": {
       "isStdio": true,
       "livenessInferred": true
     },
     "arjunkmrm/grep": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "janmacher02-xl8y/czech-vat-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -433,7 +409,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "contrastcyber/contrastapi": {
+    "googlesuper": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agonzalez/prueba-mcp-seeker": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "seahbk1006/seahboonkeong-chat-opendosm": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sfiorini/youtube-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -441,15 +429,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "contrastcyber/contrastapi": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "faresyoussef94/aws-knowledge-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "phantom/connect-sdk": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "gamzadongza/danbooru-tags-mcp": {
+    "clickhouse": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -457,7 +445,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "johnanleitner1/last_minute_deals_hq": {
+    "gamzadongza/danbooru-tags-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "linell/grimoire-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -469,10 +461,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "wtf-just-happened/stock-moves-explained": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "caullenomdahl/nextjs-react-tailwind-assistant": {
       "isStdio": true,
       "livenessInferred": true
@@ -481,11 +469,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "tavily": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "exaltedtrou6/b24-mcp-dev": {
+    "strale/agent-tools": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -493,11 +477,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "agentidx/zarq-risk": {
+    "tavily": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "googlesuper": {
+    "bopmarket/marketplace": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agentidx/zarq-risk": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -505,7 +493,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "jbb1988/wheretohit": {
+    "exaltedtrou6/b24-mcp-dev": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "namewhisper/ens-tools": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wtf-just-happened/stock-moves-explained": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -513,7 +509,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "suseendar1414/auditsnap": {
+    "googlecalendar": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "phantom/connect-sdk": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -525,7 +525,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "fibonex/mcp-server": {
+    "johnanleitner1/last_minute_deals_hq": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "synthetic-ci/vibe-marketing": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -533,15 +537,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "fibonex/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "suseendar1414/auditsnap": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jbb1988/wheretohit": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "hirofumitorato/japan-ani-search-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jobly/jobly-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aitutor3/calculator-mcp-test": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -565,7 +573,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ing-christopherleon/preciomx": {
+    "aitutor3/calculator-mcp-test": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -573,7 +581,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/la-final": {
+    "apideck/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rbxwilliams/tmcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -581,11 +593,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "mcp-foundry/real-estate": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rbxwilliams/tmcp": {
+    "santiago.blanco.vilchez/la-final": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -605,7 +613,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "apideck/mcp-server": {
+    "notion": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mcp-foundry/real-estate": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -613,19 +625,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "howard-eridani/spark": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "outtolunch/outtolunch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "christos/eoa-intermediaries": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fruitflies/connect": {
+    "jobly/jobly-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -633,11 +633,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "fruitflies/connect": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "coupang-mcp/coupang": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "slookisen/lokal-norsk-matfinner": {
+    "ing-christopherleon/preciomx": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -661,11 +665,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "cuthongthai/vimo-financial-intelligence": {
+    "docfork/mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "actiongate/actiongate": {
+    "cuthongthai/vimo-financial-intelligence": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -673,7 +677,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ragalgo/ragalgo-mcp-server-v1": {
+    "onesignal/onesignal": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "outtolunch/outtolunch": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -681,11 +689,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ateam-ai/ateam": {
+    "ragalgo/ragalgo-mcp-server-v1": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "plith/plith": {
       "isStdio": true,
       "livenessInferred": true
     },
     "santiago.blanco.vilchez/aaa": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ateam-ai/ateam": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -701,11 +717,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "plith/plith": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arabimaak/gulf-arabic": {
+    "howard-eridani/spark": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -713,7 +725,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "arabimaak/gulf-arabic": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "slookisen/lokal-norsk-matfinner": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "zerion/zerion-api": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "actiongate/actiongate": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "browserbase": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -737,7 +765,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "christos/eoa-intermediaries": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "flashalpha/options-analytics": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "clarityai": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -753,23 +789,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "info-kk33/askmia_app": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "moltrust/moltrust-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aigen/defi-data": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mansamarkets/mansa": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vestara/america-law-graph": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -781,15 +801,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "mansamarkets/mansa": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "mavengence/ustidnr-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "xiaobenyang-com/rfc-server": {
+    "ren89752/aidroid": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ren89752/aidroid": {
+    "info-kk33/askmia_app": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "securityscan-api/securityscan": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -801,11 +829,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "secureship/docs": {
+    "xiaobenyang-com/rfc-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "securityscan-api/securityscan": {
+    "secureship/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -821,7 +849,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "vestara/america-law-graph": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "invarium-ai/invarium": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aigen/defi-data": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -829,11 +865,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "eliekfouri-g8h8/studio76": {
+    "dhanyyudi/bmkg-id": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "dhanyyudi/bmkg-id": {
+    "eliekfouri-g8h8/studio76": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -865,11 +901,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rabqatab/lexlink-ko-mcp": {
+    "arjunkmrm/devin": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "arjunkmrm/devin": {
+    "rabqatab/lexlink-ko-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -885,11 +921,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "eren-solutions/report-needs": {
+    "ckbk/subwayinfo-nyc": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ckbk/subwayinfo-nyc": {
+    "eren-solutions/report-needs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -937,11 +973,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "sallvainian/ngss-mcp": {
+    "santiago.blanco.vilchez/santiago-cpa": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/santiago-cpa": {
+    "sallvainian/ngss-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -950,10 +986,6 @@
       "livenessInferred": true
     },
     "aas-ee/open-websearch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "safeagent/token-safety": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -981,15 +1013,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "plainyogurt21/clintrials-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "apteka-health/apteka-cis": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "atars-mcp/aarnaai": {
+    "plainyogurt21/clintrials-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -997,7 +1025,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "atars-mcp/aarnaai": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "nicks-brn/promptscan": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "safeagent/token-safety": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1005,11 +1041,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "kongyo2/zod": {
+    "symdex-100/symdex": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "symdex-100/symdex": {
+    "kongyo2/zod": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1045,6 +1081,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "aleatoric/causal-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "lochmueller/muell-io": {
       "isStdio": true,
       "livenessInferred": true
@@ -1057,11 +1097,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "cameronapak/free-use-bible-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "hashirsiddiqui15/ami-bookstore-mcp-h": {
       "isStdio": true,
       "livenessInferred": true
     },
     "rlhf-loop/mcp-memory-gateway-v2": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "skymoore/grokipedia-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1209,11 +1257,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "refund-decide/notary": {
+    "refetch/web": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "refetch/web": {
+    "refund-decide/notary": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1261,15 +1309,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ksruthi1992/vsftest": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "exploreaisb/aivsf": {
       "isStdio": true,
       "livenessInferred": true
     },
     "oilandgas/basinvault": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ksruthi1992/vsftest": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1281,15 +1329,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "sidharth-5u15/cupshup-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "kishvisamadd/vsf-club": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "delx/delx-mcp": {
+    "leonid-rise/base44-sdk-docs": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sidharth-5u15/cupshup-mcp": {
+    "delx/delx-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1313,11 +1365,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "rei02061986/patent-space-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "saty.prasad/vsfclub": {
       "isStdio": true,
       "livenessInferred": true
     },
     "luis.ticas1/vsfclub4": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ghostrouter/ghostrouter-web": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1349,7 +1409,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "onesignal/onesignal": {
+    "himalayas/himalayas-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1369,19 +1429,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "kirandk/vsf1234": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "sincetoday/podcast-commerce-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "learnnaga/ai-103": {
+    "kirandk/vsf1234": {
       "isStdio": true,
       "livenessInferred": true
     },
     "mikechao/metmuseum-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "learnnaga/ai-103": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1501,11 +1561,35 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "janmacher02-xl8y/sec-edgar-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ebenova/vigil-fraud-alert": {
       "isStdio": true,
       "livenessInferred": true
     },
+    "acedatacloud-mcp/mcp-seedance": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "hegetiby-jwao/anaf-efactura-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "turbopuffer": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "secondsim/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "spacemolt/gameserver": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cyanheads/clinicaltrialsgov-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1553,10 +1637,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "acedatacloud-mcp/mcp-seedance": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "pungggi/smart-terminal": {
       "isStdio": true,
       "livenessInferred": true
@@ -1570,18 +1650,6 @@
       "livenessInferred": true
     },
     "vdineshk/sg-company-lookup-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thinkfar/clear-thought-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vdineshk/asean-trade-rules-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "acedatacloud-mcp/mcp-luma": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1629,531 +1697,191 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "fabio662/yield agentic hub": {
+    "thinkfar/clear-thought-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "code-yeongyu/lsp-tools-mcp": {
+    "vdineshk/asean-trade-rules-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "solomonneas/reelgrep-mcp": {
+    "acedatacloud-mcp/mcp-luma": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "forgemeshlabs/forgemesh-imagegen": {
+    "y-sky-bro/nexus-memory": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "thinhbv/tradingview mcp bridge": {
+    "megazear7/static-mcpify": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "tszaks/keynote-mcp": {
+    "im-hal-9k/remote-mcp-server-authless": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "oaslananka/reflow-mcp": {
+    "zh/redmine mcp oauth server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "vidhijav/myrsu mcp": {
+    "jun7680/kakao moment mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "actalumen/@actalumen/mcp-server": {
+    "rogerio-grocers/grocers-design-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "lucs1590/study-mcp": {
+    "sebaustin/mcp-financial-data": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "dimitrispasakaleris/whatsapp mcp server": {
+    "deepwa7er/poe2-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "dimitrispasakaleris/gmail-mcp": {
+    "denialgelon/nano-banana-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sfluv/sfluv-mcp": {
+    "lrgex/notion mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "rglgg/rgl-mcp": {
+    "zcdeng/vimax-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "mrchartist/x algorithm toolkit": {
+    "datadawn-org/datadawn mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "hopkdj/fenshitu mcp": {
+    "darkmatter-hub/darkmatter mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "elliotttate/pix-mcp": {
+    "dhebp/dero-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "gnanam1990/kitepass-mcp": {
+    "ismailrz/travel-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "cledupe/csv mcp server": {
+    "cunning-kang/mavis mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "pawel-up/lupa mcp server": {
+    "bracesproul/lsd mcp template": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "mrnewdelhi/mailosaur mcp": {
+    "sandraschi/streamfog mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "musadev147/antigravity mcp server": {
+    "jarmstrong158/clark-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "heymrun/heym": {
+    "thehzuo/web-gui-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "dataline-xyz/dataline mcp server": {
+    "zoharbabin/web researcher mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "parkviewlab/flint-slating": {
+    "gvnrdev/budget governor": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "abdoosalomov/jira mcp server": {
+    "xinyuzjj/godot mcp enhanced": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "selfpy/science-ai-mcp-server": {
+    "achilliesbot/agentiam-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "krishnamuddala/mcp chat": {
+    "ariri48/dooray mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "elvisaryan/aiops mcp": {
+    "oyaaiprod/exploit intel platform mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "darkd/darkd-skills": {
+    "graphiteai/graphite-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "runtimeall/image-mcp": {
+    "adkit/adkit": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "teto-0401/replit mcp server": {
+    "fgambling/constructoo mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "rosconl/intodns-mcp": {
+    "rrupesh/gke-cred-audit": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "comparedge/mcp-server-comparedge": {
+    "jaykim429/report-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kyb8801/metroai — kolas compliance os": {
+    "jessiejanie/skim-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "vertical-mcp/ntis-mcp": {
+    "hhopke/intervals-icu-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "vertical-mcp/dart-mcp": {
+    "abhineet34/linkedin-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "astandrik/codex pets": {
+    "exocubeyt/openwa mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "vertical-mcp/kolas-mcp": {
+    "magarongcandy/mcp_tools": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sbenson2/gamedev-mcp-server": {
+    "tsfir/easycslearning": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "irahulstomar/brain-mcp": {
+    "maxsambento/morfex": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "miracorhan/open google image generator mcp": {
+    "kapoost/humanmcp-marketplace": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "opsconduit/jobber-mcp": {
+    "dimitry/parse-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "logly-uk/logly mcp server": {
+    "naimterrache/frigolog-haccp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "migratorywhale/stackchan-mcp": {
+    "justus/bushdrum-events": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "yksanjo/yksanjo/gmem": {
+    "arjunkmrm/perplexity-search": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "yalcin/ta-lib-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "josephibra/cryptosense-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "7majesty-m/terminal-guardian-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ramakrishnan24689/agent 365": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mohamadalhusseinie/openmembrain": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "calame-tech/calame": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "crsxmd/rewindex": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sunix/jdtls-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "yubinkim444/ai-first-scraper-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "yubinkim444/repo-memory": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bperezpereira/wasabil": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sudomichael/gizmo analytics": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "patdolitse/engram": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vighriday/veris": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "andysalvo/supership-scan": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kajolchawla98/google docs + gmail mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.autorfp/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "spacemolt/gameserver": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "janmacher02-xl8y/sec-edgar-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "cyanheads/clinicaltrialsgov-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "turbopuffer": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "secondsim/mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "himalayas/himalayas-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ghostrouter/ghostrouter-web": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "leonid-rise/base44-sdk-docs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rei02061986/patent-space-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "skymoore/grokipedia-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "cameronapak/free-use-bible-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aleatoric/causal-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "docfork/mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "clickhouse": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "clarityai": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "youtube": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "googlecalendar": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "browserbase": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "notion": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "github": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "duksh/peerglass": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "lockon-n/pdf tools mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "anikghosh256/fortnox doc mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "suchitad1950/employee management mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alfredo-ia/microsoft 365 mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shedyhs/pg-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "adarshrkumar/ai-scholarly-mode": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ashtonvaughan/agentbrowser": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "yujaeyun/learnlog-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sebastianbaltes/computer use mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "syedhussainahmad/e-commerce product hunt": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mcieunic/hybris mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "xiaozhuabcd1234/web-fetch-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "laruss/grok-imagine-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "johnalvero/promotexter mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "busybee3333/fieldedge mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "datdeboer/postgresql mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "thenewjavaman/claude-crowed": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "razvancanuci/jira issue mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tcsoftinc/testcollab mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "byulsi/notion mcp server for antigravity": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "1broseidon/mcp weather server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "magnusjohansson/siglent-sds-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "chatwithsrini/airline flight delays mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "zachhandley/zmcptools": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "godmodearch/lts mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "adamzaidi/icloud-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "cympfh/qr code mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ysm1026/cinema scheduler": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "celestialdust/deep research agent mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arunlakshmikabilan1982/shopify mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "suhasvemuri/obsidian-self-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mafzaal/dynamics 365 finance & operations mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vinbg/ib portfolio tracker mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "nakada-memo/confluence-based code review mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "leomeirae/supabase mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "howmanysmall/npm-registry-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "cafuchino/memobird mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ibm/chuk mcp maritime archives": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "seongminjaden/tok_mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "salman-arefin74/repo therapist": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pietz/mcp applescript": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "itcomgroup/vision mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ryanmccauley/d2-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "globodai-group/google cloud dns mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fil-builders/filecoin onchain cloud mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mayssenbha/news analysis agent mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "peximo/drupal mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "zpeppoz/tanstack mcp server": {
+    "philidor/defi": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3998,6 +3726,278 @@
       "livenessInferred": true
     },
     "sonaiengine/graph-tool-call": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "0xzcov/mcp-omnifun": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/mtg-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "i-can-hack/pdf-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dan24ou-cpu/palate-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "transparentlyok/mcp context manager": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "davidsimoes/digisign-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "amcharts/amcharts 5 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "feedoracle/feedoracle compliance mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "stackbilt-dev/stackbilt": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markgregg/low-code ui mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "smart-mcp-proxy/mcpproxy-go": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pantagrueliste/tei-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ajitpratap0/gosqlx": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "timkulbaev/mcp-linkedin": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "custodia-admin/pagebolt": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/lego-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wecantdoit/magni mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "iris-eval/iris-eval/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tuckerschreiber/fullrun — google ads for ai agents": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kelvinyuefanli/agent-hive": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jiarongli517021911144/hybrid rag mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kustus/monkey office mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "andrewjgalea/planning mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kspatel29/mcptool": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jawadh-salih/moodle mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zach-snell/jtk": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zach-snell/ctk": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zach-snell/adtk": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "erinlkolp/discord mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sam-david/pg-pool-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "duvaragesh/imcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "eduardo-lucas/mcp accounting": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "abhishekv87bit/openscad mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "markswendsen-code/chase mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bobooooo/asciiflow mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "projecxio/revenyu mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mphinance/momentum-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dancumberland/kit-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "r3xsean/bigread-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pistachiomatt/nanobanana mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mytours/confd-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yoginoit39/h1b-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "evo-hydra/morpheus-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "banant2/foglift-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "prixite/zulip mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "7-e1even/mcphubs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "op7418/generative ui mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "securityronin/alaya": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "timergy-app/timergy": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mordechaipotash/brain-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jinning6/noosphere-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kore-01/stock analysis mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yindia/rootcause": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dmontgomery40/bambu-printer-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jimmyracheta/ai-runtime-guard": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ianaleck/harvest-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ipgeolocation/ip geolocation mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "skyvern-ai/skyvern mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "seriserendipia/resume-onepage-autofit-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "traia-io/des mcp server testing mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hwibalyu/edinet-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "lagunapools/laguna-pools-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "quantamixsol/graqle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/3dprint-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "transloadit/transloadit mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/astronomy-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mindwear-capitian/followupboss-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "attilio81/mcp-agno": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26091403309

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.