### PR TITLE
feat(t22): add verifyMetaLanded to 6 other affected scrape scripts

### DIFF
--- a/scripts/enrich-arxiv.mjs
+++ b/scripts/enrich-arxiv.mjs
@@ -54,7 +54,7 @@ import {
   sleep,
   parseRetryAfterMs,
 } from "./_fetch-json.mjs";
-import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = resolve(__dirname, "..", "data");
@@ -449,6 +449,9 @@ async function main() {
   await mkdirAsync(DATA_DIR, { recursive: true });
   await writeFileAsync(ENRICHED_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("arxiv-enriched", payload);
+  if (redis.source === "redis") {
+    await verifyMetaLanded("arxiv-enriched", redis.writtenAt);
+  }
 
   log(`wrote ${ENRICHED_PATH} [redis: ${redis.source}]`);
   log(

--- a/scripts/fetch-base-x402-onchain.mjs
+++ b/scripts/fetch-base-x402-onchain.mjs
@@ -14,7 +14,7 @@ const USDC_BASE = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
 
 // data-store mirror — collector dual-writes file + Redis per CLAUDE.md
 // convention. Skips silently when REDIS_URL/Upstash env is absent.
-import { writeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded } from "./_data-store-write.mjs";
 
 const FACILITATORS = {
   Coinbase: [
@@ -174,6 +174,9 @@ async function main() {
   const ds = await writeDataStore("base-x402-onchain", payload, {
     stampPerRecord: false,
   });
+  if (ds.source === "redis") {
+    await verifyMetaLanded("base-x402-onchain", ds.writtenAt);
+  }
   console.log(`[x402] data-store: ${ds.source} @ ${ds.writtenAt}`);
 }
 

--- a/scripts/scrape-arxiv.mjs
+++ b/scripts/scrape-arxiv.mjs
@@ -39,7 +39,7 @@ import { fetchWithTimeout, sleep, parseRetryAfterMs } from "./_fetch-json.mjs";
 import { extractGithubRepoFullNames, extractUnknownRepoCandidates } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { loadTrackedReposFromFiles } from "./_tracked-repos.mjs";
-import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
@@ -304,6 +304,9 @@ async function main() {
   await mkdir(DATA_DIR, { recursive: true });
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const redis = await writeDataStore("arxiv-recent", payload);
+  if (redis.source === "redis") {
+    await verifyMetaLanded("arxiv-recent", redis.writtenAt);
+  }
 
   log(`wrote ${OUT_PATH} [redis: ${redis.source}]`);
   log(`  ${recentPapers.length} recent papers; ${linkedCount} cross-link to tracked repos`);

--- a/scripts/scrape-awesome-skills.mjs
+++ b/scripts/scrape-awesome-skills.mjs
@@ -29,7 +29,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { extractGithubRepoFullNames, extractUnknownRepoCandidates } from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
-import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
@@ -153,6 +153,9 @@ async function main() {
   await mkdir(DATA_DIR, { recursive: true });
   await writeFile(OUT_PATH, JSON.stringify(payload, null, 2) + "\n", "utf8");
   const result = await writeDataStore("awesome-skills", payload);
+  if (result.source === "redis") {
+    await verifyMetaLanded("awesome-skills", result.writtenAt);
+  }
 
   log(`wrote ${OUT_PATH} [redis: ${result.source}]`);
   log(`  ${payload.counts.uniqueSkills} unique skill repos across ${payload.counts.lists}/${payload.counts.listsAttempted} lists`);

--- a/scripts/scrape-claude-rss.mjs
+++ b/scripts/scrape-claude-rss.mjs
@@ -17,7 +17,7 @@ import { writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { writeDataStore, closeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
 import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { runAsRegisteredSource } from "./_source-script-runner.mjs";
 
@@ -159,6 +159,9 @@ async function main() {
   const writeResult = await writeDataStore(STORE_KEY, payload, {
     stampPerRecord: false,
   });
+  if (writeResult.source === "redis") {
+    await verifyMetaLanded(STORE_KEY, writeResult.writtenAt);
+  }
   log(`store write: ${writeResult.source} (${writeResult.writtenAt})`);
 
   await closeDataStore();

--- a/scripts/scrape-sec-form-d.mjs
+++ b/scripts/scrape-sec-form-d.mjs
@@ -56,7 +56,7 @@ import { resolve } from "path";
 import { writeFileSync, mkdirSync, existsSync } from "fs";
 
 import "./_load-env.mjs";
-import { writeDataStore } from "./_data-store-write.mjs";
+import { writeDataStore, verifyMetaLanded } from "./_data-store-write.mjs";
 import { ingestFundingSecFormdToToolbox } from "./_toolbox-ingest.mjs";
 
 const PROJECT_ROOT = resolve(process.cwd());
@@ -484,6 +484,7 @@ async function main() {
         "funding-news-sec data-store write skipped; set REDIS_URL or Upstash env",
       );
     }
+    await verifyMetaLanded("funding-news-sec", redisResult.writtenAt);
     console.log("[sec-form-d] redis write ok -> funding-news-sec");
 
     // TOOLBOX dual-write: emit `funding.sec.formd` per Form D filing.


### PR DESCRIPTION
## Summary

Pass-4 T22 follow-up to **PR #2002**. PR #2002 added `verifyMetaLanded()` guard to the 3 HuggingFace scripts. Pass-4 investigation 2026-05-20 confirmed the same silent-write pattern affects 6 additional slugs stuck since 2026-05-13. This PR ports the guard.

## Files changed (+22 / -6)

| Slug | File | Variable | Notes |
|---|---|---|---|
| `arxiv-recent` | `scripts/scrape-arxiv.mjs:307` | `redis` | conditional |
| `arxiv-enriched` | `scripts/enrich-arxiv.mjs:452` | `redis` | conditional |
| `awesome-skills` | `scripts/scrape-awesome-skills.mjs:156` | `result` | conditional |
| `base-x402-onchain` | `scripts/fetch-base-x402-onchain.mjs:177` | `ds` | conditional |
| `claude-rss` | `scripts/scrape-claude-rss.mjs:162` | `writeResult` | conditional (uses STORE_KEY) |
| `funding-news-sec` | `scripts/scrape-sec-form-d.mjs:487` | `redisResult` | **unconditional** — pre-existing throw guarantees source==redis |

## Functional impact today

**This PR is a no-op until M-16 lands** (the REDIS_URL GH secret rotation to point at production Upstash). Pass-4 verified that PR #2002's verifyMetaLanded silent-passes because the workflow's REDIS_URL points at a different Redis instance than the production Upstash that toolbox-trendingrepo-1 reads from.

Direct Pass-4 query: \`ss:meta:v1:huggingface-trending\` in Upstash is still {writtenAt: 2026-05-13, runId: 25808209674} despite #2002 + a post-merge HF workflow run going green.

Once Mirko rotates GH secret REDIS_URL (M-16) to the public Upstash URL (already in /opt/toolbox-trendingrepo-worker/.env on Hostup), this PR + #2002 together provide real protection across all 9 affected slugs.

## Test plan

- [ ] CI green
- [ ] After M-16 lands: each affected workflow's next run lands meta in Upstash (writtenAt fresh)
- [ ] If REDIS_URL stays wrong: workflow fails LOUD with verifyMetaLanded mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)