### PR TITLE
chore(data): refresh ai rss signals 2026-05-19T15:56:57Z

### DIFF
--- a/data/_meta/claude-rss.json
+++ b/data/_meta/claude-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "claude-rss",
   "reason": "ok",
-  "ts": "2026-05-19T10:13:38.923Z",
+  "ts": "2026-05-19T15:56:50.798Z",
   "count": 1,
-  "durationMs": 7076,
+  "durationMs": 1461,
   "extra": {}
 }

--- a/data/_meta/openai-rss.json
+++ b/data/_meta/openai-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "openai-rss",
   "reason": "ok",
-  "ts": "2026-05-19T10:13:41.801Z",
+  "ts": "2026-05-19T15:56:57.865Z",
   "count": 1,
-  "durationMs": 2717,
+  "durationMs": 6905,
   "extra": {}
 }

--- a/data/claude-rss.json
+++ b/data/claude-rss.json
@@ -1,9 +1,19 @@
 {
-  "fetchedAt": "2026-05-19T10:13:31.852Z",
+  "fetchedAt": "2026-05-19T15:56:49.342Z",
   "source": "claude",
   "feedUrl": "https://www.anthropic.com/news",
   "error": null,
   "items": [
+    {
+      "id": "https://www.anthropic.com/news/anthropic-kpmg",
+      "title": "Anthropic Kpmg",
+      "url": "https://www.anthropic.com/news/anthropic-kpmg",
+      "summary": "",
+      "publishedAt": "2026-05-19T13:30:59.000Z",
+      "author": "Anthropic",
+      "source": "claude",
+      "category": "POST"
+    },
     {
       "id": "https://www.anthropic.com/news/anthropic-acquires-stainless",
       "title": "Anthropic Acquires Stainless",
@@ -290,16 +300,6 @@
       "url": "https://www.anthropic.com/news/where-stand-department-war",
       "summary": "",
       "publishedAt": "2026-03-06T00:51:17.000Z",
-      "author": "Anthropic",
-      "source": "claude",
-      "category": "POST"
-    },
-    {
-      "id": "https://www.anthropic.com/news/enabling-claude-code-to-work-more-autonomously",
-      "title": "Enabling Claude Code to Work More Autonomously",
-      "url": "https://www.anthropic.com/news/enabling-claude-code-to-work-more-autonomously",
-      "summary": "",
-      "publishedAt": "2026-03-02T21:07:46.000Z",
       "author": "Anthropic",
       "source": "claude",
       "category": "POST"

--- a/data/openai-rss.json
+++ b/data/openai-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T10:13:39.088Z",
+  "fetchedAt": "2026-05-19T15:56:50.964Z",
   "source": "openai",
   "feedUrl": "https://openai.com/news/rss.xml",
   "error": null,


### PR DESCRIPTION
Automated data refresh from `Refresh AI RSS signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26108902748

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.