### PR TITLE
chore(data): refresh lobsters signals 2026-05-19T21:57:20Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-19T20:17:16.227Z",
+  "ts": "2026-05-19T21:57:20.478Z",
   "count": 1,
-  "durationMs": 5181,
+  "durationMs": 4286,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T20:17:11.060Z",
+  "fetchedAt": "2026-05-19T21:57:16.204Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -279,7 +279,7 @@
         "score": 12,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 6.443333333333333
+        "hoursSincePosted": 8.11138888888889
       },
       "stories": [
         {
@@ -291,8 +291,8 @@
           "score": 12,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 6.443333333333333,
-          "trendingScore": 0.4891142810513447,
+          "ageHours": 8.11138888888889,
+          "trendingScore": 0.3732201002725462,
           "tags": [
             "plt",
             "programming"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T20:17:11.060Z",
+  "fetchedAt": "2026-05-19T21:57:16.204Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "29pm2f",

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -208738,3 +208738,8 @@
 {"source":"twitter","fullName":"ruvnet/ruview","observedAt":"2026-05-19T21:51:07.847Z"}
 {"source":"twitter","fullName":"oven-sh/bun","observedAt":"2026-05-19T21:51:07.847Z"}
 {"source":"twitter","fullName":"openclaw/openclaw","observedAt":"2026-05-19T21:51:07.847Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-19T21:57:19.083Z"}
+{"source":"lobsters","fullName":"xataio/deltax","observedAt":"2026-05-19T21:57:19.083Z"}
+{"source":"lobsters","fullName":"samth/gradual-typing-bib","observedAt":"2026-05-19T21:57:19.083Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-19T21:57:19.083Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-19T21:57:19.083Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26127720199

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.