### PR TITLE
chore(data): refresh lobsters signals 2026-05-20T08:42:10Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-20T04:49:56.032Z",
+  "ts": "2026-05-20T08:42:10.570Z",
   "count": 1,
-  "durationMs": 4052,
+  "durationMs": 5875,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T04:49:51.994Z",
+  "fetchedAt": "2026-05-20T08:42:04.709Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 81,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -233,6 +233,44 @@
         }
       ]
     },
+    "tomekw/stcc": {
+      "count7d": 1,
+      "scoreSum7d": 19,
+      "topStory": {
+        "shortId": "pk139i",
+        "title": "The Super Tiny Compiler, but in Ada",
+        "score": 19,
+        "url": "https://github.com/tomekw/stcc",
+        "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
+        "hoursSincePosted": 18.858055555555556
+      },
+      "stories": [
+        {
+          "shortId": "pk139i",
+          "title": "The Super Tiny Compiler, but in Ada",
+          "url": "https://github.com/tomekw/stcc",
+          "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
+          "by": "",
+          "score": 19,
+          "commentCount": 3,
+          "createdUtc": 1779198635,
+          "ageHours": 18.858055555555556,
+          "trendingScore": 0.19945405545495823,
+          "tags": [
+            "plt",
+            "programming"
+          ],
+          "description": "",
+          "linkedRepos": [
+            {
+              "fullName": "tomekw/stcc",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
     "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo": {
       "count7d": 1,
       "scoreSum7d": 18,
@@ -263,44 +301,6 @@
           "linkedRepos": [
             {
               "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",
-              "matchType": "url",
-              "confidence": 1
-            }
-          ]
-        }
-      ]
-    },
-    "tomekw/stcc": {
-      "count7d": 1,
-      "scoreSum7d": 17,
-      "topStory": {
-        "shortId": "pk139i",
-        "title": "The Super Tiny Compiler, but in Ada",
-        "score": 17,
-        "url": "https://github.com/tomekw/stcc",
-        "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 14.987777777777778
-      },
-      "stories": [
-        {
-          "shortId": "pk139i",
-          "title": "The Super Tiny Compiler, but in Ada",
-          "url": "https://github.com/tomekw/stcc",
-          "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-          "by": "",
-          "score": 17,
-          "commentCount": 3,
-          "createdUtc": 1779198635,
-          "ageHours": 14.987777777777778,
-          "trendingScore": 0.24279741832097476,
-          "tags": [
-            "plt",
-            "programming"
-          ],
-          "description": "",
-          "linkedRepos": [
-            {
-              "fullName": "tomekw/stcc",
               "matchType": "url",
               "confidence": 1
             }
@@ -490,14 +490,14 @@
       "scoreSum7d": 23
     },
     {
+      "fullName": "tomekw/stcc",
+      "count7d": 1,
+      "scoreSum7d": 19
+    },
+    {
       "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",
       "count7d": 1,
       "scoreSum7d": 18
-    },
-    {
-      "fullName": "tomekw/stcc",
-      "count7d": 1,
-      "scoreSum7d": 17
     },
     {
       "fullName": "jundot/omlx",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T04:49:51.994Z",
+  "fetchedAt": "2026-05-20T08:42:04.709Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 81,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -565,6 +565,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "n1gytv",
+      "title": "Why Ruby Still Feels Like Home After All These Years",
+      "url": "https://caio.ca/blog/why-ruby-still-feels-like-home",
+      "commentsUrl": "https://lobste.rs/s/n1gytv/why_ruby_still_feels_like_home_after_all",
+      "by": "",
+      "score": 16,
+      "commentCount": 6,
+      "createdUtc": 1779251135,
+      "ageHours": 4.2747222222222225,
+      "trendingScore": 1.017954169772609,
+      "tags": [
+        "programming",
+        "ruby"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "7zppv1",
       "title": "Behind the Scenes Hardening Firefox with Claude Mythos Preview",
       "url": "https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/",
@@ -880,24 +898,6 @@
         "go",
         "networking",
         "programming"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "lrpbpg",
-      "title": "Explore Wikipedia Like a Windows XP Desktop",
-      "url": "https://explorer.samismith.com/",
-      "commentsUrl": "https://lobste.rs/s/lrpbpg/explore_wikipedia_like_windows_xp",
-      "by": "",
-      "score": 8,
-      "commentCount": 0,
-      "createdUtc": 1778920064,
-      "ageHours": 2.34,
-      "trendingScore": 0.8848209414512798,
-      "tags": [
-        "web",
-        "windows"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26151459450

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.