### PR TITLE
chore(data): refresh huggingface signals 2026-05-20T09:55:34Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-20T07:13:40.877Z",
+  "ts": "2026-05-20T09:55:34.302Z",
   "count": 1,
-  "durationMs": 7780,
+  "durationMs": 7322,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T07:13:33.098Z",
+  "fetchedAt": "2026-05-20T09:55:26.981Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -104,6 +104,34 @@
     },
     {
       "rank": 5,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/bytedance-research/Lance",
+      "downloads": 438,
+      "likes": 384,
+      "trendingScore": 381,
+      "pipelineTag": "any-to-any",
+      "libraryName": "Lance",
+      "tags": [
+        "Lance",
+        "safetensors",
+        "multimodal",
+        "image-generation",
+        "video-generation",
+        "image-editing",
+        "video-understanding",
+        "any-to-any",
+        "arxiv:2605.18678",
+        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T08:05:57.000Z",
+      "lastModified": "2026-05-20T03:23:26.000Z"
+    },
+    {
+      "rank": 6,
       "id": "deepseek-ai/DeepSeek-V4-Pro",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro",
@@ -127,34 +155,6 @@
       ],
       "createdAt": "2026-04-22T06:04:45.000Z",
       "lastModified": "2026-05-06T04:18:44.000Z"
-    },
-    {
-      "rank": 6,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 171,
-      "likes": 354,
-      "trendingScore": 353,
-      "pipelineTag": "any-to-any",
-      "libraryName": "Lance",
-      "tags": [
-        "Lance",
-        "safetensors",
-        "multimodal",
-        "image-generation",
-        "video-generation",
-        "image-editing",
-        "video-understanding",
-        "any-to-any",
-        "arxiv:2605.18678",
-        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-20T03:23:26.000Z"
     },
     {
       "rank": 7,
@@ -333,9 +333,9 @@
       "id": "circlestone-labs/Anima",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima",
-      "downloads": 558113,
-      "likes": 1429,
-      "trendingScore": 192,
+      "downloads": 571087,
+      "likes": 1433,
+      "trendingScore": 193,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
       "tags": [
@@ -385,9 +385,9 @@
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/Dramabox",
-      "downloads": 1118,
-      "likes": 187,
-      "trendingScore": 184,
+      "downloads": 1229,
+      "likes": 188,
+      "trendingScore": 185,
       "pipelineTag": "text-to-speech",
       "libraryName": "ltx-audio-tts",
       "tags": [
@@ -486,31 +486,12 @@
     },
     {
       "rank": 19,
-      "id": "TencentARC/Pixal3D",
-      "author": "TencentARC",
-      "url": "https://huggingface.co/TencentARC/Pixal3D",
-      "downloads": 0,
-      "likes": 146,
-      "trendingScore": 137,
-      "pipelineTag": "image-to-3d",
-      "libraryName": null,
-      "tags": [
-        "image-to-3d",
-        "arxiv:2605.10922",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T10:18:49.000Z",
-      "lastModified": "2026-05-12T23:37:47.000Z"
-    },
-    {
-      "rank": 20,
       "id": "sapientinc/HRM-Text-1B",
       "author": "sapientinc",
       "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 884,
-      "likes": 137,
-      "trendingScore": 136,
+      "downloads": 23532,
+      "likes": 141,
+      "trendingScore": 140,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -532,6 +513,25 @@
       ],
       "createdAt": "2026-05-17T15:13:02.000Z",
       "lastModified": "2026-05-20T03:03:36.000Z"
+    },
+    {
+      "rank": 20,
+      "id": "TencentARC/Pixal3D",
+      "author": "TencentARC",
+      "url": "https://huggingface.co/TencentARC/Pixal3D",
+      "downloads": 0,
+      "likes": 146,
+      "trendingScore": 137,
+      "pipelineTag": "image-to-3d",
+      "libraryName": null,
+      "tags": [
+        "image-to-3d",
+        "arxiv:2605.10922",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T10:18:49.000Z",
+      "lastModified": "2026-05-12T23:37:47.000Z"
     },
     {
       "rank": 21,
@@ -608,7 +608,7 @@
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
-      "downloads": 12117,
+      "downloads": 17539,
       "likes": 126,
       "trendingScore": 125,
       "pipelineTag": "image-text-to-text",
@@ -1022,6 +1022,33 @@
     },
     {
       "rank": 37,
+      "id": "microsoft/Fara-7B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Fara-7B",
+      "downloads": 15167,
+      "likes": 585,
+      "trendingScore": 90,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_5_vl",
+        "image-text-to-text",
+        "multimodal",
+        "conversational",
+        "en",
+        "arxiv:2511.19663",
+        "license:mit",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-10-30T18:56:59.000Z",
+      "lastModified": "2026-05-19T15:37:05.000Z"
+    },
+    {
+      "rank": 38,
       "id": "Cactus-Compute/needle",
       "author": "Cactus-Compute",
       "url": "https://huggingface.co/Cactus-Compute/needle",
@@ -1046,34 +1073,32 @@
       "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
-      "rank": 38,
-      "id": "microsoft/Fara-7B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Fara-7B",
-      "downloads": 14464,
-      "likes": 583,
-      "trendingScore": 88,
-      "pipelineTag": "image-text-to-text",
+      "rank": 39,
+      "id": "inclusionAI/Ring-2.6-1T",
+      "author": "inclusionAI",
+      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
+      "downloads": 3454,
+      "likes": 87,
+      "trendingScore": 86,
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "qwen2_5_vl",
-        "image-text-to-text",
-        "multimodal",
+        "bailing_hybrid",
+        "text-generation",
         "conversational",
-        "en",
-        "arxiv:2511.19663",
+        "custom_code",
         "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
+        "eval-results",
+        "compressed-tensors",
         "region:us"
       ],
-      "createdAt": "2025-10-30T18:56:59.000Z",
-      "lastModified": "2026-05-19T15:37:05.000Z"
+      "createdAt": "2026-05-14T08:10:02.000Z",
+      "lastModified": "2026-05-18T09:47:28.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/k2-fsa/OmniVoice",
@@ -1118,7 +1143,7 @@
       "lastModified": "2026-05-07T15:45:07.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
@@ -1143,31 +1168,6 @@
       ],
       "createdAt": "2026-05-06T10:29:15.000Z",
       "lastModified": "2026-05-10T15:43:51.000Z"
-    },
-    {
-      "rank": 41,
-      "id": "inclusionAI/Ring-2.6-1T",
-      "author": "inclusionAI",
-      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
-      "downloads": 3038,
-      "likes": 85,
-      "trendingScore": 84,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "bailing_hybrid",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:mit",
-        "eval-results",
-        "compressed-tensors",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T08:10:02.000Z",
-      "lastModified": "2026-05-18T09:47:28.000Z"
     },
     {
       "rank": 42,
@@ -1212,7 +1212,7 @@
       "id": "internlm/Intern-S2-Preview",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview",
-      "downloads": 1842,
+      "downloads": 2050,
       "likes": 81,
       "trendingScore": 81,
       "pipelineTag": "image-text-to-text",
@@ -1446,7 +1446,7 @@
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
-      "downloads": 18458,
+      "downloads": 18626,
       "likes": 101,
       "trendingScore": 72,
       "pipelineTag": "text-generation",
@@ -1476,6 +1476,41 @@
     },
     {
       "rank": 52,
+      "id": "NemoStation/Marlin-2B",
+      "author": "NemoStation",
+      "url": "https://huggingface.co/NemoStation/Marlin-2B",
+      "downloads": 125,
+      "likes": 75,
+      "trendingScore": 72,
+      "pipelineTag": "video-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "text-generation",
+        "video",
+        "multimodal",
+        "video-captioning",
+        "temporal-grounding",
+        "qwen",
+        "VLM",
+        "video-text-to-text",
+        "custom_code",
+        "en",
+        "arxiv:2501.00513",
+        "arxiv:2407.00634",
+        "arxiv:2512.14698",
+        "base_model:Qwen/Qwen3.5-2B",
+        "base_model:finetune:Qwen/Qwen3.5-2B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:23:12.000Z",
+      "lastModified": "2026-05-20T07:54:57.000Z"
+    },
+    {
+      "rank": 53,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -1498,7 +1533,7 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 53,
+      "rank": 54,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -1530,7 +1565,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 54,
+      "rank": 55,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -1555,7 +1590,7 @@
       "lastModified": "2026-05-12T14:25:54.000Z"
     },
     {
-      "rank": 55,
+      "rank": 56,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1600,7 +1635,27 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 56,
+      "rank": 57,
+      "id": "facebook/VGGT-Omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/VGGT-Omega",
+      "downloads": 0,
+      "likes": 68,
+      "trendingScore": 64,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "facebook",
+        "meta-pytorch",
+        "en",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-17T20:47:45.000Z",
+      "lastModified": "2026-05-14T21:23:21.000Z"
+    },
+    {
+      "rank": 58,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -1627,7 +1682,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 57,
+      "rank": 59,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -1660,7 +1715,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 58,
+      "rank": 60,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -1692,7 +1747,7 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 59,
+      "rank": 61,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -1721,27 +1776,7 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 60,
-      "id": "facebook/VGGT-Omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/VGGT-Omega",
-      "downloads": 0,
-      "likes": 65,
-      "trendingScore": 61,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "facebook",
-        "meta-pytorch",
-        "en",
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-17T20:47:45.000Z",
-      "lastModified": "2026-05-14T21:23:21.000Z"
-    },
-    {
-      "rank": 61,
+      "rank": 62,
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
@@ -1766,7 +1801,7 @@
       "lastModified": "2026-05-14T08:44:07.000Z"
     },
     {
-      "rank": 62,
+      "rank": 63,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -1794,7 +1829,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 63,
+      "rank": 64,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -1821,7 +1856,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 64,
+      "rank": 65,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -1848,7 +1883,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 65,
+      "rank": 66,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -1871,7 +1906,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 66,
+      "rank": 67,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -1902,11 +1937,11 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 67,
+      "rank": 68,
       "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "downloads": 53662,
+      "downloads": 61106,
       "likes": 60,
       "trendingScore": 57,
       "pipelineTag": "image-text-to-text",
@@ -1934,7 +1969,7 @@
       "lastModified": "2026-05-14T17:07:52.000Z"
     },
     {
-      "rank": 68,
+      "rank": 69,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -1962,41 +1997,6 @@
       ],
       "createdAt": "2026-04-27T13:37:38.000Z",
       "lastModified": "2026-05-07T04:23:16.000Z"
-    },
-    {
-      "rank": 69,
-      "id": "NemoStation/Marlin-2B",
-      "author": "NemoStation",
-      "url": "https://huggingface.co/NemoStation/Marlin-2B",
-      "downloads": 46,
-      "likes": 58,
-      "trendingScore": 55,
-      "pipelineTag": "video-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "text-generation",
-        "video",
-        "multimodal",
-        "video-captioning",
-        "temporal-grounding",
-        "qwen",
-        "VLM",
-        "video-text-to-text",
-        "custom_code",
-        "en",
-        "arxiv:2501.00513",
-        "arxiv:2407.00634",
-        "arxiv:2512.14698",
-        "base_model:Qwen/Qwen3.5-2B",
-        "base_model:finetune:Qwen/Qwen3.5-2B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:23:12.000Z",
-      "lastModified": "2026-05-20T04:07:28.000Z"
     },
     {
       "rank": 70,
@@ -2197,7 +2197,7 @@
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
-      "downloads": 1803,
+      "downloads": 2316,
       "likes": 52,
       "trendingScore": 52,
       "pipelineTag": "text-to-image",
@@ -2372,7 +2372,7 @@
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
-      "downloads": 261,
+      "downloads": 277,
       "likes": 49,
       "trendingScore": 47,
       "pipelineTag": "text-to-image",
@@ -2517,9 +2517,9 @@
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "downloads": 618,
-      "likes": 44,
-      "trendingScore": 44,
+      "downloads": 681,
+      "likes": 45,
+      "trendingScore": 45,
       "pipelineTag": "image-text-to-image",
       "libraryName": "transformers",
       "tags": [
@@ -2621,9 +2621,9 @@
       "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "downloads": 2160,
-      "likes": 42,
-      "trendingScore": 41,
+      "downloads": 6680,
+      "likes": 44,
+      "trendingScore": 42,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -2662,6 +2662,31 @@
     },
     {
       "rank": 92,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 41,
+      "trendingScore": 41,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
+    },
+    {
+      "rank": 93,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -2680,13 +2705,13 @@
       "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
-      "downloads": 41558,
-      "likes": 39,
-      "trendingScore": 38,
+      "downloads": 53048,
+      "likes": 40,
+      "trendingScore": 39,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -2705,31 +2730,6 @@
       ],
       "createdAt": "2026-05-13T13:34:47.000Z",
       "lastModified": "2026-05-16T12:39:00.000Z"
-    },
-    {
-      "rank": 94,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 38,
-      "trendingScore": 38,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
     },
     {
       "rank": 95,
@@ -2904,7 +2904,7 @@
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
-      "downloads": 9742861,
+      "downloads": 9840607,
       "likes": 6172,
       "trendingScore": 35,
       "pipelineTag": "text-to-speech",
@@ -3091,7 +3091,7 @@
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
-      "downloads": 1691,
+      "downloads": 1881,
       "likes": 39,
       "trendingScore": 34,
       "pipelineTag": "time-series-forecasting",
@@ -3119,8 +3119,8 @@
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
-      "downloads": 1175019,
-      "likes": 374,
+      "downloads": 1189089,
+      "likes": 376,
       "trendingScore": 34,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
@@ -3635,6 +3635,69 @@
     },
     {
       "rank": 125,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 1720,
+      "likes": 32,
+      "trendingScore": 31,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 126,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 65,
+      "likes": 31,
+      "trendingScore": 31,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 127,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -3660,7 +3723,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 126,
+      "rank": 128,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -3692,7 +3755,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 127,
+      "rank": 129,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -3719,7 +3782,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 128,
+      "rank": 130,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -3753,43 +3816,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 129,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 1163,
-      "likes": 31,
-      "trendingScore": 30,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T06:44:14.000Z"
-    },
-    {
-      "rank": 130,
+      "rank": 131,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -3820,7 +3847,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 131,
+      "rank": 132,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -3845,7 +3872,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -3868,7 +3895,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -3895,7 +3922,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 134,
+      "rank": 135,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -3926,7 +3953,7 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 135,
+      "rank": 136,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
@@ -3971,7 +3998,7 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 136,
+      "rank": 137,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -3993,7 +4020,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 137,
+      "rank": 138,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -4030,7 +4057,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 138,
+      "rank": 139,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -4052,7 +4079,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 139,
+      "rank": 140,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -4085,11 +4112,11 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 140,
+      "rank": 141,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
-      "downloads": 450,
+      "downloads": 491,
       "likes": 28,
       "trendingScore": 28,
       "pipelineTag": null,
@@ -4105,32 +4132,6 @@
       ],
       "createdAt": "2026-05-13T09:22:55.000Z",
       "lastModified": "2026-05-13T19:23:38.000Z"
-    },
-    {
-      "rank": 141,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 11,
-      "likes": 28,
-      "trendingScore": 28,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
       "rank": 142,
@@ -4318,6 +4319,38 @@
     },
     {
       "rank": 148,
+      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "downloads": 16599,
+      "likes": 29,
+      "trendingScore": 27,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:11:26.000Z",
+      "lastModified": "2026-05-16T21:22:27.000Z"
+    },
+    {
+      "rank": 149,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -4362,7 +4395,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 149,
+      "rank": 150,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -4389,7 +4422,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 150,
+      "rank": 151,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -4434,7 +4467,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 151,
+      "rank": 152,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -4460,7 +4493,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 152,
+      "rank": 153,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -4482,7 +4515,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 153,
+      "rank": 154,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -4498,7 +4531,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 154,
+      "rank": 155,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -4532,38 +4565,6 @@
       ],
       "createdAt": "2026-05-12T12:55:37.000Z",
       "lastModified": "2026-05-12T14:20:08.000Z"
-    },
-    {
-      "rank": 155,
-      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 14895,
-      "likes": 28,
-      "trendingScore": 26,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:11:26.000Z",
-      "lastModified": "2026-05-16T21:22:27.000Z"
     },
     {
       "rank": 156,
@@ -5522,6 +5523,27 @@
     },
     {
       "rank": 190,
+      "id": "microsoft/TRELLIS.2-4B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
+      "downloads": 0,
+      "likes": 867,
+      "trendingScore": 22,
+      "pipelineTag": "image-to-3d",
+      "libraryName": "trellis2",
+      "tags": [
+        "trellis2",
+        "image-to-3d",
+        "en",
+        "arxiv:2512.14692",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-12-01T02:25:40.000Z",
+      "lastModified": "2025-12-27T13:21:56.000Z"
+    },
+    {
+      "rank": 191,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -5566,7 +5588,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 191,
+      "rank": 192,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -5594,7 +5616,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 192,
+      "rank": 193,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -5621,7 +5643,7 @@
       "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 193,
+      "rank": 194,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -5657,11 +5679,11 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
-      "downloads": 49730,
+      "downloads": 56882,
       "likes": 21,
       "trendingScore": 21,
       "pipelineTag": "text-generation",
@@ -5689,28 +5711,24 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 195,
-      "id": "microsoft/TRELLIS.2-4B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
+      "rank": 196,
+      "id": "liujiafeng/Khala-MusicGeneration-v1.0",
+      "author": "liujiafeng",
+      "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
       "downloads": 0,
-      "likes": 865,
+      "likes": 21,
       "trendingScore": 21,
-      "pipelineTag": "image-to-3d",
-      "libraryName": "trellis2",
+      "pipelineTag": null,
+      "libraryName": null,
       "tags": [
-        "trellis2",
-        "image-to-3d",
-        "en",
-        "arxiv:2512.14692",
-        "license:mit",
+        "license:cc-by-nc-4.0",
         "region:us"
       ],
-      "createdAt": "2025-12-01T02:25:40.000Z",
-      "lastModified": "2025-12-27T13:21:56.000Z"
+      "createdAt": "2026-04-20T09:45:29.000Z",
+      "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -5738,7 +5756,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -5771,7 +5789,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 198,
+      "rank": 199,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -5796,7 +5814,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 199,
+      "rank": 200,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -5833,7 +5851,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 200,
+      "rank": 201,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -5876,7 +5894,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 201,
+      "rank": 202,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -5900,7 +5918,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 202,
+      "rank": 203,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -5924,7 +5942,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 203,
+      "rank": 204,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5956,7 +5974,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 204,
+      "rank": 205,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -5985,7 +6003,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 205,
+      "rank": 206,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -6016,11 +6034,11 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 206,
+      "rank": 207,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "downloads": 54,
+      "downloads": 65,
       "likes": 21,
       "trendingScore": 20,
       "pipelineTag": null,
@@ -6034,11 +6052,11 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 207,
+      "rank": 208,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
-      "downloads": 202,
+      "downloads": 264,
       "likes": 23,
       "trendingScore": 20,
       "pipelineTag": "text-generation",
@@ -6077,23 +6095,6 @@
       ],
       "createdAt": "2026-05-17T08:52:00.000Z",
       "lastModified": "2026-05-17T09:32:18.000Z"
-    },
-    {
-      "rank": 208,
-      "id": "liujiafeng/Khala-MusicGeneration-v1.0",
-      "author": "liujiafeng",
-      "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
-      "downloads": 0,
-      "likes": 20,
-      "trendingScore": 20,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T09:45:29.000Z",
-      "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
       "rank": 209,
@@ -6525,7 +6526,7 @@
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
-      "downloads": 2786,
+      "downloads": 3345,
       "likes": 19,
       "trendingScore": 19,
       "pipelineTag": "token-classification",
@@ -6563,7 +6564,7 @@
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "downloads": 396,
+      "downloads": 421,
       "likes": 26,
       "trendingScore": 19,
       "pipelineTag": "any-to-any",
@@ -6592,7 +6593,7 @@
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
-      "downloads": 16335,
+      "downloads": 20652,
       "likes": 19,
       "trendingScore": 19,
       "pipelineTag": "image-text-to-text",
@@ -6616,298 +6617,12 @@
     },
     {
       "rank": 227,
-      "id": "AesSedai/MiMo-V2.5-GGUF",
-      "author": "AesSedai",
-      "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
-      "downloads": 7035,
-      "likes": 31,
-      "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:XiaomiMiMo/MiMo-V2.5",
-        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-29T01:54:42.000Z",
-      "lastModified": "2026-05-07T10:17:59.000Z"
-    },
-    {
-      "rank": 228,
-      "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
-      "downloads": 41,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "audio-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "moss_music",
-        "music",
-        "music-understanding",
-        "audio",
-        "audio-language-model",
-        "moss",
-        "moss-music",
-        "lyrics-asr",
-        "music-captioning",
-        "chord-recognition",
-        "audio-text-to-text",
-        "custom_code",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-21T09:25:53.000Z",
-      "lastModified": "2026-05-01T15:12:38.000Z"
-    },
-    {
-      "rank": 229,
-      "id": "kpsss34/Walkyrie-1.3B-v1.0",
-      "author": "kpsss34",
-      "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
-      "downloads": 689,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "pytorch",
-        "wan",
-        "pruned",
-        "license:apache-2.0",
-        "diffusers:WalkyriePipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-04T07:45:07.000Z",
-      "lastModified": "2026-05-11T09:01:21.000Z"
-    },
-    {
-      "rank": 230,
-      "id": "MiniMaxAI/MiniMax-M2.7",
-      "author": "MiniMaxAI",
-      "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
-      "downloads": 635634,
-      "likes": 1128,
-      "trendingScore": 18,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "minimax_m2",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-04-09T03:37:12.000Z",
-      "lastModified": "2026-04-20T04:28:14.000Z"
-    },
-    {
-      "rank": 231,
-      "id": "baidu/ERNIE-Image",
-      "author": "baidu",
-      "url": "https://huggingface.co/baidu/ERNIE-Image",
-      "downloads": 13205,
-      "likes": 627,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "8B",
-        "license:apache-2.0",
-        "diffusers:ErnieImagePipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-04-07T07:26:56.000Z",
-      "lastModified": "2026-04-17T02:33:16.000Z"
-    },
-    {
-      "rank": 232,
-      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
-      "downloads": 5508,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "moe",
-        "mixture-of-experts",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-10T07:52:54.000Z",
-      "lastModified": "2026-05-10T08:57:13.000Z"
-    },
-    {
-      "rank": 233,
-      "id": "openbmb/MiniCPM-V-4.6-gguf",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
-      "downloads": 18422,
-      "likes": 24,
-      "trendingScore": 18,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "minicpm-v",
-        "multimodal",
-        "On-Device Model",
-        "lightweight",
-        "image-text-to-text",
-        "arxiv:2604.27393",
-        "arxiv:2509.18154",
-        "arxiv:2408.01800",
-        "arxiv:2605.08985",
-        "base_model:openbmb/MiniCPM-V-4.6",
-        "base_model:quantized:openbmb/MiniCPM-V-4.6",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-08T12:04:50.000Z",
-      "lastModified": "2026-05-19T15:33:30.000Z"
-    },
-    {
-      "rank": 234,
-      "id": "openai/gpt-oss-20b",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/gpt-oss-20b",
-      "downloads": 7550707,
-      "likes": 4618,
-      "trendingScore": 18,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gpt_oss",
-        "text-generation",
-        "vllm",
-        "conversational",
-        "arxiv:2508.10925",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "8-bit",
-        "mxfp4",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-08-04T22:33:29.000Z",
-      "lastModified": "2025-08-26T17:25:47.000Z"
-    },
-    {
-      "rank": 235,
-      "id": "facebook/sam3.1",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 294517,
-      "likes": 265,
-      "trendingScore": 18,
-      "pipelineTag": "mask-generation",
-      "libraryName": "checkpoint",
-      "tags": [
-        "checkpoint",
-        "sam3_video",
-        "sam3.1",
-        "mask-generation",
-        "en",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T01:25:54.000Z",
-      "lastModified": "2026-03-27T17:40:55.000Z"
-    },
-    {
-      "rank": 236,
-      "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
-      "author": "BigDannyPt",
-      "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
-      "downloads": 36366,
-      "likes": 84,
-      "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-11-02T10:51:30.000Z",
-      "lastModified": "2026-03-30T16:27:22.000Z"
-    },
-    {
-      "rank": 237,
-      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "downloads": 19598,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-122B-A10B",
-        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T19:03:18.000Z",
-      "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 238,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
-      "downloads": 270765,
-      "likes": 405,
-      "trendingScore": 18,
+      "downloads": 286496,
+      "likes": 406,
+      "trendingScore": 19,
       "pipelineTag": "image-to-video",
       "libraryName": "ggml",
       "tags": [
@@ -6946,6 +6661,292 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
+      "rank": 228,
+      "id": "AesSedai/MiMo-V2.5-GGUF",
+      "author": "AesSedai",
+      "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
+      "downloads": 7035,
+      "likes": 31,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:XiaomiMiMo/MiMo-V2.5",
+        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-29T01:54:42.000Z",
+      "lastModified": "2026-05-07T10:17:59.000Z"
+    },
+    {
+      "rank": 229,
+      "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
+      "downloads": 41,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "audio-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "moss_music",
+        "music",
+        "music-understanding",
+        "audio",
+        "audio-language-model",
+        "moss",
+        "moss-music",
+        "lyrics-asr",
+        "music-captioning",
+        "chord-recognition",
+        "audio-text-to-text",
+        "custom_code",
+        "en",
+        "zh",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-21T09:25:53.000Z",
+      "lastModified": "2026-05-01T15:12:38.000Z"
+    },
+    {
+      "rank": 230,
+      "id": "kpsss34/Walkyrie-1.3B-v1.0",
+      "author": "kpsss34",
+      "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
+      "downloads": 689,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "pytorch",
+        "wan",
+        "pruned",
+        "license:apache-2.0",
+        "diffusers:WalkyriePipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-04T07:45:07.000Z",
+      "lastModified": "2026-05-11T09:01:21.000Z"
+    },
+    {
+      "rank": 231,
+      "id": "MiniMaxAI/MiniMax-M2.7",
+      "author": "MiniMaxAI",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
+      "downloads": 635634,
+      "likes": 1128,
+      "trendingScore": 18,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "minimax_m2",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-04-09T03:37:12.000Z",
+      "lastModified": "2026-04-20T04:28:14.000Z"
+    },
+    {
+      "rank": 232,
+      "id": "baidu/ERNIE-Image",
+      "author": "baidu",
+      "url": "https://huggingface.co/baidu/ERNIE-Image",
+      "downloads": 13205,
+      "likes": 627,
+      "trendingScore": 18,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "8B",
+        "license:apache-2.0",
+        "diffusers:ErnieImagePipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-04-07T07:26:56.000Z",
+      "lastModified": "2026-04-17T02:33:16.000Z"
+    },
+    {
+      "rank": 233,
+      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
+      "downloads": 5508,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "moe",
+        "mixture-of-experts",
+        "qwen3.5",
+        "reasoning",
+        "chain-of-thought",
+        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-10T07:52:54.000Z",
+      "lastModified": "2026-05-10T08:57:13.000Z"
+    },
+    {
+      "rank": 234,
+      "id": "openbmb/MiniCPM-V-4.6-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
+      "downloads": 18422,
+      "likes": 24,
+      "trendingScore": 18,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "minicpm-v",
+        "multimodal",
+        "On-Device Model",
+        "lightweight",
+        "image-text-to-text",
+        "arxiv:2604.27393",
+        "arxiv:2509.18154",
+        "arxiv:2408.01800",
+        "arxiv:2605.08985",
+        "base_model:openbmb/MiniCPM-V-4.6",
+        "base_model:quantized:openbmb/MiniCPM-V-4.6",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-08T12:04:50.000Z",
+      "lastModified": "2026-05-19T15:33:30.000Z"
+    },
+    {
+      "rank": 235,
+      "id": "openai/gpt-oss-20b",
+      "author": "openai",
+      "url": "https://huggingface.co/openai/gpt-oss-20b",
+      "downloads": 7550707,
+      "likes": 4618,
+      "trendingScore": 18,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gpt_oss",
+        "text-generation",
+        "vllm",
+        "conversational",
+        "arxiv:2508.10925",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "8-bit",
+        "mxfp4",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-08-04T22:33:29.000Z",
+      "lastModified": "2025-08-26T17:25:47.000Z"
+    },
+    {
+      "rank": 236,
+      "id": "facebook/sam3.1",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3.1",
+      "downloads": 294517,
+      "likes": 265,
+      "trendingScore": 18,
+      "pipelineTag": "mask-generation",
+      "libraryName": "checkpoint",
+      "tags": [
+        "checkpoint",
+        "sam3_video",
+        "sam3.1",
+        "mask-generation",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T01:25:54.000Z",
+      "lastModified": "2026-03-27T17:40:55.000Z"
+    },
+    {
+      "rank": 237,
+      "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
+      "author": "BigDannyPt",
+      "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
+      "downloads": 35293,
+      "likes": 84,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-11-02T10:51:30.000Z",
+      "lastModified": "2026-03-30T16:27:22.000Z"
+    },
+    {
+      "rank": 238,
+      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "downloads": 22423,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-122B-A10B",
+        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T19:03:18.000Z",
+      "lastModified": "2026-05-18T03:29:50.000Z"
+    },
+    {
       "rank": 239,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
@@ -6976,6 +6977,90 @@
     },
     {
       "rank": 240,
+      "id": "zghhui/OmniNFT",
+      "author": "zghhui",
+      "url": "https://huggingface.co/zghhui/OmniNFT",
+      "downloads": 59,
+      "likes": 20,
+      "trendingScore": 18,
+      "pipelineTag": "any-to-any",
+      "libraryName": "peft",
+      "tags": [
+        "peft",
+        "safetensors",
+        "lora",
+        "reinforcement-learning",
+        "GRPO",
+        "T2AV",
+        "any-to-any",
+        "arxiv:2605.12480",
+        "base_model:Lightricks/LTX-2",
+        "base_model:adapter:Lightricks/LTX-2",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T02:28:33.000Z",
+      "lastModified": "2026-05-19T03:47:56.000Z"
+    },
+    {
+      "rank": 241,
+      "id": "Simplified-Reasoning/SU-01",
+      "author": "Simplified-Reasoning",
+      "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
+      "downloads": 712,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_moe",
+        "text-generation",
+        "reasoning",
+        "olympiad",
+        "mathematics",
+        "science",
+        "reinforcement-learning",
+        "test-time-scaling",
+        "long-context",
+        "conversational",
+        "arxiv:2605.13301",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T22:20:39.000Z",
+      "lastModified": "2026-05-20T09:44:56.000Z"
+    },
+    {
+      "rank": 242,
+      "id": "internlm/Intern-S2-Preview-FP8",
+      "author": "internlm",
+      "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
+      "downloads": 1367,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "intern_s2_preview",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "base_model:internlm/Intern-S2-Preview",
+        "base_model:quantized:internlm/Intern-S2-Preview",
+        "license:apache-2.0",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T03:51:55.000Z",
+      "lastModified": "2026-05-19T08:07:06.000Z"
+    },
+    {
+      "rank": 243,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -7020,7 +7105,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 241,
+      "rank": 244,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -7049,7 +7134,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 242,
+      "rank": 245,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -7078,7 +7163,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 243,
+      "rank": 246,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -7110,7 +7195,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 244,
+      "rank": 247,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -7140,7 +7225,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 245,
+      "rank": 248,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -7161,7 +7246,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 246,
+      "rank": 249,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -7206,7 +7291,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 247,
+      "rank": 250,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -7235,7 +7320,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 248,
+      "rank": 251,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -7263,7 +7348,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 249,
+      "rank": 252,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -7288,7 +7373,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 250,
+      "rank": 253,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -7311,7 +7396,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 251,
+      "rank": 254,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -7338,7 +7423,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 252,
+      "rank": 255,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -7364,7 +7449,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 253,
+      "rank": 256,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -7382,11 +7467,11 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 254,
+      "rank": 257,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
-      "downloads": 2789,
+      "downloads": 3041,
       "likes": 18,
       "trendingScore": 17,
       "pipelineTag": "time-series-forecasting",
@@ -7410,11 +7495,11 @@
       "lastModified": "2026-05-14T14:23:31.000Z"
     },
     {
-      "rank": 255,
+      "rank": 258,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
-      "downloads": 1720,
+      "downloads": 1860,
       "likes": 17,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
@@ -7439,7 +7524,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 256,
+      "rank": 259,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -7467,65 +7552,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 257,
-      "id": "zghhui/OmniNFT",
-      "author": "zghhui",
-      "url": "https://huggingface.co/zghhui/OmniNFT",
-      "downloads": 49,
-      "likes": 19,
-      "trendingScore": 17,
-      "pipelineTag": "any-to-any",
-      "libraryName": "peft",
-      "tags": [
-        "peft",
-        "safetensors",
-        "lora",
-        "reinforcement-learning",
-        "GRPO",
-        "T2AV",
-        "any-to-any",
-        "arxiv:2605.12480",
-        "base_model:Lightricks/LTX-2",
-        "base_model:adapter:Lightricks/LTX-2",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T02:28:33.000Z",
-      "lastModified": "2026-05-19T03:47:56.000Z"
-    },
-    {
-      "rank": 258,
-      "id": "Simplified-Reasoning/SU-01",
-      "author": "Simplified-Reasoning",
-      "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
-      "downloads": 265,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_moe",
-        "text-generation",
-        "reasoning",
-        "olympiad",
-        "mathematics",
-        "science",
-        "reinforcement-learning",
-        "test-time-scaling",
-        "long-context",
-        "conversational",
-        "arxiv:2605.13301",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T22:20:39.000Z",
-      "lastModified": "2026-05-16T08:42:52.000Z"
-    },
-    {
-      "rank": 259,
+      "rank": 260,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7554,7 +7581,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -7579,7 +7606,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -7614,7 +7641,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -7659,7 +7686,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -7686,7 +7713,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -7715,7 +7742,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -7738,7 +7765,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 266,
+      "rank": 267,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -7782,7 +7809,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 267,
+      "rank": 268,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -7827,7 +7854,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 268,
+      "rank": 269,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -7845,7 +7872,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 269,
+      "rank": 270,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -7890,37 +7917,11 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 270,
-      "id": "internlm/Intern-S2-Preview-FP8",
-      "author": "internlm",
-      "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
-      "downloads": 1341,
-      "likes": 16,
-      "trendingScore": 16,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "intern_s2_preview",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "base_model:internlm/Intern-S2-Preview",
-        "base_model:quantized:internlm/Intern-S2-Preview",
-        "license:apache-2.0",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T03:51:55.000Z",
-      "lastModified": "2026-05-19T08:07:06.000Z"
-    },
-    {
       "rank": 271,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-      "downloads": 61,
+      "downloads": 101,
       "likes": 17,
       "trendingScore": 16,
       "pipelineTag": "image-text-to-text",
@@ -7965,8 +7966,8 @@
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
-      "downloads": 17503,
-      "likes": 85,
+      "downloads": 17824,
+      "likes": 87,
       "trendingScore": 16,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -8003,7 +8004,7 @@
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "downloads": 1893,
+      "downloads": 2029,
       "likes": 19,
       "trendingScore": 16,
       "pipelineTag": "text-to-video",
@@ -8046,7 +8047,7 @@
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
-      "downloads": 212,
+      "downloads": 261,
       "likes": 16,
       "trendingScore": 16,
       "pipelineTag": "text-generation",
@@ -8079,7 +8080,7 @@
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 215966,
+      "downloads": 209596,
       "likes": 185,
       "trendingScore": 16,
       "pipelineTag": "image-text-to-text",
@@ -8138,6 +8139,33 @@
     },
     {
       "rank": 278,
+      "id": "HuggingFaceBio/Carbon-3B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
+      "downloads": 2184,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "conversational",
+        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T11:05:49.000Z",
+      "lastModified": "2026-05-19T15:48:27.000Z"
+    },
+    {
+      "rank": 279,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -8164,7 +8192,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 279,
+      "rank": 280,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -8209,7 +8237,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 280,
+      "rank": 281,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -8239,7 +8267,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 281,
+      "rank": 282,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -8269,7 +8297,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 282,
+      "rank": 283,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -8314,7 +8342,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 283,
+      "rank": 284,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -8349,7 +8377,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 284,
+      "rank": 285,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -8377,7 +8405,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 285,
+      "rank": 286,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -8406,7 +8434,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 286,
+      "rank": 287,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -8431,7 +8459,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 287,
+      "rank": 288,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -8459,7 +8487,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 288,
+      "rank": 289,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -8487,7 +8515,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 289,
+      "rank": 290,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -8518,7 +8546,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 290,
+      "rank": 291,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -8563,7 +8591,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 291,
+      "rank": 292,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -8595,7 +8623,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 292,
+      "rank": 293,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -8622,7 +8650,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 293,
+      "rank": 294,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -8645,7 +8673,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 294,
+      "rank": 295,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -8678,7 +8706,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 295,
+      "rank": 296,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -8705,7 +8733,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 296,
+      "rank": 297,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -8724,7 +8752,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 297,
+      "rank": 298,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -8747,7 +8775,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 298,
+      "rank": 299,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -8773,7 +8801,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 299,
+      "rank": 300,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -8803,11 +8831,11 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 300,
+      "rank": 301,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
-      "downloads": 90,
+      "downloads": 114,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "video-to-video",
@@ -8828,7 +8856,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 301,
+      "rank": 302,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -8855,11 +8883,11 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 302,
+      "rank": 303,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
-      "downloads": 6278,
+      "downloads": 8252,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": null,
@@ -8885,7 +8913,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 303,
+      "rank": 304,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -8909,7 +8937,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 304,
+      "rank": 305,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -8936,7 +8964,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 305,
+      "rank": 306,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -8964,7 +8992,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 306,
+      "rank": 307,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -8992,7 +9020,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 307,
+      "rank": 308,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -9011,7 +9039,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 308,
+      "rank": 309,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -9043,7 +9071,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 309,
+      "rank": 310,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -9072,7 +9100,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 310,
+      "rank": 311,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -9099,7 +9127,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 311,
+      "rank": 312,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -9123,7 +9151,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 312,
+      "rank": 313,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -9149,7 +9177,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 313,
+      "rank": 314,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -9180,7 +9208,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 314,
+      "rank": 315,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -9208,7 +9236,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 315,
+      "rank": 316,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -9231,7 +9259,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 316,
+      "rank": 317,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -9265,7 +9293,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 317,
+      "rank": 318,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -9291,7 +9319,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 318,
+      "rank": 319,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -9333,7 +9361,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 319,
+      "rank": 320,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -9371,7 +9399,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 320,
+      "rank": 321,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -9390,7 +9418,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 321,
+      "rank": 322,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -9410,7 +9438,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 322,
+      "rank": 323,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -9437,7 +9465,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 323,
+      "rank": 324,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -9463,7 +9491,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 324,
+      "rank": 325,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -9488,11 +9516,11 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 325,
+      "rank": 326,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
-      "downloads": 1523,
+      "downloads": 1730,
       "likes": 15,
       "trendingScore": 14,
       "pipelineTag": "time-series-forecasting",
@@ -9516,7 +9544,7 @@
       "lastModified": "2026-05-14T14:23:12.000Z"
     },
     {
-      "rank": 326,
+      "rank": 327,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -9561,11 +9589,11 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 327,
+      "rank": 328,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
-      "downloads": 727,
+      "downloads": 1064,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": null,
@@ -9585,7 +9613,64 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 328,
+      "rank": 329,
+      "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
+      "downloads": 107432,
+      "likes": 73,
+      "trendingScore": 14,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "gemma4",
+        "image-text-to-text",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "any-to-any",
+        "base_model:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-05T15:49:10.000Z",
+      "lastModified": "2026-04-10T23:39:26.000Z"
+    },
+    {
+      "rank": 330,
+      "id": "HuggingFaceBio/Carbon-8B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
+      "downloads": 1107,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "conversational",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:30:49.000Z",
+      "lastModified": "2026-05-19T15:48:44.000Z"
+    },
+    {
+      "rank": 331,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -9614,7 +9699,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 329,
+      "rank": 332,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -9659,7 +9744,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 330,
+      "rank": 333,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -9688,7 +9773,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 331,
+      "rank": 334,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -9715,7 +9800,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 332,
+      "rank": 335,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -9760,7 +9845,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 333,
+      "rank": 336,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -9787,7 +9872,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 334,
+      "rank": 337,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -9818,7 +9903,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 335,
+      "rank": 338,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9842,7 +9927,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -9866,7 +9951,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 337,
+      "rank": 340,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -9911,7 +9996,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 338,
+      "rank": 341,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -9938,7 +10023,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 339,
+      "rank": 342,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -9974,7 +10059,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 340,
+      "rank": 343,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -10005,7 +10090,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 341,
+      "rank": 344,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -10036,7 +10121,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 342,
+      "rank": 345,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -10069,7 +10154,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 343,
+      "rank": 346,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -10098,7 +10183,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 344,
+      "rank": 347,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -10122,7 +10207,7 @@
       "lastModified": "2026-04-16T18:11:27.000Z"
     },
     {
-      "rank": 345,
+      "rank": 348,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -10148,7 +10233,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 346,
+      "rank": 349,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -10178,7 +10263,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 347,
+      "rank": 350,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -10196,7 +10281,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 348,
+      "rank": 351,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -10227,7 +10312,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 349,
+      "rank": 352,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -10248,7 +10333,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 350,
+      "rank": 353,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -10268,38 +10353,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 351,
-      "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
-      "downloads": 106022,
-      "likes": 72,
-      "trendingScore": 13,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "gemma4",
-        "image-text-to-text",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "any-to-any",
-        "base_model:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
-        "base_model:quantized:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-05T15:49:10.000Z",
-      "lastModified": "2026-04-10T23:39:26.000Z"
-    },
-    {
-      "rank": 352,
+      "rank": 354,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -10327,7 +10381,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 353,
+      "rank": 355,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -10354,7 +10408,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 354,
+      "rank": 356,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -10384,7 +10438,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 355,
+      "rank": 357,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -10401,11 +10455,11 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 356,
+      "rank": 358,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
-      "downloads": 136,
+      "downloads": 206,
       "likes": 16,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
@@ -10428,11 +10482,11 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 357,
+      "rank": 359,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 661953,
+      "downloads": 614656,
       "likes": 1391,
       "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
@@ -10459,7 +10513,66 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 358,
+      "rank": 360,
+      "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
+      "downloads": 4890,
+      "likes": 16,
+      "trendingScore": 13,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.5",
+        "reasoning",
+        "chain-of-thought",
+        "evolutionary-merge",
+        "darwin",
+        "base_model:FINAL-Bench/Darwin-36B-Opus",
+        "base_model:quantized:FINAL-Bench/Darwin-36B-Opus",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T09:29:30.000Z",
+      "lastModified": "2026-05-15T12:12:22.000Z"
+    },
+    {
+      "rank": 361,
+      "id": "HuggingFaceBio/Carbon-500M",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
+      "downloads": 706,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "speculative-decoding",
+        "conversational",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T16:09:33.000Z",
+      "lastModified": "2026-05-19T14:45:14.000Z"
+    },
+    {
+      "rank": 362,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10504,7 +10617,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 359,
+      "rank": 363,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -10531,7 +10644,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 360,
+      "rank": 364,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -10559,7 +10672,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 361,
+      "rank": 365,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -10592,7 +10705,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 362,
+      "rank": 366,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -10608,7 +10721,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 363,
+      "rank": 367,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -10631,7 +10744,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 364,
+      "rank": 368,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -10665,7 +10778,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 365,
+      "rank": 369,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -10685,7 +10798,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 366,
+      "rank": 370,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -10720,7 +10833,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 367,
+      "rank": 371,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -10750,7 +10863,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 368,
+      "rank": 372,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -10771,7 +10884,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 369,
+      "rank": 373,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -10800,7 +10913,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 370,
+      "rank": 374,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -10830,7 +10943,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 371,
+      "rank": 375,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -10858,7 +10971,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 372,
+      "rank": 376,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -10887,7 +11000,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 373,
+      "rank": 377,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -10919,7 +11032,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 374,
+      "rank": 378,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -10948,7 +11061,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 375,
+      "rank": 379,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -10983,7 +11096,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 376,
+      "rank": 380,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -11005,7 +11118,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 377,
+      "rank": 381,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -11043,7 +11156,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 378,
+      "rank": 382,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -11082,7 +11195,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 379,
+      "rank": 383,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -11119,7 +11232,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 380,
+      "rank": 384,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -11143,11 +11256,11 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 381,
+      "rank": 385,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
-      "downloads": 1916,
+      "downloads": 2010,
       "likes": 41,
       "trendingScore": 12,
       "pipelineTag": null,
@@ -11170,7 +11283,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 382,
+      "rank": 386,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -11188,7 +11301,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 383,
+      "rank": 387,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -11207,7 +11320,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 384,
+      "rank": 388,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -11235,7 +11348,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 385,
+      "rank": 389,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -11276,7 +11389,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 386,
+      "rank": 390,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -11298,7 +11411,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 387,
+      "rank": 391,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -11335,39 +11448,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 388,
-      "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
-      "downloads": 4549,
-      "likes": 15,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "evolutionary-merge",
-        "darwin",
-        "base_model:FINAL-Bench/Darwin-36B-Opus",
-        "base_model:quantized:FINAL-Bench/Darwin-36B-Opus",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T09:29:30.000Z",
-      "lastModified": "2026-05-15T12:12:22.000Z"
-    },
-    {
-      "rank": 389,
+      "rank": 392,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -11397,11 +11478,11 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 390,
+      "rank": 393,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
-      "downloads": 1076,
+      "downloads": 1105,
       "likes": 14,
       "trendingScore": 12,
       "pipelineTag": "time-series-forecasting",
@@ -11425,11 +11506,11 @@
       "lastModified": "2026-05-14T14:23:39.000Z"
     },
     {
-      "rank": 391,
+      "rank": 394,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
-      "downloads": 3588521,
+      "downloads": 3611424,
       "likes": 473,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
@@ -11453,11 +11534,11 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 392,
+      "rank": 395,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "downloads": 9719,
+      "downloads": 11547,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -11493,7 +11574,35 @@
       "lastModified": "2026-05-18T20:11:08.000Z"
     },
     {
-      "rank": 393,
+      "rank": 396,
+      "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
+      "author": "Ex0bit",
+      "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
+      "downloads": 243,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "quantized",
+        "dynamic-quant",
+        "qwen3",
+        "llama.cpp",
+        "speculative-decoding",
+        "text-generation",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:19:08.000Z",
+      "lastModified": "2026-05-19T21:32:32.000Z"
+    },
+    {
+      "rank": 397,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -11538,7 +11647,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 394,
+      "rank": 398,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -11580,7 +11689,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 395,
+      "rank": 399,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -11606,7 +11715,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 396,
+      "rank": 400,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -11631,7 +11740,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 397,
+      "rank": 401,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -11648,7 +11757,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 398,
+      "rank": 402,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -11676,7 +11785,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 399,
+      "rank": 403,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -11702,7 +11811,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 400,
+      "rank": 404,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -11729,7 +11838,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 401,
+      "rank": 405,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -11757,7 +11866,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 402,
+      "rank": 406,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -11790,7 +11899,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 403,
+      "rank": 407,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -11824,7 +11933,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 404,
+      "rank": 408,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -11853,7 +11962,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 405,
+      "rank": 409,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -11882,7 +11991,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 406,
+      "rank": 410,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -11915,7 +12024,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 407,
+      "rank": 411,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -11942,7 +12051,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 408,
+      "rank": 412,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -11972,7 +12081,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 409,
+      "rank": 413,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11995,7 +12104,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 410,
+      "rank": 414,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -12021,7 +12130,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 411,
+      "rank": 415,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -12045,7 +12154,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 412,
+      "rank": 416,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -12072,7 +12181,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 413,
+      "rank": 417,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -12102,7 +12211,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 414,
+      "rank": 418,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -12136,7 +12245,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 415,
+      "rank": 419,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -12152,7 +12261,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 416,
+      "rank": 420,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -12183,7 +12292,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 417,
+      "rank": 421,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -12205,7 +12314,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 418,
+      "rank": 422,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -12225,7 +12334,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 419,
+      "rank": 423,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -12247,7 +12356,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 420,
+      "rank": 424,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -12276,7 +12385,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 421,
+      "rank": 425,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -12301,7 +12410,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 422,
+      "rank": 426,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -12326,7 +12435,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 423,
+      "rank": 427,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -12361,7 +12470,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 424,
+      "rank": 428,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -12385,7 +12494,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 425,
+      "rank": 429,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -12416,7 +12525,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 426,
+      "rank": 430,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -12443,7 +12552,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 427,
+      "rank": 431,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -12469,7 +12578,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 428,
+      "rank": 432,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -12499,11 +12608,11 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 429,
+      "rank": 433,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
-      "downloads": 2728,
+      "downloads": 3522,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -12525,11 +12634,11 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 430,
+      "rank": 434,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
-      "downloads": 632706,
+      "downloads": 643473,
       "likes": 253,
       "trendingScore": 11,
       "pipelineTag": "image-text-to-text",
@@ -12550,88 +12659,32 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 431,
-      "id": "HuggingFaceBio/Carbon-500M",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
-      "downloads": 526,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "speculative-decoding",
-        "conversational",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T16:09:33.000Z",
-      "lastModified": "2026-05-19T14:45:14.000Z"
-    },
-    {
-      "rank": 432,
-      "id": "HuggingFaceBio/Carbon-8B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
-      "downloads": 149,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "conversational",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:30:49.000Z",
-      "lastModified": "2026-05-19T15:48:44.000Z"
-    },
-    {
-      "rank": 433,
-      "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "author": "Ex0bit",
-      "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
+      "rank": 435,
+      "id": "Efficient-Large-Model/LongLive-2.0-5B",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
       "downloads": 0,
       "likes": 11,
       "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "gguf",
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
       "tags": [
-        "gguf",
-        "quantized",
-        "dynamic-quant",
-        "qwen3",
-        "llama.cpp",
-        "speculative-decoding",
-        "text-generation",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "wan2.2",
+        "text-to-video",
+        "multi-shot",
+        "video-generation",
+        "diffusion",
+        "long-video",
+        "longlive2",
+        "arxiv:2605.18739",
+        "license:other",
+        "region:us"
       ],
-      "createdAt": "2026-05-19T21:19:08.000Z",
-      "lastModified": "2026-05-19T21:32:32.000Z"
+      "createdAt": "2026-05-17T23:10:14.000Z",
+      "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 434,
+      "rank": 436,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -12660,7 +12713,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 435,
+      "rank": 437,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -12694,7 +12747,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 436,
+      "rank": 438,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -12739,7 +12792,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 437,
+      "rank": 439,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -12768,7 +12821,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 438,
+      "rank": 440,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -12793,7 +12846,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 439,
+      "rank": 441,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -12828,7 +12881,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 440,
+      "rank": 442,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -12855,7 +12908,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 441,
+      "rank": 443,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -12900,7 +12953,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 442,
+      "rank": 444,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -12922,7 +12975,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 443,
+      "rank": 445,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -12954,7 +13007,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 444,
+      "rank": 446,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -12979,7 +13032,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 445,
+      "rank": 447,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -13003,7 +13056,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 446,
+      "rank": 448,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -13031,7 +13084,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 447,
+      "rank": 449,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -13074,7 +13127,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 448,
+      "rank": 450,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -13098,7 +13151,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 449,
+      "rank": 451,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -13143,7 +13196,7 @@
       "lastModified": "2026-04-07T16:23:12.000Z"
     },
     {
-      "rank": 450,
+      "rank": 452,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -13188,7 +13241,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 451,
+      "rank": 453,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -13217,7 +13270,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 452,
+      "rank": 454,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -13249,7 +13302,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 453,
+      "rank": 455,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -13273,7 +13326,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 454,
+      "rank": 456,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -13295,7 +13348,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 455,
+      "rank": 457,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -13320,7 +13373,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 456,
+      "rank": 458,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -13348,7 +13401,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 457,
+      "rank": 459,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -13372,7 +13425,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 458,
+      "rank": 460,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -13399,7 +13452,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 459,
+      "rank": 461,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -13424,7 +13477,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 460,
+      "rank": 462,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -13441,7 +13494,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 461,
+      "rank": 463,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -13465,7 +13518,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 462,
+      "rank": 464,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -13489,7 +13542,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 463,
+      "rank": 465,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -13522,7 +13575,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 464,
+      "rank": 466,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -13556,7 +13609,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 465,
+      "rank": 467,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -13578,7 +13631,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 466,
+      "rank": 468,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -13601,7 +13654,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 467,
+      "rank": 469,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -13621,7 +13674,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 468,
+      "rank": 470,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -13653,7 +13706,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 469,
+      "rank": 471,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -13692,7 +13745,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 470,
+      "rank": 472,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -13726,7 +13779,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 471,
+      "rank": 473,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -13750,7 +13803,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 472,
+      "rank": 474,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -13783,7 +13836,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 473,
+      "rank": 475,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -13803,7 +13856,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 474,
+      "rank": 476,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -13832,7 +13885,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 475,
+      "rank": 477,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -13854,7 +13907,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 476,
+      "rank": 478,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -13886,7 +13939,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 477,
+      "rank": 479,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -13913,7 +13966,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 478,
+      "rank": 480,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -13957,7 +14010,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 479,
+      "rank": 481,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -13975,7 +14028,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 480,
+      "rank": 482,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -14014,7 +14067,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 481,
+      "rank": 483,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -14053,7 +14106,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 482,
+      "rank": 484,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -14087,7 +14140,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 483,
+      "rank": 485,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -14115,7 +14168,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 484,
+      "rank": 486,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -14137,11 +14190,11 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 485,
+      "rank": 487,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
-      "downloads": 81,
+      "downloads": 91,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "text-to-video",
@@ -14165,7 +14218,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 486,
+      "rank": 488,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -14183,7 +14236,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 487,
+      "rank": 489,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -14211,7 +14264,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 488,
+      "rank": 490,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -14242,7 +14295,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 489,
+      "rank": 491,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -14258,11 +14311,11 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 490,
+      "rank": 492,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
-      "downloads": 53,
+      "downloads": 109,
       "likes": 13,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -14285,11 +14338,11 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 491,
+      "rank": 493,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
-      "downloads": 3029,
+      "downloads": 3340,
       "likes": 11,
       "trendingScore": 10,
       "pipelineTag": "time-series-forecasting",
@@ -14313,11 +14366,11 @@
       "lastModified": "2026-05-14T14:23:21.000Z"
     },
     {
-      "rank": 492,
+      "rank": 494,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
-      "downloads": 91765,
+      "downloads": 92119,
       "likes": 206,
       "trendingScore": 10,
       "pipelineTag": "image-to-image",
@@ -14341,7 +14394,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 493,
+      "rank": 495,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -14370,7 +14423,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 494,
+      "rank": 496,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -14396,11 +14449,11 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 495,
+      "rank": 497,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
-      "downloads": 20,
+      "downloads": 39,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "text-to-image",
@@ -14425,11 +14478,11 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 496,
+      "rank": 498,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
-      "downloads": 168,
+      "downloads": 217,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -14454,11 +14507,11 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 497,
+      "rank": 499,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 217037,
+      "downloads": 215339,
       "likes": 430,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -14495,11 +14548,11 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 498,
+      "rank": 500,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
-      "downloads": 823,
+      "downloads": 1076,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -14538,36 +14591,11 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 499,
-      "id": "Efficient-Large-Model/LongLive-2.0-5B",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "text-to-video",
-      "libraryName": "wan2.2",
-      "tags": [
-        "wan2.2",
-        "text-to-video",
-        "multi-shot",
-        "video-generation",
-        "diffusion",
-        "long-video",
-        "longlive2",
-        "arxiv:2605.18739",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:10:14.000Z",
-      "lastModified": "2026-05-19T02:54:48.000Z"
-    },
-    {
-      "rank": 500,
+      "rank": 501,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
-      "downloads": 0,
+      "downloads": 1978,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -14591,34 +14619,66 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 501,
-      "id": "HuggingFaceBio/Carbon-3B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 1861,
+      "rank": 502,
+      "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
+      "downloads": 12738,
       "likes": 10,
       "trendingScore": 10,
-      "pipelineTag": "text-generation",
+      "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "conversational",
-        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-2B",
+        "base_model:quantized:Qwen/Qwen3.5-2B",
         "license:apache-2.0",
-        "text-generation-inference",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-05-12T11:05:49.000Z",
-      "lastModified": "2026-05-19T15:48:27.000Z"
+      "createdAt": "2026-05-13T12:01:02.000Z",
+      "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 502,
+      "rank": 503,
+      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "downloads": 6742,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T04:50:12.000Z",
+      "lastModified": "2026-05-17T06:57:22.000Z"
+    },
+    {
+      "rank": 504,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -14645,7 +14705,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 503,
+      "rank": 505,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -14671,7 +14731,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 504,
+      "rank": 506,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -14699,7 +14759,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 505,
+      "rank": 507,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -14725,7 +14785,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 506,
+      "rank": 508,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -14769,7 +14829,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 507,
+      "rank": 509,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -14809,7 +14869,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 508,
+      "rank": 510,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -14845,7 +14905,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 509,
+      "rank": 511,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -14889,7 +14949,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 510,
+      "rank": 512,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -14914,7 +14974,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 511,
+      "rank": 513,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -14959,7 +15019,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 512,
+      "rank": 514,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -14978,7 +15038,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 513,
+      "rank": 515,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -15003,7 +15063,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 514,
+      "rank": 516,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -15042,7 +15102,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 515,
+      "rank": 517,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -15059,7 +15119,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 516,
+      "rank": 518,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -15087,7 +15147,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 517,
+      "rank": 519,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -15116,7 +15176,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 518,
+      "rank": 520,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -15141,7 +15201,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 519,
+      "rank": 521,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -15176,7 +15236,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 520,
+      "rank": 522,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -15206,7 +15266,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 521,
+      "rank": 523,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -15242,7 +15302,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 522,
+      "rank": 524,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -15265,7 +15325,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 523,
+      "rank": 525,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -15282,7 +15342,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 524,
+      "rank": 526,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -15302,7 +15362,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 525,
+      "rank": 527,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -15329,7 +15389,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 526,
+      "rank": 528,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -15353,7 +15413,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 527,
+      "rank": 529,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -15375,7 +15435,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 528,
+      "rank": 530,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -15407,7 +15467,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 529,
+      "rank": 531,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -15435,7 +15495,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 530,
+      "rank": 532,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -15453,7 +15513,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 531,
+      "rank": 533,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -15478,7 +15538,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 532,
+      "rank": 534,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -15501,7 +15561,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 533,
+      "rank": 535,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -15519,7 +15579,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 534,
+      "rank": 536,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -15554,7 +15614,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 535,
+      "rank": 537,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -15582,7 +15642,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 536,
+      "rank": 538,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -15604,7 +15664,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 537,
+      "rank": 539,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -15631,7 +15691,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 538,
+      "rank": 540,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -15656,7 +15716,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 539,
+      "rank": 541,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -15690,7 +15750,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 540,
+      "rank": 542,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -15717,7 +15777,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 541,
+      "rank": 543,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -15744,7 +15804,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 542,
+      "rank": 544,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -15785,7 +15845,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 543,
+      "rank": 545,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -15815,7 +15875,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 544,
+      "rank": 546,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -15852,7 +15912,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 545,
+      "rank": 547,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -15884,7 +15944,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 546,
+      "rank": 548,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -15926,7 +15986,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 547,
+      "rank": 549,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -15956,7 +16016,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 548,
+      "rank": 550,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -16001,7 +16061,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 549,
+      "rank": 551,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -16028,11 +16088,11 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 550,
+      "rank": 552,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
-      "downloads": 8872,
+      "downloads": 10082,
       "likes": 14,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -16060,7 +16120,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 551,
+      "rank": 553,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -16094,7 +16154,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 552,
+      "rank": 554,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -16124,11 +16184,11 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 553,
+      "rank": 555,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
-      "downloads": 189671,
+      "downloads": 189867,
       "likes": 132,
       "trendingScore": 9,
       "pipelineTag": "image-to-image",
@@ -16149,7 +16209,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 554,
+      "rank": 556,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -16176,7 +16236,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 555,
+      "rank": 557,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -16208,11 +16268,11 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 556,
+      "rank": 558,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
-      "downloads": 3042,
+      "downloads": 3109,
       "likes": 65,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -16253,11 +16313,11 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 557,
+      "rank": 559,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
-      "downloads": 2876,
+      "downloads": 3284,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -16279,7 +16339,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 558,
+      "rank": 560,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -16324,38 +16384,11 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 559,
-      "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
-      "downloads": 10504,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-2B",
-        "base_model:quantized:Qwen/Qwen3.5-2B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T12:01:02.000Z",
-      "lastModified": "2026-05-16T12:38:56.000Z"
-    },
-    {
-      "rank": 560,
+      "rank": 561,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
-      "downloads": 3274617,
+      "downloads": 3269860,
       "likes": 3143,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -16379,43 +16412,11 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 561,
-      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "downloads": 5347,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T04:50:12.000Z",
-      "lastModified": "2026-05-17T06:57:22.000Z"
-    },
-    {
       "rank": 562,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
-      "downloads": 8769,
+      "downloads": 9053,
       "likes": 597,
       "trendingScore": 9,
       "pipelineTag": "text-to-video",
@@ -16437,6 +16438,27 @@
     },
     {
       "rank": 563,
+      "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
+      "author": "ggml-org",
+      "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
+      "downloads": 3413,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T11:20:11.000Z",
+      "lastModified": "2026-05-19T09:05:17.000Z"
+    },
+    {
+      "rank": 564,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -16463,7 +16485,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 564,
+      "rank": 565,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -16487,7 +16509,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 565,
+      "rank": 566,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -16507,7 +16529,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 566,
+      "rank": 567,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -16534,7 +16556,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 567,
+      "rank": 568,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -16553,7 +16575,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 568,
+      "rank": 569,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -16587,7 +16609,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 569,
+      "rank": 570,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -16619,7 +16641,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 570,
+      "rank": 571,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -16641,7 +16663,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 571,
+      "rank": 572,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -16686,7 +16708,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 572,
+      "rank": 573,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -16705,7 +16727,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 573,
+      "rank": 574,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -16739,7 +16761,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 574,
+      "rank": 575,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -16767,7 +16789,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 575,
+      "rank": 576,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -16795,7 +16817,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 576,
+      "rank": 577,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -16818,7 +16840,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 577,
+      "rank": 578,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -16845,7 +16867,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 578,
+      "rank": 579,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -16890,7 +16912,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 579,
+      "rank": 580,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -16926,7 +16948,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 580,
+      "rank": 581,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -16966,7 +16988,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 581,
+      "rank": 582,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -16995,7 +17017,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 582,
+      "rank": 583,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -17023,7 +17045,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 583,
+      "rank": 584,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -17042,7 +17064,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 584,
+      "rank": 585,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -17061,7 +17083,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 585,
+      "rank": 586,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -17093,7 +17115,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 586,
+      "rank": 587,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -17120,7 +17142,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 587,
+      "rank": 588,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -17142,7 +17164,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 588,
+      "rank": 589,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -17160,7 +17182,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 589,
+      "rank": 590,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -17189,7 +17211,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 590,
+      "rank": 591,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -17210,7 +17232,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 591,
+      "rank": 592,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -17238,7 +17260,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 592,
+      "rank": 593,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -17259,7 +17281,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 593,
+      "rank": 594,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -17295,7 +17317,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 594,
+      "rank": 595,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -17340,7 +17362,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 595,
+      "rank": 596,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -17366,7 +17388,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 596,
+      "rank": 597,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -17389,7 +17411,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 597,
+      "rank": 598,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -17414,7 +17436,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 598,
+      "rank": 599,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -17449,7 +17471,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 599,
+      "rank": 600,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -17494,7 +17516,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 600,
+      "rank": 601,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -17521,7 +17543,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 601,
+      "rank": 602,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -17550,7 +17572,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 602,
+      "rank": 603,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -17569,7 +17591,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 603,
+      "rank": 604,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -17590,7 +17612,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 604,
+      "rank": 605,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -17616,7 +17638,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 605,
+      "rank": 606,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -17642,7 +17664,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 606,
+      "rank": 607,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -17679,7 +17701,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 607,
+      "rank": 608,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -17724,7 +17746,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 608,
+      "rank": 609,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -17749,7 +17771,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 609,
+      "rank": 610,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -17766,7 +17788,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 610,
+      "rank": 611,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -17793,7 +17815,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 611,
+      "rank": 612,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -17811,7 +17833,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 612,
+      "rank": 613,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -17836,7 +17858,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 613,
+      "rank": 614,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -17868,7 +17890,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 614,
+      "rank": 615,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -17889,7 +17911,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 615,
+      "rank": 616,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -17908,7 +17930,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 616,
+      "rank": 617,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -17939,7 +17961,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 617,
+      "rank": 618,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -17962,7 +17984,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 618,
+      "rank": 619,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -18000,7 +18022,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 619,
+      "rank": 620,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -18017,7 +18039,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 620,
+      "rank": 621,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -18045,7 +18067,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 621,
+      "rank": 622,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -18062,7 +18084,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 622,
+      "rank": 623,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -18098,7 +18120,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 623,
+      "rank": 624,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -18128,11 +18150,11 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 624,
+      "rank": 625,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
-      "downloads": 233,
+      "downloads": 340,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -18157,7 +18179,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 625,
+      "rank": 626,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -18195,7 +18217,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 626,
+      "rank": 627,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -18222,11 +18244,11 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 627,
+      "rank": 628,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
-      "downloads": 400023,
+      "downloads": 397225,
       "likes": 2183,
       "trendingScore": 8,
       "pipelineTag": "image-to-video",
@@ -18245,7 +18267,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 628,
+      "rank": 629,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -18278,11 +18300,11 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 629,
+      "rank": 630,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 2114,
+      "downloads": 3495,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -18299,7 +18321,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 630,
+      "rank": 631,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -18329,11 +18351,11 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 631,
+      "rank": 632,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
-      "downloads": 3124,
+      "downloads": 3154,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-to-speech",
@@ -18354,11 +18376,11 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 632,
+      "rank": 633,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
-      "downloads": 6219,
+      "downloads": 7634,
       "likes": 18,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -18385,7 +18407,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 633,
+      "rank": 634,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -18408,11 +18430,11 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 634,
+      "rank": 635,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
-      "downloads": 1265,
+      "downloads": 1652,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -18441,11 +18463,11 @@
       "lastModified": "2026-05-19T08:00:47.000Z"
     },
     {
-      "rank": 635,
+      "rank": 636,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
-      "downloads": 96,
+      "downloads": 99,
       "likes": 9,
       "trendingScore": 8,
       "pipelineTag": "text-to-video",
@@ -18464,11 +18486,11 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 636,
+      "rank": 637,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
-      "downloads": 11528,
+      "downloads": 12333,
       "likes": 14,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -18494,11 +18516,11 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 637,
+      "rank": 638,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
-      "downloads": 23311,
+      "downloads": 23419,
       "likes": 140,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -18521,11 +18543,11 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 638,
+      "rank": 639,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
-      "downloads": 543,
+      "downloads": 801,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -18550,11 +18572,11 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 639,
+      "rank": 640,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
-      "downloads": 300,
+      "downloads": 427,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -18579,32 +18601,11 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 640,
-      "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
-      "author": "ggml-org",
-      "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
-      "downloads": 1679,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T11:20:11.000Z",
-      "lastModified": "2026-05-19T09:05:17.000Z"
-    },
-    {
       "rank": 641,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
-      "downloads": 2046,
+      "downloads": 3317,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -18639,7 +18640,7 @@
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
-      "downloads": 3448,
+      "downloads": 3793,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -18672,6 +18673,90 @@
     },
     {
       "rank": 643,
+      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "downloads": 6602,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T13:16:15.000Z",
+      "lastModified": "2026-05-17T15:23:22.000Z"
+    },
+    {
+      "rank": 644,
+      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
+      "downloads": 11093,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T17:12:28.000Z",
+      "lastModified": "2026-05-19T18:52:44.000Z"
+    },
+    {
+      "rank": 645,
+      "id": "nicolas-dufour/miro",
+      "author": "nicolas-dufour",
+      "url": "https://huggingface.co/nicolas-dufour/miro",
+      "downloads": 126,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "text-to-image",
+      "libraryName": "miro-t2i",
+      "tags": [
+        "miro-t2i",
+        "safetensors",
+        "sdxl",
+        "text-to-image",
+        "diffusion",
+        "flow-matching",
+        "miro",
+        "reward-conditioning",
+        "arxiv:2510.25897",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T14:53:08.000Z",
+      "lastModified": "2026-05-19T23:10:01.000Z"
+    },
+    {
+      "rank": 646,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -18697,7 +18782,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 644,
+      "rank": 647,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -18714,7 +18799,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 645,
+      "rank": 648,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -18742,7 +18827,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 646,
+      "rank": 649,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -18785,7 +18870,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 647,
+      "rank": 650,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -18820,7 +18905,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 648,
+      "rank": 651,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -18845,7 +18930,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 649,
+      "rank": 652,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -18875,7 +18960,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 650,
+      "rank": 653,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -18904,7 +18989,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 651,
+      "rank": 654,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -18931,7 +19016,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 652,
+      "rank": 655,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -18957,7 +19042,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 653,
+      "rank": 656,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -18988,7 +19073,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 654,
+      "rank": 657,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -19006,7 +19091,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 655,
+      "rank": 658,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -19035,7 +19120,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 656,
+      "rank": 659,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -19058,7 +19143,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 657,
+      "rank": 660,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -19103,7 +19188,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 658,
+      "rank": 661,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -19129,7 +19214,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 659,
+      "rank": 662,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -19157,7 +19242,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 660,
+      "rank": 663,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -19195,7 +19280,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 661,
+      "rank": 664,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -19222,7 +19307,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 662,
+      "rank": 665,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -19248,7 +19333,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 663,
+      "rank": 666,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -19266,7 +19351,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 664,
+      "rank": 667,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -19292,7 +19377,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 665,
+      "rank": 668,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -19316,7 +19401,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 666,
+      "rank": 669,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -19357,7 +19442,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 667,
+      "rank": 670,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -19374,7 +19459,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 668,
+      "rank": 671,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -19407,7 +19492,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 669,
+      "rank": 672,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -19441,7 +19526,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 670,
+      "rank": 673,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -19480,7 +19565,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 671,
+      "rank": 674,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -19510,7 +19595,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 672,
+      "rank": 675,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -19546,7 +19631,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 673,
+      "rank": 676,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -19572,7 +19657,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 674,
+      "rank": 677,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -19608,7 +19693,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 675,
+      "rank": 678,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -19638,7 +19723,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 676,
+      "rank": 679,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -19676,7 +19761,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 677,
+      "rank": 680,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -19711,7 +19796,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 678,
+      "rank": 681,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -19736,7 +19821,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 679,
+      "rank": 682,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -19753,7 +19838,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 680,
+      "rank": 683,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -19795,7 +19880,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 681,
+      "rank": 684,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -19825,7 +19910,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 682,
+      "rank": 685,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -19850,7 +19935,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 683,
+      "rank": 686,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -19878,7 +19963,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 684,
+      "rank": 687,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -19895,7 +19980,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 685,
+      "rank": 688,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -19922,7 +20007,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 686,
+      "rank": 689,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -19965,7 +20050,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 687,
+      "rank": 690,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -20005,7 +20090,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 688,
+      "rank": 691,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -20029,7 +20114,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 689,
+      "rank": 692,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -20058,7 +20143,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 690,
+      "rank": 693,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -20084,7 +20169,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 691,
+      "rank": 694,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -20112,7 +20197,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 692,
+      "rank": 695,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -20151,7 +20236,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 693,
+      "rank": 696,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -20175,7 +20260,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 694,
+      "rank": 697,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -20203,7 +20288,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 695,
+      "rank": 698,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -20235,7 +20320,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 696,
+      "rank": 699,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -20265,7 +20350,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 697,
+      "rank": 700,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -20294,11 +20379,11 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 698,
+      "rank": 701,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
-      "downloads": 144929,
+      "downloads": 154910,
       "likes": 992,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -20322,7 +20407,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 699,
+      "rank": 702,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -20346,7 +20431,7 @@
       "lastModified": "2026-04-23T03:18:40.000Z"
     },
     {
-      "rank": 700,
+      "rank": 703,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -20379,7 +20464,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 701,
+      "rank": 704,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -20408,7 +20493,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 702,
+      "rank": 705,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -20428,7 +20513,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 703,
+      "rank": 706,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -20457,7 +20542,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 704,
+      "rank": 707,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -20481,7 +20566,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 705,
+      "rank": 708,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -20511,7 +20596,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 706,
+      "rank": 709,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -20541,7 +20626,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 707,
+      "rank": 710,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -20559,7 +20644,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 708,
+      "rank": 711,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -20576,7 +20661,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 709,
+      "rank": 712,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -20612,7 +20697,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 710,
+      "rank": 713,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -20643,11 +20728,11 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 711,
+      "rank": 714,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "downloads": 1431965,
+      "downloads": 1433784,
       "likes": 853,
       "trendingScore": 7,
       "pipelineTag": "automatic-speech-recognition",
@@ -20682,7 +20767,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 712,
+      "rank": 715,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -20713,7 +20798,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 713,
+      "rank": 716,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -20746,7 +20831,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 714,
+      "rank": 717,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -20774,7 +20859,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 715,
+      "rank": 718,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -20799,7 +20884,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 716,
+      "rank": 719,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -20822,7 +20907,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 717,
+      "rank": 720,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -20850,7 +20935,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 718,
+      "rank": 721,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -20883,7 +20968,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 719,
+      "rank": 722,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -20913,7 +20998,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 720,
+      "rank": 723,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -20948,7 +21033,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 721,
+      "rank": 724,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -20980,7 +21065,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 722,
+      "rank": 725,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -21005,7 +21090,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 723,
+      "rank": 726,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -21028,7 +21113,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 724,
+      "rank": 727,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -21055,7 +21140,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 725,
+      "rank": 728,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -21078,11 +21163,11 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 726,
+      "rank": 729,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
-      "downloads": 149,
+      "downloads": 166,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -21103,7 +21188,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 727,
+      "rank": 730,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -21148,7 +21233,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 728,
+      "rank": 731,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -21180,7 +21265,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 729,
+      "rank": 732,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -21207,7 +21292,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 730,
+      "rank": 733,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -21233,7 +21318,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 731,
+      "rank": 734,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -21265,7 +21350,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 732,
+      "rank": 735,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -21294,7 +21379,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 733,
+      "rank": 736,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -21326,7 +21411,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 734,
+      "rank": 737,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -21356,7 +21441,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 735,
+      "rank": 738,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -21373,7 +21458,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 736,
+      "rank": 739,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -21393,7 +21478,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 737,
+      "rank": 740,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -21432,7 +21517,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 738,
+      "rank": 741,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -21470,7 +21555,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 739,
+      "rank": 742,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -21498,7 +21583,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 740,
+      "rank": 743,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -21543,11 +21628,11 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 741,
+      "rank": 744,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
-      "downloads": 62701,
+      "downloads": 60896,
       "likes": 69,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21570,7 +21655,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 742,
+      "rank": 745,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -21594,11 +21679,11 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 743,
+      "rank": 746,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
-      "downloads": 89,
+      "downloads": 112,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-to-video",
@@ -21624,7 +21709,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 744,
+      "rank": 747,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -21651,11 +21736,11 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 745,
+      "rank": 748,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
-      "downloads": 98,
+      "downloads": 149,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21684,11 +21769,11 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 746,
+      "rank": 749,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
-      "downloads": 5952,
+      "downloads": 6559,
       "likes": 13,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -21726,11 +21811,11 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 747,
+      "rank": 750,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
-      "downloads": 1964,
+      "downloads": 2403,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -21752,7 +21837,7 @@
       "lastModified": "2026-05-17T16:25:53.000Z"
     },
     {
-      "rank": 748,
+      "rank": 751,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -21778,11 +21863,11 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 749,
+      "rank": 752,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
-      "downloads": 13616,
+      "downloads": 14623,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -21806,43 +21891,11 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 750,
-      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
-      "downloads": 5734,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T13:16:15.000Z",
-      "lastModified": "2026-05-17T15:23:22.000Z"
-    },
-    {
-      "rank": 751,
+      "rank": 753,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13042,
+      "downloads": 13066,
       "likes": 515,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21865,11 +21918,11 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 752,
+      "rank": 754,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "downloads": 307,
+      "downloads": 616,
       "likes": 28,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21894,11 +21947,11 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 753,
+      "rank": 755,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
-      "downloads": 397,
+      "downloads": 481,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -21918,11 +21971,11 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 754,
+      "rank": 756,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
-      "downloads": 4985,
+      "downloads": 5678,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21947,11 +22000,11 @@
       "lastModified": "2026-05-18T22:20:53.000Z"
     },
     {
-      "rank": 755,
+      "rank": 757,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
-      "downloads": 1022,
+      "downloads": 1091,
       "likes": 11,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -21983,7 +22036,36 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 756,
+      "rank": 758,
+      "id": "LiquidAI/LFM2.5-Audio-1.5B",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
+      "downloads": 974,
+      "likes": 403,
+      "trendingScore": 7,
+      "pipelineTag": "audio-to-audio",
+      "libraryName": "liquid-audio",
+      "tags": [
+        "liquid-audio",
+        "safetensors",
+        "liquid",
+        "lfm2",
+        "audio",
+        "lfm2-audio",
+        "speech-to-speech",
+        "audio-to-audio",
+        "en",
+        "arxiv:2511.23404",
+        "base_model:LiquidAI/LFM2-1.2B",
+        "base_model:finetune:LiquidAI/LFM2-1.2B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2025-12-18T10:21:11.000Z",
+      "lastModified": "2026-03-30T14:43:52.000Z"
+    },
+    {
+      "rank": 759,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -22011,7 +22093,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 757,
+      "rank": 760,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -22050,7 +22132,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 758,
+      "rank": 761,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -22083,7 +22165,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 759,
+      "rank": 762,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -22112,7 +22194,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 760,
+      "rank": 763,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -22142,7 +22224,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 761,
+      "rank": 764,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -22187,7 +22269,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 762,
+      "rank": 765,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -22216,7 +22298,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 763,
+      "rank": 766,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -22261,7 +22343,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 764,
+      "rank": 767,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -22305,7 +22387,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 765,
+      "rank": 768,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -22331,7 +22413,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 766,
+      "rank": 769,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -22357,7 +22439,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 767,
+      "rank": 770,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -22389,7 +22471,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 768,
+      "rank": 771,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -22412,7 +22494,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 769,
+      "rank": 772,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -22455,7 +22537,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 770,
+      "rank": 773,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -22500,7 +22582,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 771,
+      "rank": 774,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -22545,7 +22627,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 772,
+      "rank": 775,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -22572,7 +22654,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 773,
+      "rank": 776,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -22599,7 +22681,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 774,
+      "rank": 777,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -22624,7 +22706,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 775,
+      "rank": 778,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -22663,7 +22745,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 776,
+      "rank": 779,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -22688,7 +22770,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 777,
+      "rank": 780,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -22716,7 +22798,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 778,
+      "rank": 781,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -22741,7 +22823,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 779,
+      "rank": 782,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -22757,7 +22839,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 780,
+      "rank": 783,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -22784,7 +22866,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 781,
+      "rank": 784,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -22816,7 +22898,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 782,
+      "rank": 785,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -22846,7 +22928,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 783,
+      "rank": 786,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -22878,7 +22960,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 784,
+      "rank": 787,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -22906,7 +22988,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 785,
+      "rank": 788,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -22932,7 +23014,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 786,
+      "rank": 789,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -22957,7 +23039,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 787,
+      "rank": 790,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -22986,7 +23068,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 788,
+      "rank": 791,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -23028,7 +23110,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 789,
+      "rank": 792,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -23055,7 +23137,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 790,
+      "rank": 793,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -23100,7 +23182,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 791,
+      "rank": 794,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -23126,7 +23208,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 792,
+      "rank": 795,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -23146,7 +23228,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 793,
+      "rank": 796,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -23173,7 +23255,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 794,
+      "rank": 797,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -23215,7 +23297,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 795,
+      "rank": 798,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -23242,7 +23324,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 796,
+      "rank": 799,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -23276,7 +23358,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 797,
+      "rank": 800,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -23305,7 +23387,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 798,
+      "rank": 801,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -23332,7 +23414,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 799,
+      "rank": 802,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -23359,7 +23441,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 800,
+      "rank": 803,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -23386,7 +23468,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 801,
+      "rank": 804,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -23414,7 +23496,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 802,
+      "rank": 805,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -23437,7 +23519,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 803,
+      "rank": 806,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -23468,7 +23550,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 804,
+      "rank": 807,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -23513,7 +23595,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 805,
+      "rank": 808,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -23535,7 +23617,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 806,
+      "rank": 809,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -23561,7 +23643,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 807,
+      "rank": 810,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -23587,7 +23669,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 808,
+      "rank": 811,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -23618,7 +23700,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 809,
+      "rank": 812,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -23641,7 +23723,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 810,
+      "rank": 813,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -23671,7 +23753,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 811,
+      "rank": 814,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -23703,7 +23785,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 812,
+      "rank": 815,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -23732,7 +23814,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 813,
+      "rank": 816,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -23764,7 +23846,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 814,
+      "rank": 817,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -23796,7 +23878,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 815,
+      "rank": 818,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -23827,7 +23909,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 816,
+      "rank": 819,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -23858,7 +23940,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 817,
+      "rank": 820,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -23881,7 +23963,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 818,
+      "rank": 821,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -23908,7 +23990,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 819,
+      "rank": 822,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -23953,7 +24035,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 820,
+      "rank": 823,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -23971,7 +24053,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 821,
+      "rank": 824,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -23994,7 +24076,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 822,
+      "rank": 825,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -24024,7 +24106,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 823,
+      "rank": 826,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -24063,7 +24145,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 824,
+      "rank": 827,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -24101,7 +24183,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 825,
+      "rank": 828,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -24146,7 +24228,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 826,
+      "rank": 829,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -24171,7 +24253,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 827,
+      "rank": 830,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -24205,7 +24287,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 828,
+      "rank": 831,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -24230,7 +24312,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 829,
+      "rank": 832,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -24263,7 +24345,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 830,
+      "rank": 833,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -24290,7 +24372,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 831,
+      "rank": 834,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -24320,7 +24402,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 832,
+      "rank": 835,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -24352,7 +24434,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 833,
+      "rank": 836,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -24385,7 +24467,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 834,
+      "rank": 837,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -24403,7 +24485,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 835,
+      "rank": 838,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -24426,7 +24508,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 836,
+      "rank": 839,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -24458,7 +24540,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 837,
+      "rank": 840,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -24503,11 +24585,11 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 838,
+      "rank": 841,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
-      "downloads": 976,
+      "downloads": 952,
       "likes": 20,
       "trendingScore": 6,
       "pipelineTag": "text-to-speech",
@@ -24544,7 +24626,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 839,
+      "rank": 842,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -24583,7 +24665,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 840,
+      "rank": 843,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -24610,7 +24692,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 841,
+      "rank": 844,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -24647,7 +24729,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 842,
+      "rank": 845,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -24683,7 +24765,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 843,
+      "rank": 846,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -24701,7 +24783,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 844,
+      "rank": 847,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -24740,7 +24822,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 845,
+      "rank": 848,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -24769,7 +24851,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 846,
+      "rank": 849,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -24796,7 +24878,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 847,
+      "rank": 850,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -24823,7 +24905,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 848,
+      "rank": 851,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -24853,7 +24935,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 849,
+      "rank": 852,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -24880,7 +24962,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 850,
+      "rank": 853,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -24911,7 +24993,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 851,
+      "rank": 854,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -24929,7 +25011,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 852,
+      "rank": 855,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -24948,7 +25030,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 853,
+      "rank": 856,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -24975,7 +25057,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 854,
+      "rank": 857,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -25000,11 +25082,11 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 855,
+      "rank": 858,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
-      "downloads": 57,
+      "downloads": 61,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -25030,7 +25112,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 856,
+      "rank": 859,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -25061,7 +25143,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 857,
+      "rank": 860,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -25083,7 +25165,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 858,
+      "rank": 861,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -25104,11 +25186,11 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 859,
+      "rank": 862,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
-      "downloads": 29770,
+      "downloads": 29696,
       "likes": 55,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -25140,7 +25222,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 860,
+      "rank": 863,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -25163,7 +25245,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 861,
+      "rank": 864,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -25208,7 +25290,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 862,
+      "rank": 865,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -25230,7 +25312,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 863,
+      "rank": 866,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -25260,11 +25342,11 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 864,
+      "rank": 867,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
-      "downloads": 62,
+      "downloads": 67,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -25287,7 +25369,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 865,
+      "rank": 868,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -25312,11 +25394,11 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 866,
+      "rank": 869,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
-      "downloads": 29106,
+      "downloads": 34932,
       "likes": 140,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -25345,7 +25427,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 867,
+      "rank": 870,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -25368,7 +25450,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 868,
+      "rank": 871,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -25388,7 +25470,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 869,
+      "rank": 872,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -25433,7 +25515,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 870,
+      "rank": 873,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -25454,11 +25536,11 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 871,
+      "rank": 874,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
-      "downloads": 347,
+      "downloads": 404,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -25484,10 +25566,10 @@
         "region:us"
       ],
       "createdAt": "2026-05-14T17:57:09.000Z",
-      "lastModified": "2026-05-18T05:10:11.000Z"
+      "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 872,
+      "rank": 875,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -25515,11 +25597,11 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 873,
+      "rank": 876,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
-      "downloads": 9409,
+      "downloads": 10311,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -25542,7 +25624,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 874,
+      "rank": 877,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -25587,7 +25669,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 875,
+      "rank": 878,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -25612,11 +25694,11 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 876,
+      "rank": 879,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
-      "downloads": 173234,
+      "downloads": 175529,
       "likes": 230,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -25630,11 +25712,11 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 877,
+      "rank": 880,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
-      "downloads": 54,
+      "downloads": 62,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -25658,7 +25740,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 878,
+      "rank": 881,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -25683,12 +25765,12 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 879,
+      "rank": 882,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
-      "downloads": 139905,
-      "likes": 124,
+      "downloads": 142246,
+      "likes": 125,
       "trendingScore": 6,
       "pipelineTag": "text-classification",
       "libraryName": "transformers",
@@ -25720,7 +25802,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 880,
+      "rank": 883,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -25745,11 +25827,11 @@
       "lastModified": "2026-05-18T05:58:18.000Z"
     },
     {
-      "rank": 881,
+      "rank": 884,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
-      "downloads": 12914,
+      "downloads": 13920,
       "likes": 14,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -25776,11 +25858,11 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 882,
+      "rank": 885,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
-      "downloads": 4797,
+      "downloads": 4824,
       "likes": 38,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -25795,7 +25877,7 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 883,
+      "rank": 886,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -25821,7 +25903,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 884,
+      "rank": 887,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -25841,11 +25923,11 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 885,
+      "rank": 888,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
-      "downloads": 2461463,
+      "downloads": 2495855,
       "likes": 407,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -25868,11 +25950,11 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 886,
+      "rank": 889,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
-      "downloads": 102780,
+      "downloads": 104142,
       "likes": 203,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -25900,11 +25982,11 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 887,
+      "rank": 890,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
-      "downloads": 11908,
+      "downloads": 12992,
       "likes": 27,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -25930,7 +26012,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 888,
+      "rank": 891,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -25948,7 +26030,7 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 889,
+      "rank": 892,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -25972,11 +26054,11 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 890,
+      "rank": 893,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
-      "downloads": 1621097,
+      "downloads": 1606070,
       "likes": 683,
       "trendingScore": 6,
       "pipelineTag": "feature-extraction",
@@ -26002,7 +26084,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 891,
+      "rank": 894,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -26025,11 +26107,11 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 892,
+      "rank": 895,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
-      "downloads": 2501,
+      "downloads": 2612,
       "likes": 21,
       "trendingScore": 6,
       "pipelineTag": "any-to-any",
@@ -26052,11 +26134,11 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 893,
+      "rank": 896,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
-      "downloads": 18525,
+      "downloads": 17868,
       "likes": 101,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -26084,11 +26166,11 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 894,
+      "rank": 897,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
-      "downloads": 910,
+      "downloads": 919,
       "likes": 28,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -26102,11 +26184,11 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 895,
+      "rank": 898,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-      "downloads": 1062,
+      "downloads": 1114,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -26142,11 +26224,11 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 896,
+      "rank": 899,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
-      "downloads": 50236,
+      "downloads": 50326,
       "likes": 168,
       "trendingScore": 6,
       "pipelineTag": "sentence-similarity",
@@ -26175,11 +26257,11 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 897,
+      "rank": 900,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
-      "downloads": 55,
+      "downloads": 57,
       "likes": 21,
       "trendingScore": 6,
       "pipelineTag": "text-to-video",
@@ -26204,11 +26286,11 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 898,
+      "rank": 901,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 5582,
+      "downloads": 5979,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -26236,66 +26318,11 @@
       "lastModified": "2026-05-17T11:23:09.000Z"
     },
     {
-      "rank": 899,
-      "id": "LiquidAI/LFM2.5-Audio-1.5B",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
-      "downloads": 891,
-      "likes": 402,
-      "trendingScore": 6,
-      "pipelineTag": "audio-to-audio",
-      "libraryName": "liquid-audio",
-      "tags": [
-        "liquid-audio",
-        "safetensors",
-        "liquid",
-        "lfm2",
-        "audio",
-        "lfm2-audio",
-        "speech-to-speech",
-        "audio-to-audio",
-        "en",
-        "arxiv:2511.23404",
-        "base_model:LiquidAI/LFM2-1.2B",
-        "base_model:finetune:LiquidAI/LFM2-1.2B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2025-12-18T10:21:11.000Z",
-      "lastModified": "2026-03-30T14:43:52.000Z"
-    },
-    {
-      "rank": 900,
-      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
-      "downloads": 10612,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-02T17:12:28.000Z",
-      "lastModified": "2026-05-19T18:52:44.000Z"
-    },
-    {
-      "rank": 901,
+      "rank": 902,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
-      "downloads": 534161,
+      "downloads": 540362,
       "likes": 516,
       "trendingScore": 6,
       "pipelineTag": "visual-document-retrieval",
@@ -26323,11 +26350,11 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 902,
+      "rank": 903,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
-      "downloads": 15781,
+      "downloads": 16715,
       "likes": 137,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -26368,11 +26395,11 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 903,
+      "rank": 904,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
-      "downloads": 12475,
+      "downloads": 14543,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -26394,7 +26421,7 @@
       "lastModified": "2026-05-19T18:52:45.000Z"
     },
     {
-      "rank": 904,
+      "rank": 905,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -26419,7 +26446,27 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 905,
+      "rank": 906,
+      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "author": "alibaba-pai",
+      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "downloads": 8257,
+      "likes": 150,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-image",
+      "libraryName": "videox_fun",
+      "tags": [
+        "videox_fun",
+        "lora",
+        "text-to-image",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-02-02T09:37:39.000Z",
+      "lastModified": "2026-03-02T11:46:41.000Z"
+    },
+    {
+      "rank": 907,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -26446,7 +26493,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 906,
+      "rank": 908,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -26482,7 +26529,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 907,
+      "rank": 909,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -26527,7 +26574,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 908,
+      "rank": 910,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -26572,7 +26619,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 909,
+      "rank": 911,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -26607,7 +26654,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 910,
+      "rank": 912,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -26635,7 +26682,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 911,
+      "rank": 913,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -26661,7 +26708,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 912,
+      "rank": 914,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -26687,7 +26734,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 913,
+      "rank": 915,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -26713,7 +26760,7 @@
       "lastModified": "2026-05-06T20:09:03.000Z"
     },
     {
-      "rank": 914,
+      "rank": 916,
       "id": "TheDrummer/Skyfall-31B-v4.2",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
@@ -26733,7 +26780,7 @@
       "lastModified": "2026-04-03T20:52:19.000Z"
     },
     {
-      "rank": 915,
+      "rank": 917,
       "id": "LiquidAI/LFM2-24B-A2B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
@@ -26771,7 +26818,7 @@
       "lastModified": "2026-03-30T12:54:26.000Z"
     },
     {
-      "rank": 916,
+      "rank": 918,
       "id": "nvidia/GR00T-N1.7-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
@@ -26791,7 +26838,7 @@
       "lastModified": "2026-04-23T19:09:30.000Z"
     },
     {
-      "rank": 917,
+      "rank": 919,
       "id": "Aratako/Irodori-TTS-500M",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
@@ -26814,7 +26861,7 @@
       "lastModified": "2026-03-18T11:03:56.000Z"
     },
     {
-      "rank": 918,
+      "rank": 920,
       "id": "Qwen/Qwen3.5-0.8B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
@@ -26837,7 +26884,7 @@
       "lastModified": "2026-04-23T11:14:09.000Z"
     },
     {
-      "rank": 919,
+      "rank": 921,
       "id": "z-lab/Qwen3.5-9B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
@@ -26870,7 +26917,7 @@
       "lastModified": "2026-04-07T14:29:47.000Z"
     },
     {
-      "rank": 920,
+      "rank": 922,
       "id": "Winnougan/Must_Have_Klein_9b_loras",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
@@ -26892,7 +26939,7 @@
       "lastModified": "2026-03-26T22:03:08.000Z"
     },
     {
-      "rank": 921,
+      "rank": 923,
       "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
@@ -26919,7 +26966,7 @@
       "lastModified": "2026-04-05T16:05:28.000Z"
     },
     {
-      "rank": 922,
+      "rank": 924,
       "id": "100percentrobot/LTX-2.3-Audio-Reactive-LORA",
       "author": "100percentrobot",
       "url": "https://huggingface.co/100percentrobot/LTX-2.3-Audio-Reactive-LORA",
@@ -26943,7 +26990,7 @@
       "lastModified": "2026-04-10T15:12:18.000Z"
     },
     {
-      "rank": 923,
+      "rank": 925,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -26970,7 +27017,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 924,
+      "rank": 926,
       "id": "YJX-Xiaomi/ControlFoley",
       "author": "YJX-Xiaomi",
       "url": "https://huggingface.co/YJX-Xiaomi/ControlFoley",
@@ -26994,7 +27041,7 @@
       "lastModified": "2026-04-22T02:02:09.000Z"
     },
     {
-      "rank": 925,
+      "rank": 927,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -27034,7 +27081,7 @@
       "lastModified": "2026-04-19T00:19:49.000Z"
     },
     {
-      "rank": 926,
+      "rank": 928,
       "id": "lovis93/crt-animation-terminal-ltx-2.3-lora",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/crt-animation-terminal-ltx-2.3-lora",
@@ -27060,7 +27107,7 @@
       "lastModified": "2026-04-20T16:33:16.000Z"
     },
     {
-      "rank": 927,
+      "rank": 929,
       "id": "uva-cv-lab/OmniShotCut",
       "author": "uva-cv-lab",
       "url": "https://huggingface.co/uva-cv-lab/OmniShotCut",
@@ -27078,7 +27125,7 @@
       "lastModified": "2026-04-28T14:59:54.000Z"
     },
     {
-      "rank": 928,
+      "rank": 930,
       "id": "Yutian10/AnyRecon",
       "author": "Yutian10",
       "url": "https://huggingface.co/Yutian10/AnyRecon",
@@ -27096,7 +27143,7 @@
       "lastModified": "2026-04-27T02:17:02.000Z"
     },
     {
-      "rank": 929,
+      "rank": 931,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
@@ -27122,7 +27169,7 @@
       "lastModified": "2026-04-30T21:34:35.000Z"
     },
     {
-      "rank": 930,
+      "rank": 932,
       "id": "vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
@@ -27145,7 +27192,7 @@
       "lastModified": "2026-04-24T02:25:18.000Z"
     },
     {
-      "rank": 931,
+      "rank": 933,
       "id": "Comfy-Org/void-model",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/void-model",
@@ -27163,7 +27210,7 @@
       "lastModified": "2026-05-07T10:17:55.000Z"
     },
     {
-      "rank": 932,
+      "rank": 934,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
@@ -27193,7 +27240,7 @@
       "lastModified": "2026-04-27T23:59:16.000Z"
     },
     {
-      "rank": 933,
+      "rank": 935,
       "id": "TheBurgstall/ltx-2.3-bodypositivity-lora",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/ltx-2.3-bodypositivity-lora",
@@ -27220,7 +27267,7 @@
       "lastModified": "2026-04-26T10:38:55.000Z"
     },
     {
-      "rank": 934,
+      "rank": 936,
       "id": "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
@@ -27250,7 +27297,7 @@
       "lastModified": "2026-05-05T17:25:56.000Z"
     },
     {
-      "rank": 935,
+      "rank": 937,
       "id": "GAi92/anima-loras",
       "author": "GAi92",
       "url": "https://huggingface.co/GAi92/anima-loras",
@@ -27271,7 +27318,7 @@
       "lastModified": "2026-05-08T23:44:33.000Z"
     },
     {
-      "rank": 936,
+      "rank": 938,
       "id": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
@@ -27298,7 +27345,7 @@
       "lastModified": "2026-05-06T05:56:30.000Z"
     },
     {
-      "rank": 937,
+      "rank": 939,
       "id": "XiaomiMiMo/MiMo-V2.5-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Base",
@@ -27327,7 +27374,7 @@
       "lastModified": "2026-05-08T10:25:24.000Z"
     },
     {
-      "rank": 938,
+      "rank": 940,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit",
@@ -27356,7 +27403,7 @@
       "lastModified": "2026-04-29T04:36:33.000Z"
     },
     {
-      "rank": 939,
+      "rank": 941,
       "id": "sokann/Qwen3.6-27B-GGUF-4.256bpw",
       "author": "sokann",
       "url": "https://huggingface.co/sokann/Qwen3.6-27B-GGUF-4.256bpw",
@@ -27380,7 +27427,7 @@
       "lastModified": "2026-04-30T05:52:10.000Z"
     },
     {
-      "rank": 940,
+      "rank": 942,
       "id": "Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
@@ -27425,7 +27472,7 @@
       "lastModified": "2026-04-30T00:55:51.000Z"
     },
     {
-      "rank": 941,
+      "rank": 943,
       "id": "mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
@@ -27470,7 +27517,7 @@
       "lastModified": "2026-04-30T08:28:27.000Z"
     },
     {
-      "rank": 942,
+      "rank": 944,
       "id": "OrobasVault/Geodesic-Phantom-12B",
       "author": "OrobasVault",
       "url": "https://huggingface.co/OrobasVault/Geodesic-Phantom-12B",
@@ -27511,7 +27558,7 @@
       "lastModified": "2026-05-01T03:53:12.000Z"
     },
     {
-      "rank": 943,
+      "rank": 945,
       "id": "Egor-3926/ToxicLord",
       "author": "Egor-3926",
       "url": "https://huggingface.co/Egor-3926/ToxicLord",
@@ -27541,7 +27588,7 @@
       "lastModified": "2026-04-30T20:07:44.000Z"
     },
     {
-      "rank": 944,
+      "rank": 946,
       "id": "Playtime-AI/LTX-2.3-Jenna_Coleman",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Jenna_Coleman",
@@ -27558,7 +27605,7 @@
       "lastModified": "2026-05-01T11:07:58.000Z"
     },
     {
-      "rank": 945,
+      "rank": 947,
       "id": "abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
       "author": "abhinand",
       "url": "https://huggingface.co/abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
@@ -27588,7 +27635,7 @@
       "lastModified": "2026-05-01T15:22:45.000Z"
     },
     {
-      "rank": 946,
+      "rank": 948,
       "id": "Naphula/Salamander-24B-v1",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/Salamander-24B-v1",
@@ -27633,7 +27680,7 @@
       "lastModified": "2026-05-02T10:32:50.000Z"
     },
     {
-      "rank": 947,
+      "rank": 949,
       "id": "Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
@@ -27650,7 +27697,7 @@
       "lastModified": "2026-05-04T13:20:35.000Z"
     },
     {
-      "rank": 948,
+      "rank": 950,
       "id": "chromadb/context-1",
       "author": "chromadb",
       "url": "https://huggingface.co/chromadb/context-1",
@@ -27675,7 +27722,7 @@
       "lastModified": "2026-03-30T01:02:07.000Z"
     },
     {
-      "rank": 949,
+      "rank": 951,
       "id": "abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
       "author": "abovespec",
       "url": "https://huggingface.co/abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
@@ -27695,7 +27742,7 @@
       "lastModified": "2026-05-04T03:28:29.000Z"
     },
     {
-      "rank": 950,
+      "rank": 952,
       "id": "bond005/whisper-podlodka-turbo",
       "author": "bond005",
       "url": "https://huggingface.co/bond005/whisper-podlodka-turbo",
@@ -27730,7 +27777,7 @@
       "lastModified": "2026-01-29T10:12:53.000Z"
     },
     {
-      "rank": 951,
+      "rank": 953,
       "id": "nvidia/canary-qwen-2.5b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/canary-qwen-2.5b",
@@ -27775,7 +27822,7 @@
       "lastModified": "2026-04-21T12:31:18.000Z"
     },
     {
-      "rank": 952,
+      "rank": 954,
       "id": "lightx2v/Wan2.2-Distill-Loras",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-Distill-Loras",
@@ -27803,7 +27850,7 @@
       "lastModified": "2025-12-17T08:00:53.000Z"
     },
     {
-      "rank": 953,
+      "rank": 955,
       "id": "Qwen/Qwen3.5-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-27B",
@@ -27828,7 +27875,7 @@
       "lastModified": "2026-04-24T02:54:49.000Z"
     },
     {
-      "rank": 954,
+      "rank": 956,
       "id": "mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
@@ -27851,7 +27898,7 @@
       "lastModified": "2026-04-23T08:30:31.000Z"
     },
     {
-      "rank": 955,
+      "rank": 957,
       "id": "sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
@@ -27890,7 +27937,7 @@
       "lastModified": "2026-04-29T00:23:13.000Z"
     },
     {
-      "rank": 956,
+      "rank": 958,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit",
@@ -27918,7 +27965,7 @@
       "lastModified": "2026-04-29T06:58:31.000Z"
     },
     {
-      "rank": 957,
+      "rank": 959,
       "id": "Harley-ml/Tenete-8M",
       "author": "Harley-ml",
       "url": "https://huggingface.co/Harley-ml/Tenete-8M",
@@ -27948,7 +27995,7 @@
       "lastModified": "2026-05-05T14:34:26.000Z"
     },
     {
-      "rank": 958,
+      "rank": 960,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -27985,7 +28032,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 959,
+      "rank": 961,
       "id": "nvidia/omni-embed-nemotron-3b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/omni-embed-nemotron-3b",
@@ -28021,7 +28068,7 @@
       "lastModified": "2026-05-06T18:02:16.000Z"
     },
     {
-      "rank": 960,
+      "rank": 962,
       "id": "fal/flux-2-klein-4b-spritesheet-lora",
       "author": "fal",
       "url": "https://huggingface.co/fal/flux-2-klein-4b-spritesheet-lora",
@@ -28055,7 +28102,7 @@
       "lastModified": "2026-01-21T14:44:55.000Z"
     },
     {
-      "rank": 961,
+      "rank": 963,
       "id": "DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
@@ -28100,7 +28147,7 @@
       "lastModified": "2026-03-09T07:04:55.000Z"
     },
     {
-      "rank": 962,
+      "rank": 964,
       "id": "Comfy-Org/ltx-2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/ltx-2",
@@ -28117,7 +28164,7 @@
       "lastModified": "2026-03-08T17:36:30.000Z"
     },
     {
-      "rank": 963,
+      "rank": 965,
       "id": "silveroxides/LTX-2.3-Quants",
       "author": "silveroxides",
       "url": "https://huggingface.co/silveroxides/LTX-2.3-Quants",
@@ -28161,7 +28208,7 @@
       "lastModified": "2026-05-17T22:31:52.000Z"
     },
     {
-      "rank": 964,
+      "rank": 966,
       "id": "z-lab/Qwen3.5-35B-A3B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-35B-A3B-PARO",
@@ -28190,7 +28237,7 @@
       "lastModified": "2026-05-08T06:21:10.000Z"
     },
     {
-      "rank": 965,
+      "rank": 967,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -28225,7 +28272,7 @@
       "lastModified": "2026-04-06T02:19:40.000Z"
     },
     {
-      "rank": 966,
+      "rank": 968,
       "id": "OpenMed/privacy-filter-multilingual",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-multilingual",
@@ -28270,7 +28317,7 @@
       "lastModified": "2026-05-03T21:36:31.000Z"
     },
     {
-      "rank": 967,
+      "rank": 969,
       "id": "prism-ml/Bonsai-8B-mlx-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-mlx-1bit",
@@ -28301,7 +28348,7 @@
       "lastModified": "2026-04-18T20:44:19.000Z"
     },
     {
-      "rank": 968,
+      "rank": 970,
       "id": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
@@ -28346,7 +28393,7 @@
       "lastModified": "2025-12-22T10:16:55.000Z"
     },
     {
-      "rank": 969,
+      "rank": 971,
       "id": "zai-org/GLM-5",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5",
@@ -28373,7 +28420,7 @@
       "lastModified": "2026-04-05T07:48:51.000Z"
     },
     {
-      "rank": 970,
+      "rank": 972,
       "id": "Comfy-Org/Wan_2.1_ComfyUI_repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged",
@@ -28391,7 +28438,7 @@
       "lastModified": "2026-01-28T12:44:01.000Z"
     },
     {
-      "rank": 971,
+      "rank": 973,
       "id": "sequelbox/Qwen3.6-27B-Tachibana-Agent",
       "author": "sequelbox",
       "url": "https://huggingface.co/sequelbox/Qwen3.6-27B-Tachibana-Agent",
@@ -28436,7 +28483,7 @@
       "lastModified": "2026-05-07T02:13:23.000Z"
     },
     {
-      "rank": 972,
+      "rank": 974,
       "id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
@@ -28462,7 +28509,7 @@
       "lastModified": "2024-07-03T05:16:11.000Z"
     },
     {
-      "rank": 973,
+      "rank": 975,
       "id": "lynaNSFW/LTX2.3_NSFW_motion",
       "author": "lynaNSFW",
       "url": "https://huggingface.co/lynaNSFW/LTX2.3_NSFW_motion",
@@ -28484,7 +28531,7 @@
       "lastModified": "2026-03-25T12:45:24.000Z"
     },
     {
-      "rank": 974,
+      "rank": 976,
       "id": "mlx-community/DeepSeek-V4-Flash-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit",
@@ -28507,7 +28554,7 @@
       "lastModified": "2026-04-25T00:58:58.000Z"
     },
     {
-      "rank": 975,
+      "rank": 977,
       "id": "Qwen/Qwen3-ForcedAligner-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B",
@@ -28528,7 +28575,7 @@
       "lastModified": "2026-01-30T03:00:55.000Z"
     },
     {
-      "rank": 976,
+      "rank": 978,
       "id": "nvidia/Cosmos-Reason2-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Cosmos-Reason2-8B",
@@ -28557,7 +28604,7 @@
       "lastModified": "2026-04-30T03:16:12.000Z"
     },
     {
-      "rank": 977,
+      "rank": 979,
       "id": "Qwen/Qwen3-VL-4B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct",
@@ -28586,7 +28633,7 @@
       "lastModified": "2025-10-15T16:15:55.000Z"
     },
     {
-      "rank": 978,
+      "rank": 980,
       "id": "mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
@@ -28631,7 +28678,7 @@
       "lastModified": "2026-05-03T18:58:47.000Z"
     },
     {
-      "rank": 979,
+      "rank": 981,
       "id": "SWivid/F5-TTS",
       "author": "SWivid",
       "url": "https://huggingface.co/SWivid/F5-TTS",
@@ -28652,7 +28699,7 @@
       "lastModified": "2025-03-21T05:05:00.000Z"
     },
     {
-      "rank": 980,
+      "rank": 982,
       "id": "bartowski/google_gemma-4-E4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF",
@@ -28675,7 +28722,7 @@
       "lastModified": "2026-05-03T18:32:47.000Z"
     },
     {
-      "rank": 981,
+      "rank": 983,
       "id": "Ashen3/SNOFS",
       "author": "Ashen3",
       "url": "https://huggingface.co/Ashen3/SNOFS",
@@ -28695,7 +28742,7 @@
       "lastModified": "2026-02-21T20:02:14.000Z"
     },
     {
-      "rank": 982,
+      "rank": 984,
       "id": "Prior-Labs/tabpfn_2_6",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_2_6",
@@ -28719,7 +28766,7 @@
       "lastModified": "2026-04-02T10:00:43.000Z"
     },
     {
-      "rank": 983,
+      "rank": 985,
       "id": "Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
       "author": "Sikaworld1990",
       "url": "https://huggingface.co/Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
@@ -28748,12 +28795,12 @@
       "lastModified": "2026-03-11T17:20:00.000Z"
     },
     {
-      "rank": 984,
+      "rank": 986,
       "id": "google/medgemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-4b-it",
-      "downloads": 307106,
-      "likes": 956,
+      "downloads": 535862,
+      "likes": 961,
       "trendingScore": 5,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -28792,7 +28839,7 @@
       "lastModified": "2025-10-28T17:24:49.000Z"
     },
     {
-      "rank": 985,
+      "rank": 987,
       "id": "nomic-ai/nomic-embed-text-v1.5-GGUF",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF",
@@ -28815,7 +28862,7 @@
       "lastModified": "2025-04-28T20:14:53.000Z"
     },
     {
-      "rank": 986,
+      "rank": 988,
       "id": "ponpoke/flux2-klein-4b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-4b-uncensored-text-encoder",
@@ -28848,7 +28895,7 @@
       "lastModified": "2026-05-02T11:35:01.000Z"
     },
     {
-      "rank": 987,
+      "rank": 989,
       "id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
       "author": "cardiffnlp",
       "url": "https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment-latest",
@@ -28875,7 +28922,7 @@
       "lastModified": "2025-08-04T07:58:29.000Z"
     },
     {
-      "rank": 988,
+      "rank": 990,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
@@ -28920,7 +28967,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 989,
+      "rank": 991,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
@@ -28950,7 +28997,7 @@
       "lastModified": "2026-05-04T02:04:15.000Z"
     },
     {
-      "rank": 990,
+      "rank": 992,
       "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
@@ -28975,7 +29022,7 @@
       "lastModified": "2025-02-24T03:31:45.000Z"
     },
     {
-      "rank": 991,
+      "rank": 993,
       "id": "microsoft/VibeVoice-Realtime-0.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-Realtime-0.5B",
@@ -29005,7 +29052,7 @@
       "lastModified": "2025-12-12T15:35:46.000Z"
     },
     {
-      "rank": 992,
+      "rank": 994,
       "id": "facebook/sam-audio-large",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam-audio-large",
@@ -29024,7 +29071,7 @@
       "lastModified": "2025-12-30T19:52:21.000Z"
     },
     {
-      "rank": 993,
+      "rank": 995,
       "id": "cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
       "author": "cognica",
       "url": "https://huggingface.co/cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
@@ -29051,7 +29098,7 @@
       "lastModified": "2026-05-16T07:11:10.000Z"
     },
     {
-      "rank": 994,
+      "rank": 996,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
@@ -29073,7 +29120,7 @@
       "lastModified": "2026-04-14T13:43:30.000Z"
     },
     {
-      "rank": 995,
+      "rank": 997,
       "id": "F16/z-image-turbo-flow-dpo",
       "author": "F16",
       "url": "https://huggingface.co/F16/z-image-turbo-flow-dpo",
@@ -29103,7 +29150,7 @@
       "lastModified": "2026-04-09T18:43:34.000Z"
     },
     {
-      "rank": 996,
+      "rank": 998,
       "id": "Jiunsong/supergemma4-e4b-abliterated",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-e4b-abliterated",
@@ -29134,7 +29181,7 @@
       "lastModified": "2026-04-17T13:20:56.000Z"
     },
     {
-      "rank": 997,
+      "rank": 999,
       "id": "deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
       "author": "deucebucket",
       "url": "https://huggingface.co/deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
@@ -29168,7 +29215,7 @@
       "lastModified": "2026-05-15T05:30:04.000Z"
     },
     {
-      "rank": 998,
+      "rank": 1000,
       "id": "deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
       "author": "deepsweet",
       "url": "https://huggingface.co/deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
@@ -29192,54 +29239,6 @@
       ],
       "createdAt": "2026-04-17T07:29:14.000Z",
       "lastModified": "2026-05-10T15:18:41.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
-      "author": "Phil2Sat",
-      "url": "https://huggingface.co/Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF",
-      "downloads": 33739,
-      "likes": 217,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-image",
-      "libraryName": "comfyUI",
-      "tags": [
-        "comfyUI",
-        "gguf",
-        "qwen",
-        "qwen-edit",
-        "t2i",
-        "i2i",
-        "text-to-image",
-        "base_model:Phr00t/Qwen-Image-Edit-Rapid-AIO",
-        "base_model:quantized:Phr00t/Qwen-Image-Edit-Rapid-AIO",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2025-10-16T11:32:49.000Z",
-      "lastModified": "2025-11-07T19:24:03.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "tencent/HunyuanVideo",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/HunyuanVideo",
-      "downloads": 763,
-      "likes": 2168,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-video",
-      "libraryName": null,
-      "tags": [
-        "text-to-video",
-        "arxiv:2412.03603",
-        "arxiv:2405.07719",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2024-12-01T06:00:34.000Z",
-      "lastModified": "2025-03-06T15:39:29.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26155098837

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.