### PR TITLE
chore(data): refresh lobsters signals 2026-05-19T12:27:56Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-19T08:45:21.246Z",
+  "ts": "2026-05-19T12:27:56.050Z",
   "count": 1,
-  "durationMs": 8710,
+  "durationMs": 3910,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T08:45:12.548Z",
+  "fetchedAt": "2026-05-19T12:27:52.154Z",
   "windowDays": 7,
-  "scannedStories": 83,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T08:45:12.548Z",
+  "fetchedAt": "2026-05-19T12:27:52.154Z",
   "windowHours": 72,
-  "scannedTotal": 83,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -292,6 +292,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "cjwt5c",
+      "title": "Comprehensive Response to Bambu's AGPLv3 Violations",
+      "url": "https://sfconservancy.org/news/2026/may/18/bambu-studio-3d-printer-agpl-violation-response/",
+      "commentsUrl": "https://lobste.rs/s/cjwt5c/comprehensive_response_bambu_s_agplv3",
+      "by": "",
+      "score": 86,
+      "commentCount": 0,
+      "createdUtc": 1779143049,
+      "ageHours": 14.061944444444444,
+      "trendingScore": 1.335984046555282,
+      "tags": [
+        "law"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "auxtwd",
       "title": "Steering Zig Fmt",
       "url": "https://matklad.github.io/2026/05/08/steering-zig-fmt.html",
@@ -306,23 +323,6 @@
         "zig"
       ],
       "description": "<p>I really like the idea of accounting for newline + numbers per line! Any other similar features people have noticed and liked in other language formatters?</p>\n",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "cjwt5c",
-      "title": "Comprehensive Response to Bambu's AGPLv3 Violations",
-      "url": "https://sfconservancy.org/news/2026/may/18/bambu-studio-3d-printer-agpl-violation-response/",
-      "commentsUrl": "https://lobste.rs/s/cjwt5c/comprehensive_response_bambu_s_agplv3",
-      "by": "",
-      "score": 31,
-      "commentCount": 0,
-      "createdUtc": 1779143049,
-      "ageHours": 6.354166666666667,
-      "trendingScore": 1.2838284364741332,
-      "tags": [
-        "law"
-      ],
-      "description": "",
       "linkedRepos": []
     },
     {

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -204726,3 +204726,7 @@
 {"source":"bluesky","fullName":"irbis-sh/zen","observedAt":"2026-05-19T12:20:48.337Z"}
 {"source":"bluesky","fullName":"irbis-sh/zen-desktop","observedAt":"2026-05-19T12:20:48.337Z"}
 {"source":"bluesky","fullName":"ksanjeev284/reddit-universal-scraper","observedAt":"2026-05-19T12:20:48.337Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-19T12:27:54.545Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-19T12:27:54.545Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-19T12:27:54.545Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-19T12:27:54.545Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26097062450

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.