### PR TITLE
chore(data): refresh lobsters signals 2026-05-20T12:10:00Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-20T08:42:10.570Z",
+  "ts": "2026-05-20T12:10:00.726Z",
   "count": 1,
-  "durationMs": 5875,
+  "durationMs": 7903,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T08:42:04.709Z",
+  "fetchedAt": "2026-05-20T12:09:52.843Z",
   "windowDays": 7,
-  "scannedStories": 81,
+  "scannedStories": 82,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -235,14 +235,14 @@
     },
     "tomekw/stcc": {
       "count7d": 1,
-      "scoreSum7d": 19,
+      "scoreSum7d": 21,
       "topStory": {
         "shortId": "pk139i",
         "title": "The Super Tiny Compiler, but in Ada",
-        "score": 19,
+        "score": 21,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 18.858055555555556
+        "hoursSincePosted": 22.32138888888889
       },
       "stories": [
         {
@@ -251,11 +251,11 @@
           "url": "https://github.com/tomekw/stcc",
           "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
           "by": "",
-          "score": 19,
+          "score": 21,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 18.858055555555556,
-          "trendingScore": 0.19945405545495823,
+          "ageHours": 22.32138888888889,
+          "trendingScore": 0.17508008015246546,
           "tags": [
             "plt",
             "programming"
@@ -492,7 +492,7 @@
     {
       "fullName": "tomekw/stcc",
       "count7d": 1,
-      "scoreSum7d": 19
+      "scoreSum7d": 21
     },
     {
       "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T08:42:04.709Z",
+  "fetchedAt": "2026-05-20T12:09:52.843Z",
   "windowHours": 72,
-  "scannedTotal": 81,
+  "scannedTotal": 82,
   "stories": [
     {
       "shortId": "29pm2f",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26161547322

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.