### PR TITLE
chore(data): refresh mcp liveness 2026-05-20T10:15:32Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,15 +1,11 @@
 {
-  "fetchedAt": "2026-05-20T04:55:59.600Z",
+  "fetchedAt": "2026-05-20T10:15:28.241Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
     "polymarket/polymarket-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "gantta/gantta-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -45,7 +41,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aryankeluskar/polymarket-mcp": {
+    "hugeicons/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -53,15 +49,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "aryankeluskar/polymarket-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "linkupplatform/linkup-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "re-rank/uiux-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hugeicons/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -73,7 +65,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "gantta/gantta-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "fabsforward2-zhoi/sbb-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "clay-inc/clay-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -89,15 +89,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "clay-inc/clay-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "titansneaker/paper-search-mcp-openai-v2": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "senzing/entity-resolution": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -109,11 +101,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rashforddamion/rivalsearch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ciprianpater/srv-d7aoqmh5pdvs7391dcqg": {
+    "etweisberg/mlb-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -121,11 +109,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "icons8community/icons8mcp": {
+    "ciprianpater/srv-d7aoqmh5pdvs7391dcqg": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "etweisberg/mlb-mcp": {
+    "rashforddamion/rivalsearch": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "icons8community/icons8mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -133,11 +125,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "octomil/octomil": {
+    "slack": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "bh-rat/context-awesome": {
+    "octomil/octomil": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -145,15 +137,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "slack": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "oevortex/ddg_search": {
+    "bh-rat/context-awesome": {
       "isStdio": true,
       "livenessInferred": true
     },
     "cloud101.kr/cloud101kr": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "oevortex/ddg_search": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -181,15 +173,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "do-droid/seoul-essentials": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "googledrive": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "settlegrid/settlegrid-discovery": {
+    "re-rank/uiux-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "do-droid/seoul-essentials": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -198,6 +190,10 @@
       "livenessInferred": true
     },
     "hjsh200219/fortuneteller": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "settlegrid/settlegrid-discovery": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -210,10 +206,6 @@
       "livenessInferred": true
     },
     "isdaniel/mcp_weather_server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "code-rabi/littlesis-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -237,15 +229,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ucpchecker/ucp-checker": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "linxule/mcp-music-studio": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "minitim222/harvard-mit-course-recommendation": {
+    "googletasks": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -269,7 +257,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "glassnode/glassnode-mcp": {
+    "github": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "minitim222/harvard-mit-course-recommendation": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kkjdaniel/bgg-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -281,7 +277,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "github": {
+    "ai-research/airesearchass": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -289,7 +285,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ai-research/airesearchass": {
+    "blake365/macrostrat-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -297,11 +293,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "chuhuoyuan/cloudflare": {
+    "spyfree/mingli-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "spyfree/mingli-mcp": {
+    "chuhuoyuan/cloudflare": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -309,11 +305,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "blake365/macrostrat-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "strale-io/strale": {
+    "pinkpixel-dev/web-scout-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -321,11 +313,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "googletasks": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pinkpixel-dev/web-scout-mcp": {
+    "parallel/search": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -333,15 +321,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "parallel/search": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "arizeai/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kkjdaniel/bgg-mcp": {
+    "strale-io/strale": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -349,15 +333,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "senzing/entity-resolution": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "artvepa80/hefestoai": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "antvis/mcp-server-chart": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aguskenari86-8bo7/cryptoiz-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -369,7 +349,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "aguskenari86-8bo7/cryptoiz-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "smithery-ai/national-weather-service": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "antvis/mcp-server-chart": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -381,7 +369,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "jarvis-stark1985/superhero-mcp-server": {
+    "bartek-ywte/gaproll": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -389,7 +377,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "bartek-ywte/gaproll": {
+    "jarvis-stark1985/superhero-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -397,11 +385,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "jacksmith3888/wuwa-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "janmacher02-xl8y/czech-vat-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jacksmith3888/wuwa-mcp-server": {
+    "ucpchecker/ucp-checker": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -409,7 +401,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "googlesuper": {
+    "clickhouse": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sfiorini/youtube-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -421,11 +417,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "sfiorini/youtube-mcp": {
+    "kwp-lab/rss-reader-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kwp-lab/rss-reader-mcp": {
+    "googlesuper": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -437,11 +433,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "clickhouse": {
+    "code-rabi/littlesis-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
     "onetrip/pulse": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "googlecalendar": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -461,6 +461,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "glassnode/glassnode-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "caullenomdahl/nextjs-react-tailwind-assistant": {
       "isStdio": true,
       "livenessInferred": true
@@ -469,15 +473,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "strale/agent-tools": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "agentidx/agentcrawl": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "tavily": {
+    "strale/agent-tools": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -485,11 +485,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "sgroy10/speclock": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "agentidx/zarq-risk": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sgroy10/speclock": {
+    "tavily": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -505,11 +509,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "convrgent/aeo-scanner": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "googlecalendar": {
+    "outlook": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -521,10 +521,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "outlook": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "johnanleitner1/last_minute_deals_hq": {
       "isStdio": true,
       "livenessInferred": true
@@ -533,11 +529,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rubenayla/partle": {
+    "fibonex/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "fibonex/mcp-server": {
+    "rubenayla/partle": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -549,15 +545,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hirofumitorato/japan-ani-search-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "cyberweasel777/botindex-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
     "glmarket2007-m1qh/gyotak-fish-market": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hirofumitorato/japan-ani-search-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -585,7 +581,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "notion": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "rbxwilliams/tmcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "convrgent/aeo-scanner": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -593,11 +597,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/la-final": {
+    "huangmy157/ddd": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "huangmy157/ddd": {
+    "santiago.blanco.vilchez/la-final": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -610,10 +614,6 @@
       "livenessInferred": true
     },
     "seahbk1006/seahboonkeong-chat-bnmapi": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "notion": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -637,11 +637,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "coupang-mcp/coupang": {
+    "ing-christopherleon/preciomx": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ing-christopherleon/preciomx": {
+    "onesignal/onesignal": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -650,6 +650,10 @@
       "livenessInferred": true
     },
     "fuddyduddy/kyrgyz-news-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "coupang-mcp/coupang": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -677,11 +681,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "onesignal/onesignal": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "outtolunch/outtolunch": {
+    "plith/plith": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -689,19 +689,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "mcpdotdirect/starknet-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "outtolunch/outtolunch": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ragalgo/ragalgo-mcp-server-v1": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "plith/plith": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "santiago.blanco.vilchez/aaa": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ateam-ai/ateam": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -721,7 +721,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "naimterrache/bjj-belt-progress": {
+    "ateam-ai/ateam": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -742,10 +742,6 @@
       "livenessInferred": true
     },
     "browserbase": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mcpdotdirect/starknet-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -781,6 +777,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "naimterrache/bjj-belt-progress": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "forage-shopping/forage-shopping": {
       "isStdio": true,
       "livenessInferred": true
@@ -805,6 +805,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "petabloom/podcasts": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "mavengence/ustidnr-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -817,11 +821,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "securityscan-api/securityscan": {
+    "smithery-ai/fetch": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "smithery-ai/fetch": {
+    "securityscan-api/securityscan": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -829,19 +833,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "xiaobenyang-com/rfc-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "secureship/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "reitsmasieto-wq/overcome-stress": {
+    "xiaobenyang-com/rfc-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "petabloom/podcasts": {
+    "reitsmasieto-wq/overcome-stress": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -850,10 +850,6 @@
       "livenessInferred": true
     },
     "vestara/america-law-graph": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "invarium-ai/invarium": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -945,6 +941,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "invarium-ai/invarium": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "iclickfreedownloads/mcp-server-airbnb": {
       "isStdio": true,
       "livenessInferred": true
@@ -985,7 +985,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aas-ee/open-websearch": {
+    "intake-triage/steadyfetch": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -993,11 +993,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "intake-triage/steadyfetch": {
+    "aas-ee/open-websearch": {
       "isStdio": true,
       "livenessInferred": true
     },
     "santiago.blanco.vilchez/asd": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "petrsovadina/sukl-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1021,15 +1025,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "petrsovadina/sukl-mcp": {
+    "nicks-brn/promptscan": {
       "isStdio": true,
       "livenessInferred": true
     },
     "atars-mcp/aarnaai": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "nicks-brn/promptscan": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1057,7 +1057,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "preetrajdeo/autoapply-mcp": {
+    "info-ybpr/gantta-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1065,7 +1065,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "info-ybpr/gantta-mcp": {
+    "preetrajdeo/autoapply-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1105,6 +1105,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "koumoul/ademe-opendata": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "rlhf-loop/mcp-memory-gateway-v2": {
       "isStdio": true,
       "livenessInferred": true
@@ -1121,7 +1125,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "koumoul/ademe-opendata": {
+    "alex-kenny-lee-vfjv/panko-food-safety": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1142,10 +1146,6 @@
       "livenessInferred": true
     },
     "koumoul/opendata": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alex-kenny-lee-vfjv/panko-food-safety": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1170,6 +1170,14 @@
       "livenessInferred": true
     },
     "smhussainm-rzp1/brcupaqtde2pisrtwto1kwscop4lwc7lngagj6v": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "philidor/defi": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "arjunkmrm/perplexity-search": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1237,10 +1245,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "science/mcp-atomictoolkit": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "henry-ships/sparkforge": {
       "isStdio": true,
       "livenessInferred": true
@@ -1253,15 +1257,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "waleed-2002/prompt-enhancer": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "refetch/web": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "refund-decide/notary": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1269,11 +1265,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "refund-decide/notary": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "saurabhsharma2u/call-for-papers": {
       "isStdio": true,
       "livenessInferred": true
     },
+    "science/mcp-atomictoolkit": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "vdineshk/sg-cpf-calculator-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "waleed-2002/prompt-enhancer": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1377,7 +1385,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "justus/bushdrum-events": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ghostrouter/ghostrouter-web": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "naimterrache/frigolog-haccp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1421,6 +1437,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "kapoost/humanmcp-marketplace": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "hustcc/mcp-icon": {
       "isStdio": true,
       "livenessInferred": true
@@ -1453,15 +1473,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "evan-follis-u0ll/preflight": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "aigen/agent-tools": {
       "isStdio": true,
       "livenessInferred": true
     },
     "sentinelsignal/verify": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "evan-follis-u0ll/preflight": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1529,6 +1549,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "maxsambento/morfex": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "pestsentinel/pest-intelligence": {
       "isStdio": true,
       "livenessInferred": true
@@ -1561,6 +1585,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "turbopuffer": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "janmacher02-xl8y/sec-edgar-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -1573,11 +1601,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hegetiby-jwao/anaf-efactura-mcp": {
+    "dimitry/parse-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "turbopuffer": {
+    "hegetiby-jwao/anaf-efactura-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1689,11 +1717,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ai.autonomad/computeback": {
+    "auxen-ai/auxen mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ai.auxen/auxen": {
+    "ai.autonomad/computeback": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1709,359 +1737,135 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "y-sky-bro/nexus-memory": {
+    "vitalini/ebb-ai": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "megazear7/static-mcpify": {
+    "aurasoph/klone-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "im-hal-9k/remote-mcp-server-authless": {
+    "pipeworx-io/mcp-spoonacular": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "zh/redmine mcp oauth server": {
+    "pipeworx-io/twelvedata": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jun7680/kakao moment mcp": {
+    "pipeworx-io/mcp-deepl": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "rogerio-grocers/grocers-design-mcp": {
+    "yuechen/plaid-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sebaustin/mcp-financial-data": {
+    "saikandikatta/cheapflights-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "deepwa7er/poe2-mcp": {
+    "pipeworx-io/mapbox mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "denialgelon/nano-banana-mcp": {
+    "jrolstad/ambient-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "lrgex/notion mcp server": {
+    "skeego/opendata-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "zcdeng/vimax-mcp": {
+    "questsystems-ai/fal-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "datadawn-org/datadawn mcp server": {
+    "amichae2/math mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "darkmatter-hub/darkmatter mcp server": {
+    "satsuj1n/xp-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "dhebp/dero-mcp-server": {
+    "pipeworx-io/mcp-clinicaltables": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ismailrz/travel-mcp-server": {
+    "survivorforge/agentalmanac-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "cunning-kang/mavis mcp server": {
+    "voftec/bora-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "bracesproul/lsd mcp template": {
+    "dajun666/schoology-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "sandraschi/streamfog mcp": {
+    "pras-labs/bichon-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jarmstrong158/clark-mcp": {
+    "sravannerella/anypoint mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "thehzuo/web-gui-mcp": {
+    "jlavoieca/access self-hosted mcp server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "zoharbabin/web researcher mcp": {
+    "semiotronika/linza-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "gvnrdev/budget governor": {
+    "ktg-one/stac2026": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "xinyuzjj/godot mcp enhanced": {
+    "mosesy5688/free2aitools": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "achilliesbot/agentiam-mcp": {
+    "top/yappers": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ariri48/dooray mcp server": {
+    "agentclear-ai/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "oyaaiprod/exploit intel platform mcp server": {
+    "shokjak/travel-deals-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "graphiteai/graphite-mcp": {
+    "databutton/databutton-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "adkit/adkit": {
+    "workos": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "fgambling/constructoo mcp server": {
+    "vercel/grep": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "rrupesh/gke-cred-audit": {
+    "google_search_console": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jaykim429/report-mcp": {
+    "docfork/docfork": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jessiejanie/skim-mcp": {
+    "googledocs": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "hhopke/intervals-icu-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "abhineet34/linkedin-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "exocubeyt/openwa mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "magarongcandy/mcp_tools": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tsfir/easycslearning": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "devtee-dot/gridpulse energy": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "junhyeok0703/policy-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "domdemetz/claude-soul": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dmang-dev/mcp-dolphin": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ayoubtadlaoui/npmguard": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "movebrickschi/harness engineering mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "xecho-dev/mcp-watermark": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "smythmyke/markitup mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pop24/lebonfoin mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "oolab-labs/patchwork-os": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "justadityaraj/amazon-in-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "snowykte0426/datagsm-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aberry-h/deepseek mcp sample": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "astandrik/local ydb mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "osirishorus/opencoffer": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "eucomplyhub/mcp-eu-ai-act": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "marcellm01/tinysearch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "coding-professional/vibe mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "stock-vibes/meeting-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "prototypr/feedbagel mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "trafficmorph-gif/tm-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "clidyn/copernicus-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fdcommercial/property-finance-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "maxsambento/morfex": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kapoost/humanmcp-marketplace": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dimitry/parse-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "naimterrache/frigolog-haccp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "justus/bushdrum-events": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arjunkmrm/perplexity-search": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "philidor/defi": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "luizdopc/mcp rag server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mnemox-ai/tradememory protocol": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "uyu423/requarks-wiki-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "joehwang/golden egg tw holdings mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aanchalakto/magic mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "puran-water/aerobic design mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "madhurtoshniwal/spotify mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "busybee3333/trello mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "odysa/rdf4j mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dockergiant/rolldev mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "davidwhitelabeledca/cloudflare playwright mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "richardsun85/remote mcp server on cloudflare": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "stig-johnny/cutie-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "macromnex/spired-stab mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "wjohns989/muninn": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "suvidha-2401/discord mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "coderdayton/semantic cache mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ronaldzuniga/microsoft 365 mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kvnpetit/src (structured repo context)": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "corporatesmalltalkconsultingltd/claudesmalltalk": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aadarshvelu/derive mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "getmystadmin/urdb mcp": {
+    "linear": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3998,6 +3802,202 @@
       "livenessInferred": true
     },
     "citesurf/citesurf mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "luciferforge/agent-safety-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tickory/tickory mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "3knightcz/codebeamer-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "geminilight/mindos": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/dnd-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "korovkoalexander/nsys-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "seshatlabs/prediction-market-intelligence-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ingipsa/kitsu mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bababoi-bibilabu/agent-mq": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nextgensoftwareuk/oasis unified mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "beat-yt/omnivox-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "letsfg/letsfg": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cerebrixos-org/tuning engines": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/lorcana-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/onepiece-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gong8/knownissue": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gregario/hearthstone-oracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "attestedintelligence/aga-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "colbymk97/clash royale mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yylgit/mcp gateway demo": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "marcoar1/botuyo mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bonsai-tech-llc/clypt mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "get-airlock/maverick mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "zas/musicbrainz mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aryankeluskar/mcp-worker": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "naren8642/duffel mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aooiuu/ttrss-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "nandi-services/nandi-proxmox-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "the-greenpanter/canvas mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hyeok-ju98/figma + notion mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "20youssef10/notebooklm mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "userdeter1/discord mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mission69b/t2000": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "andysalvo/agentic-platform": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dkurti/home assistant mcp server (ha-mcp)": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "eduresser/sqlite-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "willhou/admob mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "larasrinath/bls mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sumitnawathe/xmcp application": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "multiagentcognition/cmux-agent-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jemo69/appflowy cloud mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "miles0sage/twitter/x mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dazanza/copper mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "miles0sage/polymarket mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dazanza/mailchimp-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "lnicolaie/yapy mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jackdark425/financial modeling prep (fmp) mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "signal-found/signal found mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kakacoding1/excalidraw mcp server": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26156071896

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.