### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-19T20:50:51Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-19T17:42:15.597Z",
+  "ts": "2026-05-19T20:50:51.497Z",
   "count": 1,
-  "durationMs": 18916,
+  "durationMs": 16619,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-19T17:42:08.993Z",
+  "lastFetchedAt": "2026-05-19T20:50:44.926Z",
   "windowDays": 7,
   "launches": [
     {
@@ -249,6 +249,54 @@
       "aiAdjacent": true
     },
     {
+      "id": "1135604",
+      "name": "PollyReach",
+      "tagline": "Give your agent a real number and voice to make calls.",
+      "description": "Most AI phone tools are built for enterprises — APIs, workflows, sales automation. PollyReach is built for you. Give your AI a real phone number. Say \"book me a table for 7pm\" — it finds the number, makes the call, handles the conversation, and reports back with a summary, recording & transcript. It also answers your phone 24/7 and screens spam. Works in 50+ languages.",
+      "url": "https://www.producthunt.com/products/pollyreach?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/YNJ3R3XJ5FEEBJ",
+      "votesCount": 383,
+      "commentsCount": 117,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/a4ef6a7a-4563-402b-8578-1681fbdc19d8.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence",
+        "virtual-assistants"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1124409",
       "name": "SocLeads 3.0",
       "tagline": "Scrape emails from socials and maps by location",
@@ -295,54 +343,6 @@
         "yc-application"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1135604",
-      "name": "PollyReach",
-      "tagline": "Give your agent a real number and voice to make calls.",
-      "description": "Most AI phone tools are built for enterprises — APIs, workflows, sales automation. PollyReach is built for you. Give your AI a real phone number. Say \"book me a table for 7pm\" — it finds the number, makes the call, handles the conversation, and reports back with a summary, recording & transcript. It also answers your phone 24/7 and screens spam. Works in 50+ languages.",
-      "url": "https://www.producthunt.com/products/pollyreach?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/YNJ3R3XJ5FEEBJ",
-      "votesCount": 352,
-      "commentsCount": 114,
-      "createdAt": "2026-05-19T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/a4ef6a7a-4563-402b-8578-1681fbdc19d8.png?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence",
-        "virtual-assistants"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -493,6 +493,78 @@
         "artificial-intelligence"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1146684",
+      "name": "Drizz",
+      "tagline": "Mobile tests that write, run, and fix themselves",
+      "description": "Drizz is an AI-powered mobile test automation platform built around intent-based testing. Simply describe what you want to test in plain English, Drizz executes it on a real device using Vision AI and automatically authors a reusable test case. No scripting, no flaky selectors, no manual maintenance. It adapts to dynamic UIs, integrates with your CI/CD pipeline, and gives your team reliable end-to-end coverage without the overhead.",
+      "url": "https://www.producthunt.com/products/drizz-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/7JHDW73XTTPZ3A",
+      "votesCount": 324,
+      "commentsCount": 55,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2feba1f6-72fe-4135-aeb2-75a2f88f586c.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence",
+        "no-code"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -737,22 +809,93 @@
       "aiAdjacent": true
     },
     {
-      "id": "1146684",
-      "name": "Drizz",
-      "tagline": "Mobile tests that write, run, and fix themselves",
-      "description": "Drizz is an AI-powered mobile test automation platform built around intent-based testing. Simply describe what you want to test in plain English, Drizz executes it on a real device using Vision AI and automatically authors a reusable test case. No scripting, no flaky selectors, no manual maintenance. It adapts to dynamic UIs, integrates with your CI/CD pipeline, and gives your team reliable end-to-end coverage without the overhead.",
-      "url": "https://www.producthunt.com/products/drizz-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/7JHDW73XTTPZ3A",
-      "votesCount": 294,
-      "commentsCount": 43,
-      "createdAt": "2026-05-19T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2feba1f6-72fe-4135-aeb2-75a2f88f586c.png?auto=format",
+      "id": "942860",
+      "name": "SUN-to-Spotify ",
+      "tagline": "Generate audio with SUN and send it to your Spotify library",
+      "description": "Download 👉 https://github.com/sunapp-ai/sun-to-spotify SUN-to-Spotify is a skill that lets you generate AI podcasts, audiobooks, and then publish them directly to your Spotify library for streaming or offline listening. Just describe what you want to hear: startup advice, history deep dives, philosophy, news, or custom learning content, and SUN creates a personalized audio experience in minutes. Built for creators, developers, and curious minds exploring the future of AI native audio.",
+      "url": "https://www.producthunt.com/products/sun-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ANMWQJRL3VEODH",
+      "votesCount": 292,
+      "commentsCount": 25,
+      "createdAt": "2026-05-17T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/30200cdb-d608-494f-bb9f-b38002818e65.png?auto=format",
       "topics": [
-        "developer-tools",
+        "education",
         "artificial-intelligence",
-        "no-code"
+        "audio"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": "https://github.com/sunapp-ai/sun-to-spotify",
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true,
+      "githubRepo": {
+        "stars": 37,
+        "topics": [],
+        "readmeSnippet": "# Sun to Spotify\n\nTurn any topic, question, or feed into a **dialogue podcast** — and listen to it in Spotify or your favorite podcast app.\n\nJust say:\n\n> What's the latest in voice and audio AI? Give me a 10-minute roundup.\n\n> What's happening in the stock market this morning? Make it a 5-minute brief.\n\n> Give me my daily brief based on my calendar for the next 30 minutes.\n\n> Summarize *The Hard Thing About Hard Things* as a 20-minute podcast.\n\n> How should I think about marketing my B2B startup"
+      },
+      "tags": []
+    },
+    {
+      "id": "1150337",
+      "name": "Composer 2.5",
+      "tagline": "Cursor’s most powerful model yet",
+      "description": "A substantial improvement in intelligence and behavior over Composer 2, particularly on long-horizon agentic tasks.",
+      "url": "https://www.producthunt.com/products/cursor?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ZEXWSSPQZYCABO",
+      "votesCount": 286,
+      "commentsCount": 8,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d2edfb12-0064-4ea2-af46-12b43bbb2842.png?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "development"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -807,60 +950,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
-    },
-    {
-      "id": "942860",
-      "name": "SUN-to-Spotify ",
-      "tagline": "Generate audio with SUN and send it to your Spotify library",
-      "description": "Download 👉 https://github.com/sunapp-ai/sun-to-spotify SUN-to-Spotify is a skill that lets you generate AI podcasts, audiobooks, and then publish them directly to your Spotify library for streaming or offline listening. Just describe what you want to hear: startup advice, history deep dives, philosophy, news, or custom learning content, and SUN creates a personalized audio experience in minutes. Built for creators, developers, and curious minds exploring the future of AI native audio.",
-      "url": "https://www.producthunt.com/products/sun-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/ANMWQJRL3VEODH",
-      "votesCount": 292,
-      "commentsCount": 25,
-      "createdAt": "2026-05-17T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/30200cdb-d608-494f-bb9f-b38002818e65.png?auto=format",
-      "topics": [
-        "education",
-        "artificial-intelligence",
-        "audio"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": "https://github.com/sunapp-ai/sun-to-spotify",
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true,
-      "githubRepo": {
-        "stars": 37,
-        "topics": [],
-        "readmeSnippet": "# Sun to Spotify\n\nTurn any topic, question, or feed into a **dialogue podcast** — and listen to it in Spotify or your favorite podcast app.\n\nJust say:\n\n> What's the latest in voice and audio AI? Give me a 10-minute roundup.\n\n> What's happening in the stock market this morning? Make it a 5-minute brief.\n\n> Give me my daily brief based on my calendar for the next 30 minutes.\n\n> Summarize *The Hard Thing About Hard Things* as a 20-minute podcast.\n\n> How should I think about marketing my B2B startup"
-      },
-      "tags": []
     },
     {
       "id": "1052099",
@@ -1030,95 +1119,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1150337",
-      "name": "Composer 2.5",
-      "tagline": "Cursor’s most powerful model yet",
-      "description": "A substantial improvement in intelligence and behavior over Composer 2, particularly on long-horizon agentic tasks.",
-      "url": "https://www.producthunt.com/products/cursor?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/ZEXWSSPQZYCABO",
-      "votesCount": 267,
-      "commentsCount": 7,
-      "createdAt": "2026-05-19T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/d2edfb12-0064-4ea2-af46-12b43bbb2842.png?auto=format",
-      "topics": [
-        "artificial-intelligence",
-        "development"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1137273",
       "name": "Tailgrids 3.0",
       "tagline": "Open-source React UI library for Tailwind and AI Workflow",
@@ -1234,6 +1234,47 @@
       "aiAdjacent": false
     },
     {
+      "id": "1113430",
+      "name": "Mantle Chat",
+      "tagline": "Collaboration platform where teams work with AI together",
+      "description": "Mantle Chat helps teams boost productivity and adopt AI faster by bringing real-time messaging, AI model chats, autonomous agents, and tool integrations into one shared workspace. Communicate in Discord/Slack-style channels, mention AI agents and models (GPT, Claude, Gemini, Grok, Deepseek) with @ whenever you need help directly in conversations with teammates, build agents, run autonomous tasks together, and connect 30+ tools (Notion, Linear, Gmail and more) your team already uses.",
+      "url": "https://www.producthunt.com/products/mantle-chat?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/HNOJTU2EDLNEGN",
+      "votesCount": 254,
+      "commentsCount": 34,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/977f6301-b044-4702-893f-4e3419e560cd.png?auto=format",
+      "topics": [
+        "productivity",
+        "messaging"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1050396",
       "name": "Genpire",
       "tagline": "Make Real Products with AI, literally.",
@@ -1274,47 +1315,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1113430",
-      "name": "Mantle Chat",
-      "tagline": "Collaboration platform where teams work with AI together",
-      "description": "Mantle Chat helps teams boost productivity and adopt AI faster by bringing real-time messaging, AI model chats, autonomous agents, and tool integrations into one shared workspace. Communicate in Discord/Slack-style channels, mention AI agents and models (GPT, Claude, Gemini, Grok, Deepseek) with @ whenever you need help directly in conversations with teammates, build agents, run autonomous tasks together, and connect 30+ tools (Notion, Linear, Gmail and more) your team already uses.",
-      "url": "https://www.producthunt.com/products/mantle-chat?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/HNOJTU2EDLNEGN",
-      "votesCount": 236,
-      "commentsCount": 32,
-      "createdAt": "2026-05-19T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/977f6301-b044-4702-893f-4e3419e560cd.png?auto=format",
-      "topics": [
-        "productivity",
-        "messaging"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1617,6 +1617,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1148531",
+      "name": "CtrlOps",
+      "tagline": "Deploy, Debug & Manage Linux Servers with AI.",
+      "description": "Most devs manage servers from a spreadsheet of IPs and commands nobody remembers. CtrlOps gives you AI-powered server management without DevOps expertise. AI terminal that generates commands with your approval. Scripts library. One-click deploys from any GitHub repo. Visual file manager. Real-time server monitoring. Zero agents on servers. Deployments that took 60 minutes now take 5. 100% local. Your credentials never leave your machine. Mac. Windows. Linux.",
+      "url": "https://www.producthunt.com/products/ctrlops?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/H64HE7ZK3MVBJN",
+      "votesCount": 203,
+      "commentsCount": 50,
+      "createdAt": "2026-05-19T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2a1eb160-e2ce-4652-975c-4d715270bde7.png?auto=format",
+      "topics": [
+        "linux",
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1139500",
       "name": "deepsec",
       "tagline": "Open-source coding security harness",
@@ -1765,48 +1807,6 @@
         "yc-application"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1148531",
-      "name": "CtrlOps",
-      "tagline": "Deploy, Debug & Manage Linux Servers with AI.",
-      "description": "Most devs manage servers from a spreadsheet of IPs and commands nobody remembers. CtrlOps gives you AI-powered server management without DevOps expertise. AI terminal that generates commands with your approval. Scripts library. One-click deploys from any GitHub repo. Visual file manager. Real-time server monitoring. Zero agents on servers. Deployments that took 60 minutes now take 5. 100% local. Your credentials never leave your machine. Mac. Windows. Linux.",
-      "url": "https://www.producthunt.com/products/ctrlops?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/H64HE7ZK3MVBJN",
-      "votesCount": 186,
-      "commentsCount": 48,
-      "createdAt": "2026-05-19T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2a1eb160-e2ce-4652-975c-4d715270bde7.png?auto=format",
-      "topics": [
-        "linux",
-        "developer-tools",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26124451561

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.