### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-20T12:41:56Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-20T06:59:40.858Z",
+  "generatedAt": "2026-05-20T12:41:55.975Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",
@@ -20,6 +20,22 @@
       "matchConfidence": "exact",
       "sourceUrl": "https://trustmrr.com/startup/webclaw"
     },
+    "AChep/keyguard-app": {
+      "tier": "verified_trustmrr",
+      "fullName": "AChep/keyguard-app",
+      "trustmrrSlug": "habits-garden",
+      "mrrCents": 5896,
+      "last30DaysCents": 16264,
+      "totalCents": 332401,
+      "growthMrr30d": 0,
+      "customers": 0,
+      "activeSubscriptions": 10,
+      "paymentProvider": "revenuecat",
+      "category": "Mobile Apps",
+      "asOf": "2026-04-24T01:59:01.837Z",
+      "matchConfidence": "exact",
+      "sourceUrl": "https://trustmrr.com/startup/habits-garden"
+    },
     "Anil-matcha/Open-Generative-AI": {
       "tier": "verified_trustmrr",
       "fullName": "Anil-matcha/Open-Generative-AI",
@@ -35,6 +51,22 @@
       "asOf": "2026-04-24T01:59:01.837Z",
       "matchConfidence": "host",
       "sourceUrl": "https://trustmrr.com/startup/muapi"
+    },
+    "jasperdevs/odd-snap": {
+      "tier": "verified_trustmrr",
+      "fullName": "jasperdevs/odd-snap",
+      "trustmrrSlug": "cutiq",
+      "mrrCents": 417,
+      "last30DaysCents": 4999,
+      "totalCents": 4999,
+      "growthMrr30d": 0,
+      "customers": 1,
+      "activeSubscriptions": 1,
+      "paymentProvider": "superwall",
+      "category": "Artificial Intelligence",
+      "asOf": "2026-04-24T01:59:01.837Z",
+      "matchConfidence": "host",
+      "sourceUrl": "https://trustmrr.com/startup/cutiq"
     },
     "gitroomhq/postiz-app": {
       "tier": "verified_trustmrr",


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26163148220

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.