### PR TITLE
chore(data): refresh lobsters signals 2026-05-19T18:25:18Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-19T16:00:40.289Z",
+  "ts": "2026-05-19T18:25:17.996Z",
   "count": 1,
-  "durationMs": 3791,
+  "durationMs": 13993,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T16:00:36.513Z",
+  "fetchedAt": "2026-05-19T18:25:04.016Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -270,6 +270,44 @@
         }
       ]
     },
+    "tomekw/stcc": {
+      "count7d": 1,
+      "scoreSum7d": 12,
+      "topStory": {
+        "shortId": "pk139i",
+        "title": "The Super Tiny Compiler, but in Ada",
+        "score": 12,
+        "url": "https://github.com/tomekw/stcc",
+        "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
+        "hoursSincePosted": 4.574722222222222
+      },
+      "stories": [
+        {
+          "shortId": "pk139i",
+          "title": "The Super Tiny Compiler, but in Ada",
+          "url": "https://github.com/tomekw/stcc",
+          "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
+          "by": "",
+          "score": 12,
+          "commentCount": 3,
+          "createdUtc": 1779198635,
+          "ageHours": 4.574722222222222,
+          "trendingScore": 0.7118117172448903,
+          "tags": [
+            "plt",
+            "programming"
+          ],
+          "description": "",
+          "linkedRepos": [
+            {
+              "fullName": "tomekw/stcc",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
     "jundot/omlx": {
       "count7d": 1,
       "scoreSum7d": 8,
@@ -455,6 +493,11 @@
       "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",
       "count7d": 1,
       "scoreSum7d": 18
+    },
+    {
+      "fullName": "tomekw/stcc",
+      "count7d": 1,
+      "scoreSum7d": 12
     },
     {
       "fullName": "jundot/omlx",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T16:00:36.513Z",
+  "fetchedAt": "2026-05-19T18:25:04.016Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -113,11 +113,11 @@
       "url": "https://www.openbsd.org/79.html",
       "commentsUrl": "https://lobste.rs/s/wwcjoc/openbsd_7_9_released",
       "by": "",
-      "score": 25,
-      "commentCount": 2,
+      "score": 48,
+      "commentCount": 4,
       "createdUtc": 1779197409,
-      "ageHours": 2.5075,
-      "trendingScore": 2.612380333087812,
+      "ageHours": 4.915277777777778,
+      "trendingScore": 2.6395311559925774,
       "tags": [
         "openbsd",
         "release"
@@ -139,6 +139,23 @@
       "tags": [
         "linux",
         "security"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "zotppg",
+      "title": "Type out the code",
+      "url": "https://haskellforall.com/2026/05/type-out-the-code",
+      "commentsUrl": "https://lobste.rs/s/zotppg/type_out_code",
+      "by": "",
+      "score": 34,
+      "commentCount": 2,
+      "createdUtc": 1779201447,
+      "ageHours": 3.7936111111111113,
+      "trendingScore": 2.438119042592024,
+      "tags": [
+        "programming"
       ],
       "description": "",
       "linkedRepos": []
@@ -459,23 +476,6 @@
       "linkedRepos": []
     },
     {
-      "shortId": "zotppg",
-      "title": "Type out the code",
-      "url": "https://haskellforall.com/2026/05/type-out-the-code",
-      "commentsUrl": "https://lobste.rs/s/zotppg/type_out_code",
-      "by": "",
-      "score": 7,
-      "commentCount": 0,
-      "createdUtc": 1779201447,
-      "ageHours": 1.3858333333333333,
-      "trendingScore": 1.1235688120945133,
-      "tags": [
-        "programming"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
       "shortId": "bnfm0h",
       "title": "Let's Encrypt Stopping Issuance for Potential Incident",
       "url": "https://letsencrypt.status.io/",
@@ -634,6 +634,24 @@
         "hardware"
       ],
       "description": "<p>AFAIU this is a wired device even if promotional images seem to suggest different.</p>\n",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "maqmo2",
+      "title": "How we used Quint to find over 10 bugs in SQLite while hardening Turso",
+      "url": "https://turso.tech/blog/how-we-used-quint-to-find-over-10-bugs-in-sqlite",
+      "commentsUrl": "https://lobste.rs/s/maqmo2/how_we_used_quint_find_over_10_bugs_sqlite",
+      "by": "",
+      "score": 10,
+      "commentCount": 1,
+      "createdUtc": 1779205399,
+      "ageHours": 2.6958333333333333,
+      "trendingScore": 0.9827227011836208,
+      "tags": [
+        "databases",
+        "formalmethods"
+      ],
+      "description": "",
       "linkedRepos": []
     },
     {
@@ -881,25 +899,6 @@
         "meta"
       ],
       "description": "<p>There've been endless discussions about whether we should ban LLM-generated text, or change the ai/vibecoding tags, or etc.  The general consensus seems to be (???) flag low-effort/uninformative stories as spam and move on.</p>\n<p>My proposal here is that <em>comments</em> on these stories that just say \"this is LLM slop\" or something equivalent should be flagged as off-topic.  Clearly everyone has different thresholds for what triggers their \"slop-o-meter\" but at least 80% of the reason I re",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "njobov",
-      "title": "let-go: Almost Clojure written in Go",
-      "url": "https://github.com/nooga/let-go",
-      "commentsUrl": "https://lobste.rs/s/njobov/let_go_almost_clojure_written_go",
-      "by": "",
-      "score": 11,
-      "commentCount": 1,
-      "createdUtc": 1778443677,
-      "ageHours": 3.3833333333333333,
-      "trendingScore": 0.8806752213857781,
-      "tags": [
-        "clojure",
-        "go",
-        "lisp"
-      ],
-      "description": "",
       "linkedRepos": []
     }
   ]

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -206831,3 +206831,8 @@
 {"source":"hackernews","fullName":"googlarz/collaborate","observedAt":"2026-05-19T16:47:39.874Z"}
 {"source":"hackernews","fullName":"zeroentropy-ai/probe","observedAt":"2026-05-19T16:47:39.874Z"}
 {"source":"hackernews","fullName":"kentaniguchi-r/ledgr","observedAt":"2026-05-19T16:47:39.874Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-19T18:25:16.670Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-19T18:25:16.670Z"}
+{"source":"lobsters","fullName":"samth/gradual-typing-bib","observedAt":"2026-05-19T18:25:16.670Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-19T18:25:16.670Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-19T18:25:16.670Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26116826209

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.