### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-20T09:56:55Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-20T04:41:07.037Z",
+  "ts": "2026-05-20T09:56:55.100Z",
   "count": 1,
-  "durationMs": 3961,
+  "durationMs": 3284,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T04:41:03.078Z",
+  "fetchedAt": "2026-05-20T09:56:51.817Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -64,9 +64,9 @@
       "id": "AlienKevin/SWE-ZERO-12M-trajectories",
       "author": "AlienKevin",
       "url": "https://huggingface.co/datasets/AlienKevin/SWE-ZERO-12M-trajectories",
-      "downloads": 7573,
-      "likes": 84,
-      "trendingScore": 80,
+      "downloads": 8670,
+      "likes": 87,
+      "trendingScore": 83,
       "tags": [
         "task_categories:text-generation",
         "language:en",
@@ -260,7 +260,7 @@
       "id": "5CD-AI/Viet-Handwriting-OCR-v2",
       "author": "5CD-AI",
       "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
-      "downloads": 171,
+      "downloads": 268,
       "likes": 41,
       "trendingScore": 38,
       "tags": [
@@ -457,8 +457,8 @@
       "id": "Qwen/WebWorldData",
       "author": "Qwen",
       "url": "https://huggingface.co/datasets/Qwen/WebWorldData",
-      "downloads": 604,
-      "likes": 41,
+      "downloads": 648,
+      "likes": 42,
       "trendingScore": 26,
       "tags": [
         "task_categories:text-generation",
@@ -1106,7 +1106,7 @@
       "id": "camvsl/Articraft-10K",
       "author": "camvsl",
       "url": "https://huggingface.co/datasets/camvsl/Articraft-10K",
-      "downloads": 12386,
+      "downloads": 12441,
       "likes": 16,
       "trendingScore": 15,
       "tags": [
@@ -1382,7 +1382,7 @@
       "id": "LukaDev13/Liminal-Dreamcore-1K",
       "author": "LukaDev13",
       "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
-      "downloads": 1860,
+      "downloads": 2076,
       "likes": 14,
       "trendingScore": 13,
       "tags": [
@@ -1403,7 +1403,7 @@
       "id": "sensenova/SenseNova-SI-8M",
       "author": "sensenova",
       "url": "https://huggingface.co/datasets/sensenova/SenseNova-SI-8M",
-      "downloads": 2981,
+      "downloads": 3111,
       "likes": 12,
       "trendingScore": 12,
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26155171072

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.