### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-19T14:06:42Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-19T00:17:19.694Z",
+  "ts": "2026-05-19T14:06:42.069Z",
   "count": 1,
-  "durationMs": 11887,
+  "durationMs": 16226,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-19T00:17:16.691Z",
+  "lastFetchedAt": "2026-05-19T14:06:35.280Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1163,6 +1163,54 @@
       "aiAdjacent": true
     },
     {
+      "id": "1135604",
+      "name": "PollyReach",
+      "tagline": "Give your agent a real number and voice to make calls.",
+      "description": "Most AI phone tools are built for enterprises — APIs, workflows, sales automation. PollyReach is built for you. Give your AI a real phone number. Say \"book me a table for 7pm\" — it finds the number, makes the call, handles the conversation, and reports back with a summary, recording & transcript. It also answers your phone 24/7 and screens spam. Works in 50+ languages.",
+      "url": "https://www.producthunt.com/products/pollyreach?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/YNJ3R3XJ5FEEBJ",
+      "votesCount": 235,
+      "commentsCount": 107,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/a4ef6a7a-4563-402b-8578-1681fbdc19d8.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence",
+        "virtual-assistants"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1138787",
       "name": "Open Vibe",
       "tagline": "Ship your SaaS with AI, without getting stuck",
@@ -1360,6 +1408,78 @@
         "artificial-intelligence"
       ],
       "makers": [],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1146684",
+      "name": "Drizz",
+      "tagline": "Mobile tests that write, run, and fix themselves",
+      "description": "Drizz is an AI-powered mobile test automation platform built around intent-based testing. Simply describe what you want to test in plain English, Drizz executes it on a real device using Vision AI and automatically authors a reusable test case. No scripting, no flaky selectors, no manual maintenance. It adapts to dynamic UIs, integrates with your CI/CD pipeline, and gives your team reliable end-to-end coverage without the overhead.",
+      "url": "https://www.producthunt.com/products/drizz-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/7JHDW73XTTPZ3A",
+      "votesCount": 201,
+      "commentsCount": 31,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2feba1f6-72fe-4135-aeb2-75a2f88f586c.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence",
+        "no-code"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,
@@ -1667,6 +1787,95 @@
       "aiAdjacent": true
     },
     {
+      "id": "1150337",
+      "name": "Composer 2.5",
+      "tagline": "Cursor’s most powerful model yet",
+      "description": "A substantial improvement in intelligence and behavior over Composer 2, particularly on long-horizon agentic tasks.",
+      "url": "https://www.producthunt.com/products/cursor?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ZEXWSSPQZYCABO",
+      "votesCount": 174,
+      "commentsCount": 6,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d2edfb12-0064-4ea2-af46-12b43bbb2842.png?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "development"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1148297",
       "name": "Kirki",
       "tagline": "WordPress finally has a freeform canvas website builder.",
@@ -1862,6 +2071,47 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1113430",
+      "name": "Mantle Chat",
+      "tagline": "Collaboration platform where teams work with AI together",
+      "description": "Mantle Chat helps teams boost productivity and adopt AI faster by bringing real-time messaging, AI model chats, autonomous agents, and tool integrations into one shared workspace. Communicate in Discord/Slack-style channels, mention AI agents and models (GPT, Claude, Gemini, Grok, Deepseek) with @ whenever you need help directly in conversations with teammates, build agents, run autonomous tasks together, and connect 30+ tools (Notion, Linear, Gmail and more) your team already uses.",
+      "url": "https://www.producthunt.com/products/mantle-chat?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/HNOJTU2EDLNEGN",
+      "votesCount": 167,
+      "commentsCount": 25,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/977f6301-b044-4702-893f-4e3419e560cd.png?auto=format",
+      "topics": [
+        "productivity",
+        "messaging"
+      ],
+      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2116,199 +2366,6 @@
         "llm",
         "agent"
       ]
-    },
-    {
-      "id": "1142097",
-      "name": "Shadow",
-      "tagline": "AI computer screen and voice control with custom automation",
-      "description": "Shadow is the AI interface for your Mac. It sees your screen, hears your voice, and runs the prompts you build — on a keyboard shortcut, or in your meetings. 🪄 Skills do the work. Quick Reply drafts emails from what you say and what’s on screen. Voice Typing turns talking into clean text, anywhere. Meeting Skills capture every word and screen, then deliver notes and follow-ups the moment you hang up. Build your own — every Skill is a prompt, a context, and an output.",
-      "url": "https://www.producthunt.com/products/shadow-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/RTMG35ETHSLUIL",
-      "votesCount": 163,
-      "commentsCount": 16,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/ff3ba4af-52e1-41a3-9893-5f68be95f072.png?auto=format",
-      "topics": [
-        "productivity",
-        "writing",
-        "meetings"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1146556",
-      "name": "Agentic Website Builder 2.0 by Lokuma",
-      "tagline": "Design, build, and run your site with a design agent harness",
-      "description": "Lokuma 2.0 is a design-aware agent harness for websites. Most AI builders can generate a first draft. But real sites need structure, taste, brand consistency, editing, publishing, forms, and ongoing updates. Lokuma connects planning, design, style, assets, site state, edits, and publishing into one agentic workflow — so your website feels designed, not just generated. Design, build, and run your site with agents.",
-      "url": "https://www.producthunt.com/products/agentic-website-builder-2-0-by-lokuma?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DWJQQXBEGBRBCS",
-      "votesCount": 160,
-      "commentsCount": 42,
-      "createdAt": "2026-05-15T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/552a17b6-3d07-4831-9dcc-b2a743e0fa33.x-icon?auto=format",
-      "topics": [
-        "design-tools",
-        "artificial-intelligence",
-        "vercel-day"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1142580",
-      "name": "Adject 2.0",
-      "tagline": "Create hyperrealistic product visuals with AI",
-      "description": "Adject 2.0 is an agentic product studio where brands can create, edit, and iterate product visuals inside an infinite creative workflow. Instead of isolated generations, products, models, edits, videos, and assets stay connected inside projects and evolve continuously over time. Upload once, generate in context, iterate visually, and build complete campaigns without fragmented tools or repetitive prompting.",
-      "url": "https://www.producthunt.com/products/adject?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/BPB5EVZOROWIVC",
-      "votesCount": 159,
-      "commentsCount": 17,
-      "createdAt": "2026-05-10T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/71bffed4-4e53-4c02-aff9-d9d5cf2fcd84.png?auto=format",
-      "topics": [
-        "design-tools",
-        "artificial-intelligence",
-        "e-commerce"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1140367",
-      "name": "MiroMiro v2",
-      "tagline": "Inspect, edit, and export any website's design",
-      "description": "Inspect, edit, and export any website's design as clean code. Hover to see styles, click to edit colors, fonts, spacing, and shadows live like in Figma. Export sections as Tailwind or HTML/CSS. Capture the full design system: colors, fonts, spacing, radii, shadows, even the tech stack. Pull SVGs, Lottie animations, and images. Extract design tokens for Tailwind, CSS vars, or JSON. Check WCAG contrast on any text. Copy any value with one click. The fastest path from inspiration to working code.",
-      "url": "https://www.producthunt.com/products/miromiro?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/FZXHZAPXMQHI2M",
-      "votesCount": 157,
-      "commentsCount": 14,
-      "createdAt": "2026-05-11T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/126b2645-196d-4fa0-bc86-c8a36c9618c3.png?auto=format",
-      "topics": [
-        "chrome-extensions",
-        "design-tools",
-        "productivity",
-        "developer-tools"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26102466562

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.