### PR TITLE
chore(data): refresh huggingface space signals 2026-05-20T04:49:59Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-19T20:18:15.062Z",
+  "ts": "2026-05-20T04:49:58.784Z",
   "count": 1,
-  "durationMs": 9063,
+  "durationMs": 5186,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T20:18:06.001Z",
+  "fetchedAt": "2026-05-20T04:49:53.601Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -214,8 +214,8 @@
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 64,
-      "trendingScore": 64,
+      "likes": 66,
+      "trendingScore": 66,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -227,6 +227,23 @@
     },
     {
       "rank": 14,
+      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
+      "author": "cbensimon",
+      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
+      "likes": 73,
+      "trendingScore": 65,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:08:17.000Z",
+      "lastModified": "2026-05-14T11:52:10.000Z",
+      "models": []
+    },
+    {
+      "rank": 15,
       "id": "ysharma/fast-image-studio",
       "author": "ysharma",
       "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
@@ -239,23 +256,6 @@
       ],
       "createdAt": "2026-04-29T14:15:57.000Z",
       "lastModified": "2026-04-30T12:10:32.000Z",
-      "models": []
-    },
-    {
-      "rank": 15,
-      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
-      "author": "cbensimon",
-      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 71,
-      "trendingScore": 63,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:08:17.000Z",
-      "lastModified": "2026-05-14T11:52:10.000Z",
       "models": []
     },
     {
@@ -424,6 +424,22 @@
     },
     {
       "rank": 26,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 35,
+      "trendingScore": 35,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-19T17:29:04.000Z",
+      "models": []
+    },
+    {
+      "rank": 27,
       "id": "multimodalart/qwen-image-multiple-angles-3d-camera",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/qwen-image-multiple-angles-3d-camera",
@@ -439,7 +455,7 @@
       "models": []
     },
     {
-      "rank": 27,
+      "rank": 28,
       "id": "suraj291/Survival_Island_Game",
       "author": "suraj291",
       "url": "https://huggingface.co/spaces/suraj291/Survival_Island_Game",
@@ -456,7 +472,7 @@
       "models": []
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "r3gm/wan2-2-fp8da-aoti-previewG",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewG",
@@ -473,7 +489,7 @@
       "models": []
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -489,7 +505,7 @@
       "models": []
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -506,7 +522,7 @@
       "models": []
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -522,7 +538,7 @@
       "models": []
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -538,7 +554,7 @@
       "models": []
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -555,7 +571,7 @@
       "models": []
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -571,7 +587,7 @@
       "models": []
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -588,12 +604,12 @@
       "models": []
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
-      "likes": 26,
-      "trendingScore": 26,
+      "likes": 29,
+      "trendingScore": 29,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -604,7 +620,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -624,7 +640,7 @@
       "models": []
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -641,7 +657,24 @@
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
+      "id": "black-forest-labs/FLUX.2-klein-9B",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
+      "likes": 834,
+      "trendingScore": 23,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-01-15T09:50:22.000Z",
+      "lastModified": "2026-01-16T13:56:36.000Z",
+      "models": []
+    },
+    {
+      "rank": 41,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -657,24 +690,7 @@
       "models": []
     },
     {
-      "rank": 40,
-      "id": "black-forest-labs/FLUX.2-klein-9B",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
-      "likes": 833,
-      "trendingScore": 22,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-01-15T09:50:22.000Z",
-      "lastModified": "2026-01-16T13:56:36.000Z",
-      "models": []
-    },
-    {
-      "rank": 41,
+      "rank": 42,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -690,7 +706,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -706,7 +722,7 @@
       "models": []
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "Overworld/waypoint-1-5",
       "author": "Overworld",
       "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
@@ -722,7 +738,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "carlofkl/DreamLite",
       "author": "carlofkl",
       "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
@@ -742,7 +758,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "huggingface/physics-intern",
       "author": "huggingface",
       "url": "https://huggingface.co/spaces/huggingface/physics-intern",
@@ -759,7 +775,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
       "author": "BoobyBoobs",
       "url": "https://huggingface.co/spaces/BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
@@ -775,7 +791,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "NucleusAI/nucleus-image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/spaces/NucleusAI/nucleus-image",
@@ -791,7 +807,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
@@ -804,22 +820,6 @@
       ],
       "createdAt": "2025-12-09T19:01:39.000Z",
       "lastModified": "2026-03-13T17:12:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 49,
-      "id": "HuggingFaceBio/carbon-demo",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 20,
-      "trendingScore": 20,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T14:18:55.000Z",
-      "lastModified": "2026-05-19T17:29:04.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26141994250

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.