### PR TITLE
chore(p3f): consolidate sync-trustmrr.yml double cron into single hourly

### DIFF
--- a/.github/workflows/sync-trustmrr.yml
+++ b/.github/workflows/sync-trustmrr.yml
@@ -2,13 +2,11 @@ name: Sync TrustMRR revenue overlays
 
 on:
   schedule:
-    # One full catalog sweep per day at 02:27 UTC. ~130 API requests total,
-    # paced well under the 20 req/min ceiling. Data doesn't change fast enough
-    # to warrant more frequent hits.
-    - cron: "27 2 * * *"
-    # Cheap re-match against the cached catalog every hour on :27.
-    # Zero external API calls — only rederives overlays from committed JSON.
-    - cron: "27 0,1,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23 * * *"
+    # Every hour on :27 UTC. The "Decide mode" step below dispatches `full`
+    # (heavy, ~130 API requests) at 02:27 and `incremental` (cheap re-match
+    # against committed JSON, zero external API calls) at every other hour.
+    # Pacing well under the 20 req/min API ceiling.
+    - cron: "27 * * * *"
   workflow_dispatch:
     inputs:
       mode:


### PR DESCRIPTION
## Summary

Pass-5 Tier-C P3-F from audit `.audits/HOSTUP-TOOLBOX-AUDIT-2026-05-19.md`. Consolidates the double cron entry in `sync-trustmrr.yml` from two split entries (\`27 2 * * *\` + \`27 0,1,3,...23 * * *\`) into a single \`27 * * * *\`.

## Why

The split-cron pattern was to avoid double-firing at 02:27 while still covering all 24 hours. Investigation shows the \"Decide mode\" step at lines 48-64 already inspects \`date -u +%H\` to dispatch \`full\` (heavy, ~130 API requests) at 02:27 vs \`incremental\` (cheap re-match, zero external API calls) at every other hour. With one cron, the mode-check still handles the split correctly. Behavior is identical, schedule is cleaner.

## Test plan

- [ ] CI green (workflow yaml validates)
- [ ] After merge: next 02:27 UTC tick runs with mode=full (~130 API requests, recompute benchmarks step fires)
- [ ] Every other :27 tick runs with mode=incremental (no API calls, just rederive overlays)

## Rollback

\`git revert <merge-sha>\` — workflow returns to split-cron. No data loss or behavior regression possible since net effect is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)