### PR TITLE
chore(data): refresh scoring shadow report 2026-05-20T05:57:38Z

### DIFF
--- a/data/scoring-shadow-report.json
+++ b/data/scoring-shadow-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-19T05:58:26.628Z",
+  "generatedAt": "2026-05-20T05:57:37.175Z",
   "reports": [
     {
       "domainKey": "skill",
@@ -8,301 +8,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.594,
+          "momentum": 9.626,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 8.923,
+          "momentum": 8.776,
           "rank": 2
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 8.688,
+          "momentum": 8.544,
           "rank": 3
         },
         {
           "id": "agricidaniel-claude-ads",
           "title": "claude-ads",
-          "momentum": 8.46,
+          "momentum": 8.319,
           "rank": 4
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.7,
-          "rank": 5
         },
         {
           "id": "agents365-ai-drawio-skill",
           "title": "drawio-skill",
-          "momentum": 7.655,
+          "momentum": 7.871,
+          "rank": 5
+        },
+        {
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.58,
           "rank": 6
         },
         {
           "id": "eugeniughelbur-obsidian-second-brain",
           "title": "obsidian-second-brain",
-          "momentum": 7.557,
+          "momentum": 7.444,
           "rank": 7
-        },
-        {
-          "id": "glitternetwork-pinme",
-          "title": "pinme",
-          "momentum": 7.464,
-          "rank": 8
         },
         {
           "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
           "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.31,
+          "momentum": 7.353,
+          "rank": 8
+        },
+        {
+          "id": "glitternetwork-pinme",
+          "title": "pinme",
+          "momentum": 7.337,
           "rank": 9
-        },
-        {
-          "id": "alexgreensh-token-optimizer",
-          "title": "token-optimizer",
-          "momentum": 6.843,
-          "rank": 10
-        },
-        {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 6.647,
-          "rank": 11
-        },
-        {
-          "id": "agricidaniel-claude-blog",
-          "title": "claude-blog",
-          "momentum": 6.569,
-          "rank": 12
-        },
-        {
-          "id": "can4hou6joeng4-boss-agent-cli",
-          "title": "boss-agent-cli",
-          "momentum": 6.439,
-          "rank": 13
-        },
-        {
-          "id": "juneyaooo-gpt-image2-ppt-skills",
-          "title": "gpt-image2-ppt-skills",
-          "momentum": 6.343,
-          "rank": 14
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.268,
-          "rank": 15
-        },
-        {
-          "id": "denissergeevitch-agents-best-practices",
-          "title": "agents-best-practices",
-          "momentum": 6.25,
-          "rank": 16
         },
         {
           "id": "wuji-labs-nopua",
           "title": "nopua",
-          "momentum": 6.127,
+          "momentum": 7.116,
+          "rank": 10
+        },
+        {
+          "id": "alexgreensh-token-optimizer",
+          "title": "token-optimizer",
+          "momentum": 6.934,
+          "rank": 11
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 6.536,
+          "rank": 12
+        },
+        {
+          "id": "agricidaniel-claude-blog",
+          "title": "claude-blog",
+          "momentum": 6.478,
+          "rank": 13
+        },
+        {
+          "id": "can4hou6joeng4-boss-agent-cli",
+          "title": "boss-agent-cli",
+          "momentum": 6.404,
+          "rank": 14
+        },
+        {
+          "id": "juneyaooo-gpt-image2-ppt-skills",
+          "title": "gpt-image2-ppt-skills",
+          "momentum": 6.268,
+          "rank": 15
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.225,
+          "rank": 16
+        },
+        {
+          "id": "denissergeevitch-agents-best-practices",
+          "title": "agents-best-practices",
+          "momentum": 6.17,
           "rank": 17
-        },
-        {
-          "id": "wuyoscar-gpt-image-2-skill",
-          "title": "gpt_image_2_skill",
-          "momentum": 6.056,
-          "rank": 18
-        },
-        {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 5.925,
-          "rank": 19
-        },
-        {
-          "id": "alirezarezvani-claudeforge",
-          "title": "ClaudeForge",
-          "momentum": 5.91,
-          "rank": 20
-        },
-        {
-          "id": "avdlee-rocketsimapp",
-          "title": "RocketSimApp",
-          "momentum": 5.837,
-          "rank": 21
-        },
-        {
-          "id": "alirezarezvani-claude-code-aso-skill",
-          "title": "claude-code-aso-skill",
-          "momentum": 5.833,
-          "rank": 22
-        },
-        {
-          "id": "mrgediao-shuorenhua",
-          "title": "shuorenhua",
-          "momentum": 5.672,
-          "rank": 23
-        },
-        {
-          "id": "aaronjmars-soul-md",
-          "title": "soul.md",
-          "momentum": 5.624,
-          "rank": 24
-        },
-        {
-          "id": "bharathkumarsuresh-claude-design-system-hooks",
-          "title": "claude-design-system-hooks",
-          "momentum": 5.502,
-          "rank": 25
-        },
-        {
-          "id": "giuseppe-trisciuoglio-developer-kit",
-          "title": "developer-kit",
-          "momentum": 5.486,
-          "rank": 26
-        },
-        {
-          "id": "aspegio-nelson",
-          "title": "nelson",
-          "momentum": 5.47,
-          "rank": 27
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.364,
-          "rank": 28
-        },
-        {
-          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
-          "title": "Claude-Mythos-AI-Anthropic-App",
-          "momentum": 5.354,
-          "rank": 29
         },
         {
           "id": "pegasi-ai-reins",
           "title": "reins",
-          "momentum": 5.344,
-          "rank": 30
+          "momentum": 6.006,
+          "rank": 18
         },
         {
-          "id": "vast-ai-vast-cli",
-          "title": "vast-cli",
-          "momentum": 5.239,
-          "rank": 31
+          "id": "wuyoscar-gpt-image2-skill",
+          "title": "GPT-Image2-Skill",
+          "momentum": 5.963,
+          "rank": 19
+        },
+        {
+          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
+          "title": "Claude-Mythos-AI-Anthropic-App",
+          "momentum": 5.954,
+          "rank": 20
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 5.827,
+          "rank": 21
+        },
+        {
+          "id": "alirezarezvani-claudeforge",
+          "title": "ClaudeForge",
+          "momentum": 5.824,
+          "rank": 22
+        },
+        {
+          "id": "alirezarezvani-claude-code-aso-skill",
+          "title": "claude-code-aso-skill",
+          "momentum": 5.763,
+          "rank": 23
+        },
+        {
+          "id": "avdlee-rocketsimapp",
+          "title": "RocketSimApp",
+          "momentum": 5.738,
+          "rank": 24
+        },
+        {
+          "id": "mrgediao-shuorenhua",
+          "title": "shuorenhua",
+          "momentum": 5.577,
+          "rank": 25
+        },
+        {
+          "id": "aaronjmars-soul-md",
+          "title": "soul.md",
+          "momentum": 5.532,
+          "rank": 26
+        },
+        {
+          "id": "giuseppe-trisciuoglio-developer-kit",
+          "title": "developer-kit",
+          "momentum": 5.509,
+          "rank": 27
+        },
+        {
+          "id": "bharathkumarsuresh-claude-design-system-hooks",
+          "title": "claude-design-system-hooks",
+          "momentum": 5.412,
+          "rank": 28
+        },
+        {
+          "id": "aspegio-nelson",
+          "title": "nelson",
+          "momentum": 5.378,
+          "rank": 29
         },
         {
           "id": "memtensor-skills-vote",
           "title": "skills-vote",
-          "momentum": 5.237,
+          "momentum": 5.349,
+          "rank": 30
+        },
+        {
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.28,
+          "rank": 31
+        },
+        {
+          "id": "vast-ai-vast-cli",
+          "title": "vast-cli",
+          "momentum": 5.149,
           "rank": 32
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 5.064,
-          "rank": 33
-        },
-        {
-          "id": "bitwize-music-studio-claude-ai-music-skills",
-          "title": "claude-ai-music-skills",
-          "momentum": 5.027,
-          "rank": 34
         },
         {
           "id": "agents365-ai-asta-skill",
           "title": "asta-skill",
-          "momentum": 4.945,
-          "rank": 35
+          "momentum": 5.088,
+          "rank": 33
         },
         {
           "id": "agents365-ai-paper-fetch",
           "title": "paper-fetch",
-          "momentum": 4.886,
+          "momentum": 5,
+          "rank": 34
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 4.982,
+          "rank": 35
+        },
+        {
+          "id": "bitwize-music-studio-claude-ai-music-skills",
+          "title": "claude-ai-music-skills",
+          "momentum": 4.95,
           "rank": 36
+        },
+        {
+          "id": "greekr4-playwright-bot-bypass",
+          "title": "playwright-bot-bypass",
+          "momentum": 4.921,
+          "rank": 37
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 4.846,
-          "rank": 37
+          "momentum": 4.767,
+          "rank": 38
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.822,
-          "rank": 38
-        },
-        {
-          "id": "keerthanapranesh-claude-code-swarm-toolkit",
-          "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.758,
+          "momentum": 4.761,
           "rank": 39
-        },
-        {
-          "id": "oaustegard-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.695,
-          "rank": 40
-        },
-        {
-          "id": "jeecgboot-skills",
-          "title": "skills",
-          "momentum": 4.679,
-          "rank": 41
         },
         {
           "id": "luoling8192-technical-writing",
           "title": "technical-writing",
-          "momentum": 4.669,
+          "momentum": 4.755,
+          "rank": 40
+        },
+        {
+          "id": "keerthanapranesh-claude-code-swarm-toolkit",
+          "title": "Claude-Code-Swarm-Toolkit",
+          "momentum": 4.676,
+          "rank": 41
+        },
+        {
+          "id": "jeecgboot-skills",
+          "title": "skills",
+          "momentum": 4.621,
           "rank": 42
         },
         {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.592,
-          "rank": 43
-        },
-        {
-          "id": "likaku-mck-ppt-design-skill",
-          "title": "Mck-ppt-design-skill",
-          "momentum": 4.577,
-          "rank": 44
-        },
-        {
-          "id": "secondsky-claude-skills",
+          "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.528,
-          "rank": 45
+          "momentum": 4.614,
+          "rank": 43
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.49,
+          "momentum": 4.526,
+          "rank": 44
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.522,
+          "rank": 45
+        },
+        {
+          "id": "likaku-mck-ppt-design-skill",
+          "title": "Mck-ppt-design-skill",
+          "momentum": 4.507,
           "rank": 46
+        },
+        {
+          "id": "secondsky-claude-skills",
+          "title": "claude-skills",
+          "momentum": 4.456,
+          "rank": 47
         },
         {
           "id": "xquik-dev-x-twitter-scraper",
           "title": "x-twitter-scraper",
-          "momentum": 4.468,
-          "rank": 47
+          "momentum": 4.403,
+          "rank": 48
         },
         {
           "id": "agents365-ai-excalidraw-skill",
           "title": "excalidraw-skill",
-          "momentum": 4.459,
-          "rank": 48
+          "momentum": 4.391,
+          "rank": 49
         },
         {
           "id": "ylsssq926-relic-skill",
           "title": "relic.skill",
-          "momentum": 4.439,
-          "rank": 49
-        },
-        {
-          "id": "hao0321-claude-skill-social-post",
-          "title": "claude-skill-social-post",
-          "momentum": 4.338,
+          "momentum": 4.356,
           "rank": 50
         }
       ],
@@ -310,301 +310,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.594,
+          "momentum": 9.626,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 8.923,
+          "momentum": 8.776,
           "rank": 2
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 8.688,
+          "momentum": 8.544,
           "rank": 3
         },
         {
           "id": "agricidaniel-claude-ads",
           "title": "claude-ads",
-          "momentum": 8.46,
+          "momentum": 8.319,
           "rank": 4
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.7,
-          "rank": 5
         },
         {
           "id": "agents365-ai-drawio-skill",
           "title": "drawio-skill",
-          "momentum": 7.655,
+          "momentum": 7.871,
+          "rank": 5
+        },
+        {
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.58,
           "rank": 6
         },
         {
           "id": "eugeniughelbur-obsidian-second-brain",
           "title": "obsidian-second-brain",
-          "momentum": 7.557,
+          "momentum": 7.444,
           "rank": 7
-        },
-        {
-          "id": "glitternetwork-pinme",
-          "title": "pinme",
-          "momentum": 7.464,
-          "rank": 8
         },
         {
           "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
           "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.31,
+          "momentum": 7.353,
+          "rank": 8
+        },
+        {
+          "id": "glitternetwork-pinme",
+          "title": "pinme",
+          "momentum": 7.337,
           "rank": 9
-        },
-        {
-          "id": "alexgreensh-token-optimizer",
-          "title": "token-optimizer",
-          "momentum": 6.843,
-          "rank": 10
-        },
-        {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 6.647,
-          "rank": 11
-        },
-        {
-          "id": "agricidaniel-claude-blog",
-          "title": "claude-blog",
-          "momentum": 6.569,
-          "rank": 12
-        },
-        {
-          "id": "can4hou6joeng4-boss-agent-cli",
-          "title": "boss-agent-cli",
-          "momentum": 6.439,
-          "rank": 13
-        },
-        {
-          "id": "juneyaooo-gpt-image2-ppt-skills",
-          "title": "gpt-image2-ppt-skills",
-          "momentum": 6.343,
-          "rank": 14
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.268,
-          "rank": 15
-        },
-        {
-          "id": "denissergeevitch-agents-best-practices",
-          "title": "agents-best-practices",
-          "momentum": 6.25,
-          "rank": 16
         },
         {
           "id": "wuji-labs-nopua",
           "title": "nopua",
-          "momentum": 6.127,
+          "momentum": 7.116,
+          "rank": 10
+        },
+        {
+          "id": "alexgreensh-token-optimizer",
+          "title": "token-optimizer",
+          "momentum": 6.934,
+          "rank": 11
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 6.536,
+          "rank": 12
+        },
+        {
+          "id": "agricidaniel-claude-blog",
+          "title": "claude-blog",
+          "momentum": 6.478,
+          "rank": 13
+        },
+        {
+          "id": "can4hou6joeng4-boss-agent-cli",
+          "title": "boss-agent-cli",
+          "momentum": 6.404,
+          "rank": 14
+        },
+        {
+          "id": "juneyaooo-gpt-image2-ppt-skills",
+          "title": "gpt-image2-ppt-skills",
+          "momentum": 6.268,
+          "rank": 15
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.225,
+          "rank": 16
+        },
+        {
+          "id": "denissergeevitch-agents-best-practices",
+          "title": "agents-best-practices",
+          "momentum": 6.17,
           "rank": 17
-        },
-        {
-          "id": "wuyoscar-gpt-image-2-skill",
-          "title": "gpt_image_2_skill",
-          "momentum": 6.056,
-          "rank": 18
-        },
-        {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 5.925,
-          "rank": 19
-        },
-        {
-          "id": "alirezarezvani-claudeforge",
-          "title": "ClaudeForge",
-          "momentum": 5.91,
-          "rank": 20
-        },
-        {
-          "id": "avdlee-rocketsimapp",
-          "title": "RocketSimApp",
-          "momentum": 5.837,
-          "rank": 21
-        },
-        {
-          "id": "alirezarezvani-claude-code-aso-skill",
-          "title": "claude-code-aso-skill",
-          "momentum": 5.833,
-          "rank": 22
-        },
-        {
-          "id": "mrgediao-shuorenhua",
-          "title": "shuorenhua",
-          "momentum": 5.672,
-          "rank": 23
-        },
-        {
-          "id": "aaronjmars-soul-md",
-          "title": "soul.md",
-          "momentum": 5.624,
-          "rank": 24
-        },
-        {
-          "id": "bharathkumarsuresh-claude-design-system-hooks",
-          "title": "claude-design-system-hooks",
-          "momentum": 5.502,
-          "rank": 25
-        },
-        {
-          "id": "giuseppe-trisciuoglio-developer-kit",
-          "title": "developer-kit",
-          "momentum": 5.486,
-          "rank": 26
-        },
-        {
-          "id": "aspegio-nelson",
-          "title": "nelson",
-          "momentum": 5.47,
-          "rank": 27
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.364,
-          "rank": 28
-        },
-        {
-          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
-          "title": "Claude-Mythos-AI-Anthropic-App",
-          "momentum": 5.354,
-          "rank": 29
         },
         {
           "id": "pegasi-ai-reins",
           "title": "reins",
-          "momentum": 5.344,
-          "rank": 30
+          "momentum": 6.006,
+          "rank": 18
         },
         {
-          "id": "vast-ai-vast-cli",
-          "title": "vast-cli",
-          "momentum": 5.239,
-          "rank": 31
+          "id": "wuyoscar-gpt-image2-skill",
+          "title": "GPT-Image2-Skill",
+          "momentum": 5.963,
+          "rank": 19
+        },
+        {
+          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
+          "title": "Claude-Mythos-AI-Anthropic-App",
+          "momentum": 5.954,
+          "rank": 20
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 5.827,
+          "rank": 21
+        },
+        {
+          "id": "alirezarezvani-claudeforge",
+          "title": "ClaudeForge",
+          "momentum": 5.824,
+          "rank": 22
+        },
+        {
+          "id": "alirezarezvani-claude-code-aso-skill",
+          "title": "claude-code-aso-skill",
+          "momentum": 5.763,
+          "rank": 23
+        },
+        {
+          "id": "avdlee-rocketsimapp",
+          "title": "RocketSimApp",
+          "momentum": 5.738,
+          "rank": 24
+        },
+        {
+          "id": "mrgediao-shuorenhua",
+          "title": "shuorenhua",
+          "momentum": 5.577,
+          "rank": 25
+        },
+        {
+          "id": "aaronjmars-soul-md",
+          "title": "soul.md",
+          "momentum": 5.532,
+          "rank": 26
+        },
+        {
+          "id": "giuseppe-trisciuoglio-developer-kit",
+          "title": "developer-kit",
+          "momentum": 5.509,
+          "rank": 27
+        },
+        {
+          "id": "bharathkumarsuresh-claude-design-system-hooks",
+          "title": "claude-design-system-hooks",
+          "momentum": 5.412,
+          "rank": 28
+        },
+        {
+          "id": "aspegio-nelson",
+          "title": "nelson",
+          "momentum": 5.378,
+          "rank": 29
         },
         {
           "id": "memtensor-skills-vote",
           "title": "skills-vote",
-          "momentum": 5.237,
+          "momentum": 5.349,
+          "rank": 30
+        },
+        {
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.28,
+          "rank": 31
+        },
+        {
+          "id": "vast-ai-vast-cli",
+          "title": "vast-cli",
+          "momentum": 5.149,
           "rank": 32
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 5.064,
-          "rank": 33
-        },
-        {
-          "id": "bitwize-music-studio-claude-ai-music-skills",
-          "title": "claude-ai-music-skills",
-          "momentum": 5.027,
-          "rank": 34
         },
         {
           "id": "agents365-ai-asta-skill",
           "title": "asta-skill",
-          "momentum": 4.945,
-          "rank": 35
+          "momentum": 5.088,
+          "rank": 33
         },
         {
           "id": "agents365-ai-paper-fetch",
           "title": "paper-fetch",
-          "momentum": 4.886,
+          "momentum": 5,
+          "rank": 34
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 4.982,
+          "rank": 35
+        },
+        {
+          "id": "bitwize-music-studio-claude-ai-music-skills",
+          "title": "claude-ai-music-skills",
+          "momentum": 4.95,
           "rank": 36
+        },
+        {
+          "id": "greekr4-playwright-bot-bypass",
+          "title": "playwright-bot-bypass",
+          "momentum": 4.921,
+          "rank": 37
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 4.846,
-          "rank": 37
+          "momentum": 4.767,
+          "rank": 38
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.822,
-          "rank": 38
-        },
-        {
-          "id": "keerthanapranesh-claude-code-swarm-toolkit",
-          "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.758,
+          "momentum": 4.761,
           "rank": 39
-        },
-        {
-          "id": "oaustegard-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.695,
-          "rank": 40
-        },
-        {
-          "id": "jeecgboot-skills",
-          "title": "skills",
-          "momentum": 4.679,
-          "rank": 41
         },
         {
           "id": "luoling8192-technical-writing",
           "title": "technical-writing",
-          "momentum": 4.669,
+          "momentum": 4.755,
+          "rank": 40
+        },
+        {
+          "id": "keerthanapranesh-claude-code-swarm-toolkit",
+          "title": "Claude-Code-Swarm-Toolkit",
+          "momentum": 4.676,
+          "rank": 41
+        },
+        {
+          "id": "jeecgboot-skills",
+          "title": "skills",
+          "momentum": 4.621,
           "rank": 42
         },
         {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.592,
-          "rank": 43
-        },
-        {
-          "id": "likaku-mck-ppt-design-skill",
-          "title": "Mck-ppt-design-skill",
-          "momentum": 4.577,
-          "rank": 44
-        },
-        {
-          "id": "secondsky-claude-skills",
+          "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.528,
-          "rank": 45
+          "momentum": 4.614,
+          "rank": 43
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.49,
+          "momentum": 4.526,
+          "rank": 44
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.522,
+          "rank": 45
+        },
+        {
+          "id": "likaku-mck-ppt-design-skill",
+          "title": "Mck-ppt-design-skill",
+          "momentum": 4.507,
           "rank": 46
+        },
+        {
+          "id": "secondsky-claude-skills",
+          "title": "claude-skills",
+          "momentum": 4.456,
+          "rank": 47
         },
         {
           "id": "xquik-dev-x-twitter-scraper",
           "title": "x-twitter-scraper",
-          "momentum": 4.468,
-          "rank": 47
+          "momentum": 4.403,
+          "rank": 48
         },
         {
           "id": "agents365-ai-excalidraw-skill",
           "title": "excalidraw-skill",
-          "momentum": 4.459,
-          "rank": 48
+          "momentum": 4.391,
+          "rank": 49
         },
         {
           "id": "ylsssq926-relic-skill",
           "title": "relic.skill",
-          "momentum": 4.439,
-          "rank": 49
-        },
-        {
-          "id": "hao0321-claude-skill-social-post",
-          "title": "claude-skill-social-post",
-          "momentum": 4.338,
+          "momentum": 4.356,
           "rank": 50
         }
       ],
@@ -613,7 +613,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-19T05:58:25.040Z",
+      "generatedAt": "2026-05-20T05:57:35.617Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     },
@@ -646,14 +646,14 @@
           "rank": 4
         },
         {
-          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
-          "title": "Reddit",
+          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
+          "title": "Exa Search",
           "momentum": 0,
           "rank": 5
         },
         {
-          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
-          "title": "Exa Search",
+          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
+          "title": "Reddit",
           "momentum": 0,
           "rank": 6
         },
@@ -664,188 +664,188 @@
           "rank": 7
         },
         {
-          "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
-          "title": "MCP Server for Singapore Government Open Data",
+          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
+          "title": "AI Research Assistant",
           "momentum": 0,
           "rank": 8
         },
         {
-          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
-          "title": "rivalsearch",
+          "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
+          "title": "MCP Server for Singapore Government Open Data",
           "momentum": 0,
           "rank": 9
-        },
-        {
-          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
-          "title": "AI Research Assistant",
-          "momentum": 0,
-          "rank": 10
-        },
-        {
-          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
-          "title": "Swiss Truth MCP",
-          "momentum": 0,
-          "rank": 11
         },
         {
           "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
           "title": "12306 Ticket Search Server",
           "momentum": 0,
-          "rank": 12
-        },
-        {
-          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
-          "title": "Polymarket",
-          "momentum": 0,
-          "rank": 13
-        },
-        {
-          "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
-          "title": "Standard Accounting Public MCP",
-          "momentum": 0,
-          "rank": 14
+          "rank": 10
         },
         {
           "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
           "title": "AgentMail",
           "momentum": 0,
-          "rank": 15
+          "rank": 11
         },
         {
-          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
-          "title": "ai-agent-index",
+          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
+          "title": "Polymarket",
           "momentum": 0,
-          "rank": 16
-        },
-        {
-          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
-          "title": "sbb-mcp",
-          "momentum": 0,
-          "rank": 17
+          "rank": 12
         },
         {
           "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
           "title": "Flight Search MCP Server",
           "momentum": 0,
-          "rank": 18
+          "rank": 13
         },
         {
           "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
           "title": "Linkup",
           "momentum": 0,
-          "rank": 19
-        },
-        {
-          "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
-          "title": "settlegrid-discovery",
-          "momentum": 0,
-          "rank": 20
+          "rank": 14
         },
         {
           "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
           "title": "KRDS Design System",
           "momentum": 0,
-          "rank": 21
+          "rank": 15
         },
         {
           "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
           "title": "Hugeicons MCP Server",
           "momentum": 0,
-          "rank": 22
+          "rank": 16
+        },
+        {
+          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
+          "title": "Swiss Truth MCP",
+          "momentum": 0,
+          "rank": 17
         },
         {
           "id": "9a58e6b6-6486-47c2-b05d-5362e3b85da7",
           "title": "AKShare One MCP Server",
           "momentum": 0,
-          "rank": 23
+          "rank": 18
         },
         {
-          "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
-          "title": "cultural-intelligence",
+          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
+          "title": "sbb-mcp",
           "momentum": 0,
-          "rank": 24
-        },
-        {
-          "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
-          "title": "Microsoft Learn MCP",
-          "momentum": 0,
-          "rank": 25
-        },
-        {
-          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
-          "title": "Context Awesome",
-          "momentum": 0,
-          "rank": 26
+          "rank": 19
         },
         {
           "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
           "title": "Paper Search",
           "momentum": 0,
-          "rank": 27
+          "rank": 20
         },
         {
           "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
           "title": "Brave Search",
           "momentum": 0,
-          "rank": 28
-        },
-        {
-          "id": "706d98f8-dc33-453d-9103-d28364976e58",
-          "title": "icons8mcp",
-          "momentum": 0,
-          "rank": 29
-        },
-        {
-          "id": "7c0e4ef9-c2e0-4826-a2c9-949ebc5f5b5f",
-          "title": "Ayni",
-          "momentum": 0,
-          "rank": 30
+          "rank": 21
         },
         {
           "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
           "title": "Context7",
           "momentum": 0,
-          "rank": 31
-        },
-        {
-          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
-          "title": "paper-search-mcp-openai-v2",
-          "momentum": 0,
-          "rank": 32
+          "rank": 22
         },
         {
           "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
           "title": "Mesh MCP",
           "momentum": 0,
-          "rank": 33
+          "rank": 23
         },
         {
-          "id": "ffa3bd03-4c4e-4547-a440-79a1951d9bcd",
-          "title": "quantoracle",
+          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
+          "title": "paper-search-mcp-openai-v2",
           "momentum": 0,
-          "rank": 34
-        },
-        {
-          "id": "ba8d79ca-2d8e-40dc-9dbd-df2e1731904b",
-          "title": "Bitpoort",
-          "momentum": 0,
-          "rank": 35
+          "rank": 24
         },
         {
           "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
           "title": "Senzing",
           "momentum": 0,
-          "rank": 36
+          "rank": 25
         },
         {
           "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
           "title": "Blockscout MCP Server",
           "momentum": 0,
-          "rank": 37
+          "rank": 26
         },
         {
           "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
           "title": "Ternary Intelligence Stack",
+          "momentum": 0,
+          "rank": 27
+        },
+        {
+          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
+          "title": "rivalsearch",
+          "momentum": 0,
+          "rank": 28
+        },
+        {
+          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
+          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "momentum": 0,
+          "rank": 29
+        },
+        {
+          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
+          "title": "Supabase",
+          "momentum": 0,
+          "rank": 30
+        },
+        {
+          "id": "706d98f8-dc33-453d-9103-d28364976e58",
+          "title": "icons8mcp",
+          "momentum": 0,
+          "rank": 31
+        },
+        {
+          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
+          "title": "MLB Stats Server",
+          "momentum": 0,
+          "rank": 32
+        },
+        {
+          "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
+          "title": "Microsoft Learn MCP",
+          "momentum": 0,
+          "rank": 33
+        },
+        {
+          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
+          "title": "Octomil",
+          "momentum": 0,
+          "rank": 34
+        },
+        {
+          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
+          "title": "Context Awesome",
+          "momentum": 0,
+          "rank": 35
+        },
+        {
+          "id": "ffebb7a1-9654-4ddc-8d0a-3018cf8ca05d",
+          "title": "ai-compliance-monitor",
+          "momentum": 0,
+          "rank": 36
+        },
+        {
+          "id": "69f8e0df-fb64-4f79-a684-6cfbdc2ba7ad",
+          "title": "Slack",
+          "momentum": 0,
+          "rank": 37
+        },
+        {
+          "id": "0401fdd4-89a4-4cb3-b951-3df1975e978b",
+          "title": "DuckDuckGo & Felo AI Search",
           "momentum": 0,
           "rank": 38
         },
@@ -856,68 +856,68 @@
           "rank": 39
         },
         {
-          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
-          "title": "Seoul Essentials",
+          "id": "9223f566-1b23-4ffc-a085-95f0bc769bed",
+          "title": "Instagram",
           "momentum": 0,
           "rank": 40
         },
         {
-          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
-          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
+          "title": "Standard Accounting Public MCP",
           "momentum": 0,
           "rank": 41
         },
         {
-          "id": "1fa33040-57e6-4ab1-9828-329b1204ebc7",
-          "title": "Visualization Charts Server",
+          "id": "ffa3bd03-4c4e-4547-a440-79a1951d9bcd",
+          "title": "quantoracle",
           "momentum": 0,
           "rank": 42
         },
         {
-          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
-          "title": "Supabase",
+          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
+          "title": "ai-agent-index",
           "momentum": 0,
           "rank": 43
         },
         {
-          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
-          "title": "MLB Stats Server",
+          "id": "5507b60f-1d64-4085-a1fb-0a270e7d3e35",
+          "title": "AI Skill Store",
           "momentum": 0,
           "rank": 44
         },
         {
-          "id": "dc70d6a2-f904-4a0c-b5b0-d6585e323d65",
-          "title": "ai-marketing-agent",
+          "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
+          "title": "cultural-intelligence",
           "momentum": 0,
           "rank": 45
         },
         {
-          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
-          "title": "Saju Insights",
+          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
+          "title": "Seoul Essentials",
           "momentum": 0,
           "rank": 46
         },
         {
-          "id": "9df2fd7e-6ff0-46c9-8b1f-17ba466edad1",
-          "title": "cryptoiz-mcp",
+          "id": "0f77dd5e-d60e-4f48-90d0-151b4876a3ca",
+          "title": "Google Drive",
           "momentum": 0,
           "rank": 47
         },
         {
-          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
-          "title": "Octomil",
+          "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
+          "title": "settlegrid-discovery",
           "momentum": 0,
           "rank": 48
         },
         {
-          "id": "de0ed2fa-ad2a-4cca-b45d-16a6ff80bfd7",
-          "title": "Harvard Course Explorer",
+          "id": "c1fa01dc-1a02-4ca1-81a6-9042a0731a69",
+          "title": "Instant Domain Search",
           "momentum": 0,
           "rank": 49
         },
         {
-          "id": "d38dd88c-9ced-4ef3-8a56-56ea0ce2ceb4",
-          "title": "cancersupport",
+          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
+          "title": "Saju Insights",
           "momentum": 0,
           "rank": 50
         }
@@ -948,14 +948,14 @@
           "rank": 4
         },
         {
-          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
-          "title": "Reddit",
+          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
+          "title": "Exa Search",
           "momentum": 0,
           "rank": 5
         },
         {
-          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
-          "title": "Exa Search",
+          "id": "8330b5fd-bcad-46cc-a536-7f6a25834737",
+          "title": "Reddit",
           "momentum": 0,
           "rank": 6
         },
@@ -966,188 +966,188 @@
           "rank": 7
         },
         {
-          "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
-          "title": "MCP Server for Singapore Government Open Data",
+          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
+          "title": "AI Research Assistant",
           "momentum": 0,
           "rank": 8
         },
         {
-          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
-          "title": "rivalsearch",
+          "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
+          "title": "MCP Server for Singapore Government Open Data",
           "momentum": 0,
           "rank": 9
-        },
-        {
-          "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
-          "title": "AI Research Assistant",
-          "momentum": 0,
-          "rank": 10
-        },
-        {
-          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
-          "title": "Swiss Truth MCP",
-          "momentum": 0,
-          "rank": 11
         },
         {
           "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
           "title": "12306 Ticket Search Server",
           "momentum": 0,
-          "rank": 12
-        },
-        {
-          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
-          "title": "Polymarket",
-          "momentum": 0,
-          "rank": 13
-        },
-        {
-          "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
-          "title": "Standard Accounting Public MCP",
-          "momentum": 0,
-          "rank": 14
+          "rank": 10
         },
         {
           "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
           "title": "AgentMail",
           "momentum": 0,
-          "rank": 15
+          "rank": 11
         },
         {
-          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
-          "title": "ai-agent-index",
+          "id": "2b22a249-2215-4624-8741-d3fed21bbe5a",
+          "title": "Polymarket",
           "momentum": 0,
-          "rank": 16
-        },
-        {
-          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
-          "title": "sbb-mcp",
-          "momentum": 0,
-          "rank": 17
+          "rank": 12
         },
         {
           "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
           "title": "Flight Search MCP Server",
           "momentum": 0,
-          "rank": 18
+          "rank": 13
         },
         {
           "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
           "title": "Linkup",
           "momentum": 0,
-          "rank": 19
-        },
-        {
-          "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
-          "title": "settlegrid-discovery",
-          "momentum": 0,
-          "rank": 20
+          "rank": 14
         },
         {
           "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
           "title": "KRDS Design System",
           "momentum": 0,
-          "rank": 21
+          "rank": 15
         },
         {
           "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
           "title": "Hugeicons MCP Server",
           "momentum": 0,
-          "rank": 22
+          "rank": 16
+        },
+        {
+          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
+          "title": "Swiss Truth MCP",
+          "momentum": 0,
+          "rank": 17
         },
         {
           "id": "9a58e6b6-6486-47c2-b05d-5362e3b85da7",
           "title": "AKShare One MCP Server",
           "momentum": 0,
-          "rank": 23
+          "rank": 18
         },
         {
-          "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
-          "title": "cultural-intelligence",
+          "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
+          "title": "sbb-mcp",
           "momentum": 0,
-          "rank": 24
-        },
-        {
-          "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
-          "title": "Microsoft Learn MCP",
-          "momentum": 0,
-          "rank": 25
-        },
-        {
-          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
-          "title": "Context Awesome",
-          "momentum": 0,
-          "rank": 26
+          "rank": 19
         },
         {
           "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
           "title": "Paper Search",
           "momentum": 0,
-          "rank": 27
+          "rank": 20
         },
         {
           "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
           "title": "Brave Search",
           "momentum": 0,
-          "rank": 28
-        },
-        {
-          "id": "706d98f8-dc33-453d-9103-d28364976e58",
-          "title": "icons8mcp",
-          "momentum": 0,
-          "rank": 29
-        },
-        {
-          "id": "7c0e4ef9-c2e0-4826-a2c9-949ebc5f5b5f",
-          "title": "Ayni",
-          "momentum": 0,
-          "rank": 30
+          "rank": 21
         },
         {
           "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
           "title": "Context7",
           "momentum": 0,
-          "rank": 31
-        },
-        {
-          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
-          "title": "paper-search-mcp-openai-v2",
-          "momentum": 0,
-          "rank": 32
+          "rank": 22
         },
         {
           "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
           "title": "Mesh MCP",
           "momentum": 0,
-          "rank": 33
+          "rank": 23
         },
         {
-          "id": "ffa3bd03-4c4e-4547-a440-79a1951d9bcd",
-          "title": "quantoracle",
+          "id": "b2099458-8711-4f83-a029-eebf247ebe64",
+          "title": "paper-search-mcp-openai-v2",
           "momentum": 0,
-          "rank": 34
-        },
-        {
-          "id": "ba8d79ca-2d8e-40dc-9dbd-df2e1731904b",
-          "title": "Bitpoort",
-          "momentum": 0,
-          "rank": 35
+          "rank": 24
         },
         {
           "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
           "title": "Senzing",
           "momentum": 0,
-          "rank": 36
+          "rank": 25
         },
         {
           "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
           "title": "Blockscout MCP Server",
           "momentum": 0,
-          "rank": 37
+          "rank": 26
         },
         {
           "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
           "title": "Ternary Intelligence Stack",
+          "momentum": 0,
+          "rank": 27
+        },
+        {
+          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
+          "title": "rivalsearch",
+          "momentum": 0,
+          "rank": 28
+        },
+        {
+          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
+          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "momentum": 0,
+          "rank": 29
+        },
+        {
+          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
+          "title": "Supabase",
+          "momentum": 0,
+          "rank": 30
+        },
+        {
+          "id": "706d98f8-dc33-453d-9103-d28364976e58",
+          "title": "icons8mcp",
+          "momentum": 0,
+          "rank": 31
+        },
+        {
+          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
+          "title": "MLB Stats Server",
+          "momentum": 0,
+          "rank": 32
+        },
+        {
+          "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
+          "title": "Microsoft Learn MCP",
+          "momentum": 0,
+          "rank": 33
+        },
+        {
+          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
+          "title": "Octomil",
+          "momentum": 0,
+          "rank": 34
+        },
+        {
+          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
+          "title": "Context Awesome",
+          "momentum": 0,
+          "rank": 35
+        },
+        {
+          "id": "ffebb7a1-9654-4ddc-8d0a-3018cf8ca05d",
+          "title": "ai-compliance-monitor",
+          "momentum": 0,
+          "rank": 36
+        },
+        {
+          "id": "69f8e0df-fb64-4f79-a684-6cfbdc2ba7ad",
+          "title": "Slack",
+          "momentum": 0,
+          "rank": 37
+        },
+        {
+          "id": "0401fdd4-89a4-4cb3-b951-3df1975e978b",
+          "title": "DuckDuckGo & Felo AI Search",
           "momentum": 0,
           "rank": 38
         },
@@ -1158,68 +1158,68 @@
           "rank": 39
         },
         {
-          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
-          "title": "Seoul Essentials",
+          "id": "9223f566-1b23-4ffc-a085-95f0bc769bed",
+          "title": "Instagram",
           "momentum": 0,
           "rank": 40
         },
         {
-          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
-          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
+          "title": "Standard Accounting Public MCP",
           "momentum": 0,
           "rank": 41
         },
         {
-          "id": "1fa33040-57e6-4ab1-9828-329b1204ebc7",
-          "title": "Visualization Charts Server",
+          "id": "ffa3bd03-4c4e-4547-a440-79a1951d9bcd",
+          "title": "quantoracle",
           "momentum": 0,
           "rank": 42
         },
         {
-          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
-          "title": "Supabase",
+          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
+          "title": "ai-agent-index",
           "momentum": 0,
           "rank": 43
         },
         {
-          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
-          "title": "MLB Stats Server",
+          "id": "5507b60f-1d64-4085-a1fb-0a270e7d3e35",
+          "title": "AI Skill Store",
           "momentum": 0,
           "rank": 44
         },
         {
-          "id": "dc70d6a2-f904-4a0c-b5b0-d6585e323d65",
-          "title": "ai-marketing-agent",
+          "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
+          "title": "cultural-intelligence",
           "momentum": 0,
           "rank": 45
         },
         {
-          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
-          "title": "Saju Insights",
+          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
+          "title": "Seoul Essentials",
           "momentum": 0,
           "rank": 46
         },
         {
-          "id": "9df2fd7e-6ff0-46c9-8b1f-17ba466edad1",
-          "title": "cryptoiz-mcp",
+          "id": "0f77dd5e-d60e-4f48-90d0-151b4876a3ca",
+          "title": "Google Drive",
           "momentum": 0,
           "rank": 47
         },
         {
-          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
-          "title": "Octomil",
+          "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
+          "title": "settlegrid-discovery",
           "momentum": 0,
           "rank": 48
         },
         {
-          "id": "de0ed2fa-ad2a-4cca-b45d-16a6ff80bfd7",
-          "title": "Harvard Course Explorer",
+          "id": "c1fa01dc-1a02-4ca1-81a6-9042a0731a69",
+          "title": "Instant Domain Search",
           "momentum": 0,
           "rank": 49
         },
         {
-          "id": "d38dd88c-9ced-4ef3-8a56-56ea0ce2ceb4",
-          "title": "cancersupport",
+          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
+          "title": "Saju Insights",
           "momentum": 0,
           "rank": 50
         }
@@ -1229,7 +1229,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-19T05:58:25.819Z",
+      "generatedAt": "2026-05-20T05:57:36.380Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     }


### PR DESCRIPTION
Automated data refresh from `Run shadow scoring`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26144330696

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.