### PR TITLE
fix(m15): huggingface-trending workflow succeeds but data not landing

### DIFF
--- a/scripts/__tests__/data-store-write.test.mjs
+++ b/scripts/__tests__/data-store-write.test.mjs
@@ -13,6 +13,7 @@ import {
   writeDataStore,
   readDataStoreMany,
   writeDataStoreMany,
+  verifyMetaLanded,
   _resetForTests,
   closeDataStore,
 } from "../_data-store-write.mjs";
@@ -261,6 +262,60 @@ test("writeDataStoreMany: non-array input collapses to skipped/empty", async () 
     const result = await writeDataStoreMany(undefined);
     assert.equal(result.source, "skipped");
     assert.deepEqual(result.results, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M-15 — verifyMetaLanded (silent-write guard)
+// ---------------------------------------------------------------------------
+//
+// The "happy path" (meta exists + writtenAt matches) is exercised end-to-end
+// against live Redis via `npm run verify:data-store`. Unit coverage here is
+// scoped to the no-Redis-env skip path and the argument-validation rails.
+
+test("verifyMetaLanded: no-op when Redis disabled (env-missing)", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    // No throw expected — verifyMetaLanded matches writeDataStore's
+    // "skipped" contract so the script keeps working in local dev without
+    // Redis creds.
+    await verifyMetaLanded("scr11-noop-noenv", new Date().toISOString());
+  });
+});
+
+test("verifyMetaLanded: no-op when DATA_STORE_DISABLE=1", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    process.env.DATA_STORE_DISABLE = "1";
+    try {
+      await verifyMetaLanded("scr11-noop-disabled", new Date().toISOString());
+    } finally {
+      delete process.env.DATA_STORE_DISABLE;
+    }
+  });
+});
+
+test("verifyMetaLanded: rejects empty/blank key", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    await assert.rejects(
+      () => verifyMetaLanded("", "2026-01-01T00:00:00.000Z"),
+      /verifyMetaLanded: key/i,
+    );
+    await assert.rejects(
+      () => verifyMetaLanded("   ", "2026-01-01T00:00:00.000Z"),
+      /verifyMetaLanded: key/i,
+    );
+  });
+});
+
+test("verifyMetaLanded: rejects empty expectedWrittenAt", async () => {
+  await withClearedEnv(async () => {
+    _resetForTests();
+    await assert.rejects(
+      () => verifyMetaLanded("scr11-verify-needs-ts", ""),
+      /verifyMetaLanded: expectedWrittenAt/i,
+    );
   });
 });
 

--- a/scripts/_data-store-write.mjs
+++ b/scripts/_data-store-write.mjs
@@ -499,6 +499,72 @@ export async function readDataStore(key) {
 }
 
 /**
+ * M-15 guard — read back `ss:meta:v1:<slug>` and assert its writtenAt
+ * matches `expectedWrittenAt`. Throws on mismatch so the calling script
+ * (and its workflow) fails LOUD when the SET resolved locally but never
+ * actually landed in Redis.
+ *
+ * Background: when the workflow runner was migrated from a TOOLBOX-VPS
+ * self-hosted runner to GitHub-hosted `ubuntu-latest` (2026-05-15), the
+ * `REDIS_URL` secret pointed at a hostname only reachable from inside
+ * the TOOLBOX network. ioredis's `enableOfflineQueue=true` queued the
+ * SET, the script's `closeDataStore()` then quit the never-connected
+ * client, the SETs were dropped, but the script logged
+ * `[redis: redis]` and the workflow exited success. The
+ * `huggingface-{trending,datasets,spaces}` slugs went silently stale
+ * for ~6 days before /api/worker/health surfaced the gap. This helper
+ * makes the next such regression visible within one cron tick.
+ *
+ * @param {string} key Slug, e.g. "huggingface-trending"
+ * @param {string} expectedWrittenAt The writtenAt returned by writeDataStore
+ * @returns {Promise<void>} resolves on match; rejects otherwise
+ */
+export async function verifyMetaLanded(key, expectedWrittenAt) {
+  if (typeof key !== "string" || !key.trim()) {
+    throw new Error("[data-store-write] verifyMetaLanded: key must be a non-empty string");
+  }
+  if (typeof expectedWrittenAt !== "string" || !expectedWrittenAt) {
+    throw new Error("[data-store-write] verifyMetaLanded: expectedWrittenAt must be a non-empty string");
+  }
+  const client = await getClient();
+  if (!client) {
+    // Redis disabled (DATA_STORE_DISABLE=1 or no env) — writeDataStore
+    // returned source="skipped"; nothing to verify.
+    return;
+  }
+  const raw = await client.get(`${META_NAMESPACE}:${key.trim()}`);
+  if (raw === null || raw === undefined) {
+    throw new Error(
+      `[data-store-write] verifyMetaLanded: meta key "${META_NAMESPACE}:${key}" is missing after write ` +
+        `(expected writtenAt=${expectedWrittenAt}). Redis SET silently dropped — check REDIS_URL ` +
+        `reachability from this runner.`,
+    );
+  }
+  let actual;
+  if (typeof raw === "string") {
+    if (raw[0] === "{") {
+      try {
+        const parsed = JSON.parse(raw);
+        actual = typeof parsed.writtenAt === "string" ? parsed.writtenAt : null;
+      } catch {
+        actual = null;
+      }
+    } else {
+      actual = raw; // bare ISO shape (back-compat)
+    }
+  } else if (typeof raw === "object" && raw !== null) {
+    actual = typeof raw.writtenAt === "string" ? raw.writtenAt : null;
+  }
+  if (actual !== expectedWrittenAt) {
+    throw new Error(
+      `[data-store-write] verifyMetaLanded: meta writtenAt mismatch for "${key}" ` +
+        `(expected=${expectedWrittenAt} actual=${actual ?? "<unparseable>"}). ` +
+        `Redis is either responding from a stale replica or the SET landed elsewhere.`,
+    );
+  }
+}
+
+/**
  * Gracefully close the underlying Redis connection. Optional — ioredis lets
  * the process exit cleanly even with a live client. Useful in long-running
  * scripts (e.g. test harness) that want explicit cleanup.

--- a/scripts/scrape-huggingface-datasets.mjs
+++ b/scripts/scrape-huggingface-datasets.mjs
@@ -29,7 +29,7 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
-import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
 import { ingestHuggingfaceDatasetsToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
@@ -149,6 +149,13 @@ async function main() {
   await mkdir(DATA_DIR, { recursive: true });
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("huggingface-datasets", payload);
+  // M-15 guard — assert the meta SET actually landed in Redis. Without
+  // this, a runner that can't reach REDIS_URL silently queues + drops
+  // SETs while the script logs success. See verifyMetaLanded() docs in
+  // _data-store-write.mjs for the full incident narrative.
+  if (redis.source === "redis") {
+    await verifyMetaLanded("huggingface-datasets", redis.writtenAt);
+  }
 
   // Dual-write to TOOLBOX (`trending.huggingface.datasets`).
   const toolboxResult = await ingestHuggingfaceDatasetsToToolbox(payload);

--- a/scripts/scrape-huggingface-spaces.mjs
+++ b/scripts/scrape-huggingface-spaces.mjs
@@ -31,7 +31,7 @@ import { fileURLToPath } from "node:url";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { extractGithubRepoFullNames } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
-import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
 import { ingestHuggingfaceSpacesToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
@@ -259,6 +259,13 @@ async function main() {
   await mkdir(DATA_DIR, { recursive: true });
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("huggingface-spaces", payload);
+  // M-15 guard — assert the meta SET actually landed in Redis. Without
+  // this, a runner that can't reach REDIS_URL silently queues + drops
+  // SETs while the script logs success. See verifyMetaLanded() docs in
+  // _data-store-write.mjs for the full incident narrative.
+  if (redis.source === "redis") {
+    await verifyMetaLanded("huggingface-spaces", redis.writtenAt);
+  }
 
   // Dual-write to TOOLBOX (`trending.huggingface.spaces`).
   const toolboxResult = await ingestHuggingfaceSpacesToToolbox(payload);

--- a/scripts/scrape-huggingface.mjs
+++ b/scripts/scrape-huggingface.mjs
@@ -31,7 +31,7 @@ import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
 import { fetchJsonWithRetry } from "./_fetch-json.mjs";
 import { extractGithubRepoFullNames } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
-import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
 import { ingestHuggingfaceModelsToToolbox } from "./_toolbox-ingest.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
@@ -274,6 +274,13 @@ async function main() {
   await mkdir(DATA_DIR, { recursive: true });
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("huggingface-trending", payload);
+  // M-15 guard — assert the meta SET actually landed in Redis. Without
+  // this, a runner that can't reach REDIS_URL silently queues + drops
+  // SETs while the script logs success. See verifyMetaLanded() docs in
+  // _data-store-write.mjs for the full incident narrative.
+  if (redis.source === "redis") {
+    await verifyMetaLanded("huggingface-trending", redis.writtenAt);
+  }
 
   // Dual-write to TOOLBOX (`trending.huggingface.models`, capped at 100).
   const toolboxResult = await ingestHuggingfaceModelsToToolbox(payload);


### PR DESCRIPTION
## Summary

The `huggingface-trending` slug (and its `-datasets` / `-spaces` siblings) report stale dates in `/api/worker/health` — `huggingface-trending` has been frozen at **2026-05-13T20:51:41.983Z** for ~6 days while the GH Actions workflow exits success on every cron tick.

**Root cause (Mirko-side, NOT fixed in this PR):** After PR #1269 migrated the HF workflows from `[self-hosted, linux, x64]` to `ubuntu-latest` on 2026-05-15, the `REDIS_URL` GH secret (last rotated 2026-04-26) became unreachable from GitHub-hosted runners. The secret was set when the workflow ran on TOOLBOX VPS — it apparently resolves to an internal hostname (e.g. `redis://host.docker.internal:6379` or a private VPC IP) that GitHub's `ubuntu-latest` runner can't dial.

**Why it went silent:** `_data-store-write.mjs` uses `ioredis` with `enableOfflineQueue: true` (the default) + `maxRetriesPerRequest: 3`. When the connection never establishes, the `client.set()` call is enqueued, `Promise.all([...])` resolves, the script logs `[redis: redis]`, then `closeDataStore()` (in the `.finally` block) calls `client.quit()` which drops the never-sent queue. Workflow exits 0, no error surfaces.

**Scope of breakage:** 7 GH-Actions-written Upstash slugs are silently stuck at 2026-05-13 timestamps:
- `huggingface-trending`, `huggingface-datasets`, `huggingface-spaces` (the M-15 trigger)
- `arxiv-recent`, `arxiv-enriched`, `awesome-skills`, `base-x402-onchain`, `claude-rss`, `funding-news-sec` (other affected GH-actions writers; left for a follow-up since they're out of M-15's scope)

This PR fixes the **observability** half — makes the silent-write mode impossible for the 3 HF scripts.

## Changes

- **`scripts/_data-store-write.mjs`** — add `verifyMetaLanded(slug, expectedWrittenAt)` export. Reads back `ss:meta:v1:<slug>`, asserts writtenAt matches what `writeDataStore` claimed, throws on mismatch. No-op when Redis is disabled (matches the existing skip contract).
- **`scripts/scrape-huggingface.mjs`** — call `verifyMetaLanded("huggingface-trending", redis.writtenAt)` after `writeDataStore`.
- **`scripts/scrape-huggingface-datasets.mjs`** — same for `huggingface-datasets`.
- **`scripts/scrape-huggingface-spaces.mjs`** — same for `huggingface-spaces`.
- **`scripts/__tests__/data-store-write.test.mjs`** — 4 new unit tests covering the skip path + arg validation.

Net diff: +145 / -3 lines across 5 files.

## Before / after behaviour

**Before:** workflow exits 0 → `[redis: redis]` logged → Upstash never sees the SET → `/api/worker/health` shows the slug red for days until someone notices.

**After:** workflow exits 0 only if the meta key in Redis matches the writtenAt we just wrote. Mismatch → throw → `runAsRegisteredSource` re-throws → `process.exitCode = 1` → workflow run goes red in GH UI within 1 cron tick → fix surfaces immediately.

## Test plan

- [x] `node --test scripts/__tests__/data-store-write.test.mjs` — 19/19 pass (15 pre-existing + 4 new)
- [x] `node --test tests/data-store-write.test.mjs` — 6/6 pass (no regressions)
- [x] `npx tsc --noEmit` — clean
- [x] `DATA_STORE_DISABLE=1 node scripts/scrape-huggingface.mjs` — runs to completion, exits ok (verify is no-op when Redis disabled)
- [ ] Live CI confirms the next HF cron tick STILL exits red until Mirko rotates `REDIS_URL` (this is the desired behaviour — workflow now fails loud instead of lying)

## Mirko follow-up (M-15 close-out)

After this PR merges, the next HF cron tick (within 6h) will fail RED on the verify step. To unblock:

```bash
# 1. Get the Upstash rediss:// URL the trendingrepo-worker container uses:
ssh -i ~/.ssh/AndyAikey.pem root@193.53.40.118 \
  'grep ^REDIS_URL= /opt/toolbox-trendingrepo-worker/.env'

# 2. Push it as the GH secret (replace <URL>):
gh secret set REDIS_URL --repo 0motionguy/starscreener --body "<URL>"

# 3. Re-trigger one HF workflow to verify:
gh workflow run scrape-huggingface.yml --repo 0motionguy/starscreener

# 4. After it succeeds, watch /api/worker/health flip green:
curl -s https://trendingrepo.com/api/worker/health | jq '.slugs[] | select(.slug | startswith("huggingface"))'
```

The 6 other affected slugs (`arxiv-*`, `awesome-skills`, `base-x402-onchain`, `claude-rss`, `funding-news-sec`) will also start landing after step 2 lands.

## Rollback

`git revert <merge-sha>`. Pre-fix, the 3 HF scripts silently no-op'd their Redis writes. Reverting just restores that silent no-op (i.e. back to the bug, but no other consequence).

## Why this PR doesn't rotate the secret directly

Per global rule "If the fix turns out to require Mirko-side input (new secret), STOP and report" — I don't have write access to GH secrets and shouldn't guess the right URL. The guard ensures we'll never spend 6 days unaware of this class of bug again.