### PR TITLE
chore(p3e): stagger snapshot-consensus from 23:55 → 23:45 UTC

### DIFF
--- a/.github/workflows/snapshot-consensus.yml
+++ b/.github/workflows/snapshot-consensus.yml
@@ -1,12 +1,16 @@
 name: Snapshot /consensus daily
 
-# 23:55 UTC every day — captures the live `consensus-trending` and
+# 23:45 UTC every day — captures the live `consensus-trending` and
 # `consensus-verdicts` payloads to date-keyed Redis slots so historical
 # views and the Early-Call Hall of Fame can walk back N days.
 # 90-day TTL on the destination keys.
+#
+# Staggered with snapshot-top10-sparklines (23:50) and snapshot-top10
+# (23:55) so the three daily snapshot workflows don't collide on the
+# self-hosted GH runner queue. Each gets ~5 min of dedicated runner time.
 on:
   schedule:
-    - cron: "55 23 * * *"
+    - cron: "45 23 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Pass-5 Tier-C **P3-E** from audit §6. \`snapshot-top10\` + \`snapshot-consensus\` both fire at 23:55 UTC, with \`snapshot-top10-sparklines\` at 23:50 — three heavy snapshot workflows within a 5-minute window competing for the self-hosted GH runner queue.

## Change

\`snapshot-consensus.yml\`: \`55 23 * * *\` → \`45 23 * * *\` (10 min earlier).

## New stagger

| Time | Workflow |
|---|---|
| 23:45 UTC | snapshot-consensus |
| 23:50 UTC | snapshot-top10-sparklines |
| 23:55 UTC | snapshot-top10 |

5 min between each → enough for one to finish before the next starts on the same runner.

## Test plan

- [ ] CI green
- [ ] Tomorrow 23:45 UTC: confirm snapshot-consensus starts on schedule
- [ ] Verify `consensus-trending` / `consensus-verdicts` Redis slots still get fresh writes
- [ ] Confirm no overlap with 23:50 / 23:55 workflows in the next-day runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)