### PR TITLE
chore(data): refresh lobsters signals 2026-05-19T16:00:40Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-19T12:27:56.050Z",
+  "ts": "2026-05-19T16:00:40.289Z",
   "count": 1,
-  "durationMs": 3910,
+  "durationMs": 3791,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T12:27:52.154Z",
+  "fetchedAt": "2026-05-19T16:00:36.513Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T12:27:52.154Z",
+  "fetchedAt": "2026-05-19T16:00:36.513Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -103,6 +103,24 @@
       "trendingScore": 2.707042920142815,
       "tags": [
         "linux"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "wwcjoc",
+      "title": "OpenBSD 7.9 released",
+      "url": "https://www.openbsd.org/79.html",
+      "commentsUrl": "https://lobste.rs/s/wwcjoc/openbsd_7_9_released",
+      "by": "",
+      "score": 25,
+      "commentCount": 2,
+      "createdUtc": 1779197409,
+      "ageHours": 2.5075,
+      "trendingScore": 2.612380333087812,
+      "tags": [
+        "openbsd",
+        "release"
       ],
       "description": "",
       "linkedRepos": []
@@ -435,6 +453,23 @@
       "tags": [
         "pdf",
         "practices",
+        "programming"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "zotppg",
+      "title": "Type out the code",
+      "url": "https://haskellforall.com/2026/05/type-out-the-code",
+      "commentsUrl": "https://lobste.rs/s/zotppg/type_out_code",
+      "by": "",
+      "score": 7,
+      "commentCount": 0,
+      "createdUtc": 1779201447,
+      "ageHours": 1.3858333333333333,
+      "trendingScore": 1.1235688120945133,
+      "tags": [
         "programming"
       ],
       "description": "",
@@ -863,40 +898,6 @@
         "clojure",
         "go",
         "lisp"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "szsqdd",
-      "title": "Git Is Not Fine",
-      "url": "https://www.billjings.com/posts/title/git-is-not-fine/",
-      "commentsUrl": "https://lobste.rs/s/szsqdd/git_is_not_fine",
-      "by": "",
-      "score": 14,
-      "commentCount": 1,
-      "createdUtc": 1778872316,
-      "ageHours": 4.325555555555556,
-      "trendingScore": 0.8799946343791463,
-      "tags": [
-        "vcs"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "huqdtj",
-      "title": "Coding on Paper",
-      "url": "https://wickstrom.tech/2026-05-16-coding-on-paper.html",
-      "commentsUrl": "https://lobste.rs/s/huqdtj/coding_on_paper",
-      "by": "",
-      "score": 20,
-      "commentCount": 2,
-      "createdUtc": 1779031710,
-      "ageHours": 6.027222222222222,
-      "trendingScore": 0.8793911015066856,
-      "tags": [
-        "hardware"
       ],
       "description": "",
       "linkedRepos": []

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -205905,3 +205905,8 @@
 {"source":"devto","fullName":"nees-anna/nees-core-developer-preview","observedAt":"2026-05-19T15:29:26.381Z"}
 {"source":"devto","fullName":"hypecuts619-source/ledger-guard","observedAt":"2026-05-19T15:29:26.381Z"}
 {"source":"devto","fullName":"containers/skopeo","observedAt":"2026-05-19T15:29:26.381Z"}
+{"source":"lobsters","fullName":"tomekw/stcc","observedAt":"2026-05-19T16:00:38.819Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-19T16:00:38.819Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-19T16:00:38.819Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-19T16:00:38.819Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-19T16:00:38.819Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26109115225

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.