### PR TITLE
chore(data): refresh mcp liveness 2026-05-19T20:21:53Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T16:05:04.320Z",
+  "fetchedAt": "2026-05-19T20:21:48.282Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -1901,6 +1901,54 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "snowykte0426/datagsm-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aberry-h/deepseek mcp sample": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "astandrik/local ydb mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "osirishorus/opencoffer": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "eucomplyhub/mcp-eu-ai-act": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "marcellm01/tinysearch": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "coding-professional/vibe mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "stock-vibes/meeting-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "prototypr/feedbagel mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "trafficmorph-gif/tm-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "clidyn/copernicus-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "fdcommercial/property-finance-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "maxsambento/morfex": {
       "isStdio": true,
       "livenessInferred": true
@@ -1926,38 +1974,6 @@
       "livenessInferred": true
     },
     "philidor/defi": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pskinnertech/skyfi mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "optltd/mcp pdf server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "samik081/mcp pve": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bdteo/codebasehq mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tocharianou/elastic brain zh": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jpalmerr/hedgehog": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "roandegraaf/lordicon-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kumaran-is/mcp weather server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3982,22 +3998,6 @@
       "livenessInferred": true
     },
     "citesurf/citesurf mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "luciferforge/agent-safety-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tickory/tickory mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "3knightcz/codebeamer-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "geminilight/mindos": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26122930135

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.