### PR TITLE
chore(data): refresh huggingface space signals 2026-05-19T20:18:15Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-19T16:01:48.089Z",
+  "ts": "2026-05-19T20:18:15.062Z",
   "count": 1,
-  "durationMs": 9214,
+  "durationMs": 9063,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T16:01:38.877Z",
+  "fetchedAt": "2026-05-19T20:18:06.001Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -211,6 +211,22 @@
     },
     {
       "rank": 13,
+      "id": "ResembleAI/Dramabox",
+      "author": "ResembleAI",
+      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
+      "likes": 64,
+      "trendingScore": 64,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T05:09:42.000Z",
+      "lastModified": "2026-05-14T10:06:44.000Z",
+      "models": []
+    },
+    {
+      "rank": 14,
       "id": "ysharma/fast-image-studio",
       "author": "ysharma",
       "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
@@ -226,12 +242,12 @@
       "models": []
     },
     {
-      "rank": 14,
+      "rank": 15,
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 70,
-      "trendingScore": 62,
+      "likes": 71,
+      "trendingScore": 63,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -240,22 +256,6 @@
       ],
       "createdAt": "2026-05-12T10:08:17.000Z",
       "lastModified": "2026-05-14T11:52:10.000Z",
-      "models": []
-    },
-    {
-      "rank": 15,
-      "id": "ResembleAI/Dramabox",
-      "author": "ResembleAI",
-      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 62,
-      "trendingScore": 62,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T05:09:42.000Z",
-      "lastModified": "2026-05-14T10:06:44.000Z",
       "models": []
     },
     {
@@ -795,8 +795,8 @@
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 28,
-      "trendingScore": 19,
+      "likes": 29,
+      "trendingScore": 20,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -808,6 +808,22 @@
     },
     {
       "rank": 49,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 20,
+      "trendingScore": 20,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-19T17:29:04.000Z",
+      "models": []
+    },
+    {
+      "rank": 50,
       "id": "lerobot/visualize_dataset",
       "author": "lerobot",
       "url": "https://huggingface.co/spaces/lerobot/visualize_dataset",
@@ -820,22 +836,6 @@
       ],
       "createdAt": "2024-07-17T10:30:46.000Z",
       "lastModified": "2026-04-27T17:48:48.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "openai/privacy-filter",
-      "author": "openai",
-      "url": "https://huggingface.co/spaces/openai/privacy-filter",
-      "likes": 61,
-      "trendingScore": 18,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T23:23:53.000Z",
-      "lastModified": "2026-04-24T14:39:09.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26122738457

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.