### PR TITLE
Expose repo profile scan backlog status

### DIFF
--- a/src/app/api/pipeline/profiles/enrich/route.ts
+++ b/src/app/api/pipeline/profiles/enrich/route.ts
@@ -15,10 +15,10 @@ import { resolve } from "node:path";
 import { NextRequest, NextResponse } from "next/server";
 import { authFailureResponse, verifyCronAuth } from "@/lib/api/auth";
 import {
-  getRepoProfilesGeneratedAt,
   readRepoProfilesFileSync,
   refreshRepoProfilesFromStore,
 } from "@/lib/repo-profiles";
+import { summarizeRepoProfileStatus } from "@/lib/repo-profile-status";
 
 export const runtime = "nodejs";
 
@@ -77,34 +77,7 @@ function stringifyScanOverrides(values: unknown): string | null {
 }
 
 function summarizeProfiles() {
-  const file = readRepoProfilesFileSync();
-  const counts = {
-    total: file.profiles.length,
-    scanned: file.profiles.filter((profile) => profile.status === "scanned").length,
-    queued: file.profiles.filter(
-      (profile) =>
-        profile.status === "scan_pending" || profile.status === "scan_running",
-    ).length,
-    noWebsite: file.profiles.filter((profile) => profile.status === "no_website")
-      .length,
-    failed: file.profiles.filter(
-      (profile) =>
-        profile.status === "scan_failed" || profile.status === "rate_limited",
-    ).length,
-  };
-  const recent = file.profiles.slice(0, 12).map((profile) => ({
-    fullName: profile.fullName,
-    rank: profile.rank,
-    status: profile.status,
-    websiteUrl: profile.websiteUrl,
-    lastProfiledAt: profile.lastProfiledAt,
-  }));
-  return {
-    generatedAt: getRepoProfilesGeneratedAt(),
-    selection: file.selection,
-    counts,
-    recent,
-  };
+  return summarizeRepoProfileStatus(readRepoProfilesFileSync());
 }
 
 function runEnricher(args: string[]): Promise<{

--- a/src/lib/pipeline/__tests__/repo-profile-status.test.ts
+++ b/src/lib/pipeline/__tests__/repo-profile-status.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { AisoToolsScan } from "../../aiso-tools";
+import type { RepoProfile, RepoProfilesFile } from "../../repo-profiles";
+import { summarizeRepoProfileStatus } from "../../repo-profile-status";
+
+const NOW = new Date("2026-05-19T12:00:00.000Z");
+
+function makeScan(overrides: Partial<AisoToolsScan> = {}): AisoToolsScan {
+  return {
+    scanId: "scan-1",
+    url: "https://example.com",
+    projectName: null,
+    projectUrl: null,
+    source: "trendingrepo",
+    status: "completed",
+    score: 80,
+    tier: "visible",
+    runtimeVisibility: 80,
+    scanDurationMs: 1000,
+    completedAt: "2026-05-19T10:00:00.000Z",
+    resultUrl: "https://aiso.tools/scan/scan-1",
+    dimensions: [],
+    issues: [],
+    promptTests: [],
+    ...overrides,
+  };
+}
+
+function makeProfile(
+  fullName: string,
+  overrides: Partial<RepoProfile> = {},
+): RepoProfile {
+  return {
+    fullName,
+    rank: 100,
+    selectedFrom: "test",
+    websiteUrl: "https://example.com",
+    websiteSource: "github_homepage",
+    status: "scan_pending",
+    lastProfiledAt: "2026-05-19T09:00:00.000Z",
+    nextScanAfter: null,
+    surfaces: {
+      githubUrl: `https://github.com/${fullName}`,
+      docsUrl: null,
+      npmPackages: [],
+      productHuntLaunchId: null,
+    },
+    aisoScan: null,
+    expertTrendBrief: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+test("summarizes repo-profile AISO backlog, budget, and expert brief coverage", () => {
+  const file: RepoProfilesFile = {
+    generatedAt: "2026-05-19T11:00:00.000Z",
+    version: 1,
+    selection: {
+      source: "catchup",
+      limit: 10,
+      maxScans: 5,
+      dailyScanBudget: 3,
+      scanned: 1,
+      queued: 2,
+      noWebsite: 1,
+      failed: 1,
+      expertBriefs: 1,
+    },
+    profiles: [
+      makeProfile("alpha/scanned", {
+        rank: 1,
+        status: "scanned",
+        aisoScan: makeScan({ scanId: "recent-completed" }),
+        expertTrendBrief: {
+          provider: "kimi",
+          model: "moonshot-v1-auto",
+          generatedAt: "2026-05-19T10:30:00.000Z",
+          headline: "Alpha is accelerating",
+          summary: "Alpha is trending because adoption is growing.",
+          drivers: ["new integrations"],
+          evidence: ["stars are rising"],
+          caveats: ["early signal"],
+        },
+      }),
+      makeProfile("beta/pending", {
+        rank: 2,
+        status: "scan_pending",
+        websiteUrl: "https://beta.example",
+      }),
+      makeProfile("gamma/running", {
+        rank: 3,
+        status: "scan_running",
+        websiteUrl: "https://gamma.example",
+        aisoScan: makeScan({
+          scanId: "running-fallback",
+          status: "running",
+          completedAt: null,
+        }),
+      }),
+      makeProfile("delta/failed", {
+        rank: 4,
+        status: "scan_failed",
+        websiteUrl: "https://delta.example",
+        error: "AISO submit failed",
+      }),
+      makeProfile("epsilon/limited", {
+        rank: 5,
+        status: "rate_limited",
+        websiteUrl: "https://epsilon.example",
+        lastProfiledAt: "2026-05-17T00:00:00.000Z",
+        aisoScan: makeScan({
+          scanId: "old-limited",
+          completedAt: "2026-05-17T00:00:00.000Z",
+        }),
+      }),
+      makeProfile("zeta/none", {
+        rank: 6,
+        status: "no_website",
+        websiteUrl: null,
+        websiteSource: null,
+      }),
+    ],
+  };
+
+  const summary = summarizeRepoProfileStatus(file, {
+    now: NOW,
+    backlogLimit: 3,
+  });
+
+  assert.deepEqual(summary.counts, {
+    total: 6,
+    scanned: 1,
+    scanPending: 1,
+    scanRunning: 1,
+    queued: 2,
+    noWebsite: 1,
+    scanFailed: 1,
+    rateLimited: 1,
+    failed: 2,
+    withAiso: 3,
+    withExpertBrief: 1,
+    actionableBacklog: 4,
+  });
+  assert.deepEqual(summary.budget, {
+    dailyScanBudget: 3,
+    recentAisoSubmissions24h: 2,
+    remainingToday: 1,
+    windowHours: 24,
+    latestAisoScanAt: "2026-05-19T10:00:00.000Z",
+  });
+  assert.deepEqual(
+    summary.backlogPreview.map((row) => [row.fullName, row.status, row.websiteUrl]),
+    [
+      ["beta/pending", "scan_pending", "https://beta.example"],
+      ["gamma/running", "scan_running", "https://gamma.example"],
+      ["delta/failed", "scan_failed", "https://delta.example"],
+    ],
+  );
+});

--- a/src/lib/repo-profile-status.ts
+++ b/src/lib/repo-profile-status.ts
@@ -1,0 +1,216 @@
+import type { RepoProfile, RepoProfilesFile, RepoProfileStatus } from "./repo-profiles";
+
+const DEFAULT_RECENT_LIMIT = 12;
+const DEFAULT_BACKLOG_LIMIT = 12;
+const DEFAULT_RECENT_WINDOW_HOURS = 24;
+const HOUR_MS = 60 * 60 * 1000;
+
+const ACTIONABLE_BACKLOG_STATUSES = new Set<RepoProfileStatus>([
+  "scan_pending",
+  "scan_running",
+  "scan_failed",
+  "rate_limited",
+]);
+
+export interface RepoProfileStatusOptions {
+  now?: Date;
+  recentLimit?: number;
+  backlogLimit?: number;
+  recentWindowHours?: number;
+}
+
+export interface RepoProfileStatusSummary {
+  generatedAt: string | null;
+  selection: RepoProfilesFile["selection"];
+  counts: {
+    total: number;
+    scanned: number;
+    scanPending: number;
+    scanRunning: number;
+    queued: number;
+    noWebsite: number;
+    scanFailed: number;
+    rateLimited: number;
+    failed: number;
+    withAiso: number;
+    withExpertBrief: number;
+    actionableBacklog: number;
+  };
+  budget: {
+    dailyScanBudget: number | null;
+    recentAisoSubmissions24h: number;
+    remainingToday: number | null;
+    windowHours: number;
+    latestAisoScanAt: string | null;
+  };
+  recent: Array<{
+    fullName: string;
+    rank: number | null;
+    status: RepoProfileStatus;
+    websiteUrl: string | null;
+    lastProfiledAt: string;
+  }>;
+  backlogPreview: Array<{
+    fullName: string;
+    rank: number | null;
+    status: RepoProfileStatus;
+    websiteUrl: string | null;
+    websiteSource: RepoProfile["websiteSource"];
+    lastProfiledAt: string;
+    nextScanAfter: string | null;
+    error: string | null;
+  }>;
+}
+
+function scanIdentifier(profile: RepoProfile): string | null {
+  if (!profile.aisoScan) return null;
+  if (profile.aisoScan.scanId) return profile.aisoScan.scanId;
+  const legacyId = (profile.aisoScan as unknown as Record<string, unknown>).id;
+  return typeof legacyId === "string" && legacyId.trim() ? legacyId : null;
+}
+
+function parseIsoMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function scanTimestamp(profile: RepoProfile): { iso: string; ms: number } | null {
+  if (!scanIdentifier(profile)) return null;
+  const scan = profile.aisoScan as unknown as Record<string, unknown>;
+  const raw =
+    (typeof scan.completedAt === "string" ? scan.completedAt : null) ??
+    (typeof scan.submittedAt === "string" ? scan.submittedAt : null) ??
+    (typeof scan.createdAt === "string" ? scan.createdAt : null) ??
+    profile.lastProfiledAt;
+  const ms = parseIsoMs(raw);
+  if (ms === null) return null;
+  return { iso: new Date(ms).toISOString(), ms };
+}
+
+function compareByRankThenName(a: RepoProfile, b: RepoProfile): number {
+  const ar = a.rank ?? Number.MAX_SAFE_INTEGER;
+  const br = b.rank ?? Number.MAX_SAFE_INTEGER;
+  if (ar !== br) return ar - br;
+  return a.fullName.localeCompare(b.fullName);
+}
+
+function positiveInt(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || value === undefined) return fallback;
+  return Math.max(1, Math.floor(value));
+}
+
+export function summarizeRepoProfileStatus(
+  file: RepoProfilesFile,
+  options: RepoProfileStatusOptions = {},
+): RepoProfileStatusSummary {
+  const nowMs = (options.now ?? new Date()).getTime();
+  const recentLimit = positiveInt(options.recentLimit, DEFAULT_RECENT_LIMIT);
+  const backlogLimit = positiveInt(options.backlogLimit, DEFAULT_BACKLOG_LIMIT);
+  const windowHours = positiveInt(
+    options.recentWindowHours,
+    DEFAULT_RECENT_WINDOW_HOURS,
+  );
+  const windowMs = windowHours * HOUR_MS;
+  const counts: RepoProfileStatusSummary["counts"] = {
+    total: 0,
+    scanned: 0,
+    scanPending: 0,
+    scanRunning: 0,
+    queued: 0,
+    noWebsite: 0,
+    scanFailed: 0,
+    rateLimited: 0,
+    failed: 0,
+    withAiso: 0,
+    withExpertBrief: 0,
+    actionableBacklog: 0,
+  };
+  let recentAisoSubmissions24h = 0;
+  let latestAiso: { iso: string; ms: number } | null = null;
+
+  for (const profile of file.profiles) {
+    counts.total += 1;
+    if (profile.status === "scanned") counts.scanned += 1;
+    else if (profile.status === "scan_pending") counts.scanPending += 1;
+    else if (profile.status === "scan_running") counts.scanRunning += 1;
+    else if (profile.status === "no_website") counts.noWebsite += 1;
+    else if (profile.status === "scan_failed") counts.scanFailed += 1;
+    else if (profile.status === "rate_limited") counts.rateLimited += 1;
+
+    if (profile.status === "scan_pending" || profile.status === "scan_running") {
+      counts.queued += 1;
+    }
+    if (profile.status === "scan_failed" || profile.status === "rate_limited") {
+      counts.failed += 1;
+    }
+    if (scanIdentifier(profile)) {
+      counts.withAiso += 1;
+      const timestamp = scanTimestamp(profile);
+      if (timestamp) {
+        if (!latestAiso || timestamp.ms > latestAiso.ms) latestAiso = timestamp;
+        if (timestamp.ms <= nowMs && nowMs - timestamp.ms <= windowMs) {
+          recentAisoSubmissions24h += 1;
+        }
+      }
+    }
+    if (profile.expertTrendBrief) counts.withExpertBrief += 1;
+    if (
+      profile.websiteUrl &&
+      ACTIONABLE_BACKLOG_STATUSES.has(profile.status)
+    ) {
+      counts.actionableBacklog += 1;
+    }
+  }
+
+  const dailyScanBudget =
+    typeof file.selection.dailyScanBudget === "number" &&
+    Number.isFinite(file.selection.dailyScanBudget)
+      ? file.selection.dailyScanBudget
+      : null;
+  const remainingToday =
+    dailyScanBudget === null
+      ? null
+      : Math.max(0, dailyScanBudget - recentAisoSubmissions24h);
+
+  const recent = file.profiles.slice(0, recentLimit).map((profile) => ({
+    fullName: profile.fullName,
+    rank: profile.rank,
+    status: profile.status,
+    websiteUrl: profile.websiteUrl,
+    lastProfiledAt: profile.lastProfiledAt,
+  }));
+  const backlogPreview = file.profiles
+    .filter(
+      (profile) =>
+        Boolean(profile.websiteUrl) &&
+        ACTIONABLE_BACKLOG_STATUSES.has(profile.status),
+    )
+    .sort(compareByRankThenName)
+    .slice(0, backlogLimit)
+    .map((profile) => ({
+      fullName: profile.fullName,
+      rank: profile.rank,
+      status: profile.status,
+      websiteUrl: profile.websiteUrl,
+      websiteSource: profile.websiteSource,
+      lastProfiledAt: profile.lastProfiledAt,
+      nextScanAfter: profile.nextScanAfter,
+      error: profile.error,
+    }));
+
+  return {
+    generatedAt: file.generatedAt ?? null,
+    selection: file.selection,
+    counts,
+    budget: {
+      dailyScanBudget,
+      recentAisoSubmissions24h,
+      remainingToday,
+      windowHours,
+      latestAisoScanAt: latestAiso?.iso ?? null,
+    },
+    recent,
+    backlogPreview,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable repo-profile status summarizer for scan/backlog/budget coverage
- expose detailed AISO counts, daily budget state, and backlog preview from /api/pipeline/profiles/enrich
- add focused coverage for backlog, budget, and Kimi brief counts

## Validation
- npx.cmd tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/pipeline/__tests__/repo-profile-status.test.ts
- npm.cmd run typecheck
- npm.cmd run lint:guards
- npm.cmd run lint
- npm.cmd audit --audit-level=high
- npm.cmd run build
- npm.cmd run test