### PR TITLE
chore(data): refresh huggingface space signals 2026-05-20T10:03:03Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-20T04:49:58.784Z",
+  "ts": "2026-05-20T10:03:03.725Z",
   "count": 1,
-  "durationMs": 5186,
+  "durationMs": 6002,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T04:49:53.601Z",
+  "fetchedAt": "2026-05-20T10:02:57.726Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -214,15 +214,15 @@
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 66,
-      "trendingScore": 66,
+      "likes": 69,
+      "trendingScore": 69,
       "sdk": "gradio",
       "tags": [
         "gradio",
         "region:us"
       ],
       "createdAt": "2026-04-28T05:09:42.000Z",
-      "lastModified": "2026-05-14T10:06:44.000Z",
+      "lastModified": "2026-05-20T05:14:48.000Z",
       "models": []
     },
     {
@@ -230,8 +230,8 @@
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 73,
-      "trendingScore": 65,
+      "likes": 75,
+      "trendingScore": 66,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -326,6 +326,22 @@
     },
     {
       "rank": 20,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 45,
+      "trendingScore": 45,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-20T09:15:09.000Z",
+      "models": []
+    },
+    {
+      "rank": 21,
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
@@ -341,7 +357,7 @@
       "models": []
     },
     {
-      "rank": 21,
+      "rank": 22,
       "id": "FrameAI4687/Omni-Video-Factory",
       "author": "FrameAI4687",
       "url": "https://huggingface.co/spaces/FrameAI4687/Omni-Video-Factory",
@@ -357,7 +373,7 @@
       "models": []
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
       "author": "akhaliq",
       "url": "https://huggingface.co/spaces/akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
@@ -373,7 +389,7 @@
       "models": []
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -389,7 +405,7 @@
       "models": []
     },
     {
-      "rank": 24,
+      "rank": 25,
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
@@ -406,7 +422,7 @@
       "models": []
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
@@ -420,22 +436,6 @@
       ],
       "createdAt": "2026-04-30T19:11:32.000Z",
       "lastModified": "2026-05-13T17:12:57.000Z",
-      "models": []
-    },
-    {
-      "rank": 26,
-      "id": "HuggingFaceBio/carbon-demo",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 35,
-      "trendingScore": 35,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T14:18:55.000Z",
-      "lastModified": "2026-05-19T17:29:04.000Z",
       "models": []
     },
     {
@@ -661,7 +661,7 @@
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
-      "likes": 834,
+      "likes": 835,
       "trendingScore": 23,
       "sdk": "gradio",
       "tags": [
@@ -739,6 +739,22 @@
     },
     {
       "rank": 45,
+      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
+      "author": "Saravutw",
+      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
+      "likes": 30,
+      "trendingScore": 21,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-09T19:01:39.000Z",
+      "lastModified": "2026-03-13T17:12:16.000Z",
+      "models": []
+    },
+    {
+      "rank": 46,
       "id": "carlofkl/DreamLite",
       "author": "carlofkl",
       "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
@@ -758,7 +774,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "huggingface/physics-intern",
       "author": "huggingface",
       "url": "https://huggingface.co/spaces/huggingface/physics-intern",
@@ -775,7 +791,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
       "author": "BoobyBoobs",
       "url": "https://huggingface.co/spaces/BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
@@ -791,7 +807,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "NucleusAI/nucleus-image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/spaces/NucleusAI/nucleus-image",
@@ -807,35 +823,19 @@
       "models": []
     },
     {
-      "rank": 49,
-      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
-      "author": "Saravutw",
-      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 29,
+      "rank": 50,
+      "id": "multimodalart/scenema-audio",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
+      "likes": 22,
       "trendingScore": 20,
       "sdk": "gradio",
       "tags": [
         "gradio",
         "region:us"
       ],
-      "createdAt": "2025-12-09T19:01:39.000Z",
-      "lastModified": "2026-03-13T17:12:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "lerobot/visualize_dataset",
-      "author": "lerobot",
-      "url": "https://huggingface.co/spaces/lerobot/visualize_dataset",
-      "likes": 482,
-      "trendingScore": 18,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2024-07-17T10:30:46.000Z",
-      "lastModified": "2026-04-27T17:48:48.000Z",
+      "createdAt": "2026-05-14T10:12:08.000Z",
+      "lastModified": "2026-05-16T00:07:35.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26155473957

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.