### PR TITLE
feat(trending): extend OSS Insight scrape 5 → 10 languages (684 → ~1400+ distinct repos)

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
@@ -16,7 +16,20 @@ import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
 import { writeDataStore } from '../../lib/redis.js';
 
 const PERIODS = ['past_24_hours', 'past_week', 'past_month'] as const;
-const LANGUAGES = ['All', 'Python', 'TypeScript', 'Rust', 'Go'] as const;
+// 2026-05-20: expanded from 5 → 10 languages alongside scripts/scrape-trending.mjs
+// + src/lib/trending.ts. Goal: grow distinct-repo coverage from ~684 → 1400+.
+const LANGUAGES = [
+  'All',
+  'Python',
+  'TypeScript',
+  'Rust',
+  'Go',
+  'JavaScript',
+  'Java',
+  'C++',
+  'C#',
+  'Kotlin',
+] as const;
 const TRENDS_PAUSE_MS = 1500;
 const TRENDS_URL = 'https://api.ossinsight.io/v1/trends/repos/';
 const HOT_COLLECTIONS_URL = 'https://api.ossinsight.io/v1/collections/hot/';

--- a/scripts/scrape-trending.mjs
+++ b/scripts/scrape-trending.mjs
@@ -13,7 +13,24 @@ import { writeSourceMetaFromOutcome } from "./_data-meta.mjs";
 import { mergeAndKeepLastN, loadExistingJson } from "./_cache-merge.mjs";
 
 const PERIODS = ["past_24_hours", "past_week", "past_month"];
-const LANGUAGES = ["All", "Python", "TypeScript", "Rust", "Go"];
+// 2026-05-20: expand from 5 → 10 languages to grow distinct-repo coverage
+// from ~684 → target 1400+. Adds the 5 highest-volume languages OSS Insight
+// returns full-100-row buckets for (verified 2026-05-20: JavaScript=100,
+// Java=100, C++=100, C#=88, Kotlin=84). Total buckets: 3 periods × 10 langs
+// = 30 (was 15). At 1500ms throttle between calls scrape wall time grows
+// ~22.5s → ~45s — well inside OSS Insight's 600 req/hr rate budget.
+const LANGUAGES = [
+  "All",
+  "Python",
+  "TypeScript",
+  "Rust",
+  "Go",
+  "JavaScript",
+  "Java",
+  "C++",
+  "C#",
+  "Kotlin",
+];
 const TRENDS_PAUSE_MS = 1500;
 const COLLECTIONS_PAUSE_MS = 400;
 const COLLECTION_RANKING_PERIOD = "past_28_days";

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -18,7 +18,21 @@ import deltasData from "../../data/deltas.json";
 import type { Repo } from "./types";
 
 export type TrendingPeriod = "past_24_hours" | "past_week" | "past_month";
-export type TrendingLanguage = "All" | "Python" | "TypeScript" | "Rust" | "Go";
+// 2026-05-20: expanded from 5 → 10 languages alongside scripts/scrape-trending.mjs
+// to grow distinct-repo coverage from ~684 → target 1400+. Keep this union in
+// sync with the scraper LANGUAGES array AND
+// apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts.
+export type TrendingLanguage =
+  | "All"
+  | "Python"
+  | "TypeScript"
+  | "Rust"
+  | "Go"
+  | "JavaScript"
+  | "Java"
+  | "C++"
+  | "C#"
+  | "Kotlin";
 
 // OSS Insight returns all numeric columns as strings. We preserve the raw
 // shape here; callers that need numbers should parse at the boundary.
@@ -393,7 +407,18 @@ export interface TrendingTopMover {
 export function getTopMoversByDelta24h(limit: number): TrendingTopMover[] {
   if (limit <= 0) return [];
   const byRepo = new Map<string, TrendingTopMover>();
-  const languages: TrendingLanguage[] = ["All", "Python", "TypeScript", "Rust", "Go"];
+  const languages: TrendingLanguage[] = [
+    "All",
+    "Python",
+    "TypeScript",
+    "Rust",
+    "Go",
+    "JavaScript",
+    "Java",
+    "C++",
+    "C#",
+    "Kotlin",
+  ];
 
   for (const language of languages) {
     for (const row of getTrending("past_24_hours", language)) {


### PR DESCRIPTION
## What

Add 5 languages to the OSS Insight trending scrape: **JavaScript, Java, C++, C#, Kotlin**. Total buckets: **15 → 30**. Estimated distinct-repo coverage: **~684 → ~1300-1500**.

Files:
- `scripts/scrape-trending.mjs` — `LANGUAGES` array (10 entries)
- `src/lib/trending.ts` — `TrendingLanguage` type union + `getTopMoversByDelta24h` loop
- `apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts` — worker fetcher `LANGUAGES` const

(All 3 must stay in sync; added a `2026-05-20` comment in each pointing at the others.)

## Why

Mirko: "github data shows we always around 850, we want 1400".

Measured today (2026-05-20) on `data/trending.json`:
- 3 periods × 5 languages × 100 rows = 1500 total rows
- After dedupe: **684 distinct repos** (heavy overlap between "All" and per-language buckets)

The 5 new languages were chosen because they're the highest-row-yield buckets OSS Insight returns. Verified live:

| Language | Rows returned (past_24_hours) |
|---|---|
| JavaScript | 100 |
| Java | 100 |
| C++ | 100 |
| C# | 88 |
| Kotlin | 84 |
| PHP | 23 (skipped — low yield) |
| Ruby | 19 (skipped) |
| Swift | 64 (borderline; skipped to keep PR focused) |
| Solidity | 1 (skipped) |

## Impact

- **Rate-limit budget**: OSS Insight is 600 req/hr per IP. Before: ~15 req/run. After: ~30 req/run. Even at 4 runs/day (60 → 120 req/day) we're well inside budget.
- **Scrape wall time**: 1500ms throttle × 30 buckets = ~45s (was ~22.5s). Still under any cron cadence.
- **Data file size**: `data/trending.json` will roughly double from ~780 KB → ~1.6 MB. UI lite-bucket (`trending-lite.json`) unaffected (still serves only past_24_hours/All, ~32 KB).
- **TrendingLanguage type**: union widened from 5 → 10 string literals. No exhaustive switches in the codebase that depend on the closed union (grep shows only filter UI which auto-iterates).

## Verify post-merge

After the next `Refresh trending` workflow run:
```bash
# On VPS or locally after git pull
node -e "
const j = JSON.parse(require('fs').readFileSync('data/trending.json', 'utf8'));
const all = new Set();
for (const period of Object.keys(j.buckets))
  for (const lang of Object.keys(j.buckets[period]))
    for (const r of j.buckets[period][lang]) all.add(r.repo_id);
console.log('distinct repos:', all.size);
"
# Expect: ~1300-1500 (was ~684)
```

If under target, follow-up options: add Swift (64 rows) + PHP/Ruby (low yield but distinct ecosystem repos).

## Rollback

`git revert <merge-sha> && git push` — array slimmed back to 5 langs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)