### PR TITLE
chore(data): refresh huggingface space signals 2026-05-19T16:01:48Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-19T10:26:45.896Z",
+  "ts": "2026-05-19T16:01:48.089Z",
   "count": 1,
-  "durationMs": 10357,
+  "durationMs": 9214,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T10:26:35.541Z",
+  "fetchedAt": "2026-05-19T16:01:38.877Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -227,6 +227,39 @@
     },
     {
       "rank": 14,
+      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
+      "author": "cbensimon",
+      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
+      "likes": 70,
+      "trendingScore": 62,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:08:17.000Z",
+      "lastModified": "2026-05-14T11:52:10.000Z",
+      "models": []
+    },
+    {
+      "rank": 15,
+      "id": "ResembleAI/Dramabox",
+      "author": "ResembleAI",
+      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
+      "likes": 62,
+      "trendingScore": 62,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T05:09:42.000Z",
+      "lastModified": "2026-05-14T10:06:44.000Z",
+      "models": []
+    },
+    {
+      "rank": 16,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/spaces/k2-fsa/OmniVoice",
@@ -239,39 +272,6 @@
       ],
       "createdAt": "2026-03-30T13:56:16.000Z",
       "lastModified": "2026-04-13T06:55:17.000Z",
-      "models": []
-    },
-    {
-      "rank": 15,
-      "id": "ResembleAI/Dramabox",
-      "author": "ResembleAI",
-      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 61,
-      "trendingScore": 61,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T05:09:42.000Z",
-      "lastModified": "2026-05-14T10:06:44.000Z",
-      "models": []
-    },
-    {
-      "rank": 16,
-      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
-      "author": "cbensimon",
-      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 68,
-      "trendingScore": 60,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:08:17.000Z",
-      "lastModified": "2026-05-14T11:52:10.000Z",
       "models": []
     },
     {
@@ -407,6 +407,23 @@
     },
     {
       "rank": 25,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 45,
+      "trendingScore": 35,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 26,
       "id": "multimodalart/qwen-image-multiple-angles-3d-camera",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/qwen-image-multiple-angles-3d-camera",
@@ -422,7 +439,7 @@
       "models": []
     },
     {
-      "rank": 26,
+      "rank": 27,
       "id": "suraj291/Survival_Island_Game",
       "author": "suraj291",
       "url": "https://huggingface.co/spaces/suraj291/Survival_Island_Game",
@@ -439,7 +456,7 @@
       "models": []
     },
     {
-      "rank": 27,
+      "rank": 28,
       "id": "r3gm/wan2-2-fp8da-aoti-previewG",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewG",
@@ -456,7 +473,7 @@
       "models": []
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -472,7 +489,7 @@
       "models": []
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -486,23 +503,6 @@
       ],
       "createdAt": "2026-02-09T13:55:04.000Z",
       "lastModified": "2026-05-13T07:34:37.000Z",
-      "models": []
-    },
-    {
-      "rank": 30,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 42,
-      "trendingScore": 32,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -589,6 +589,22 @@
     },
     {
       "rank": 36,
+      "id": "Lakonik/AsymFLUX.2-klein",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
+      "likes": 26,
+      "trendingScore": 26,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:06:55.000Z",
+      "lastModified": "2026-05-19T00:50:26.000Z",
+      "models": []
+    },
+    {
+      "rank": 37,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -608,7 +624,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -622,22 +638,6 @@
       ],
       "createdAt": "2025-12-28T08:15:28.000Z",
       "lastModified": "2025-12-29T13:46:27.000Z",
-      "models": []
-    },
-    {
-      "rank": 38,
-      "id": "Lakonik/AsymFLUX.2-klein",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
-      "likes": 24,
-      "trendingScore": 24,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:06:55.000Z",
-      "lastModified": "2026-05-19T00:50:26.000Z",
       "models": []
     },
     {
@@ -658,6 +658,23 @@
     },
     {
       "rank": 40,
+      "id": "black-forest-labs/FLUX.2-klein-9B",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
+      "likes": 833,
+      "trendingScore": 22,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-01-15T09:50:22.000Z",
+      "lastModified": "2026-01-16T13:56:36.000Z",
+      "models": []
+    },
+    {
+      "rank": 41,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -673,7 +690,7 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -689,7 +706,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "Overworld/waypoint-1-5",
       "author": "Overworld",
       "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
@@ -705,7 +722,7 @@
       "models": []
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "carlofkl/DreamLite",
       "author": "carlofkl",
       "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
@@ -725,7 +742,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "huggingface/physics-intern",
       "author": "huggingface",
       "url": "https://huggingface.co/spaces/huggingface/physics-intern",
@@ -739,23 +756,6 @@
       ],
       "createdAt": "2026-04-09T06:56:52.000Z",
       "lastModified": "2026-05-12T14:59:53.000Z",
-      "models": []
-    },
-    {
-      "rank": 45,
-      "id": "black-forest-labs/FLUX.2-klein-9B",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
-      "likes": 830,
-      "trendingScore": 20,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-01-15T09:50:22.000Z",
-      "lastModified": "2026-01-16T13:56:36.000Z",
       "models": []
     },
     {
@@ -792,6 +792,22 @@
     },
     {
       "rank": 48,
+      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
+      "author": "Saravutw",
+      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
+      "likes": 28,
+      "trendingScore": 19,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-09T19:01:39.000Z",
+      "lastModified": "2026-03-13T17:12:16.000Z",
+      "models": []
+    },
+    {
+      "rank": 49,
       "id": "lerobot/visualize_dataset",
       "author": "lerobot",
       "url": "https://huggingface.co/spaces/lerobot/visualize_dataset",
@@ -807,7 +823,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "openai/privacy-filter",
       "author": "openai",
       "url": "https://huggingface.co/spaces/openai/privacy-filter",
@@ -820,22 +836,6 @@
       ],
       "createdAt": "2026-04-17T23:23:53.000Z",
       "lastModified": "2026-04-24T14:39:09.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
-      "author": "Saravutw",
-      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 23,
-      "trendingScore": 18,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-12-09T19:01:39.000Z",
-      "lastModified": "2026-03-13T17:12:16.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26109177446

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.