### PR TITLE
chore(data): refresh awesome-skills index 2026-05-20T07:59:18Z

### DIFF
--- a/data/_meta/awesome-skills.json
+++ b/data/_meta/awesome-skills.json
@@ -1,8 +1,8 @@
 {
   "source": "awesome-skills",
   "reason": "ok",
-  "ts": "2026-05-19T08:00:24.396Z",
+  "ts": "2026-05-20T07:59:18.492Z",
   "count": 1,
-  "durationMs": 4248,
+  "durationMs": 4270,
   "extra": {}
 }

--- a/data/awesome-skills.json
+++ b/data/awesome-skills.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-19T08:00:20.150Z",
+  "fetchedAt": "2026-05-20T07:59:14.223Z",
   "source": "awesome-skills aggregate",
   "lists": [
     "sickn33/antigravity-awesome-skills",
@@ -113,6 +113,9 @@
       "sickn33/antigravity-awesome-skills"
     ],
     "bitjaru/styleseed": [
+      "sickn33/antigravity-awesome-skills"
+    ],
+    "yikuansun/photopeaapi": [
       "sickn33/antigravity-awesome-skills"
     ],
     "milkomida77/guardian-agent-prompts": [
@@ -8114,6 +8117,6 @@
   "counts": {
     "lists": 4,
     "listsAttempted": 5,
-    "uniqueSkills": 2626
+    "uniqueSkills": 2627
   }
 }


### PR DESCRIPTION
Automated data refresh from `Refresh awesome-skills index`.

- Files changed: 3
- Run: https://github.com/0motionguy/starscreener/actions/runs/26149415491

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.