### PR TITLE
chore(data): refresh staleness report 2026-05-20T06:13:05Z

### DIFF
--- a/data/staleness-report.json
+++ b/data/staleness-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-19T06:12:26.881Z",
+  "generatedAt": "2026-05-20T06:13:03.876Z",
   "sources": [
     {
       "slug": "trending",
@@ -13,12 +13,12 @@
     },
     {
       "slug": "repo-profiles",
-      "total": 1899,
+      "total": 2244,
       "stale": 0,
       "thresholdHours": 4,
       "examples": [],
       "notes": [
-        "1899/1899 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
+        "2244/2244 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
       ]
     },
     {


### PR DESCRIPTION
Automated data refresh from `Sweep staleness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26144911554

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.