### PR TITLE
chore(data): promote unknown mentions 2026-05-20T08:02:27Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,27 @@
 {
-  "generatedAt": "2026-05-19T08:02:44.716Z",
-  "totalUnknownMentions": 202946,
-  "distinctRepos": 18607,
+  "generatedAt": "2026-05-20T08:02:26.025Z",
+  "totalUnknownMentions": 212736,
+  "distinctRepos": 19525,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
+      "fullName": "oven-sh/bun",
+      "totalCount": 149,
+      "sourceCount": 5,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "lobsters",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-02T03:53:18.691Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 74,
+      "totalCount": 79,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -17,11 +31,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 159,
+      "totalCount": 172,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -30,11 +44,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "vercel/next.js",
-      "totalCount": 151,
+      "totalCount": 156,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -43,20 +57,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
-      "fullName": "oven-sh/bun",
-      "totalCount": 137,
-      "sourceCount": 4,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "hmbown/deepseek-tui",
@@ -73,7 +74,7 @@
     },
     {
       "fullName": "vitejs/vite",
-      "totalCount": 83,
+      "totalCount": 87,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -82,7 +83,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "antirez/ds4",
@@ -99,7 +100,7 @@
     },
     {
       "fullName": "facebook/react",
-      "totalCount": 78,
+      "totalCount": 80,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -108,7 +109,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-15T11:31:13.243Z"
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "kolapsis/maintenant",
@@ -122,6 +123,19 @@
       ],
       "firstSeenAt": "2026-05-01T17:15:27.672Z",
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
+    },
+    {
+      "fullName": "trycua/cua",
+      "totalCount": 34,
+      "sourceCount": 4,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "hackernews",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
       "fullName": "aattaran/deepclaude",
@@ -138,7 +152,7 @@
     },
     {
       "fullName": "onyks-os/transparenttorproxy",
-      "totalCount": 153,
+      "totalCount": 158,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -146,11 +160,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T11:34:16.788Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "microsoft/vscode",
-      "totalCount": 148,
+      "totalCount": 153,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -158,11 +172,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "graemeg/blaise",
-      "totalCount": 132,
+      "totalCount": 137,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -170,11 +184,11 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-08T06:11:19.000Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "ninjahawk/hollow-agentos",
-      "totalCount": 111,
+      "totalCount": 116,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -182,7 +196,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "minishlab/semble",
@@ -195,6 +209,18 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-18T04:41:26.919Z"
+    },
+    {
+      "fullName": "manojmallick/sigmap",
+      "totalCount": 105,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "scosman/cursed_browser",
@@ -219,18 +245,6 @@
       ],
       "firstSeenAt": "2026-05-07T17:19:14.533Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "manojmallick/sigmap",
-      "totalCount": 101,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
       "fullName": "leaningtech/browsercode",
@@ -281,6 +295,18 @@
       "lastSeenAt": "2026-05-11T00:07:14.314Z"
     },
     {
+      "fullName": "reviewstage/stage-cli",
+      "totalCount": 92,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T17:19:14.533Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+    },
+    {
       "fullName": "bring-shrubbery/ml-sharp-web",
       "totalCount": 91,
       "sourceCount": 3,
@@ -291,6 +317,18 @@
       ],
       "firstSeenAt": "2026-05-03T10:35:18.415Z",
       "lastSeenAt": "2026-05-12T14:51:56.628Z"
+    },
+    {
+      "fullName": "luce-org/lucebox-hub",
+      "totalCount": 90,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T15:36:14.012Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "shadcn-ui/ui",
@@ -305,32 +343,8 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "luce-org/lucebox-hub",
-      "totalCount": 88,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T15:36:14.012Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
-      "fullName": "reviewstage/stage-cli",
-      "totalCount": 88,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T17:19:14.533Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
       "fullName": "sifter-ai/sifter",
-      "totalCount": 85,
+      "totalCount": 86,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -338,7 +352,31 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+    },
+    {
+      "fullName": "higangssh/homebutler",
+      "totalCount": 85,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+    },
+    {
+      "fullName": "tanstack/router",
+      "totalCount": 84,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-02T04:02:25.023Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "waybarrios/opencode-power-pack",
@@ -353,30 +391,6 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 80,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
-    },
-    {
-      "fullName": "tanstack/router",
-      "totalCount": 80,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T04:02:25.023Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
       "fullName": "snyk/agent-scan",
       "totalCount": 79,
       "sourceCount": 3,
@@ -389,32 +403,8 @@
       "lastSeenAt": "2026-05-12T08:49:51.709Z"
     },
     {
-      "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 73,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
-    },
-    {
-      "fullName": "fsnotify/fsnotify",
-      "totalCount": 72,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
       "fullName": "torrix-ai/install",
-      "totalCount": 67,
+      "totalCount": 76,
       "sourceCount": 3,
       "sources": [
         "devto",
@@ -422,7 +412,31 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "fsnotify/fsnotify",
+      "totalCount": 76,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T07:20:32.729Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+    },
+    {
+      "fullName": "sipyourdrink-ltd/bernstein",
+      "totalCount": 74,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
       "fullName": "sambigeara/pollen",
@@ -447,6 +461,42 @@
       ],
       "firstSeenAt": "2026-05-03T17:17:34.365Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "andyyyy64/whichllm",
+      "totalCount": 64,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T10:12:27.167Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "genymobile/scrcpy",
+      "totalCount": 64,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T08:45:16.184Z",
+      "lastSeenAt": "2026-05-19T18:33:33.494Z"
+    },
+    {
+      "fullName": "ollama/ollama",
+      "totalCount": 63,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "angular/angular",
@@ -497,18 +547,6 @@
       "lastSeenAt": "2026-05-18T21:27:26.803Z"
     },
     {
-      "fullName": "genymobile/scrcpy",
-      "totalCount": 60,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-02T08:45:16.184Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
       "fullName": "redis/redis",
       "totalCount": 60,
       "sourceCount": 3,
@@ -533,20 +571,32 @@
       "lastSeenAt": "2026-05-12T12:19:51.467Z"
     },
     {
-      "fullName": "ollama/ollama",
+      "fullName": "n8n-io/n8n",
+      "totalCount": 59,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "reddit",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+    },
+    {
+      "fullName": "statewright/statewright",
       "totalCount": 59,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
-        "reddit"
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+      "firstSeenAt": "2026-05-12T17:04:51.325Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "manankharwar/fusioncore",
-      "totalCount": 58,
+      "totalCount": 59,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -554,7 +604,19 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-07T21:45:14.561Z"
+      "lastSeenAt": "2026-05-19T12:20:48.337Z"
+    },
+    {
+      "fullName": "vercel/ai",
+      "totalCount": 57,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "uw-syfi/vibe-serve",
@@ -569,28 +631,16 @@
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
-      "fullName": "n8n-io/n8n",
+      "fullName": "navid-m/flightsim",
       "totalCount": 55,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "reddit",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
-      "fullName": "andyyyy64/whichllm",
-      "totalCount": 54,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-15T10:12:27.167Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "minio/minio",
@@ -605,40 +655,28 @@
       "lastSeenAt": "2026-05-09T08:04:55.501Z"
     },
     {
-      "fullName": "statewright/statewright",
-      "totalCount": 53,
+      "fullName": "v12-security/pocs",
+      "totalCount": 50,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "devto",
-        "hackernews"
+        "hackernews",
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-12T17:04:51.325Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
-      "fullName": "navid-m/flightsim",
-      "totalCount": 51,
+      "fullName": "vllm-project/vllm",
+      "totalCount": 49,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
-        "hackernews"
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
-      "fullName": "vercel/ai",
-      "totalCount": 51,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+      "firstSeenAt": "2026-05-01T19:21:26.285Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -701,18 +739,6 @@
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
     },
     {
-      "fullName": "vllm-project/vllm",
-      "totalCount": 46,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-18T19:48:27.935Z"
-    },
-    {
       "fullName": "nooga/let-go",
       "totalCount": 46,
       "sourceCount": 3,
@@ -737,18 +763,6 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "v12-security/pocs",
-      "totalCount": 44,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
       "fullName": "simdjson/simdjson",
       "totalCount": 44,
       "sourceCount": 3,
@@ -762,7 +776,7 @@
     },
     {
       "fullName": "0xmassi/webclaw",
-      "totalCount": 42,
+      "totalCount": 43,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -770,35 +784,23 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
-      "fullName": "iliaal/fastchart",
-      "totalCount": 41,
+      "fullName": "rust-lang/rust",
+      "totalCount": 43,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
-      "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 40,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "junegunn/fzf",
-      "totalCount": 39,
+      "totalCount": 43,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -806,11 +808,35 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+    },
+    {
+      "fullName": "iliaal/fastchart",
+      "totalCount": 43,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-19T13:44:19.677Z"
+    },
+    {
+      "fullName": "igorganapolsky/thumbgate",
+      "totalCount": 42,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
       "fullName": "zed-industries/zed",
-      "totalCount": 37,
+      "totalCount": 41,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -818,7 +844,31 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+    },
+    {
+      "fullName": "stardockcorp/wireloom",
+      "totalCount": 39,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "tabularisdb/tabularis",
+      "totalCount": 37,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "tidwall/btype",
@@ -833,44 +883,8 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "rust-lang/rust",
-      "totalCount": 35,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
-      "fullName": "tabularisdb/tabularis",
-      "totalCount": 33,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
-      "fullName": "trycua/cua",
-      "totalCount": 30,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "hackernews",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
-    },
-    {
       "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
-      "totalCount": 30,
+      "totalCount": 35,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -878,11 +892,11 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-15T06:43:54.808Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "open-webui/open-webui",
-      "totalCount": 27,
+      "totalCount": 32,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -890,7 +904,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T04:53:38.982Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -903,6 +917,30 @@
       ],
       "firstSeenAt": "2026-05-07T19:50:24.370Z",
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
+    },
+    {
+      "fullName": "anishathalye/ai-agent-security-lecture",
+      "totalCount": 24,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-18T16:34:28.470Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "anthropics/claude-cookbooks",
+      "totalCount": 22,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -929,8 +967,20 @@
       "lastSeenAt": "2026-05-04T00:13:30.621Z"
     },
     {
+      "fullName": "sander110419/lightroom-cc-on-linux",
+      "totalCount": 17,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-18T12:48:24.691Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
       "fullName": "duriantaco/skylos",
-      "totalCount": 15,
+      "totalCount": 16,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -938,30 +988,42 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
-      "fullName": "anishathalye/ai-agent-security-lecture",
-      "totalCount": 12,
+      "fullName": "nodejs/node",
+      "totalCount": 7,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T03:48:07.888Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "xataio/deltax",
+      "totalCount": 6,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "hackernews",
         "lobsters"
       ],
-      "firstSeenAt": "2026-05-18T16:34:28.470Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "firstSeenAt": "2026-05-19T19:17:55.212Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 147,
+      "totalCount": 153,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-19T08:00:24.394Z"
+      "lastSeenAt": "2026-05-20T07:59:18.489Z"
     },
     {
       "fullName": "wojtczyk/trust",
@@ -987,14 +1049,14 @@
     },
     {
       "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 125,
+      "totalCount": 127,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-18T12:12:25.407Z"
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "translate-tools/transly",
@@ -1031,14 +1093,36 @@
     },
     {
       "fullName": "samplexbro/agentsmesh",
-      "totalCount": 114,
+      "totalCount": 115,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+      "lastSeenAt": "2026-05-19T09:50:47.617Z"
+    },
+    {
+      "fullName": "raiyanyahya/how-to-train-your-gpt",
+      "totalCount": 110,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "warwickwood-cell/gengeo-agent-registry",
+      "totalCount": 110,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "jossephus/chuchu",
@@ -1052,15 +1136,26 @@
       "lastSeenAt": "2026-05-16T00:18:32.194Z"
     },
     {
-      "fullName": "raiyanyahya/how-to-train-your-gpt",
-      "totalCount": 105,
+      "fullName": "drcathicks/learning-opportunities",
+      "totalCount": 106,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "orhun/ratty",
+      "totalCount": 106,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-19T13:44:19.677Z"
     },
     {
       "fullName": "opensensenova/sensenova-u1",
@@ -1074,28 +1169,6 @@
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
     },
     {
-      "fullName": "orhun/ratty",
-      "totalCount": 104,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
-      "fullName": "warwickwood-cell/gengeo-agent-registry",
-      "totalCount": 104,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
       "fullName": "facebookresearch/tuna-2",
       "totalCount": 102,
       "sourceCount": 2,
@@ -1105,17 +1178,6 @@
       ],
       "firstSeenAt": "2026-05-01T23:09:58.018Z",
       "lastSeenAt": "2026-05-19T01:56:00.808Z"
-    },
-    {
-      "fullName": "drcathicks/learning-opportunities",
-      "totalCount": 101,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "ifixai-ai/diagnostic",
@@ -1130,14 +1192,14 @@
     },
     {
       "fullName": "celestoai/smolvm",
-      "totalCount": 99,
+      "totalCount": 100,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
+      "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
       "fullName": "mekickdemons-creator/mnemara",
@@ -1149,6 +1211,17 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 94,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-19T20:52:58.618Z"
     },
     {
       "fullName": "avarok-cybersecurity/atlas",
@@ -1182,17 +1255,6 @@
       ],
       "firstSeenAt": "2026-05-02T17:16:19.580Z",
       "lastSeenAt": "2026-05-17T23:08:31.913Z"
-    },
-    {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 91,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-19T04:33:47.216Z"
     },
     {
       "fullName": "emad-elsaid/xlog",
@@ -1248,6 +1310,28 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
+    },
+    {
+      "fullName": "naver/lispe",
+      "totalCount": 88,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "harnexa/nexa-gauge",
+      "totalCount": 87,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T01:29:16.934Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "cubiczan/consensus-hardening-protocol",
@@ -1338,17 +1422,6 @@
       "lastSeenAt": "2026-05-09T18:44:58.134Z"
     },
     {
-      "fullName": "harnexa/nexa-gauge",
-      "totalCount": 82,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T01:29:16.934Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
       "fullName": "dmarshaltu/coord",
       "totalCount": 82,
       "sourceCount": 2,
@@ -1369,6 +1442,17 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-12T14:38:16.802Z"
+    },
+    {
+      "fullName": "arriemeijer-creator/aerojax",
+      "totalCount": 81,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
@@ -1393,15 +1477,15 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "naver/lispe",
+      "fullName": "jher7/tokenyst",
       "totalCount": 79,
       "sourceCount": 2,
       "sources": [
-        "hackernews",
-        "lobsters"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-19T04:45:29.398Z"
+      "firstSeenAt": "2026-05-09T20:33:23.845Z",
+      "lastSeenAt": "2026-05-19T15:29:26.381Z"
     },
     {
       "fullName": "bep/grrep",
@@ -1525,17 +1609,6 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "jher7/tokenyst",
-      "totalCount": 77,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T20:33:23.845Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
       "fullName": "wiaahmarketplace/typerion-oss",
       "totalCount": 77,
       "sourceCount": 2,
@@ -1558,6 +1631,17 @@
       "lastSeenAt": "2026-05-11T11:39:37.103Z"
     },
     {
+      "fullName": "scottgl9/skelm",
+      "totalCount": 76,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+    },
+    {
       "fullName": "datadog/java-reggie",
       "totalCount": 76,
       "sourceCount": 2,
@@ -1578,6 +1662,17 @@
       ],
       "firstSeenAt": "2026-05-03T04:20:52.369Z",
       "lastSeenAt": "2026-05-10T16:09:01.639Z"
+    },
+    {
+      "fullName": "eleutherai/lm-evaluation-harness",
+      "totalCount": 75,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "davesimoes/crustai",
@@ -1622,6 +1717,17 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "pyinfra-dev/pyinfra",
+      "totalCount": 74,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-19T12:20:48.337Z"
     },
     {
       "fullName": "autoloops/upskill",
@@ -1701,6 +1807,17 @@
       "lastSeenAt": "2026-05-09T15:42:37.217Z"
     },
     {
+      "fullName": "enmanuelmag/heimdall-mcp",
+      "totalCount": 73,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+    },
+    {
       "fullName": "averygan/reclip",
       "totalCount": 73,
       "sourceCount": 2,
@@ -1710,17 +1827,6 @@
       ],
       "firstSeenAt": "2026-05-02T21:01:52.519Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "arriemeijer-creator/aerojax",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
     },
     {
       "fullName": "heymrun/heym",
@@ -1921,17 +2027,6 @@
       "lastSeenAt": "2026-05-12T14:51:56.628Z"
     },
     {
-      "fullName": "enmanuelmag/heimdall-mcp",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-19T03:43:08.866Z"
-    },
-    {
       "fullName": "sudarshan8417/tfdrift",
       "totalCount": 69,
       "sourceCount": 2,
@@ -2007,6 +2102,39 @@
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
       "lastSeenAt": "2026-05-04T11:06:19.016Z"
+    },
+    {
+      "fullName": "c2sp/wycheproof",
+      "totalCount": 68,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T10:30:24.305Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "chojs23/concord",
+      "totalCount": 68,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+    },
+    {
+      "fullName": "valhalla/valhalla",
+      "totalCount": 68,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T20:50:24.350Z",
+      "lastSeenAt": "2026-05-19T19:17:55.212Z"
     },
     {
       "fullName": "derekpascarella/universaldreamcastpatcher",
@@ -2097,15 +2225,15 @@
       "lastSeenAt": "2026-05-09T21:15:18.927Z"
     },
     {
-      "fullName": "eleutherai/lm-evaluation-harness",
+      "fullName": "backnotprop/rig",
       "totalCount": 66,
       "sourceCount": 2,
       "sources": [
-        "devto",
+        "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T14:30:15.363Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
+      "firstSeenAt": "2026-05-07T20:50:24.350Z",
+      "lastSeenAt": "2026-05-19T19:17:55.212Z"
     },
     {
       "fullName": "intel/auto-round",
@@ -2152,17 +2280,6 @@
       "lastSeenAt": "2026-05-08T16:28:40.683Z"
     },
     {
-      "fullName": "chojs23/concord",
-      "totalCount": 64,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-18T12:12:25.407Z"
-    },
-    {
       "fullName": "advisories/ghsa-vp62-r36r-9xqp",
       "totalCount": 64,
       "sourceCount": 2,
@@ -2183,116 +2300,6 @@
       ],
       "firstSeenAt": "2026-05-02T08:08:25.290Z",
       "lastSeenAt": "2026-05-09T07:04:12.114Z"
-    },
-    {
-      "fullName": "cashapp/hermit",
-      "totalCount": 64,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-09T01:29:16.934Z"
-    },
-    {
-      "fullName": "upenn/web-scroll-video",
-      "totalCount": 64,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T04:02:25.023Z",
-      "lastSeenAt": "2026-05-09T01:29:16.934Z"
-    },
-    {
-      "fullName": "c2sp/wycheproof",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-02T10:30:24.305Z",
-      "lastSeenAt": "2026-05-19T06:24:14.379Z"
-    },
-    {
-      "fullName": "mozilla/standards-positions",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-18T16:34:28.470Z"
-    },
-    {
-      "fullName": "liamromanis101/cve-2026-31431-copy-fail---vulnerability-detection-script",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T15:06:30.276Z",
-      "lastSeenAt": "2026-05-18T15:38:08.835Z"
-    },
-    {
-      "fullName": "perufitlife/supabase-security-skill",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T13:30:06.157Z",
-      "lastSeenAt": "2026-05-18T10:09:50.074Z"
-    },
-    {
-      "fullName": "merkoba/meltdown",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T03:39:00.340Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "dgr8akki/claude-tab-watcher",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T11:33:06.098Z",
-      "lastSeenAt": "2026-05-15T10:12:27.167Z"
-    },
-    {
-      "fullName": "egroup-labs/kept",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T09:54:31.486Z",
-      "lastSeenAt": "2026-05-15T09:06:57.504Z"
-    },
-    {
-      "fullName": "matheus-git/systemd-manager-tui",
-      "totalCount": 63,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T11:59:33.442Z",
-      "lastSeenAt": "2026-05-10T10:08:57.038Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26149570996

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.