### PR TITLE
chore(data): refresh mcp liveness 2026-05-19T16:05:08Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T10:28:34.071Z",
+  "fetchedAt": "2026-05-19T16:05:04.320Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -1857,6 +1857,50 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "devtee-dot/gridpulse energy": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "junhyeok0703/policy-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "domdemetz/claude-soul": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dmang-dev/mcp-dolphin": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ayoubtadlaoui/npmguard": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "movebrickschi/harness engineering mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "xecho-dev/mcp-watermark": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "smythmyke/markitup mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pop24/lebonfoin mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "oolab-labs/patchwork-os": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "justadityaraj/amazon-in-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "maxsambento/morfex": {
       "isStdio": true,
       "livenessInferred": true
@@ -1882,90 +1926,6 @@
       "livenessInferred": true
     },
     "philidor/defi": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "macromnex/esmfold mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mindfullabai/yearataglance mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "erenozdemirrr/pitchlink mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "wmt-mobile/localnest mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kanvabhatia-alaan/slack-indexed": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dweekly/quicken mac mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "freshsk/mcp outlook server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "n3wth/r3 (recall)": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ansvar-systems/zambian law mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "batu-sonmez/infraclaude": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "opaldecisionsciences/openai token manager mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "omgeverdo/browser-pool-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "phil65/llmling": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "boabai/mcp cliniko server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "felipe-cal/marketing brain": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "block-town/mcp gateway": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dsouzaanush/heroku code mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "chaitanyaatlan/fifth elephant mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "urlbox/urlbox mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "apify/playwright mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tolatolatop/runninghub mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3998,6 +3958,46 @@
       "livenessInferred": true
     },
     "attilio81/mcp-agno": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "linnienaryshkin/teams mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "seite-sh/seite": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dohyung1/fpl intelligence": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sanzco/kubernetes mcp server – 5g core edition": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "saikodi/hive-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "citesurf/citesurf mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "luciferforge/agent-safety-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tickory/tickory mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "3knightcz/codebeamer-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "geminilight/mindos": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26109364973

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.