### PR TITLE
chore(data): refresh lobsters signals 2026-05-19T20:17:16Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-19T18:25:17.996Z",
+  "ts": "2026-05-19T20:17:16.227Z",
   "count": 1,
-  "durationMs": 13993,
+  "durationMs": 5181,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T18:25:04.016Z",
+  "fetchedAt": "2026-05-19T20:17:11.060Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -279,7 +279,7 @@
         "score": 12,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 4.574722222222222
+        "hoursSincePosted": 6.443333333333333
       },
       "stories": [
         {
@@ -291,8 +291,8 @@
           "score": 12,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 4.574722222222222,
-          "trendingScore": 0.7118117172448903,
+          "ageHours": 6.443333333333333,
+          "trendingScore": 0.4891142810513447,
           "tags": [
             "plt",
             "programming"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T18:25:04.016Z",
+  "fetchedAt": "2026-05-19T20:17:11.060Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -743,6 +743,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "2fqahd",
+      "title": "I am not a Software Engineer",
+      "url": "https://huronbikes.mataroa.blog/blog/i-am-not-a-software-engineer/",
+      "commentsUrl": "https://lobste.rs/s/2fqahd/i_am_not_software_engineer",
+      "by": "",
+      "score": 3,
+      "commentCount": 1,
+      "createdUtc": 1779221169,
+      "ageHours": 0.18388888888888888,
+      "trendingScore": 0.9295557606879611,
+      "tags": [
+        "practices",
+        "vibecoding"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "ktqfov",
       "title": "Open Source Resistance",
       "url": "https://ossresistance.com/",
@@ -882,23 +900,6 @@
         "windows"
       ],
       "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "wee21u",
-      "title": "\"This is written by an LLM\" comments should be flagged as off-topic",
-      "url": "",
-      "commentsUrl": "https://lobste.rs/s/wee21u/this_is_written_by_llm_comments_should_be",
-      "by": "",
-      "score": 55,
-      "commentCount": 62,
-      "createdUtc": 1778778024,
-      "ageHours": 13.724166666666667,
-      "trendingScore": 0.882086614615526,
-      "tags": [
-        "meta"
-      ],
-      "description": "<p>There've been endless discussions about whether we should ban LLM-generated text, or change the ai/vibecoding tags, or etc.  The general consensus seems to be (???) flag low-effort/uninformative stories as spam and move on.</p>\n<p>My proposal here is that <em>comments</em> on these stories that just say \"this is LLM slop\" or something equivalent should be flagged as off-topic.  Clearly everyone has different thresholds for what triggers their \"slop-o-meter\" but at least 80% of the reason I re",
       "linkedRepos": []
     }
   ]

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -208382,3 +208382,9 @@
 {"source":"devto","fullName":"containers/skopeo","observedAt":"2026-05-19T19:56:00.542Z"}
 {"source":"devto","fullName":"openbmb/minicpm-v","observedAt":"2026-05-19T19:56:00.542Z"}
 {"source":"devto","fullName":"whoamihappyhacking/lazycat-movie-search-skill","observedAt":"2026-05-19T19:56:00.542Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-19T20:17:14.748Z"}
+{"source":"lobsters","fullName":"sander110419/lightroom-cc-on-linux","observedAt":"2026-05-19T20:17:14.748Z"}
+{"source":"lobsters","fullName":"xataio/deltax","observedAt":"2026-05-19T20:17:14.748Z"}
+{"source":"lobsters","fullName":"samth/gradual-typing-bib","observedAt":"2026-05-19T20:17:14.748Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-19T20:17:14.748Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-19T20:17:14.748Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26122687485

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.