### PR TITLE
chore(data): refresh lobsters signals 2026-05-20T04:49:56Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-19T21:57:20.478Z",
+  "ts": "2026-05-20T04:49:56.032Z",
   "count": 1,
-  "durationMs": 4286,
+  "durationMs": 4052,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T21:57:16.204Z",
+  "fetchedAt": "2026-05-20T04:49:51.994Z",
   "windowDays": 7,
-  "scannedStories": 78,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -272,14 +272,14 @@
     },
     "tomekw/stcc": {
       "count7d": 1,
-      "scoreSum7d": 12,
+      "scoreSum7d": 17,
       "topStory": {
         "shortId": "pk139i",
         "title": "The Super Tiny Compiler, but in Ada",
-        "score": 12,
+        "score": 17,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 8.11138888888889
+        "hoursSincePosted": 14.987777777777778
       },
       "stories": [
         {
@@ -288,11 +288,11 @@
           "url": "https://github.com/tomekw/stcc",
           "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
           "by": "",
-          "score": 12,
+          "score": 17,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 8.11138888888889,
-          "trendingScore": 0.3732201002725462,
+          "ageHours": 14.987777777777778,
+          "trendingScore": 0.24279741832097476,
           "tags": [
             "plt",
             "programming"
@@ -497,7 +497,7 @@
     {
       "fullName": "tomekw/stcc",
       "count7d": 1,
-      "scoreSum7d": 12
+      "scoreSum7d": 17
     },
     {
       "fullName": "jundot/omlx",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-19T21:57:16.204Z",
+  "fetchedAt": "2026-05-20T04:49:51.994Z",
   "windowHours": 72,
-  "scannedTotal": 78,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "29pm2f",

--- a/data/unknown-mentions.jsonl
+++ b/data/unknown-mentions.jsonl
@@ -209363,3 +209363,8 @@
 {"source":"devto","fullName":"gin-gonic/gin","observedAt":"2026-05-20T03:46:01.433Z"}
 {"source":"devto","fullName":"bube054/validatorgo","observedAt":"2026-05-20T03:46:01.433Z"}
 {"source":"devto","fullName":"tidwall/gjson","observedAt":"2026-05-20T03:46:01.433Z"}
+{"source":"lobsters","fullName":"xataio/deltax","observedAt":"2026-05-20T04:49:54.653Z"}
+{"source":"lobsters","fullName":"samth/gradual-typing-bib","observedAt":"2026-05-20T04:49:54.653Z"}
+{"source":"lobsters","fullName":"anishathalye/ai-agent-security-lecture","observedAt":"2026-05-20T04:49:54.653Z"}
+{"source":"lobsters","fullName":"naver/lispe","observedAt":"2026-05-20T04:49:54.653Z"}
+{"source":"lobsters","fullName":"ejoffe/spr","observedAt":"2026-05-20T04:49:54.653Z"}


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26141992966

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.