### PR TITLE
ci: rename workflow secret refs to canonical non-reserved names

### DIFF
--- a/.github/workflows/cron-agent-commerce.yml
+++ b/.github/workflows/cron-agent-commerce.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Enrich agent-commerce live signals
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_POOL || github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_POOL || github.token }}
         run: node scripts/fetch-agent-commerce-live.mjs --concurrency 6
 
       - name: Enrich agent-commerce social mentions

--- a/.github/workflows/sweep-cross-source-mentions.yml
+++ b/.github/workflows/sweep-cross-source-mentions.yml
@@ -113,7 +113,7 @@ jobs:
           REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
           DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
-          PRODUCTHUNT_API_TOKEN: ${{ secrets.PRODUCTHUNT_API_TOKEN }}
+          PRODUCTHUNT_API_TOKEN: ${{ secrets.PRODUCTHUNT_TOKEN }}
         run: |
           ARGS=(--top "${{ steps.params.outputs.top }}")
           if [[ -n "${{ steps.params.outputs.queue }}" ]]; then


### PR DESCRIPTION
## What

Two surgical renames in workflow YAML — the secret reference on the right-hand side only. Environment variable names on the left (what the script reads) are unchanged.

| File | Line | Before | After |
|---|---|---|---|
| `.github/workflows/sweep-cross-source-mentions.yml` | 116 | `${{ secrets.PRODUCTHUNT_API_TOKEN }}` | `${{ secrets.PRODUCTHUNT_TOKEN }}` |
| `.github/workflows/cron-agent-commerce.yml` | 101 | `${{ secrets.GITHUB_TOKEN_POOL \|\| github.token }}` | `${{ secrets.GH_TOKEN_POOL \|\| github.token }}` |

## Why

**PRODUCTHUNT_TOKEN**: The canonical secret is already provisioned in repo settings (verified via `gh secret list -R 0motionguy/starscreener`). The old `PRODUCTHUNT_API_TOKEN` name still exists too but is no longer the canonical reference.

**GH_TOKEN_POOL**: The `GITHUB_*` prefix is reserved in GitHub Actions — workflow references like `${{ secrets.GITHUB_TOKEN_POOL }}` silently resolve to empty string. This workflow has been quietly falling through to the `|| github.token` fallback rather than using the configured token pool. Renaming to `GH_TOKEN_POOL` (which exists in `gh secret list`) makes the pool actually take effect.

## Verify

Pre-merge:
```bash
grep -rEn 'secrets\.PRODUCTHUNT_API_TOKEN|secrets\.GITHUB_TOKEN_POOL' .github/workflows/
# expect: empty
```

Post-merge:
```bash
gh run list -R 0motionguy/starscreener --workflow cron-agent-commerce.yml --limit 3
gh run list -R 0motionguy/starscreener --workflow sweep-cross-source-mentions.yml --limit 3
# expect: no auth failures; cron-agent-commerce should now use the pooled token
```

## Out of scope (callouts for follow-up)

Enumeration via `gh secret list` + grep diff against all 68 workflow files found additional unresolved secret references that did NOT have an obvious canonical equivalent. They need Mirko-side decisions (provision new secret OR rewrite workflow), so they're left out of this PR:

**Needs Mirko to provision** (no canonical equivalent exists):
- `AA_API_KEY`, `AGENT_COMMERCE_WEBHOOK_URL`, `AISO_TRENDINGREPO_SECRET`, `GH_PAT_DEFAULT`, `LIBRARIES_IO_API_KEY`, `OPS_ALERT_WEBHOOK`, `PAGESPEED_API_KEY`, `R2_ACCESS_KEY_ID` + `R2_ACCOUNT_ID` + `R2_BUCKET` + `R2_PREFIX` + `R2_SECRET_ACCESS_KEY`, `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `SMITHERY_API_KEY`, `SOLANA_RPC_URL`, `TAVILY_API_KEY`, `UPSTASH_REDIS_REST_TOKEN`, `UPSTASH_REDIS_REST_URL`

**Ambiguous (singular vs plural — needs script-level decision)**:
- `DEVTO_API_KEY` (singular) referenced in 2 workflows but canonical is `DEVTO_API_KEYS` (plural). `scrape-devto.yml` references BOTH on consecutive lines — looks intentional, suggests script handles both forms.
- `REDDIT_USER_AGENTS` (plural) referenced in 5 workflows but canonical is `REDDIT_USER_AGENT` (singular). Several workflows reference BOTH on consecutive lines — likely the script uses one for default + the other for rotation pool.

Built-in `secrets.GITHUB_TOKEN` is GitHub's auto-injected token, not a missing repo secret — correctly resolves at runtime.

Part of X6 CI/CD cleanup lane from post-Vultr-Hostup migration close-out (`STEADY-STATE-2026-05-19.md`).

## Rollback

```bash
git revert <merge-sha>
git push origin main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)