### PR TITLE
chore(data): refresh huggingface signals 2026-05-20T15:57:58Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-20T09:55:34.302Z",
+  "ts": "2026-05-20T15:57:57.997Z",
   "count": 1,
-  "durationMs": 7322,
+  "durationMs": 8073,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T09:55:26.981Z",
+  "fetchedAt": "2026-05-20T15:57:49.926Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -108,8 +108,8 @@
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/Lance",
       "downloads": 438,
-      "likes": 384,
-      "trendingScore": 381,
+      "likes": 427,
+      "trendingScore": 421,
       "pipelineTag": "any-to-any",
       "libraryName": "Lance",
       "tags": [
@@ -128,7 +128,7 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-20T03:23:26.000Z"
+      "lastModified": "2026-05-20T12:40:00.000Z"
     },
     {
       "rank": 6,
@@ -334,8 +334,8 @@
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima",
       "downloads": 571087,
-      "likes": 1433,
-      "trendingScore": 193,
+      "likes": 1446,
+      "trendingScore": 205,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
       "tags": [
@@ -349,6 +349,35 @@
     },
     {
       "rank": 14,
+      "id": "ResembleAI/Dramabox",
+      "author": "ResembleAI",
+      "url": "https://huggingface.co/ResembleAI/Dramabox",
+      "downloads": 1229,
+      "likes": 195,
+      "trendingScore": 192,
+      "pipelineTag": "text-to-speech",
+      "libraryName": "ltx-audio-tts",
+      "tags": [
+        "ltx-audio-tts",
+        "dramabox-tts",
+        "tts",
+        "voice-cloning",
+        "audio-generation",
+        "diffusion-transformer",
+        "flow-matching",
+        "ltx-2",
+        "text-to-speech",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:finetune:Lightricks/LTX-2.3",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-17T07:17:52.000Z",
+      "lastModified": "2026-05-13T16:39:38.000Z"
+    },
+    {
+      "rank": 15,
       "id": "SeeSee21/Z-Anime",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Anime",
@@ -381,35 +410,6 @@
       "lastModified": "2026-04-27T01:13:30.000Z"
     },
     {
-      "rank": 15,
-      "id": "ResembleAI/Dramabox",
-      "author": "ResembleAI",
-      "url": "https://huggingface.co/ResembleAI/Dramabox",
-      "downloads": 1229,
-      "likes": 188,
-      "trendingScore": 185,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "ltx-audio-tts",
-      "tags": [
-        "ltx-audio-tts",
-        "dramabox-tts",
-        "tts",
-        "voice-cloning",
-        "audio-generation",
-        "diffusion-transformer",
-        "flow-matching",
-        "ltx-2",
-        "text-to-speech",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:finetune:Lightricks/LTX-2.3",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T07:17:52.000Z",
-      "lastModified": "2026-05-13T16:39:38.000Z"
-    },
-    {
       "rank": 16,
       "id": "TenStrip/LTX2.3-10Eros",
       "author": "TenStrip",
@@ -429,12 +429,42 @@
     },
     {
       "rank": 17,
+      "id": "sapientinc/HRM-Text-1B",
+      "author": "sapientinc",
+      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
+      "downloads": 23532,
+      "likes": 162,
+      "trendingScore": 161,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hrm_text",
+        "text-generation",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T15:13:02.000Z",
+      "lastModified": "2026-05-20T03:03:36.000Z"
+    },
+    {
+      "rank": 18,
       "id": "froggeric/Qwen-Fixed-Chat-Templates",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
       "downloads": 0,
-      "likes": 320,
-      "trendingScore": 150,
+      "likes": 329,
+      "trendingScore": 156,
       "pipelineTag": null,
       "libraryName": "mlx",
       "tags": [
@@ -456,7 +486,7 @@
       "lastModified": "2026-05-16T13:44:07.000Z"
     },
     {
-      "rank": 18,
+      "rank": 19,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -483,36 +513,6 @@
       ],
       "createdAt": "2026-04-27T12:52:53.000Z",
       "lastModified": "2026-04-28T07:01:37.000Z"
-    },
-    {
-      "rank": 19,
-      "id": "sapientinc/HRM-Text-1B",
-      "author": "sapientinc",
-      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 23532,
-      "likes": 141,
-      "trendingScore": 140,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hrm_text",
-        "text-generation",
-        "hrm",
-        "hierarchical-reasoning",
-        "prefix-lm",
-        "pre-alignment",
-        "non-chat",
-        "non-instruction-tuned",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T15:13:02.000Z",
-      "lastModified": "2026-05-20T03:03:36.000Z"
     },
     {
       "rank": 20,
@@ -609,8 +609,8 @@
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "downloads": 17539,
-      "likes": 126,
-      "trendingScore": 125,
+      "likes": 132,
+      "trendingScore": 131,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -696,6 +696,41 @@
     },
     {
       "rank": 26,
+      "id": "NemoStation/Marlin-2B",
+      "author": "NemoStation",
+      "url": "https://huggingface.co/NemoStation/Marlin-2B",
+      "downloads": 125,
+      "likes": 121,
+      "trendingScore": 117,
+      "pipelineTag": "video-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "text-generation",
+        "video",
+        "multimodal",
+        "video-captioning",
+        "temporal-grounding",
+        "qwen",
+        "VLM",
+        "video-text-to-text",
+        "custom_code",
+        "en",
+        "arxiv:2501.00513",
+        "arxiv:2407.00634",
+        "arxiv:2512.14698",
+        "base_model:Qwen/Qwen3.5-2B",
+        "base_model:finetune:Qwen/Qwen3.5-2B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:23:12.000Z",
+      "lastModified": "2026-05-20T07:54:57.000Z"
+    },
+    {
+      "rank": 27,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -737,7 +772,7 @@
       "lastModified": "2026-05-07T02:39:32.000Z"
     },
     {
-      "rank": 27,
+      "rank": 28,
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
@@ -770,7 +805,7 @@
       "lastModified": "2026-04-12T13:42:43.000Z"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -796,7 +831,7 @@
       "lastModified": "2026-05-06T04:18:09.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "sensenova/SenseNova-U1-8B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
@@ -824,7 +859,7 @@
       "lastModified": "2026-05-07T08:00:27.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "jackxinning/Leanly_AI",
       "author": "jackxinning",
       "url": "https://huggingface.co/jackxinning/Leanly_AI",
@@ -848,7 +883,7 @@
       "lastModified": "2026-05-04T07:50:46.000Z"
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
@@ -872,7 +907,7 @@
       "lastModified": "2026-05-15T10:40:24.000Z"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "google/gemma-4-31B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B-it",
@@ -899,7 +934,7 @@
       "lastModified": "2026-05-07T07:39:17.000Z"
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "ScenemaAI/scenema-audio",
       "author": "ScenemaAI",
       "url": "https://huggingface.co/ScenemaAI/scenema-audio",
@@ -938,7 +973,7 @@
       "lastModified": "2026-05-14T03:19:58.000Z"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -967,7 +1002,7 @@
       "lastModified": "2026-05-05T12:57:20.000Z"
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
@@ -993,7 +1028,7 @@
       "lastModified": "2026-04-25T21:33:07.000Z"
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "unsloth/Qwen3.6-27B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
@@ -1021,12 +1056,12 @@
       "lastModified": "2026-04-22T16:01:39.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "microsoft/Fara-7B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Fara-7B",
       "downloads": 15167,
-      "likes": 585,
+      "likes": 586,
       "trendingScore": 90,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -1048,7 +1083,7 @@
       "lastModified": "2026-05-19T15:37:05.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "Cactus-Compute/needle",
       "author": "Cactus-Compute",
       "url": "https://huggingface.co/Cactus-Compute/needle",
@@ -1073,13 +1108,13 @@
       "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "inclusionAI/Ring-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
       "downloads": 3454,
-      "likes": 87,
-      "trendingScore": 86,
+      "likes": 88,
+      "trendingScore": 87,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1098,7 +1133,7 @@
       "lastModified": "2026-05-18T09:47:28.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/k2-fsa/OmniVoice",
@@ -1143,7 +1178,31 @@
       "lastModified": "2026-05-07T15:45:07.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
+      "id": "internlm/Intern-S2-Preview",
+      "author": "internlm",
+      "url": "https://huggingface.co/internlm/Intern-S2-Preview",
+      "downloads": 2050,
+      "likes": 85,
+      "trendingScore": 85,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "intern_s2_preview",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T03:49:25.000Z",
+      "lastModified": "2026-05-19T08:01:07.000Z"
+    },
+    {
+      "rank": 43,
       "id": "havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
@@ -1170,7 +1229,7 @@
       "lastModified": "2026-05-10T15:43:51.000Z"
     },
     {
-      "rank": 42,
+      "rank": 44,
       "id": "antirez/deepseek-v4-gguf",
       "author": "antirez",
       "url": "https://huggingface.co/antirez/deepseek-v4-gguf",
@@ -1208,31 +1267,7 @@
       "lastModified": "2026-05-12T16:08:16.000Z"
     },
     {
-      "rank": 43,
-      "id": "internlm/Intern-S2-Preview",
-      "author": "internlm",
-      "url": "https://huggingface.co/internlm/Intern-S2-Preview",
-      "downloads": 2050,
-      "likes": 81,
-      "trendingScore": 81,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "intern_s2_preview",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T03:49:25.000Z",
-      "lastModified": "2026-05-19T08:01:07.000Z"
-    },
-    {
-      "rank": 44,
+      "rank": 45,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -1260,7 +1295,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1289,7 +1324,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -1315,7 +1350,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -1344,7 +1379,7 @@
       "lastModified": "2026-04-20T12:42:25.000Z"
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -1377,7 +1412,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -1422,7 +1457,7 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 50,
+      "rank": 51,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -1442,13 +1477,13 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 51,
+      "rank": 52,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "downloads": 18626,
-      "likes": 101,
-      "trendingScore": 72,
+      "likes": 102,
+      "trendingScore": 73,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1475,41 +1510,6 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 52,
-      "id": "NemoStation/Marlin-2B",
-      "author": "NemoStation",
-      "url": "https://huggingface.co/NemoStation/Marlin-2B",
-      "downloads": 125,
-      "likes": 75,
-      "trendingScore": 72,
-      "pipelineTag": "video-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "text-generation",
-        "video",
-        "multimodal",
-        "video-captioning",
-        "temporal-grounding",
-        "qwen",
-        "VLM",
-        "video-text-to-text",
-        "custom_code",
-        "en",
-        "arxiv:2501.00513",
-        "arxiv:2407.00634",
-        "arxiv:2512.14698",
-        "base_model:Qwen/Qwen3.5-2B",
-        "base_model:finetune:Qwen/Qwen3.5-2B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:23:12.000Z",
-      "lastModified": "2026-05-20T07:54:57.000Z"
-    },
-    {
       "rank": 53,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
@@ -1534,6 +1534,26 @@
     },
     {
       "rank": 54,
+      "id": "facebook/VGGT-Omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/VGGT-Omega",
+      "downloads": 0,
+      "likes": 73,
+      "trendingScore": 69,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "facebook",
+        "meta-pytorch",
+        "en",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-17T20:47:45.000Z",
+      "lastModified": "2026-05-14T21:23:21.000Z"
+    },
+    {
+      "rank": 55,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -1565,7 +1585,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 55,
+      "rank": 56,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -1590,7 +1610,7 @@
       "lastModified": "2026-05-12T14:25:54.000Z"
     },
     {
-      "rank": 56,
+      "rank": 57,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1633,26 +1653,6 @@
       ],
       "createdAt": "2026-04-29T16:12:36.000Z",
       "lastModified": "2026-05-02T14:32:42.000Z"
-    },
-    {
-      "rank": 57,
-      "id": "facebook/VGGT-Omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/VGGT-Omega",
-      "downloads": 0,
-      "likes": 68,
-      "trendingScore": 64,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "facebook",
-        "meta-pytorch",
-        "en",
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-17T20:47:45.000Z",
-      "lastModified": "2026-05-14T21:23:21.000Z"
     },
     {
       "rank": 58,
@@ -1777,6 +1777,63 @@
     },
     {
       "rank": 62,
+      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "downloads": 61106,
+      "likes": 63,
+      "trendingScore": 60,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "gemma4",
+        "moe",
+        "vision",
+        "multimodal",
+        "agentic",
+        "coding",
+        "image-text-to-text",
+        "en",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-14T16:24:48.000Z",
+      "lastModified": "2026-05-14T17:07:52.000Z"
+    },
+    {
+      "rank": 63,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 60,
+      "trendingScore": 60,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
+    },
+    {
+      "rank": 64,
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
@@ -1801,7 +1858,7 @@
       "lastModified": "2026-05-14T08:44:07.000Z"
     },
     {
-      "rank": 63,
+      "rank": 65,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -1829,7 +1886,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 64,
+      "rank": 66,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -1856,7 +1913,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 65,
+      "rank": 67,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -1883,7 +1940,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 66,
+      "rank": 68,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -1906,7 +1963,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 67,
+      "rank": 69,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -1937,39 +1994,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 68,
-      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "downloads": 61106,
-      "likes": 60,
-      "trendingScore": 57,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "moe",
-        "vision",
-        "multimodal",
-        "agentic",
-        "coding",
-        "image-text-to-text",
-        "en",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-14T16:24:48.000Z",
-      "lastModified": "2026-05-14T17:07:52.000Z"
-    },
-    {
-      "rank": 69,
+      "rank": 70,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -1999,7 +2024,7 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 70,
+      "rank": 71,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2043,7 +2068,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 71,
+      "rank": 72,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -2061,7 +2086,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 72,
+      "rank": 73,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -2088,7 +2113,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 73,
+      "rank": 74,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2121,7 +2146,34 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 74,
+      "rank": 75,
+      "id": "Lakonik/AsymFLUX.2-klein-9B",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
+      "downloads": 2316,
+      "likes": 53,
+      "trendingScore": 53,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "flow-matching",
+        "pixel-diffusion",
+        "pixel-generation",
+        "flux2",
+        "text-to-image",
+        "arxiv:2605.12964",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T20:19:24.000Z",
+      "lastModified": "2026-05-14T02:37:15.000Z"
+    },
+    {
+      "rank": 76,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2166,7 +2218,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 75,
+      "rank": 77,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2193,34 +2245,7 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 76,
-      "id": "Lakonik/AsymFLUX.2-klein-9B",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
-      "downloads": 2316,
-      "likes": 52,
-      "trendingScore": 52,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "flow-matching",
-        "pixel-diffusion",
-        "pixel-generation",
-        "flux2",
-        "text-to-image",
-        "arxiv:2605.12964",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T20:19:24.000Z",
-      "lastModified": "2026-05-14T02:37:15.000Z"
-    },
-    {
-      "rank": 77,
+      "rank": 78,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2248,7 +2273,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 78,
+      "rank": 79,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2282,7 +2307,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 79,
+      "rank": 80,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2312,7 +2337,27 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 80,
+      "rank": 81,
+      "id": "snwy/SD1.5-DALLE-2",
+      "author": "snwy",
+      "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
+      "downloads": 277,
+      "likes": 50,
+      "trendingScore": 48,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "endpoints_compatible",
+        "diffusers:StableDiffusionPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T05:38:45.000Z",
+      "lastModified": "2026-05-14T05:39:47.000Z"
+    },
+    {
+      "rank": 82,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -2343,7 +2388,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 81,
+      "rank": 83,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -2368,27 +2413,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 82,
-      "id": "snwy/SD1.5-DALLE-2",
-      "author": "snwy",
-      "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
-      "downloads": 277,
-      "likes": 49,
-      "trendingScore": 47,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "endpoints_compatible",
-        "diffusers:StableDiffusionPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T05:38:45.000Z",
-      "lastModified": "2026-05-14T05:39:47.000Z"
-    },
-    {
-      "rank": 83,
+      "rank": 84,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -2425,7 +2450,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 84,
+      "rank": 85,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -2462,7 +2487,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 85,
+      "rank": 86,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -2490,7 +2515,31 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
+      "downloads": 681,
+      "likes": 46,
+      "trendingScore": 46,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T15:12:13.000Z",
+      "lastModified": "2026-05-15T10:41:43.000Z"
+    },
+    {
+      "rank": 88,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -2513,117 +2562,13 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 87,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "downloads": 681,
-      "likes": 45,
-      "trendingScore": 45,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T15:12:13.000Z",
-      "lastModified": "2026-05-15T10:41:43.000Z"
-    },
-    {
-      "rank": 88,
-      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
-      "downloads": 462273,
-      "likes": 92,
-      "trendingScore": 43,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "NemotronH_Nano_Omni_Reasoning_V3",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "multimodal",
-        "any-to-any",
-        "custom_code",
-        "dataset:nvidia/Nemotron-Image-Training-v3",
-        "arxiv:2604.24954",
-        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "license:other",
-        "8-bit",
-        "modelopt",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T16:09:58.000Z",
-      "lastModified": "2026-05-05T14:35:03.000Z"
-    },
-    {
       "rank": 89,
-      "id": "manjunathshiva/gpt-oss-20b-tq3",
-      "author": "manjunathshiva",
-      "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
-      "downloads": 2474,
-      "likes": 45,
-      "trendingScore": 43,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "gpt_oss",
-        "turboquant",
-        "quantization",
-        "apple-silicon",
-        "moe",
-        "gpt-oss",
-        "text-generation",
-        "conversational",
-        "arxiv:2504.19874",
-        "base_model:openai/gpt-oss-20b",
-        "base_model:quantized:openai/gpt-oss-20b",
-        "license:apache-2.0",
-        "3-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-08T12:08:02.000Z",
-      "lastModified": "2026-05-09T11:23:07.000Z"
-    },
-    {
-      "rank": 90,
-      "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
-      "author": "Zlikwid",
-      "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
-      "downloads": 0,
-      "likes": 43,
-      "trendingScore": 43,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T06:04:26.000Z",
-      "lastModified": "2026-05-09T01:15:32.000Z"
-    },
-    {
-      "rank": 91,
       "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "downloads": 6680,
-      "likes": 44,
-      "trendingScore": 42,
+      "likes": 47,
+      "trendingScore": 45,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -2661,57 +2606,93 @@
       "lastModified": "2026-05-19T23:43:59.000Z"
     },
     {
-      "rank": 92,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 41,
-      "trendingScore": 41,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
+      "rank": 90,
+      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+      "downloads": 462273,
+      "likes": 92,
+      "trendingScore": 43,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
+        "transformers",
         "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
-        "license:apache-2.0",
+        "NemotronH_Nano_Omni_Reasoning_V3",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "multimodal",
+        "any-to-any",
+        "custom_code",
+        "dataset:nvidia/Nemotron-Image-Training-v3",
+        "arxiv:2604.24954",
+        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "license:other",
+        "8-bit",
+        "modelopt",
+        "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
+      "createdAt": "2026-04-24T16:09:58.000Z",
+      "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 93,
-      "id": "Zyphra/ZAYA1-74B-preview",
-      "author": "Zyphra",
-      "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
-      "downloads": 1180,
-      "likes": 39,
-      "trendingScore": 39,
+      "rank": 91,
+      "id": "manjunathshiva/gpt-oss-20b-tq3",
+      "author": "manjunathshiva",
+      "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
+      "downloads": 2474,
+      "likes": 45,
+      "trendingScore": 43,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "gpt_oss",
+        "turboquant",
+        "quantization",
+        "apple-silicon",
+        "moe",
+        "gpt-oss",
+        "text-generation",
+        "conversational",
+        "arxiv:2504.19874",
+        "base_model:openai/gpt-oss-20b",
+        "base_model:quantized:openai/gpt-oss-20b",
+        "license:apache-2.0",
+        "3-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-08T12:08:02.000Z",
+      "lastModified": "2026-05-09T11:23:07.000Z"
+    },
+    {
+      "rank": 92,
+      "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
+      "author": "Zlikwid",
+      "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
+      "downloads": 0,
+      "likes": 43,
+      "trendingScore": 43,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "safetensors",
-        "zaya",
-        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-05T23:12:08.000Z",
-      "lastModified": "2026-05-08T23:21:12.000Z"
+      "createdAt": "2026-05-07T06:04:26.000Z",
+      "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 94,
+      "rank": 93,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
       "downloads": 53048,
-      "likes": 40,
-      "trendingScore": 39,
+      "likes": 43,
+      "trendingScore": 42,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -2730,6 +2711,25 @@
       ],
       "createdAt": "2026-05-13T13:34:47.000Z",
       "lastModified": "2026-05-16T12:39:00.000Z"
+    },
+    {
+      "rank": 94,
+      "id": "Zyphra/ZAYA1-74B-preview",
+      "author": "Zyphra",
+      "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
+      "downloads": 1180,
+      "likes": 39,
+      "trendingScore": 39,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "zaya",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-05T23:12:08.000Z",
+      "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
       "rank": 95,
@@ -2820,6 +2820,32 @@
     },
     {
       "rank": 98,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 65,
+      "likes": 36,
+      "trendingScore": 36,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 99,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -2851,7 +2877,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 99,
+      "rank": 100,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -2874,7 +2900,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 100,
+      "rank": 101,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -2900,7 +2926,7 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 101,
+      "rank": 102,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -2924,7 +2950,36 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
+      "id": "Datadog/Toto-2.0-2.5B",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
+      "downloads": 1881,
+      "likes": 40,
+      "trendingScore": 35,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "arxiv:2605.20119",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-17T16:56:02.000Z",
+      "lastModified": "2026-05-20T14:30:55.000Z"
+    },
+    {
+      "rank": 104,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -2948,7 +3003,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 103,
+      "rank": 105,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -2965,7 +3020,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 104,
+      "rank": 106,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -2989,7 +3044,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 105,
+      "rank": 107,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3015,7 +3070,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 106,
+      "rank": 108,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -3031,7 +3086,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 107,
+      "rank": 109,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -3058,7 +3113,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 108,
+      "rank": 110,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -3087,35 +3142,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 109,
-      "id": "Datadog/Toto-2.0-2.5B",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
-      "downloads": 1881,
-      "likes": 39,
-      "trendingScore": 34,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T16:56:02.000Z",
-      "lastModified": "2026-05-14T14:23:46.000Z"
-    },
-    {
-      "rank": 110,
+      "rank": 111,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3134,7 +3161,44 @@
       "lastModified": "2026-05-19T22:46:11.000Z"
     },
     {
-      "rank": 111,
+      "rank": 112,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 1720,
+      "likes": 35,
+      "trendingScore": 34,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 113,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -3179,7 +3243,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 112,
+      "rank": 114,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -3224,7 +3288,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 113,
+      "rank": 115,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -3268,7 +3332,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 114,
+      "rank": 116,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3308,7 +3372,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 115,
+      "rank": 117,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -3334,7 +3398,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 116,
+      "rank": 118,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -3378,7 +3442,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 117,
+      "rank": 119,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3403,7 +3467,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 118,
+      "rank": 120,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -3448,12 +3512,12 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 119,
+      "rank": 121,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "downloads": 43048,
-      "likes": 61,
+      "downloads": 51124,
+      "likes": 63,
       "trendingScore": 32,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -3480,7 +3544,7 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 120,
+      "rank": 122,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -3513,7 +3577,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 121,
+      "rank": 123,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -3537,7 +3601,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 122,
+      "rank": 124,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -3564,7 +3628,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 123,
+      "rank": 125,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -3606,7 +3670,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 124,
+      "rank": 126,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -3632,69 +3696,6 @@
       ],
       "createdAt": "2026-05-07T22:41:50.000Z",
       "lastModified": "2026-05-08T19:09:36.000Z"
-    },
-    {
-      "rank": 125,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 1720,
-      "likes": 32,
-      "trendingScore": 31,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "image-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T09:24:47.000Z"
-    },
-    {
-      "rank": 126,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 65,
-      "likes": 31,
-      "trendingScore": 31,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
       "rank": 127,
@@ -3817,6 +3818,28 @@
     },
     {
       "rank": 131,
+      "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
+      "author": "systms",
+      "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
+      "downloads": 491,
+      "likes": 30,
+      "trendingScore": 30,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ltx-video",
+        "base_model:Lightricks/LTX-Video",
+        "base_model:adapter:Lightricks/LTX-Video",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T09:22:55.000Z",
+      "lastModified": "2026-05-13T19:23:38.000Z"
+    },
+    {
+      "rank": 132,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -3847,7 +3870,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -3872,7 +3895,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -3895,7 +3918,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 134,
+      "rank": 135,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -3922,7 +3945,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 135,
+      "rank": 136,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -3953,12 +3976,12 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 136,
+      "rank": 137,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
       "downloads": 4925733,
-      "likes": 5709,
+      "likes": 5710,
       "trendingScore": 29,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
@@ -3998,7 +4021,39 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 137,
+      "rank": 138,
+      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "downloads": 16599,
+      "likes": 31,
+      "trendingScore": 29,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:11:26.000Z",
+      "lastModified": "2026-05-16T21:22:27.000Z"
+    },
+    {
+      "rank": 139,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -4020,7 +4075,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 138,
+      "rank": 140,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -4057,7 +4112,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 139,
+      "rank": 141,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -4079,7 +4134,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 140,
+      "rank": 142,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -4112,34 +4167,12 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 141,
-      "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
-      "author": "systms",
-      "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
-      "downloads": 491,
-      "likes": 28,
-      "trendingScore": 28,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ltx-video",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T09:22:55.000Z",
-      "lastModified": "2026-05-13T19:23:38.000Z"
-    },
-    {
-      "rank": 142,
+      "rank": 143,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
       "downloads": 0,
-      "likes": 69,
+      "likes": 73,
       "trendingScore": 27,
       "pipelineTag": null,
       "libraryName": null,
@@ -4150,10 +4183,10 @@
         "region:us"
       ],
       "createdAt": "2026-04-27T12:32:06.000Z",
-      "lastModified": "2026-05-17T00:26:38.000Z"
+      "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 143,
+      "rank": 144,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -4193,7 +4226,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 144,
+      "rank": 145,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -4230,7 +4263,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 145,
+      "rank": 146,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -4273,7 +4306,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 146,
+      "rank": 147,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -4293,7 +4326,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 147,
+      "rank": 148,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -4316,38 +4349,6 @@
       ],
       "createdAt": "2026-02-28T14:04:29.000Z",
       "lastModified": "2026-03-02T14:08:36.000Z"
-    },
-    {
-      "rank": 148,
-      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 16599,
-      "likes": 29,
-      "trendingScore": 27,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:11:26.000Z",
-      "lastModified": "2026-05-16T21:22:27.000Z"
     },
     {
       "rank": 149,
@@ -4568,6 +4569,36 @@
     },
     {
       "rank": 156,
+      "id": "ByteDance-Seed/Cola-DLM",
+      "author": "ByteDance-Seed",
+      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
+      "downloads": 0,
+      "likes": 26,
+      "trendingScore": 26,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "text-generation",
+        "language-model",
+        "diffusion",
+        "latent-diffusion",
+        "flow-matching",
+        "text-vae",
+        "pytorch",
+        "research",
+        "en",
+        "arxiv:2605.06548",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T07:55:26.000Z",
+      "lastModified": "2026-05-15T09:38:05.000Z"
+    },
+    {
+      "rank": 157,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -4605,7 +4636,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 157,
+      "rank": 158,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -4623,7 +4654,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 158,
+      "rank": 159,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -4649,7 +4680,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 159,
+      "rank": 160,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -4669,7 +4700,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 160,
+      "rank": 161,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -4696,7 +4727,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 161,
+      "rank": 162,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -4722,7 +4753,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 162,
+      "rank": 163,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -4748,7 +4779,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 163,
+      "rank": 164,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -4785,7 +4816,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 164,
+      "rank": 165,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -4801,7 +4832,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 165,
+      "rank": 166,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -4824,7 +4855,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 166,
+      "rank": 167,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -4866,7 +4897,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 167,
+      "rank": 168,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -4903,36 +4934,6 @@
       ],
       "createdAt": "2026-05-09T05:16:20.000Z",
       "lastModified": "2026-05-15T03:09:50.000Z"
-    },
-    {
-      "rank": 168,
-      "id": "ByteDance-Seed/Cola-DLM",
-      "author": "ByteDance-Seed",
-      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
-      "downloads": 0,
-      "likes": 25,
-      "trendingScore": 25,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "text-generation",
-        "language-model",
-        "diffusion",
-        "latent-diffusion",
-        "flow-matching",
-        "text-vae",
-        "pytorch",
-        "research",
-        "en",
-        "arxiv:2605.06548",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T07:55:26.000Z",
-      "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
       "rank": 169,
@@ -5194,6 +5195,24 @@
     },
     {
       "rank": 178,
+      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "downloads": 65,
+      "likes": 25,
+      "trendingScore": 24,
+      "pipelineTag": null,
+      "libraryName": "nemo",
+      "tags": [
+        "nemo",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T21:52:25.000Z",
+      "lastModified": "2026-05-16T05:35:07.000Z"
+    },
+    {
+      "rank": 179,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -5220,7 +5239,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 179,
+      "rank": 180,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -5249,7 +5268,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 180,
+      "rank": 181,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -5266,7 +5285,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 181,
+      "rank": 182,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -5287,7 +5306,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 182,
+      "rank": 183,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -5308,7 +5327,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 183,
+      "rank": 184,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -5340,7 +5359,54 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 184,
+      "rank": 185,
+      "id": "microsoft/TRELLIS.2-4B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
+      "downloads": 0,
+      "likes": 868,
+      "trendingScore": 23,
+      "pipelineTag": "image-to-3d",
+      "libraryName": "trellis2",
+      "tags": [
+        "trellis2",
+        "image-to-3d",
+        "en",
+        "arxiv:2512.14692",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-12-01T02:25:40.000Z",
+      "lastModified": "2025-12-27T13:21:56.000Z"
+    },
+    {
+      "rank": 186,
+      "id": "HuggingFaceBio/Carbon-3B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
+      "downloads": 2184,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T11:05:49.000Z",
+      "lastModified": "2026-05-20T13:39:48.000Z"
+    },
+    {
+      "rank": 187,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -5371,7 +5437,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 185,
+      "rank": 188,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -5400,7 +5466,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 186,
+      "rank": 189,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -5445,7 +5511,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 187,
+      "rank": 190,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -5472,7 +5538,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 188,
+      "rank": 191,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5498,7 +5564,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 189,
+      "rank": 192,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -5522,28 +5588,39 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 190,
-      "id": "microsoft/TRELLIS.2-4B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
-      "downloads": 0,
-      "likes": 867,
+      "rank": 193,
+      "id": "nvidia/Kimi-K2.6-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
+      "downloads": 56882,
+      "likes": 22,
       "trendingScore": 22,
-      "pipelineTag": "image-to-3d",
-      "libraryName": "trellis2",
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
       "tags": [
-        "trellis2",
-        "image-to-3d",
-        "en",
-        "arxiv:2512.14692",
-        "license:mit",
+        "Model Optimizer",
+        "safetensors",
+        "kimi_k25",
+        "nvidia",
+        "ModelOpt",
+        "Kimi-K2.6",
+        "quantized",
+        "FP4",
+        "fp4",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "base_model:moonshotai/Kimi-K2.6",
+        "base_model:quantized:moonshotai/Kimi-K2.6",
+        "license:other",
+        "modelopt",
         "region:us"
       ],
-      "createdAt": "2025-12-01T02:25:40.000Z",
-      "lastModified": "2025-12-27T13:21:56.000Z"
+      "createdAt": "2026-05-11T04:37:55.000Z",
+      "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 191,
+      "rank": 194,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -5588,7 +5665,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 192,
+      "rank": 195,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -5616,7 +5693,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 193,
+      "rank": 196,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -5643,7 +5720,7 @@
       "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 194,
+      "rank": 197,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -5679,39 +5756,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 195,
-      "id": "nvidia/Kimi-K2.6-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
-      "downloads": 56882,
-      "likes": 21,
-      "trendingScore": 21,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "kimi_k25",
-        "nvidia",
-        "ModelOpt",
-        "Kimi-K2.6",
-        "quantized",
-        "FP4",
-        "fp4",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "base_model:moonshotai/Kimi-K2.6",
-        "base_model:quantized:moonshotai/Kimi-K2.6",
-        "license:other",
-        "modelopt",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T04:37:55.000Z",
-      "lastModified": "2026-05-15T17:40:07.000Z"
-    },
-    {
-      "rank": 196,
+      "rank": 198,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -5728,7 +5773,119 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 197,
+      "rank": 199,
+      "id": "FINAL-Bench/Darwin-28B-REASON",
+      "author": "FINAL-Bench",
+      "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
+      "downloads": 264,
+      "likes": 24,
+      "trendingScore": 21,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "darwin",
+        "darwin-reason",
+        "reasoning",
+        "advanced-reasoning",
+        "chain-of-thought",
+        "thinking",
+        "reasoning-trace-distillation",
+        "rtd",
+        "darwin-delphi",
+        "test-time-compute",
+        "qwen3.6",
+        "qwen",
+        "gpqa",
+        "benchmark",
+        "open-source",
+        "apache-2.0",
+        "proto-agi",
+        "vidraft",
+        "eval-results",
+        "text-generation",
+        "conversational",
+        "en",
+        "zh",
+        "ko",
+        "ja",
+        "multilingual"
+      ],
+      "createdAt": "2026-05-17T08:52:00.000Z",
+      "lastModified": "2026-05-17T09:32:18.000Z"
+    },
+    {
+      "rank": 200,
+      "id": "fastino/gliner2-privacy-filter-PII-multi",
+      "author": "fastino",
+      "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
+      "downloads": 3345,
+      "likes": 21,
+      "trendingScore": 21,
+      "pipelineTag": "token-classification",
+      "libraryName": "gliner2",
+      "tags": [
+        "gliner2",
+        "safetensors",
+        "extractor",
+        "pii",
+        "ner",
+        "privacy",
+        "redaction",
+        "gliner",
+        "information-extraction",
+        "span-extraction",
+        "token-classification",
+        "en",
+        "fr",
+        "es",
+        "de",
+        "it",
+        "pt",
+        "nl",
+        "dataset:synthetic",
+        "arxiv:2605.09973",
+        "arxiv:2604.09791",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-10T23:59:32.000Z",
+      "lastModified": "2026-05-14T18:18:54.000Z"
+    },
+    {
+      "rank": 201,
+      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "author": "sensenova",
+      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "downloads": 421,
+      "likes": 28,
+      "trendingScore": 21,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "neo_chat",
+        "feature-extraction",
+        "multimodal",
+        "text-to-image",
+        "image-to-text",
+        "image-editing",
+        "interleaved-generation",
+        "custom_code",
+        "any-to-any",
+        "arxiv:2502.01522",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T09:54:29.000Z",
+      "lastModified": "2026-05-16T06:48:11.000Z"
+    },
+    {
+      "rank": 202,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -5756,7 +5913,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 198,
+      "rank": 203,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -5789,7 +5946,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 199,
+      "rank": 204,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -5814,7 +5971,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 200,
+      "rank": 205,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -5851,7 +6008,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 201,
+      "rank": 206,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -5894,7 +6051,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 202,
+      "rank": 207,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -5918,7 +6075,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 203,
+      "rank": 208,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -5942,7 +6099,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 204,
+      "rank": 209,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5974,7 +6131,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 205,
+      "rank": 210,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -6003,7 +6160,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 206,
+      "rank": 211,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -6034,70 +6191,122 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 207,
-      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "downloads": 65,
-      "likes": 21,
+      "rank": 212,
+      "id": "Comfy-Org/MoGe",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/MoGe",
+      "downloads": 0,
+      "likes": 20,
       "trendingScore": 20,
       "pipelineTag": null,
-      "libraryName": "nemo",
+      "libraryName": null,
       "tags": [
-        "nemo",
-        "license:other",
+        "comfyui",
+        "license:mit",
         "region:us"
       ],
-      "createdAt": "2026-05-15T21:52:25.000Z",
-      "lastModified": "2026-05-16T05:35:07.000Z"
+      "createdAt": "2026-05-13T18:45:15.000Z",
+      "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 208,
-      "id": "FINAL-Bench/Darwin-28B-REASON",
-      "author": "FINAL-Bench",
-      "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
-      "downloads": 264,
-      "likes": 23,
+      "rank": 213,
+      "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
+      "downloads": 20652,
+      "likes": 20,
+      "trendingScore": 20,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:quantized:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T12:44:22.000Z",
+      "lastModified": "2026-05-16T12:38:58.000Z"
+    },
+    {
+      "rank": 214,
+      "id": "unsloth/LTX-2.3-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
+      "downloads": 286496,
+      "likes": 408,
+      "trendingScore": 20,
+      "pipelineTag": "image-to-video",
+      "libraryName": "ggml",
+      "tags": [
+        "ggml",
+        "gguf",
+        "image-to-video",
+        "unsloth",
+        "text-to-video",
+        "video-to-video",
+        "image-text-to-video",
+        "audio-to-video",
+        "text-to-audio",
+        "video-to-audio",
+        "audio-to-audio",
+        "text-to-audio-video",
+        "image-to-audio-video",
+        "image-text-to-audio-video",
+        "ltx-2",
+        "ltx-2-3",
+        "ltx-video",
+        "ltxv",
+        "lightricks",
+        "en",
+        "de",
+        "es",
+        "fr",
+        "ja",
+        "ko",
+        "zh",
+        "it",
+        "pt",
+        "arxiv:2601.03233",
+        "base_model:Lightricks/LTX-2.3"
+      ],
+      "createdAt": "2026-03-05T17:47:55.000Z",
+      "lastModified": "2026-04-20T01:59:13.000Z"
+    },
+    {
+      "rank": 215,
+      "id": "HuggingFaceBio/Carbon-8B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
+      "downloads": 1107,
+      "likes": 20,
       "trendingScore": 20,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "darwin",
-        "darwin-reason",
-        "reasoning",
-        "advanced-reasoning",
-        "chain-of-thought",
-        "thinking",
-        "reasoning-trace-distillation",
-        "rtd",
-        "darwin-delphi",
-        "test-time-compute",
-        "qwen3.6",
-        "qwen",
-        "gpqa",
-        "benchmark",
-        "open-source",
-        "apache-2.0",
-        "proto-agi",
-        "vidraft",
-        "eval-results",
+        "llama",
         "text-generation",
-        "conversational",
-        "en",
-        "zh",
-        "ko",
-        "ja",
-        "multilingual"
+        "dna",
+        "genomic",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
       ],
-      "createdAt": "2026-05-17T08:52:00.000Z",
-      "lastModified": "2026-05-17T09:32:18.000Z"
+      "createdAt": "2026-05-17T23:30:49.000Z",
+      "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 209,
+      "rank": 216,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -6142,7 +6351,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 210,
+      "rank": 217,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -6175,7 +6384,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 211,
+      "rank": 218,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -6197,7 +6406,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 212,
+      "rank": 219,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -6224,7 +6433,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 213,
+      "rank": 220,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -6240,7 +6449,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 214,
+      "rank": 221,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -6257,7 +6466,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 215,
+      "rank": 222,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -6280,7 +6489,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 216,
+      "rank": 223,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -6305,7 +6514,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 217,
+      "rank": 224,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -6341,7 +6550,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 218,
+      "rank": 225,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -6370,7 +6579,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 219,
+      "rank": 226,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -6400,25 +6609,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 220,
-      "id": "Comfy-Org/MoGe",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/MoGe",
-      "downloads": 0,
-      "likes": 19,
-      "trendingScore": 19,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T18:45:15.000Z",
-      "lastModified": "2026-05-19T23:25:01.000Z"
-    },
-    {
-      "rank": 221,
+      "rank": 227,
       "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
       "author": "fal",
       "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
@@ -6450,7 +6641,7 @@
       "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
-      "rank": 222,
+      "rank": 228,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -6495,7 +6686,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 223,
+      "rank": 229,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -6522,146 +6713,64 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 224,
-      "id": "fastino/gliner2-privacy-filter-PII-multi",
-      "author": "fastino",
-      "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
-      "downloads": 3345,
+      "rank": 230,
+      "id": "Simplified-Reasoning/SU-01",
+      "author": "Simplified-Reasoning",
+      "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
+      "downloads": 712,
       "likes": 19,
       "trendingScore": 19,
-      "pipelineTag": "token-classification",
-      "libraryName": "gliner2",
-      "tags": [
-        "gliner2",
-        "safetensors",
-        "extractor",
-        "pii",
-        "ner",
-        "privacy",
-        "redaction",
-        "gliner",
-        "information-extraction",
-        "span-extraction",
-        "token-classification",
-        "en",
-        "fr",
-        "es",
-        "de",
-        "it",
-        "pt",
-        "nl",
-        "dataset:synthetic",
-        "arxiv:2605.09973",
-        "arxiv:2604.09791",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-10T23:59:32.000Z",
-      "lastModified": "2026-05-14T18:18:54.000Z"
-    },
-    {
-      "rank": 225,
-      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "author": "sensenova",
-      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "downloads": 421,
-      "likes": 26,
-      "trendingScore": 19,
-      "pipelineTag": "any-to-any",
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "neo_chat",
-        "feature-extraction",
-        "multimodal",
-        "text-to-image",
-        "image-to-text",
-        "image-editing",
-        "interleaved-generation",
-        "custom_code",
-        "any-to-any",
-        "arxiv:2502.01522",
+        "qwen3_moe",
+        "text-generation",
+        "reasoning",
+        "olympiad",
+        "mathematics",
+        "science",
+        "reinforcement-learning",
+        "test-time-scaling",
+        "long-context",
+        "conversational",
+        "arxiv:2605.13301",
         "license:apache-2.0",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-14T09:54:29.000Z",
-      "lastModified": "2026-05-16T06:48:11.000Z"
+      "createdAt": "2026-05-12T22:20:39.000Z",
+      "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 226,
-      "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
-      "downloads": 20652,
+      "rank": 231,
+      "id": "internlm/Intern-S2-Preview-FP8",
+      "author": "internlm",
+      "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
+      "downloads": 1367,
       "likes": 19,
       "trendingScore": 19,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
+        "safetensors",
+        "intern_s2_preview",
         "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:quantized:Qwen/Qwen3.5-4B",
+        "conversational",
+        "custom_code",
+        "base_model:internlm/Intern-S2-Preview",
+        "base_model:quantized:internlm/Intern-S2-Preview",
         "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "fp8",
+        "region:us"
       ],
-      "createdAt": "2026-05-13T12:44:22.000Z",
-      "lastModified": "2026-05-16T12:38:58.000Z"
+      "createdAt": "2026-05-15T03:51:55.000Z",
+      "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 227,
-      "id": "unsloth/LTX-2.3-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
-      "downloads": 286496,
-      "likes": 406,
-      "trendingScore": 19,
-      "pipelineTag": "image-to-video",
-      "libraryName": "ggml",
-      "tags": [
-        "ggml",
-        "gguf",
-        "image-to-video",
-        "unsloth",
-        "text-to-video",
-        "video-to-video",
-        "image-text-to-video",
-        "audio-to-video",
-        "text-to-audio",
-        "video-to-audio",
-        "audio-to-audio",
-        "text-to-audio-video",
-        "image-to-audio-video",
-        "image-text-to-audio-video",
-        "ltx-2",
-        "ltx-2-3",
-        "ltx-video",
-        "ltxv",
-        "lightricks",
-        "en",
-        "de",
-        "es",
-        "fr",
-        "ja",
-        "ko",
-        "zh",
-        "it",
-        "pt",
-        "arxiv:2601.03233",
-        "base_model:Lightricks/LTX-2.3"
-      ],
-      "createdAt": "2026-03-05T17:47:55.000Z",
-      "lastModified": "2026-04-20T01:59:13.000Z"
-    },
-    {
-      "rank": 228,
+      "rank": 232,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -6683,7 +6792,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 229,
+      "rank": 233,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -6717,7 +6826,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 230,
+      "rank": 234,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -6741,7 +6850,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 231,
+      "rank": 235,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -6767,7 +6876,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 232,
+      "rank": 236,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -6789,7 +6898,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 233,
+      "rank": 237,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -6818,7 +6927,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 234,
+      "rank": 238,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -6850,7 +6959,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 235,
+      "rank": 239,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -6879,7 +6988,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 236,
+      "rank": 240,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -6901,7 +7010,7 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 237,
+      "rank": 241,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -6919,7 +7028,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 238,
+      "rank": 242,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -6947,7 +7056,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 239,
+      "rank": 243,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -6976,7 +7085,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 240,
+      "rank": 244,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7003,11 +7112,57 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 241,
-      "id": "Simplified-Reasoning/SU-01",
-      "author": "Simplified-Reasoning",
-      "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
-      "downloads": 712,
+      "rank": 245,
+      "id": "Comfy-Org/TRELLIS.2",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
+      "downloads": 0,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T00:59:09.000Z",
+      "lastModified": "2026-05-19T23:22:30.000Z"
+    },
+    {
+      "rank": 246,
+      "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
+      "author": "perplexity-ai",
+      "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
+      "downloads": 4865,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "kernels",
+      "tags": [
+        "kernels",
+        "safetensors",
+        "bidirectional_pplx_qwen3",
+        "feature-extraction",
+        "custom_code",
+        "late-interaction",
+        "maxsim",
+        "pylate",
+        "base_model:perplexity-ai/pplx-embed-v1-0.6b",
+        "arxiv:2602.11151",
+        "base_model:finetune:perplexity-ai/pplx-embed-v1-0.6b",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-03-13T15:07:30.000Z",
+      "lastModified": "2026-05-19T15:05:48.000Z"
+    },
+    {
+      "rank": 247,
+      "id": "HuggingFaceBio/Carbon-500M",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
+      "downloads": 706,
       "likes": 18,
       "trendingScore": 18,
       "pipelineTag": "text-generation",
@@ -7015,52 +7170,21 @@
       "tags": [
         "transformers",
         "safetensors",
-        "qwen3_moe",
+        "llama",
         "text-generation",
-        "reasoning",
-        "olympiad",
-        "mathematics",
-        "science",
-        "reinforcement-learning",
-        "test-time-scaling",
-        "long-context",
-        "conversational",
-        "arxiv:2605.13301",
+        "dna",
+        "genomic",
+        "speculative-decoding",
         "license:apache-2.0",
+        "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-12T22:20:39.000Z",
-      "lastModified": "2026-05-20T09:44:56.000Z"
+      "createdAt": "2026-05-12T16:09:33.000Z",
+      "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 242,
-      "id": "internlm/Intern-S2-Preview-FP8",
-      "author": "internlm",
-      "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
-      "downloads": 1367,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "intern_s2_preview",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "base_model:internlm/Intern-S2-Preview",
-        "base_model:quantized:internlm/Intern-S2-Preview",
-        "license:apache-2.0",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T03:51:55.000Z",
-      "lastModified": "2026-05-19T08:07:06.000Z"
-    },
-    {
-      "rank": 243,
+      "rank": 248,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -7105,7 +7229,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 244,
+      "rank": 249,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -7134,7 +7258,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 245,
+      "rank": 250,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -7163,7 +7287,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 246,
+      "rank": 251,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -7195,7 +7319,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 247,
+      "rank": 252,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -7225,7 +7349,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 248,
+      "rank": 253,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -7246,7 +7370,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 249,
+      "rank": 254,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -7291,7 +7415,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 250,
+      "rank": 255,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -7320,7 +7444,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 251,
+      "rank": 256,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -7348,7 +7472,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 252,
+      "rank": 257,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -7373,7 +7497,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 253,
+      "rank": 258,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -7396,7 +7520,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 254,
+      "rank": 259,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -7423,7 +7547,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 255,
+      "rank": 260,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -7449,25 +7573,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 256,
-      "id": "Comfy-Org/TRELLIS.2",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
-      "downloads": 0,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T00:59:09.000Z",
-      "lastModified": "2026-05-19T23:22:30.000Z"
-    },
-    {
-      "rank": 257,
+      "rank": 261,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -7487,15 +7593,16 @@
         "observability",
         "pytorch_model_hub_mixin",
         "arxiv:2602.12147",
+        "arxiv:2605.20119",
         "license:apache-2.0",
         "model-index",
         "region:us"
       ],
       "createdAt": "2026-04-14T20:39:39.000Z",
-      "lastModified": "2026-05-14T14:23:31.000Z"
+      "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 258,
+      "rank": 262,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -7524,35 +7631,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 259,
-      "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
-      "author": "perplexity-ai",
-      "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
-      "downloads": 4865,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "kernels",
-      "tags": [
-        "kernels",
-        "safetensors",
-        "bidirectional_pplx_qwen3",
-        "feature-extraction",
-        "custom_code",
-        "late-interaction",
-        "maxsim",
-        "pylate",
-        "base_model:perplexity-ai/pplx-embed-v1-0.6b",
-        "arxiv:2602.11151",
-        "base_model:finetune:perplexity-ai/pplx-embed-v1-0.6b",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-03-13T15:07:30.000Z",
-      "lastModified": "2026-05-19T15:05:48.000Z"
-    },
-    {
-      "rank": 260,
+      "rank": 263,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7581,7 +7660,75 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 261,
+      "rank": 264,
+      "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+      "author": "DavidAU",
+      "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+      "downloads": 101,
+      "likes": 18,
+      "trendingScore": 17,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "unsloth",
+        "heretic",
+        "uncensored",
+        "abliterated",
+        "fine tune",
+        "creative",
+        "creative writing",
+        "fiction writing",
+        "plot generation",
+        "sub-plot generation",
+        "story generation",
+        "scene continue",
+        "storytelling",
+        "fiction story",
+        "science fiction",
+        "romance",
+        "all genres",
+        "story",
+        "writing",
+        "vivid prosing",
+        "vivid writing",
+        "fiction",
+        "roleplaying",
+        "bfloat16",
+        "all use cases",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T08:53:53.000Z",
+      "lastModified": "2026-05-18T07:56:29.000Z"
+    },
+    {
+      "rank": 265,
+      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "author": "vrgamedevgirl84",
+      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "downloads": 2029,
+      "likes": 20,
+      "trendingScore": 17,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ltx-video",
+        "text-to-video",
+        "safetensors",
+        "base_model:Lightricks/LTX-Video",
+        "base_model:adapter:Lightricks/LTX-Video",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T00:29:34.000Z",
+      "lastModified": "2026-04-24T02:26:47.000Z"
+    },
+    {
+      "rank": 266,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -7606,7 +7753,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 262,
+      "rank": 267,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -7641,7 +7788,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 263,
+      "rank": 268,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -7686,7 +7833,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 264,
+      "rank": 269,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -7713,7 +7860,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 265,
+      "rank": 270,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -7742,7 +7889,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 266,
+      "rank": 271,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -7765,7 +7912,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 267,
+      "rank": 272,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -7809,7 +7956,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 268,
+      "rank": 273,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -7854,7 +8001,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 269,
+      "rank": 274,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -7872,7 +8019,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 270,
+      "rank": 275,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -7917,52 +8064,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 271,
-      "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-      "author": "DavidAU",
-      "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-      "downloads": 101,
-      "likes": 17,
-      "trendingScore": 16,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "unsloth",
-        "heretic",
-        "uncensored",
-        "abliterated",
-        "fine tune",
-        "creative",
-        "creative writing",
-        "fiction writing",
-        "plot generation",
-        "sub-plot generation",
-        "story generation",
-        "scene continue",
-        "storytelling",
-        "fiction story",
-        "science fiction",
-        "romance",
-        "all genres",
-        "story",
-        "writing",
-        "vivid prosing",
-        "vivid writing",
-        "fiction",
-        "roleplaying",
-        "bfloat16",
-        "all use cases",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T08:53:53.000Z",
-      "lastModified": "2026-05-18T07:56:29.000Z"
-    },
-    {
-      "rank": 272,
+      "rank": 276,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -8000,30 +8102,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 273,
-      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "author": "vrgamedevgirl84",
-      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "downloads": 2029,
-      "likes": 19,
-      "trendingScore": 16,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ltx-video",
-        "text-to-video",
-        "safetensors",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T00:29:34.000Z",
-      "lastModified": "2026-04-24T02:26:47.000Z"
-    },
-    {
-      "rank": 274,
+      "rank": 277,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -8043,7 +8122,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 275,
+      "rank": 278,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -8076,7 +8155,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 276,
+      "rank": 279,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -8106,7 +8185,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 277,
+      "rank": 280,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -8138,34 +8217,60 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 278,
-      "id": "HuggingFaceBio/Carbon-3B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 2184,
+      "rank": 281,
+      "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
+      "author": "OmerHagage",
+      "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
+      "downloads": 114,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "video-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "ltx-video",
+        "text-to-video",
+        "ltx-2.3",
+        "video-to-video",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:finetune:Lightricks/LTX-2.3",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T20:51:17.000Z",
+      "lastModified": "2026-05-19T17:13:23.000Z"
+    },
+    {
+      "rank": 282,
+      "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
+      "author": "Ex0bit",
+      "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
+      "downloads": 243,
       "likes": 16,
       "trendingScore": 16,
       "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "libraryName": "gguf",
       "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
+        "gguf",
+        "quantized",
+        "dynamic-quant",
+        "qwen3",
+        "llama.cpp",
+        "speculative-decoding",
         "text-generation",
-        "dna",
-        "genomic",
-        "conversational",
-        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
         "license:apache-2.0",
-        "text-generation-inference",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-05-12T11:05:49.000Z",
-      "lastModified": "2026-05-19T15:48:27.000Z"
+      "createdAt": "2026-05-19T21:19:08.000Z",
+      "lastModified": "2026-05-19T21:32:32.000Z"
     },
     {
-      "rank": 279,
+      "rank": 283,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -8192,7 +8297,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 280,
+      "rank": 284,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -8237,7 +8342,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 281,
+      "rank": 285,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -8267,7 +8372,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 282,
+      "rank": 286,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -8297,7 +8402,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 283,
+      "rank": 287,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -8342,7 +8447,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 284,
+      "rank": 288,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -8377,7 +8482,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 285,
+      "rank": 289,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -8405,7 +8510,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 286,
+      "rank": 290,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -8434,7 +8539,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 287,
+      "rank": 291,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -8459,7 +8564,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 288,
+      "rank": 292,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -8487,7 +8592,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 289,
+      "rank": 293,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -8515,7 +8620,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 290,
+      "rank": 294,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -8546,7 +8651,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 291,
+      "rank": 295,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -8591,7 +8696,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 292,
+      "rank": 296,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -8623,7 +8728,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 293,
+      "rank": 297,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -8650,7 +8755,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 294,
+      "rank": 298,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -8673,7 +8778,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 295,
+      "rank": 299,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -8706,7 +8811,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 296,
+      "rank": 300,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -8733,7 +8838,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 297,
+      "rank": 301,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -8752,7 +8857,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 298,
+      "rank": 302,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -8775,7 +8880,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 299,
+      "rank": 303,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -8801,7 +8906,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 300,
+      "rank": 304,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -8831,32 +8936,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 301,
-      "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
-      "author": "OmerHagage",
-      "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
-      "downloads": 114,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "video-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "ltx-video",
-        "text-to-video",
-        "ltx-2.3",
-        "video-to-video",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:finetune:Lightricks/LTX-2.3",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T20:51:17.000Z",
-      "lastModified": "2026-05-19T17:13:23.000Z"
-    },
-    {
-      "rank": 302,
+      "rank": 305,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -8883,7 +8963,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 303,
+      "rank": 306,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -8913,7 +8993,38 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 304,
+      "rank": 307,
+      "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
+      "downloads": 107432,
+      "likes": 75,
+      "trendingScore": 15,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "gemma4",
+        "image-text-to-text",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "any-to-any",
+        "base_model:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-05T15:49:10.000Z",
+      "lastModified": "2026-04-10T23:39:26.000Z"
+    },
+    {
+      "rank": 308,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -8937,7 +9048,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 305,
+      "rank": 309,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -8964,7 +9075,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 306,
+      "rank": 310,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -8992,7 +9103,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 307,
+      "rank": 311,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -9020,7 +9131,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 308,
+      "rank": 312,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -9039,7 +9150,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 309,
+      "rank": 313,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -9071,7 +9182,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 310,
+      "rank": 314,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -9100,7 +9211,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 311,
+      "rank": 315,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -9127,7 +9238,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 312,
+      "rank": 316,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -9151,7 +9262,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 313,
+      "rank": 317,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -9177,7 +9288,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 314,
+      "rank": 318,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -9208,7 +9319,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 315,
+      "rank": 319,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -9236,7 +9347,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 316,
+      "rank": 320,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -9259,7 +9370,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 317,
+      "rank": 321,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -9293,7 +9404,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 318,
+      "rank": 322,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -9319,7 +9430,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 319,
+      "rank": 323,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -9361,7 +9472,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 320,
+      "rank": 324,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -9399,7 +9510,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 321,
+      "rank": 325,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -9418,7 +9529,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 322,
+      "rank": 326,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -9438,7 +9549,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 323,
+      "rank": 327,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -9465,7 +9576,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 324,
+      "rank": 328,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -9491,7 +9602,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 325,
+      "rank": 329,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -9516,7 +9627,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 326,
+      "rank": 330,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -9536,15 +9647,16 @@
         "observability",
         "pytorch_model_hub_mixin",
         "arxiv:2602.12147",
+        "arxiv:2605.20119",
         "license:apache-2.0",
         "model-index",
         "region:us"
       ],
       "createdAt": "2026-04-14T20:21:36.000Z",
-      "lastModified": "2026-05-14T14:23:12.000Z"
+      "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 327,
+      "rank": 331,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -9589,7 +9701,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 328,
+      "rank": 332,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -9613,64 +9725,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 329,
-      "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
-      "downloads": 107432,
-      "likes": 73,
-      "trendingScore": 14,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "gemma4",
-        "image-text-to-text",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "any-to-any",
-        "base_model:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
-        "base_model:quantized:llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-05T15:49:10.000Z",
-      "lastModified": "2026-04-10T23:39:26.000Z"
-    },
-    {
-      "rank": 330,
-      "id": "HuggingFaceBio/Carbon-8B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
-      "downloads": 1107,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "conversational",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:30:49.000Z",
-      "lastModified": "2026-05-19T15:48:44.000Z"
-    },
-    {
-      "rank": 331,
+      "rank": 333,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -9699,7 +9754,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 332,
+      "rank": 334,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -9744,7 +9799,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 333,
+      "rank": 335,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -9773,7 +9828,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 334,
+      "rank": 336,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -9800,7 +9855,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 335,
+      "rank": 337,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -9845,7 +9900,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 336,
+      "rank": 338,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -9872,7 +9927,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 337,
+      "rank": 339,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -9903,7 +9958,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 338,
+      "rank": 340,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9927,7 +9982,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 339,
+      "rank": 341,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -9951,7 +10006,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 340,
+      "rank": 342,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -9996,7 +10051,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 341,
+      "rank": 343,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -10023,7 +10078,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 342,
+      "rank": 344,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -10059,7 +10114,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 343,
+      "rank": 345,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -10090,7 +10145,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 344,
+      "rank": 346,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -10121,7 +10176,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 345,
+      "rank": 347,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -10154,7 +10209,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 346,
+      "rank": 348,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -10183,7 +10238,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 347,
+      "rank": 349,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -10207,7 +10262,7 @@
       "lastModified": "2026-04-16T18:11:27.000Z"
     },
     {
-      "rank": 348,
+      "rank": 350,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -10233,7 +10288,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 349,
+      "rank": 351,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -10263,7 +10318,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 350,
+      "rank": 352,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -10281,7 +10336,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 351,
+      "rank": 353,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -10312,7 +10367,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 352,
+      "rank": 354,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -10333,7 +10388,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 353,
+      "rank": 355,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -10353,7 +10408,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 354,
+      "rank": 356,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -10381,7 +10436,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 355,
+      "rank": 357,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -10408,7 +10463,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 356,
+      "rank": 358,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -10438,7 +10493,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 357,
+      "rank": 359,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -10455,7 +10510,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 358,
+      "rank": 360,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -10482,7 +10537,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 359,
+      "rank": 361,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -10513,7 +10568,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 360,
+      "rank": 362,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -10545,34 +10600,84 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 361,
-      "id": "HuggingFaceBio/Carbon-500M",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
-      "downloads": 706,
-      "likes": 13,
+      "rank": 363,
+      "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
+      "author": "ibm-research",
+      "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
+      "downloads": 2010,
+      "likes": 42,
       "trendingScore": 13,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "pipelineTag": null,
+      "libraryName": "biomed-multi-alignment",
       "tags": [
-        "transformers",
+        "biomed-multi-alignment",
         "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "speculative-decoding",
-        "conversational",
+        "biology",
+        "small-molecules",
+        "single-cell-genes",
+        "drug-discovery",
+        "ibm",
+        "mammal",
+        "pytorch",
+        "arxiv:2410.22367",
         "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-12T16:09:33.000Z",
-      "lastModified": "2026-05-19T14:45:14.000Z"
+      "createdAt": "2024-10-08T12:22:46.000Z",
+      "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 362,
+      "rank": 364,
+      "id": "Efficient-Large-Model/LongLive-2.0-5B",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
+      "downloads": 0,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "text-to-video",
+        "multi-shot",
+        "video-generation",
+        "diffusion",
+        "long-video",
+        "longlive2",
+        "arxiv:2605.18739",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:10:14.000Z",
+      "lastModified": "2026-05-19T02:54:48.000Z"
+    },
+    {
+      "rank": 365,
+      "id": "kjanh/KhanhTTS-OmniVoice",
+      "author": "kjanh",
+      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
+      "downloads": 3154,
+      "likes": 14,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "omnivoice",
+        "text-to-speech",
+        "vi",
+        "en",
+        "arxiv:2604.00688",
+        "base_model:k2-fsa/OmniVoice",
+        "base_model:finetune:k2-fsa/OmniVoice",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T02:00:22.000Z",
+      "lastModified": "2026-05-16T04:32:12.000Z"
+    },
+    {
+      "rank": 366,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10617,7 +10722,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 363,
+      "rank": 367,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -10644,7 +10749,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 364,
+      "rank": 368,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -10672,7 +10777,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 365,
+      "rank": 369,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -10705,7 +10810,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 366,
+      "rank": 370,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -10721,7 +10826,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 367,
+      "rank": 371,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -10744,7 +10849,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 368,
+      "rank": 372,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -10778,7 +10883,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 369,
+      "rank": 373,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -10798,7 +10903,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 370,
+      "rank": 374,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -10833,7 +10938,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 371,
+      "rank": 375,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -10863,7 +10968,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 372,
+      "rank": 376,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -10884,7 +10989,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 373,
+      "rank": 377,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -10913,7 +11018,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 374,
+      "rank": 378,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -10943,7 +11048,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 375,
+      "rank": 379,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -10971,7 +11076,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 376,
+      "rank": 380,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -11000,7 +11105,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 377,
+      "rank": 381,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -11032,7 +11137,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 378,
+      "rank": 382,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -11061,7 +11166,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 379,
+      "rank": 383,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -11096,7 +11201,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 380,
+      "rank": 384,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -11118,7 +11223,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 381,
+      "rank": 385,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -11156,7 +11261,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 382,
+      "rank": 386,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -11195,7 +11300,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 383,
+      "rank": 387,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -11232,7 +11337,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 384,
+      "rank": 388,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -11256,34 +11361,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 385,
-      "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
-      "author": "ibm-research",
-      "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
-      "downloads": 2010,
-      "likes": 41,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": "biomed-multi-alignment",
-      "tags": [
-        "biomed-multi-alignment",
-        "safetensors",
-        "biology",
-        "small-molecules",
-        "single-cell-genes",
-        "drug-discovery",
-        "ibm",
-        "mammal",
-        "pytorch",
-        "arxiv:2410.22367",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2024-10-08T12:22:46.000Z",
-      "lastModified": "2024-12-19T17:04:32.000Z"
-    },
-    {
-      "rank": 386,
+      "rank": 389,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -11301,7 +11379,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 387,
+      "rank": 390,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -11320,7 +11398,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 388,
+      "rank": 391,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -11348,7 +11426,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 389,
+      "rank": 392,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -11389,7 +11467,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 390,
+      "rank": 393,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -11411,7 +11489,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 391,
+      "rank": 394,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -11448,7 +11526,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 392,
+      "rank": 395,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -11478,7 +11556,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 393,
+      "rank": 396,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -11498,15 +11576,16 @@
         "observability",
         "pytorch_model_hub_mixin",
         "arxiv:2602.12147",
+        "arxiv:2605.20119",
         "license:apache-2.0",
         "model-index",
         "region:us"
       ],
       "createdAt": "2026-04-14T20:41:57.000Z",
-      "lastModified": "2026-05-14T14:23:39.000Z"
+      "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 394,
+      "rank": 397,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -11534,7 +11613,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 395,
+      "rank": 398,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -11574,23 +11653,23 @@
       "lastModified": "2026-05-18T20:11:08.000Z"
     },
     {
-      "rank": 396,
-      "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "author": "Ex0bit",
-      "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "downloads": 243,
+      "rank": 399,
+      "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
+      "downloads": 1978,
       "likes": 12,
       "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "gguf",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
+        "transformers",
         "gguf",
-        "quantized",
-        "dynamic-quant",
-        "qwen3",
-        "llama.cpp",
-        "speculative-decoding",
-        "text-generation",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
+        "image-text-to-text",
         "base_model:Qwen/Qwen3.6-27B",
         "base_model:quantized:Qwen/Qwen3.6-27B",
         "license:apache-2.0",
@@ -11598,11 +11677,11 @@
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-19T21:19:08.000Z",
-      "lastModified": "2026-05-19T21:32:32.000Z"
+      "createdAt": "2026-05-19T05:52:43.000Z",
+      "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 397,
+      "rank": 400,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -11647,7 +11726,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 398,
+      "rank": 401,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -11689,7 +11768,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 399,
+      "rank": 402,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -11715,7 +11794,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 400,
+      "rank": 403,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -11740,7 +11819,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 401,
+      "rank": 404,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -11757,7 +11836,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 402,
+      "rank": 405,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -11785,7 +11864,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 403,
+      "rank": 406,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -11811,7 +11890,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 404,
+      "rank": 407,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -11838,7 +11917,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 405,
+      "rank": 408,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -11866,7 +11945,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 406,
+      "rank": 409,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -11899,7 +11978,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 407,
+      "rank": 410,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -11933,7 +12012,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 408,
+      "rank": 411,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -11962,7 +12041,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 409,
+      "rank": 412,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -11991,7 +12070,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 410,
+      "rank": 413,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -12024,7 +12103,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 411,
+      "rank": 414,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -12051,7 +12130,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 412,
+      "rank": 415,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -12081,7 +12160,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 413,
+      "rank": 416,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -12104,7 +12183,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 414,
+      "rank": 417,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -12130,7 +12209,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 415,
+      "rank": 418,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -12154,7 +12233,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 416,
+      "rank": 419,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -12181,7 +12260,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 417,
+      "rank": 420,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -12211,7 +12290,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 418,
+      "rank": 421,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -12245,7 +12324,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 419,
+      "rank": 422,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -12261,7 +12340,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 420,
+      "rank": 423,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -12292,7 +12371,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 421,
+      "rank": 424,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -12314,7 +12393,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 422,
+      "rank": 425,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -12334,7 +12413,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 423,
+      "rank": 426,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -12356,7 +12435,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 424,
+      "rank": 427,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -12385,12 +12464,12 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 425,
+      "rank": 428,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
       "downloads": 0,
-      "likes": 924,
+      "likes": 930,
       "trendingScore": 11,
       "pipelineTag": "video-to-video",
       "libraryName": null,
@@ -12410,7 +12489,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -12435,7 +12514,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -12470,7 +12549,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -12494,7 +12573,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -12525,7 +12604,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -12552,7 +12631,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 431,
+      "rank": 434,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -12578,7 +12657,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 432,
+      "rank": 435,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -12608,7 +12687,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 433,
+      "rank": 436,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -12634,7 +12713,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 434,
+      "rank": 437,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -12659,32 +12738,33 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 435,
-      "id": "Efficient-Large-Model/LongLive-2.0-5B",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
-      "downloads": 0,
+      "rank": 438,
+      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
+      "downloads": 11093,
       "likes": 11,
       "trendingScore": 11,
-      "pipelineTag": "text-to-video",
-      "libraryName": "wan2.2",
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "wan2.2",
-        "text-to-video",
-        "multi-shot",
-        "video-generation",
-        "diffusion",
-        "long-video",
-        "longlive2",
-        "arxiv:2605.18739",
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
         "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-17T23:10:14.000Z",
-      "lastModified": "2026-05-19T02:54:48.000Z"
+      "createdAt": "2026-03-02T17:12:28.000Z",
+      "lastModified": "2026-05-19T18:52:44.000Z"
     },
     {
-      "rank": 436,
+      "rank": 439,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -12713,7 +12793,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 437,
+      "rank": 440,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -12747,7 +12827,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 438,
+      "rank": 441,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -12792,7 +12872,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 439,
+      "rank": 442,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -12821,7 +12901,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 440,
+      "rank": 443,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -12846,7 +12926,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 441,
+      "rank": 444,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -12881,7 +12961,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 442,
+      "rank": 445,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -12908,7 +12988,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 443,
+      "rank": 446,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -12953,7 +13033,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 444,
+      "rank": 447,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -12975,7 +13055,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 445,
+      "rank": 448,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -13007,7 +13087,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 446,
+      "rank": 449,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -13032,7 +13112,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 447,
+      "rank": 450,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -13056,7 +13136,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 448,
+      "rank": 451,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -13084,7 +13164,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 449,
+      "rank": 452,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -13127,7 +13207,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 450,
+      "rank": 453,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -13151,7 +13231,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 451,
+      "rank": 454,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -13196,12 +13276,12 @@
       "lastModified": "2026-04-07T16:23:12.000Z"
     },
     {
-      "rank": 452,
+      "rank": 455,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
-      "downloads": 2261962,
-      "likes": 1578,
+      "downloads": 2147867,
+      "likes": 1591,
       "trendingScore": 10,
       "pipelineTag": "text-to-speech",
       "libraryName": "chatterbox",
@@ -13241,7 +13321,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 453,
+      "rank": 456,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -13270,7 +13350,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 454,
+      "rank": 457,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -13302,7 +13382,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 455,
+      "rank": 458,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -13326,7 +13406,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 456,
+      "rank": 459,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -13348,7 +13428,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 457,
+      "rank": 460,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -13373,7 +13453,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 458,
+      "rank": 461,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -13401,7 +13481,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 459,
+      "rank": 462,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -13425,7 +13505,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 460,
+      "rank": 463,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -13452,7 +13532,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 461,
+      "rank": 464,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -13477,7 +13557,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 462,
+      "rank": 465,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -13494,7 +13574,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 463,
+      "rank": 466,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -13518,7 +13598,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 464,
+      "rank": 467,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -13542,7 +13622,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 465,
+      "rank": 468,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -13575,7 +13655,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 466,
+      "rank": 469,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -13609,7 +13689,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 467,
+      "rank": 470,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -13631,7 +13711,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 468,
+      "rank": 471,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -13654,7 +13734,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 469,
+      "rank": 472,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -13674,7 +13754,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 470,
+      "rank": 473,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -13706,7 +13786,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 471,
+      "rank": 474,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -13745,7 +13825,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 472,
+      "rank": 475,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -13779,7 +13859,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 473,
+      "rank": 476,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -13803,7 +13883,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 474,
+      "rank": 477,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -13836,7 +13916,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 475,
+      "rank": 478,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -13856,7 +13936,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 476,
+      "rank": 479,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -13885,7 +13965,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 477,
+      "rank": 480,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -13907,7 +13987,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 478,
+      "rank": 481,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -13939,7 +14019,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 479,
+      "rank": 482,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -13966,7 +14046,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 480,
+      "rank": 483,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -14010,7 +14090,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 481,
+      "rank": 484,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -14028,7 +14108,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 482,
+      "rank": 485,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -14067,7 +14147,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 483,
+      "rank": 486,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -14106,7 +14186,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 484,
+      "rank": 487,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -14140,7 +14220,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 485,
+      "rank": 488,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -14168,7 +14248,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 486,
+      "rank": 489,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -14190,7 +14270,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 487,
+      "rank": 490,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -14218,7 +14298,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 488,
+      "rank": 491,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -14236,7 +14316,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 489,
+      "rank": 492,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -14264,7 +14344,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 490,
+      "rank": 493,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -14295,7 +14375,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 491,
+      "rank": 494,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -14311,7 +14391,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 492,
+      "rank": 495,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -14338,7 +14418,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 493,
+      "rank": 496,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -14358,15 +14438,16 @@
         "observability",
         "pytorch_model_hub_mixin",
         "arxiv:2602.12147",
+        "arxiv:2605.20119",
         "license:apache-2.0",
         "model-index",
         "region:us"
       ],
       "createdAt": "2026-04-14T20:38:58.000Z",
-      "lastModified": "2026-05-14T14:23:21.000Z"
+      "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 494,
+      "rank": 497,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -14394,7 +14475,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 495,
+      "rank": 498,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -14423,7 +14504,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 496,
+      "rank": 499,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -14449,7 +14530,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 497,
+      "rank": 500,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -14478,7 +14559,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 498,
+      "rank": 501,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -14507,7 +14588,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 499,
+      "rank": 502,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -14548,7 +14629,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 500,
+      "rank": 503,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -14591,35 +14672,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 501,
-      "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
-      "downloads": 1978,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T05:52:43.000Z",
-      "lastModified": "2026-05-19T08:16:03.000Z"
-    },
-    {
-      "rank": 502,
+      "rank": 504,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -14646,7 +14699,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 503,
+      "rank": 505,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -14678,7 +14731,120 @@
       "lastModified": "2026-05-17T06:57:22.000Z"
     },
     {
-      "rank": 504,
+      "rank": 506,
+      "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
+      "author": "ggml-org",
+      "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
+      "downloads": 3413,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T11:20:11.000Z",
+      "lastModified": "2026-05-19T09:05:17.000Z"
+    },
+    {
+      "rank": 507,
+      "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "ggml-org",
+      "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 3495,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T11:20:53.000Z",
+      "lastModified": "2026-05-19T09:20:22.000Z"
+    },
+    {
+      "rank": 508,
+      "id": "nicolas-dufour/miro",
+      "author": "nicolas-dufour",
+      "url": "https://huggingface.co/nicolas-dufour/miro",
+      "downloads": 126,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "text-to-image",
+      "libraryName": "miro-t2i",
+      "tags": [
+        "miro-t2i",
+        "safetensors",
+        "sdxl",
+        "text-to-image",
+        "diffusion",
+        "flow-matching",
+        "miro",
+        "reward-conditioning",
+        "arxiv:2510.25897",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T14:53:08.000Z",
+      "lastModified": "2026-05-19T23:10:01.000Z"
+    },
+    {
+      "rank": 509,
+      "id": "CohereLabs/command-a-plus-05-2026-bf16",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
+      "downloads": 0,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere2_vision",
+        "image-text-to-text",
+        "conversational",
+        "chat",
+        "en",
+        "ar",
+        "bg",
+        "bn",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fil",
+        "fr",
+        "ga",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "is",
+        "it",
+        "ja"
+      ],
+      "createdAt": "2026-05-11T12:31:04.000Z",
+      "lastModified": "2026-05-20T15:51:30.000Z"
+    },
+    {
+      "rank": 510,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -14705,7 +14871,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 505,
+      "rank": 511,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -14731,7 +14897,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 506,
+      "rank": 512,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -14759,7 +14925,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 507,
+      "rank": 513,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -14785,7 +14951,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 508,
+      "rank": 514,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -14829,7 +14995,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 509,
+      "rank": 515,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -14869,7 +15035,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 510,
+      "rank": 516,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -14905,7 +15071,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 511,
+      "rank": 517,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -14949,7 +15115,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 512,
+      "rank": 518,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -14974,7 +15140,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 513,
+      "rank": 519,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -15019,7 +15185,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 514,
+      "rank": 520,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -15038,7 +15204,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 515,
+      "rank": 521,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -15063,7 +15229,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 516,
+      "rank": 522,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -15102,7 +15268,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 517,
+      "rank": 523,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -15119,7 +15285,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 518,
+      "rank": 524,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -15147,7 +15313,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 519,
+      "rank": 525,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -15176,7 +15342,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 520,
+      "rank": 526,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -15201,7 +15367,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 521,
+      "rank": 527,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -15236,7 +15402,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 522,
+      "rank": 528,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -15266,7 +15432,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 523,
+      "rank": 529,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -15302,7 +15468,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 524,
+      "rank": 530,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -15325,7 +15491,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 525,
+      "rank": 531,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -15342,7 +15508,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 526,
+      "rank": 532,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -15362,7 +15528,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 527,
+      "rank": 533,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -15389,7 +15555,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 528,
+      "rank": 534,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -15413,7 +15579,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 529,
+      "rank": 535,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -15435,7 +15601,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 530,
+      "rank": 536,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -15467,7 +15633,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 531,
+      "rank": 537,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -15495,7 +15661,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 532,
+      "rank": 538,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -15513,7 +15679,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 533,
+      "rank": 539,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -15538,7 +15704,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 534,
+      "rank": 540,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -15561,7 +15727,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 535,
+      "rank": 541,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -15579,7 +15745,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 536,
+      "rank": 542,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -15614,7 +15780,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 537,
+      "rank": 543,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -15642,7 +15808,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 538,
+      "rank": 544,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -15664,7 +15830,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 539,
+      "rank": 545,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -15691,7 +15857,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 540,
+      "rank": 546,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -15716,7 +15882,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 541,
+      "rank": 547,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -15750,7 +15916,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 542,
+      "rank": 548,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -15777,7 +15943,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 543,
+      "rank": 549,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -15804,7 +15970,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 544,
+      "rank": 550,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -15845,7 +16011,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 545,
+      "rank": 551,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -15875,7 +16041,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 546,
+      "rank": 552,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -15912,7 +16078,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 547,
+      "rank": 553,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -15944,7 +16110,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 548,
+      "rank": 554,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -15986,7 +16152,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 549,
+      "rank": 555,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -16016,7 +16182,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 550,
+      "rank": 556,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -16061,7 +16227,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 551,
+      "rank": 557,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -16088,7 +16254,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 552,
+      "rank": 558,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -16120,7 +16286,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 553,
+      "rank": 559,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -16154,7 +16320,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 554,
+      "rank": 560,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -16184,7 +16350,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 555,
+      "rank": 561,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -16209,7 +16375,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 556,
+      "rank": 562,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -16236,7 +16402,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 557,
+      "rank": 563,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -16268,12 +16434,12 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 558,
+      "rank": 564,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
       "downloads": 3109,
-      "likes": 65,
+      "likes": 66,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -16313,7 +16479,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 559,
+      "rank": 565,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -16339,7 +16505,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 560,
+      "rank": 566,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -16384,7 +16550,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 561,
+      "rank": 567,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -16412,7 +16578,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 562,
+      "rank": 568,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -16437,28 +16603,169 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 563,
-      "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
-      "author": "ggml-org",
-      "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
-      "downloads": 3413,
+      "rank": 569,
+      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "downloads": 6602,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
         "gguf",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-15T11:20:11.000Z",
-      "lastModified": "2026-05-19T09:05:17.000Z"
+      "createdAt": "2026-05-17T13:16:15.000Z",
+      "lastModified": "2026-05-17T15:23:22.000Z"
     },
     {
-      "rank": 564,
+      "rank": 570,
+      "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "author": "mistralai",
+      "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "downloads": 1433784,
+      "likes": 855,
+      "trendingScore": 9,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "vllm",
+      "tags": [
+        "vllm",
+        "safetensors",
+        "voxtral_realtime",
+        "mistral-common",
+        "automatic-speech-recognition",
+        "en",
+        "fr",
+        "es",
+        "de",
+        "ru",
+        "zh",
+        "ja",
+        "it",
+        "pt",
+        "nl",
+        "ar",
+        "hi",
+        "ko",
+        "arxiv:2602.11298",
+        "base_model:mistralai/Ministral-3-3B-Base-2512",
+        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-01-21T17:22:02.000Z",
+      "lastModified": "2026-03-11T15:04:02.000Z"
+    },
+    {
+      "rank": 571,
+      "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
+      "author": "noctrex",
+      "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
+      "downloads": 2403,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen",
+        "qwen3_5_moe",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Jackrong/Qwopus3.6-27B-v1-preview",
+        "base_model:quantized:Jackrong/Qwopus3.6-27B-v1-preview",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T21:42:10.000Z",
+      "lastModified": "2026-05-17T16:25:53.000Z"
+    },
+    {
+      "rank": 572,
+      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "author": "alibaba-pai",
+      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "downloads": 8257,
+      "likes": 153,
+      "trendingScore": 9,
+      "pipelineTag": "text-to-image",
+      "libraryName": "videox_fun",
+      "tags": [
+        "videox_fun",
+        "lora",
+        "text-to-image",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-02-02T09:37:39.000Z",
+      "lastModified": "2026-03-02T11:46:41.000Z"
+    },
+    {
+      "rank": 573,
+      "id": "CohereLabs/command-a-plus-05-2026-w4a4",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
+      "downloads": 0,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere2_vision",
+        "image-text-to-text",
+        "conversational",
+        "chat",
+        "en",
+        "ar",
+        "bg",
+        "bn",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fil",
+        "fr",
+        "ga",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "is",
+        "it",
+        "ja"
+      ],
+      "createdAt": "2026-05-18T04:51:16.000Z",
+      "lastModified": "2026-05-20T15:51:04.000Z"
+    },
+    {
+      "rank": 574,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -16485,7 +16792,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 565,
+      "rank": 575,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -16509,7 +16816,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 566,
+      "rank": 576,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -16529,7 +16836,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 567,
+      "rank": 577,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -16556,7 +16863,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 568,
+      "rank": 578,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -16575,7 +16882,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 569,
+      "rank": 579,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -16609,7 +16916,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 570,
+      "rank": 580,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -16641,7 +16948,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 571,
+      "rank": 581,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -16663,7 +16970,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 572,
+      "rank": 582,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -16708,7 +17015,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 573,
+      "rank": 583,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -16727,7 +17034,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 574,
+      "rank": 584,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -16761,7 +17068,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 575,
+      "rank": 585,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -16789,7 +17096,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 576,
+      "rank": 586,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -16817,7 +17124,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 577,
+      "rank": 587,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -16840,7 +17147,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 578,
+      "rank": 588,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -16867,7 +17174,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 579,
+      "rank": 589,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -16912,7 +17219,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 580,
+      "rank": 590,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -16948,7 +17255,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 581,
+      "rank": 591,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -16988,7 +17295,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 582,
+      "rank": 592,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -17017,7 +17324,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 583,
+      "rank": 593,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -17045,7 +17352,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 584,
+      "rank": 594,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -17064,7 +17371,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 585,
+      "rank": 595,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -17083,7 +17390,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 586,
+      "rank": 596,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -17115,7 +17422,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 587,
+      "rank": 597,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -17142,7 +17449,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 588,
+      "rank": 598,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -17164,7 +17471,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 589,
+      "rank": 599,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -17182,7 +17489,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 590,
+      "rank": 600,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -17211,7 +17518,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 591,
+      "rank": 601,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -17232,7 +17539,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 592,
+      "rank": 602,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -17260,7 +17567,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 593,
+      "rank": 603,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -17281,7 +17588,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 594,
+      "rank": 604,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -17317,7 +17624,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 595,
+      "rank": 605,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -17362,7 +17669,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 596,
+      "rank": 606,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -17388,7 +17695,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 597,
+      "rank": 607,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -17411,7 +17718,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 598,
+      "rank": 608,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -17436,7 +17743,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 599,
+      "rank": 609,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -17471,7 +17778,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 600,
+      "rank": 610,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -17516,7 +17823,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 601,
+      "rank": 611,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -17543,7 +17850,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 602,
+      "rank": 612,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -17572,7 +17879,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 603,
+      "rank": 613,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -17591,7 +17898,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 604,
+      "rank": 614,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -17612,7 +17919,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 605,
+      "rank": 615,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -17638,7 +17945,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 606,
+      "rank": 616,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -17664,7 +17971,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 607,
+      "rank": 617,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -17701,7 +18008,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 608,
+      "rank": 618,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -17746,7 +18053,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 609,
+      "rank": 619,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -17771,7 +18078,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 610,
+      "rank": 620,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -17788,7 +18095,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 611,
+      "rank": 621,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -17815,7 +18122,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 612,
+      "rank": 622,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -17833,7 +18140,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 613,
+      "rank": 623,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -17858,7 +18165,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 614,
+      "rank": 624,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -17890,12 +18197,12 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 615,
+      "rank": 625,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
-      "downloads": 449554,
-      "likes": 644,
+      "downloads": 474603,
+      "likes": 645,
       "trendingScore": 8,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
@@ -17911,7 +18218,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 616,
+      "rank": 626,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -17930,7 +18237,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 617,
+      "rank": 627,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -17961,7 +18268,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 618,
+      "rank": 628,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -17984,7 +18291,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 619,
+      "rank": 629,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -18022,7 +18329,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 620,
+      "rank": 630,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -18039,7 +18346,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 621,
+      "rank": 631,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -18067,7 +18374,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 622,
+      "rank": 632,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -18084,7 +18391,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 623,
+      "rank": 633,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -18120,7 +18427,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 624,
+      "rank": 634,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -18150,7 +18457,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 625,
+      "rank": 635,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -18179,7 +18486,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 626,
+      "rank": 636,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -18217,12 +18524,12 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 627,
+      "rank": 637,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
-      "downloads": 1955539,
-      "likes": 279,
+      "downloads": 1932670,
+      "likes": 280,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -18244,7 +18551,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 628,
+      "rank": 638,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -18267,7 +18574,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 629,
+      "rank": 639,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -18300,33 +18607,12 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 630,
-      "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "ggml-org",
-      "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 3495,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T11:20:53.000Z",
-      "lastModified": "2026-05-19T09:20:22.000Z"
-    },
-    {
-      "rank": 631,
+      "rank": 640,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
-      "downloads": 1697458,
-      "likes": 408,
+      "downloads": 1631256,
+      "likes": 409,
       "trendingScore": 8,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -18351,32 +18637,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 632,
-      "id": "kjanh/KhanhTTS-OmniVoice",
-      "author": "kjanh",
-      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
-      "downloads": 3154,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "omnivoice",
-        "text-to-speech",
-        "vi",
-        "en",
-        "arxiv:2604.00688",
-        "base_model:k2-fsa/OmniVoice",
-        "base_model:finetune:k2-fsa/OmniVoice",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T02:00:22.000Z",
-      "lastModified": "2026-05-16T04:32:12.000Z"
-    },
-    {
-      "rank": 633,
+      "rank": 641,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -18407,7 +18668,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 634,
+      "rank": 642,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -18430,7 +18691,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 635,
+      "rank": 643,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -18463,7 +18724,7 @@
       "lastModified": "2026-05-19T08:00:47.000Z"
     },
     {
-      "rank": 636,
+      "rank": 644,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -18486,7 +18747,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 637,
+      "rank": 645,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -18516,7 +18777,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 638,
+      "rank": 646,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -18543,7 +18804,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 639,
+      "rank": 647,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -18572,7 +18833,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 640,
+      "rank": 648,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -18601,7 +18862,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 641,
+      "rank": 649,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -18636,7 +18897,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 642,
+      "rank": 650,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -18672,43 +18933,174 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 643,
-      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
-      "downloads": 6602,
-      "likes": 8,
+      "rank": 651,
+      "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
+      "author": "bartowski",
+      "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
+      "downloads": 125495,
+      "likes": 45,
       "trendingScore": 8,
-      "pipelineTag": null,
+      "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
         "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-17T13:16:15.000Z",
-      "lastModified": "2026-05-17T15:23:22.000Z"
+      "createdAt": "2026-04-22T14:24:37.000Z",
+      "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 644,
-      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
+      "rank": 652,
+      "id": "HiDream-ai/Prompt-Refine",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
+      "downloads": 166,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "conversational",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:finetune:google/gemma-4-31B-it",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T18:50:44.000Z",
+      "lastModified": "2026-05-14T07:24:09.000Z"
+    },
+    {
+      "rank": 653,
+      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "author": "dphn",
+      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "downloads": 13066,
+      "likes": 516,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "mistral3",
+        "image-text-to-text",
+        "text-generation",
+        "conversational",
+        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
+        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-06-12T05:29:16.000Z",
+      "lastModified": "2026-04-24T13:52:18.000Z"
+    },
+    {
+      "rank": 654,
+      "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
+      "author": "aifeifei798",
+      "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
+      "downloads": 616,
+      "likes": 30,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "roleplay",
+        "llama3",
+        "sillytavern",
+        "idol",
+        "en",
+        "arxiv:2403.19522",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-07-21T23:20:43.000Z",
+      "lastModified": "2024-07-23T10:35:13.000Z"
+    },
+    {
+      "rank": 655,
+      "id": "LiquidAI/LFM2.5-Audio-1.5B",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
+      "downloads": 974,
+      "likes": 404,
+      "trendingScore": 8,
+      "pipelineTag": "audio-to-audio",
+      "libraryName": "liquid-audio",
+      "tags": [
+        "liquid-audio",
+        "safetensors",
+        "liquid",
+        "lfm2",
+        "audio",
+        "lfm2-audio",
+        "speech-to-speech",
+        "audio-to-audio",
+        "en",
+        "arxiv:2511.23404",
+        "base_model:LiquidAI/LFM2-1.2B",
+        "base_model:finetune:LiquidAI/LFM2-1.2B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2025-12-18T10:21:11.000Z",
+      "lastModified": "2026-03-30T14:43:52.000Z"
+    },
+    {
+      "rank": 656,
+      "id": "Qwen/Qwen3-Embedding-8B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
+      "downloads": 1606070,
+      "likes": 685,
+      "trendingScore": 8,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "transformers",
+        "sentence-similarity",
+        "feature-extraction",
+        "text-embeddings-inference",
+        "arxiv:2506.05176",
+        "base_model:Qwen/Qwen3-8B-Base",
+        "base_model:finetune:Qwen/Qwen3-8B-Base",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-06-03T14:39:10.000Z",
+      "lastModified": "2025-07-07T09:02:21.000Z"
+    },
+    {
+      "rank": 657,
+      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
-      "downloads": 11093,
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
+      "downloads": 14543,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -18726,37 +19118,11 @@
         "license:other",
         "region:us"
       ],
-      "createdAt": "2026-03-02T17:12:28.000Z",
-      "lastModified": "2026-05-19T18:52:44.000Z"
+      "createdAt": "2026-03-18T17:45:13.000Z",
+      "lastModified": "2026-05-19T18:52:45.000Z"
     },
     {
-      "rank": 645,
-      "id": "nicolas-dufour/miro",
-      "author": "nicolas-dufour",
-      "url": "https://huggingface.co/nicolas-dufour/miro",
-      "downloads": 126,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": "text-to-image",
-      "libraryName": "miro-t2i",
-      "tags": [
-        "miro-t2i",
-        "safetensors",
-        "sdxl",
-        "text-to-image",
-        "diffusion",
-        "flow-matching",
-        "miro",
-        "reward-conditioning",
-        "arxiv:2510.25897",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T14:53:08.000Z",
-      "lastModified": "2026-05-19T23:10:01.000Z"
-    },
-    {
-      "rank": 646,
+      "rank": 658,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -18782,7 +19148,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 647,
+      "rank": 659,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -18799,7 +19165,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 648,
+      "rank": 660,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -18827,7 +19193,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 649,
+      "rank": 661,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -18870,7 +19236,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 650,
+      "rank": 662,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -18905,7 +19271,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 651,
+      "rank": 663,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -18930,7 +19296,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 652,
+      "rank": 664,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -18960,7 +19326,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 653,
+      "rank": 665,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -18989,7 +19355,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 654,
+      "rank": 666,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -19016,7 +19382,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 655,
+      "rank": 667,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -19042,7 +19408,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 656,
+      "rank": 668,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -19073,7 +19439,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 657,
+      "rank": 669,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -19091,7 +19457,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 658,
+      "rank": 670,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -19120,7 +19486,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 659,
+      "rank": 671,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -19143,7 +19509,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 660,
+      "rank": 672,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -19188,7 +19554,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 661,
+      "rank": 673,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -19214,7 +19580,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 662,
+      "rank": 674,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -19242,7 +19608,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 663,
+      "rank": 675,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -19280,7 +19646,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 664,
+      "rank": 676,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -19307,7 +19673,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 665,
+      "rank": 677,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -19333,7 +19699,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 666,
+      "rank": 678,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -19351,7 +19717,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 667,
+      "rank": 679,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -19377,7 +19743,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 668,
+      "rank": 680,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -19401,7 +19767,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 669,
+      "rank": 681,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -19442,7 +19808,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 670,
+      "rank": 682,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -19459,7 +19825,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 671,
+      "rank": 683,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -19492,7 +19858,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 672,
+      "rank": 684,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -19526,7 +19892,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 673,
+      "rank": 685,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -19565,7 +19931,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 674,
+      "rank": 686,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -19595,7 +19961,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 675,
+      "rank": 687,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -19631,7 +19997,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 676,
+      "rank": 688,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -19657,7 +20023,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 677,
+      "rank": 689,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -19693,7 +20059,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 678,
+      "rank": 690,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -19723,7 +20089,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 679,
+      "rank": 691,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -19761,7 +20127,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 680,
+      "rank": 692,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -19796,7 +20162,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 681,
+      "rank": 693,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -19821,7 +20187,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 682,
+      "rank": 694,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -19838,7 +20204,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 683,
+      "rank": 695,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -19880,7 +20246,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 684,
+      "rank": 696,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -19910,12 +20276,12 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 685,
+      "rank": 697,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
-      "downloads": 337391,
-      "likes": 165,
+      "downloads": 338949,
+      "likes": 166,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -19935,7 +20301,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 686,
+      "rank": 698,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -19963,7 +20329,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 687,
+      "rank": 699,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -19980,7 +20346,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 688,
+      "rank": 700,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -20007,7 +20373,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 689,
+      "rank": 701,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -20050,7 +20416,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 690,
+      "rank": 702,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -20090,7 +20456,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 691,
+      "rank": 703,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -20114,7 +20480,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 692,
+      "rank": 704,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -20143,7 +20509,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 693,
+      "rank": 705,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -20169,7 +20535,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 694,
+      "rank": 706,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -20197,7 +20563,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 695,
+      "rank": 707,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -20236,7 +20602,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 696,
+      "rank": 708,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -20260,7 +20626,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 697,
+      "rank": 709,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -20288,7 +20654,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 698,
+      "rank": 710,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -20320,7 +20686,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 699,
+      "rank": 711,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -20350,7 +20716,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 700,
+      "rank": 712,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -20379,7 +20745,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 701,
+      "rank": 713,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -20407,31 +20773,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 702,
-      "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
-      "author": "bartowski",
-      "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
-      "downloads": 96553,
-      "likes": 36,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-22T14:24:37.000Z",
-      "lastModified": "2026-04-23T03:18:40.000Z"
-    },
-    {
-      "rank": 703,
+      "rank": 714,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -20464,7 +20806,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 704,
+      "rank": 715,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -20493,7 +20835,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 705,
+      "rank": 716,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -20513,7 +20855,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 706,
+      "rank": 717,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -20542,7 +20884,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 707,
+      "rank": 718,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -20566,7 +20908,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 708,
+      "rank": 719,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -20596,7 +20938,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 709,
+      "rank": 720,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -20626,7 +20968,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 710,
+      "rank": 721,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -20644,7 +20986,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 711,
+      "rank": 722,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -20661,7 +21003,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 712,
+      "rank": 723,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -20697,7 +21039,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 713,
+      "rank": 724,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -20728,46 +21070,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 714,
-      "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "author": "mistralai",
-      "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "downloads": 1433784,
-      "likes": 853,
-      "trendingScore": 7,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "vllm",
-      "tags": [
-        "vllm",
-        "safetensors",
-        "voxtral_realtime",
-        "mistral-common",
-        "automatic-speech-recognition",
-        "en",
-        "fr",
-        "es",
-        "de",
-        "ru",
-        "zh",
-        "ja",
-        "it",
-        "pt",
-        "nl",
-        "ar",
-        "hi",
-        "ko",
-        "arxiv:2602.11298",
-        "base_model:mistralai/Ministral-3-3B-Base-2512",
-        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-01-21T17:22:02.000Z",
-      "lastModified": "2026-03-11T15:04:02.000Z"
-    },
-    {
-      "rank": 715,
+      "rank": 725,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -20798,7 +21101,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 716,
+      "rank": 726,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -20831,7 +21134,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 717,
+      "rank": 727,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -20859,7 +21162,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 718,
+      "rank": 728,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -20884,7 +21187,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 719,
+      "rank": 729,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -20907,7 +21210,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 720,
+      "rank": 730,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -20935,7 +21238,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 721,
+      "rank": 731,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -20968,7 +21271,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 722,
+      "rank": 732,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -20998,7 +21301,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 723,
+      "rank": 733,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -21033,7 +21336,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 724,
+      "rank": 734,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -21065,7 +21368,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 725,
+      "rank": 735,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -21090,7 +21393,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 726,
+      "rank": 736,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -21113,7 +21416,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 727,
+      "rank": 737,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -21140,7 +21443,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 728,
+      "rank": 738,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -21163,32 +21466,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 729,
-      "id": "HiDream-ai/Prompt-Refine",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
-      "downloads": 166,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "conversational",
-        "base_model:google/gemma-4-31B-it",
-        "base_model:finetune:google/gemma-4-31B-it",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T18:50:44.000Z",
-      "lastModified": "2026-05-14T07:24:09.000Z"
-    },
-    {
-      "rank": 730,
+      "rank": 739,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -21233,7 +21511,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 731,
+      "rank": 740,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -21265,7 +21543,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 732,
+      "rank": 741,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -21292,7 +21570,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 733,
+      "rank": 742,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -21318,7 +21596,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 734,
+      "rank": 743,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -21350,7 +21628,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 735,
+      "rank": 744,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -21379,7 +21657,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 736,
+      "rank": 745,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -21411,7 +21689,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 737,
+      "rank": 746,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -21441,7 +21719,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 738,
+      "rank": 747,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -21458,7 +21736,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 739,
+      "rank": 748,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -21478,7 +21756,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 740,
+      "rank": 749,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -21517,7 +21795,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 741,
+      "rank": 750,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -21555,7 +21833,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 742,
+      "rank": 751,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -21583,7 +21861,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 743,
+      "rank": 752,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -21628,7 +21906,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 744,
+      "rank": 753,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -21655,7 +21933,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 745,
+      "rank": 754,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -21679,7 +21957,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 746,
+      "rank": 755,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -21709,7 +21987,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 747,
+      "rank": 756,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -21736,7 +22014,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 748,
+      "rank": 757,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -21769,7 +22047,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 749,
+      "rank": 758,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -21811,38 +22089,12 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 750,
-      "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
-      "author": "noctrex",
-      "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
-      "downloads": 2403,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen",
-        "qwen3_5_moe",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Jackrong/Qwopus3.6-27B-v1-preview",
-        "base_model:quantized:Jackrong/Qwopus3.6-27B-v1-preview",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T21:42:10.000Z",
-      "lastModified": "2026-05-17T16:25:53.000Z"
-    },
-    {
-      "rank": 751,
+      "rank": 759,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
-      "downloads": 1564525,
-      "likes": 45,
+      "downloads": 1595755,
+      "likes": 46,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -21863,7 +22115,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 752,
+      "rank": 760,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -21891,63 +22143,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 753,
-      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "author": "dphn",
-      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13066,
-      "likes": 515,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "mistral3",
-        "image-text-to-text",
-        "text-generation",
-        "conversational",
-        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
-        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-06-12T05:29:16.000Z",
-      "lastModified": "2026-04-24T13:52:18.000Z"
-    },
-    {
-      "rank": 754,
-      "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "author": "aifeifei798",
-      "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "downloads": 616,
-      "likes": 28,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "roleplay",
-        "llama3",
-        "sillytavern",
-        "idol",
-        "en",
-        "arxiv:2403.19522",
-        "license:llama3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-07-21T23:20:43.000Z",
-      "lastModified": "2024-07-23T10:35:13.000Z"
-    },
-    {
-      "rank": 755,
+      "rank": 761,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -21971,7 +22167,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 756,
+      "rank": 762,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -22000,7 +22196,7 @@
       "lastModified": "2026-05-18T22:20:53.000Z"
     },
     {
-      "rank": 757,
+      "rank": 763,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -22036,36 +22232,180 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 758,
-      "id": "LiquidAI/LFM2.5-Audio-1.5B",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
-      "downloads": 974,
-      "likes": 403,
+      "rank": 764,
+      "id": "Comfy-Org/z_image",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/z_image",
+      "downloads": 175529,
+      "likes": 231,
       "trendingScore": 7,
-      "pipelineTag": "audio-to-audio",
-      "libraryName": "liquid-audio",
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
       "tags": [
-        "liquid-audio",
-        "safetensors",
-        "liquid",
-        "lfm2",
-        "audio",
-        "lfm2-audio",
-        "speech-to-speech",
-        "audio-to-audio",
+        "diffusion-single-file",
+        "comfyui",
+        "region:us"
+      ],
+      "createdAt": "2026-01-27T01:23:23.000Z",
+      "lastModified": "2026-01-27T16:10:00.000Z"
+    },
+    {
+      "rank": 765,
+      "id": "xai-org/grok-1",
+      "author": "xai-org",
+      "url": "https://huggingface.co/xai-org/grok-1",
+      "downloads": 507,
+      "likes": 2409,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "grok",
+      "tags": [
+        "grok",
+        "grok-1",
+        "text-generation",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2024-03-17T05:47:21.000Z",
+      "lastModified": "2024-03-28T16:25:32.000Z"
+    },
+    {
+      "rank": 766,
+      "id": "Efficient-Large-Model/SANA-Video_2B_720p",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
+      "downloads": 57,
+      "likes": 22,
+      "trendingScore": 7,
+      "pipelineTag": "text-to-video",
+      "libraryName": "sana, sana-video",
+      "tags": [
+        "sana, sana-video",
+        "text-to-video",
+        "SANA-Video",
+        "720p_5s_pretrained_model",
+        "BF16",
+        "diffusion",
+        "LTX2-VAE",
         "en",
-        "arxiv:2511.23404",
-        "base_model:LiquidAI/LFM2-1.2B",
-        "base_model:finetune:LiquidAI/LFM2-1.2B",
+        "zh",
+        "arxiv:2509.24695",
+        "base_model:Efficient-Large-Model/SANA-Video_2B_720p",
+        "base_model:finetune:Efficient-Large-Model/SANA-Video_2B_720p",
         "license:other",
         "region:us"
       ],
-      "createdAt": "2025-12-18T10:21:11.000Z",
-      "lastModified": "2026-03-30T14:43:52.000Z"
+      "createdAt": "2026-03-16T10:01:28.000Z",
+      "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 759,
+      "rank": 767,
+      "id": "jinaai/jina-embeddings-v4",
+      "author": "jinaai",
+      "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
+      "downloads": 540362,
+      "likes": 517,
+      "trendingScore": 7,
+      "pipelineTag": "visual-document-retrieval",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "feature-extraction",
+        "vidore",
+        "colpali",
+        "multimodal-embedding",
+        "multilingual-embedding",
+        "Text-to-Visual Document (T→VD) retrieval",
+        "sentence-similarity",
+        "mteb",
+        "sentence-transformers",
+        "vllm",
+        "visual-document-retrieval",
+        "custom_code",
+        "multilingual",
+        "arxiv:2506.18902",
+        "region:eu"
+      ],
+      "createdAt": "2025-05-07T12:19:26.000Z",
+      "lastModified": "2026-04-08T14:29:59.000Z"
+    },
+    {
+      "rank": 768,
+      "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
+      "downloads": 22,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion_vlm",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "multimodal",
+        "vlm",
+        "diffusion-language-model",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T17:45:40.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 769,
+      "id": "CohereLabs/command-a-plus-05-2026-fp8",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
+      "downloads": 0,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere2_vision",
+        "image-text-to-text",
+        "conversational",
+        "chat",
+        "en",
+        "ar",
+        "bg",
+        "bn",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fil",
+        "fr",
+        "ga",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "is",
+        "it",
+        "ja"
+      ],
+      "createdAt": "2026-05-18T04:50:57.000Z",
+      "lastModified": "2026-05-20T15:51:46.000Z"
+    },
+    {
+      "rank": 770,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -22093,7 +22433,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 760,
+      "rank": 771,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -22132,7 +22472,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 761,
+      "rank": 772,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -22165,7 +22505,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 762,
+      "rank": 773,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -22194,7 +22534,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 763,
+      "rank": 774,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -22224,7 +22564,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 764,
+      "rank": 775,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -22269,7 +22609,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 765,
+      "rank": 776,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -22298,7 +22638,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 766,
+      "rank": 777,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -22343,7 +22683,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 767,
+      "rank": 778,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -22387,7 +22727,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 768,
+      "rank": 779,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -22413,7 +22753,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 769,
+      "rank": 780,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -22439,7 +22779,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 770,
+      "rank": 781,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -22471,7 +22811,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 771,
+      "rank": 782,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -22494,7 +22834,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 772,
+      "rank": 783,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -22537,7 +22877,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 773,
+      "rank": 784,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -22582,7 +22922,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 774,
+      "rank": 785,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -22627,7 +22967,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 775,
+      "rank": 786,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -22654,7 +22994,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 776,
+      "rank": 787,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -22681,7 +23021,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 777,
+      "rank": 788,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -22706,7 +23046,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 778,
+      "rank": 789,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -22745,7 +23085,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 779,
+      "rank": 790,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -22770,7 +23110,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 780,
+      "rank": 791,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -22798,7 +23138,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 781,
+      "rank": 792,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -22823,7 +23163,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 782,
+      "rank": 793,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -22839,7 +23179,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 783,
+      "rank": 794,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -22866,7 +23206,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 784,
+      "rank": 795,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -22898,7 +23238,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 785,
+      "rank": 796,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -22928,7 +23268,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 786,
+      "rank": 797,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -22960,7 +23300,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 787,
+      "rank": 798,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -22988,7 +23328,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 788,
+      "rank": 799,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -23014,7 +23354,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 789,
+      "rank": 800,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -23039,7 +23379,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 790,
+      "rank": 801,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -23068,7 +23408,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 791,
+      "rank": 802,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -23110,7 +23450,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 792,
+      "rank": 803,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -23137,7 +23477,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 793,
+      "rank": 804,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -23182,7 +23522,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 794,
+      "rank": 805,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -23208,7 +23548,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 795,
+      "rank": 806,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -23228,7 +23568,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 796,
+      "rank": 807,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -23255,7 +23595,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 797,
+      "rank": 808,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -23297,7 +23637,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 798,
+      "rank": 809,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -23324,7 +23664,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 799,
+      "rank": 810,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -23358,7 +23698,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 800,
+      "rank": 811,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -23387,7 +23727,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 801,
+      "rank": 812,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -23414,7 +23754,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 802,
+      "rank": 813,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -23441,7 +23781,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 803,
+      "rank": 814,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -23468,7 +23808,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 804,
+      "rank": 815,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -23496,7 +23836,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 805,
+      "rank": 816,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -23519,7 +23859,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 806,
+      "rank": 817,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -23550,7 +23890,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 807,
+      "rank": 818,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -23595,7 +23935,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 808,
+      "rank": 819,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -23617,7 +23957,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 809,
+      "rank": 820,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -23643,7 +23983,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 810,
+      "rank": 821,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -23669,7 +24009,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 811,
+      "rank": 822,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -23700,7 +24040,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 812,
+      "rank": 823,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -23723,7 +24063,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 813,
+      "rank": 824,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -23753,7 +24093,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 814,
+      "rank": 825,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -23785,7 +24125,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 815,
+      "rank": 826,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -23814,7 +24154,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 816,
+      "rank": 827,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -23846,7 +24186,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 817,
+      "rank": 828,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -23878,7 +24218,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 818,
+      "rank": 829,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -23909,7 +24249,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 819,
+      "rank": 830,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -23940,7 +24280,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 820,
+      "rank": 831,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -23963,7 +24303,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 821,
+      "rank": 832,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -23990,7 +24330,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 822,
+      "rank": 833,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -24035,7 +24375,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 823,
+      "rank": 834,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -24053,7 +24393,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 824,
+      "rank": 835,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -24076,7 +24416,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 825,
+      "rank": 836,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -24106,7 +24446,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 826,
+      "rank": 837,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -24145,7 +24485,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 827,
+      "rank": 838,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -24183,7 +24523,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 828,
+      "rank": 839,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -24228,7 +24568,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 829,
+      "rank": 840,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -24253,7 +24593,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 830,
+      "rank": 841,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -24287,7 +24627,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 831,
+      "rank": 842,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -24312,7 +24652,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 832,
+      "rank": 843,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -24345,7 +24685,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 833,
+      "rank": 844,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -24372,7 +24712,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 834,
+      "rank": 845,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -24402,7 +24742,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 835,
+      "rank": 846,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -24434,7 +24774,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 836,
+      "rank": 847,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -24467,7 +24807,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 837,
+      "rank": 848,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -24485,7 +24825,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 838,
+      "rank": 849,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -24508,7 +24848,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 839,
+      "rank": 850,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -24540,7 +24880,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 840,
+      "rank": 851,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -24585,7 +24925,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 841,
+      "rank": 852,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -24626,7 +24966,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 842,
+      "rank": 853,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -24665,7 +25005,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 843,
+      "rank": 854,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -24692,7 +25032,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 844,
+      "rank": 855,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -24729,7 +25069,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 845,
+      "rank": 856,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -24765,7 +25105,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 846,
+      "rank": 857,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -24783,7 +25123,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 847,
+      "rank": 858,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -24822,7 +25162,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 848,
+      "rank": 859,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -24851,7 +25191,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 849,
+      "rank": 860,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -24878,7 +25218,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 850,
+      "rank": 861,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -24905,7 +25245,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 851,
+      "rank": 862,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -24935,7 +25275,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 852,
+      "rank": 863,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -24962,7 +25302,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 853,
+      "rank": 864,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -24993,7 +25333,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 854,
+      "rank": 865,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -25011,7 +25351,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 855,
+      "rank": 866,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -25030,7 +25370,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 856,
+      "rank": 867,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -25057,7 +25397,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 857,
+      "rank": 868,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -25082,7 +25422,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 858,
+      "rank": 869,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -25112,7 +25452,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 859,
+      "rank": 870,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -25143,7 +25483,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 860,
+      "rank": 871,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -25165,7 +25505,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 861,
+      "rank": 872,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -25186,12 +25526,12 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 862,
+      "rank": 873,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
       "downloads": 29696,
-      "likes": 55,
+      "likes": 56,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -25222,7 +25562,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 863,
+      "rank": 874,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -25245,7 +25585,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 864,
+      "rank": 875,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -25290,7 +25630,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 865,
+      "rank": 876,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -25312,7 +25652,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 866,
+      "rank": 877,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -25342,7 +25682,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 867,
+      "rank": 878,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -25369,7 +25709,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 868,
+      "rank": 879,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -25394,12 +25734,12 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 869,
+      "rank": 880,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
       "downloads": 34932,
-      "likes": 140,
+      "likes": 141,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -25427,7 +25767,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 870,
+      "rank": 881,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -25450,7 +25790,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 871,
+      "rank": 882,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -25470,7 +25810,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 872,
+      "rank": 883,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -25515,7 +25855,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 873,
+      "rank": 884,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -25536,7 +25876,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 874,
+      "rank": 885,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -25569,7 +25909,7 @@
       "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 875,
+      "rank": 886,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -25597,7 +25937,7 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 876,
+      "rank": 887,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -25624,7 +25964,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 877,
+      "rank": 888,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -25669,7 +26009,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 878,
+      "rank": 889,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -25694,25 +26034,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 879,
-      "id": "Comfy-Org/z_image",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/z_image",
-      "downloads": 175529,
-      "likes": 230,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
-      "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "region:us"
-      ],
-      "createdAt": "2026-01-27T01:23:23.000Z",
-      "lastModified": "2026-01-27T16:10:00.000Z"
-    },
-    {
-      "rank": 880,
+      "rank": 890,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -25740,12 +26062,12 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 881,
+      "rank": 891,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
-      "downloads": 8743011,
-      "likes": 1073,
+      "downloads": 8439589,
+      "likes": 1075,
       "trendingScore": 6,
       "pipelineTag": "image-classification",
       "libraryName": "transformers",
@@ -25765,7 +26087,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 882,
+      "rank": 892,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -25802,7 +26124,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 883,
+      "rank": 893,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -25827,7 +26149,7 @@
       "lastModified": "2026-05-18T05:58:18.000Z"
     },
     {
-      "rank": 884,
+      "rank": 894,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
@@ -25858,7 +26180,7 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 885,
+      "rank": 895,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
@@ -25877,7 +26199,7 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 886,
+      "rank": 896,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -25903,27 +26225,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 887,
-      "id": "xai-org/grok-1",
-      "author": "xai-org",
-      "url": "https://huggingface.co/xai-org/grok-1",
-      "downloads": 507,
-      "likes": 2409,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "grok",
-      "tags": [
-        "grok",
-        "grok-1",
-        "text-generation",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2024-03-17T05:47:21.000Z",
-      "lastModified": "2024-03-28T16:25:32.000Z"
-    },
-    {
-      "rank": 888,
+      "rank": 897,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -25950,7 +26252,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 889,
+      "rank": 898,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
@@ -25982,7 +26284,7 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 890,
+      "rank": 899,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -26012,7 +26314,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 891,
+      "rank": 900,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -26030,12 +26332,12 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 892,
+      "rank": 901,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
-      "downloads": 622,
-      "likes": 6,
+      "downloads": 717,
+      "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-video",
       "libraryName": "mlx",
@@ -26054,37 +26356,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 893,
-      "id": "Qwen/Qwen3-Embedding-8B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
-      "downloads": 1606070,
-      "likes": 683,
-      "trendingScore": 6,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "transformers",
-        "sentence-similarity",
-        "feature-extraction",
-        "text-embeddings-inference",
-        "arxiv:2506.05176",
-        "base_model:Qwen/Qwen3-8B-Base",
-        "base_model:finetune:Qwen/Qwen3-8B-Base",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-06-03T14:39:10.000Z",
-      "lastModified": "2025-07-07T09:02:21.000Z"
-    },
-    {
-      "rank": 894,
+      "rank": 902,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -26107,7 +26379,7 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 895,
+      "rank": 903,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
@@ -26134,7 +26406,7 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 896,
+      "rank": 904,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
@@ -26166,7 +26438,7 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 897,
+      "rank": 905,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
@@ -26184,7 +26456,7 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 898,
+      "rank": 906,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -26224,7 +26496,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 899,
+      "rank": 907,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
@@ -26257,36 +26529,7 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 900,
-      "id": "Efficient-Large-Model/SANA-Video_2B_720p",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
-      "downloads": 57,
-      "likes": 21,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-video",
-      "libraryName": "sana, sana-video",
-      "tags": [
-        "sana, sana-video",
-        "text-to-video",
-        "SANA-Video",
-        "720p_5s_pretrained_model",
-        "BF16",
-        "diffusion",
-        "LTX2-VAE",
-        "en",
-        "zh",
-        "arxiv:2509.24695",
-        "base_model:Efficient-Large-Model/SANA-Video_2B_720p",
-        "base_model:finetune:Efficient-Large-Model/SANA-Video_2B_720p",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-16T10:01:28.000Z",
-      "lastModified": "2026-03-16T13:38:42.000Z"
-    },
-    {
-      "rank": 901,
+      "rank": 908,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -26318,39 +26561,7 @@
       "lastModified": "2026-05-17T11:23:09.000Z"
     },
     {
-      "rank": 902,
-      "id": "jinaai/jina-embeddings-v4",
-      "author": "jinaai",
-      "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
-      "downloads": 540362,
-      "likes": 516,
-      "trendingScore": 6,
-      "pipelineTag": "visual-document-retrieval",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "feature-extraction",
-        "vidore",
-        "colpali",
-        "multimodal-embedding",
-        "multilingual-embedding",
-        "Text-to-Visual Document (T→VD) retrieval",
-        "sentence-similarity",
-        "mteb",
-        "sentence-transformers",
-        "vllm",
-        "visual-document-retrieval",
-        "custom_code",
-        "multilingual",
-        "arxiv:2506.18902",
-        "region:eu"
-      ],
-      "createdAt": "2025-05-07T12:19:26.000Z",
-      "lastModified": "2026-04-08T14:29:59.000Z"
-    },
-    {
-      "rank": 903,
+      "rank": 909,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -26395,33 +26606,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 904,
-      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
-      "downloads": 14543,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T17:45:13.000Z",
-      "lastModified": "2026-05-19T18:52:45.000Z"
-    },
-    {
-      "rank": 905,
+      "rank": 910,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -26446,27 +26631,98 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 906,
-      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "author": "alibaba-pai",
-      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "downloads": 8257,
-      "likes": 150,
+      "rank": 911,
+      "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
+      "downloads": 10223,
+      "likes": 6,
       "trendingScore": 6,
-      "pipelineTag": "text-to-image",
-      "libraryName": "videox_fun",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "videox_fun",
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-0.8B",
+        "base_model:quantized:Qwen/Qwen3.5-0.8B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T11:24:44.000Z",
+      "lastModified": "2026-05-16T12:38:54.000Z"
+    },
+    {
+      "rank": 912,
+      "id": "allenai/OlmoEarth-v1_1-Base",
+      "author": "allenai",
+      "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
+      "downloads": 48,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T15:14:45.000Z",
+      "lastModified": "2026-05-15T15:53:18.000Z"
+    },
+    {
+      "rank": 913,
+      "id": "SyFeee/LTX2.3-Dual-Character-en",
+      "author": "SyFeee",
+      "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
+      "downloads": 0,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "image-to-video",
+      "libraryName": null,
+      "tags": [
+        "video-generation",
         "lora",
-        "text-to-image",
+        "ic-lora",
+        "ltx-video",
+        "dual-character",
+        "dialogue",
+        "cinematic",
+        "chinese-drama",
+        "image-to-video",
+        "en",
+        "zh",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-02-02T09:37:39.000Z",
-      "lastModified": "2026-03-02T11:46:41.000Z"
+      "createdAt": "2026-05-19T06:58:52.000Z",
+      "lastModified": "2026-05-19T07:20:08.000Z"
     },
     {
-      "rank": 907,
+      "rank": 914,
+      "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
+      "author": "Lora-Daddy",
+      "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
+      "downloads": 0,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "image-to-video",
+      "libraryName": null,
+      "tags": [
+        "image-to-video",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T12:47:53.000Z",
+      "lastModified": "2026-05-19T13:07:28.000Z"
+    },
+    {
+      "rank": 915,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -26493,7 +26749,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 908,
+      "rank": 916,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -26529,7 +26785,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 909,
+      "rank": 917,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -26574,7 +26830,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 910,
+      "rank": 918,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -26619,7 +26875,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 911,
+      "rank": 919,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -26654,7 +26910,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 912,
+      "rank": 920,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -26682,7 +26938,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 913,
+      "rank": 921,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -26708,7 +26964,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 914,
+      "rank": 922,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -26734,7 +26990,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 915,
+      "rank": 923,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -26760,7 +27016,7 @@
       "lastModified": "2026-05-06T20:09:03.000Z"
     },
     {
-      "rank": 916,
+      "rank": 924,
       "id": "TheDrummer/Skyfall-31B-v4.2",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
@@ -26780,7 +27036,7 @@
       "lastModified": "2026-04-03T20:52:19.000Z"
     },
     {
-      "rank": 917,
+      "rank": 925,
       "id": "LiquidAI/LFM2-24B-A2B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
@@ -26818,7 +27074,7 @@
       "lastModified": "2026-03-30T12:54:26.000Z"
     },
     {
-      "rank": 918,
+      "rank": 926,
       "id": "nvidia/GR00T-N1.7-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
@@ -26838,7 +27094,7 @@
       "lastModified": "2026-04-23T19:09:30.000Z"
     },
     {
-      "rank": 919,
+      "rank": 927,
       "id": "Aratako/Irodori-TTS-500M",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
@@ -26861,7 +27117,7 @@
       "lastModified": "2026-03-18T11:03:56.000Z"
     },
     {
-      "rank": 920,
+      "rank": 928,
       "id": "Qwen/Qwen3.5-0.8B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
@@ -26884,7 +27140,7 @@
       "lastModified": "2026-04-23T11:14:09.000Z"
     },
     {
-      "rank": 921,
+      "rank": 929,
       "id": "z-lab/Qwen3.5-9B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
@@ -26917,7 +27173,7 @@
       "lastModified": "2026-04-07T14:29:47.000Z"
     },
     {
-      "rank": 922,
+      "rank": 930,
       "id": "Winnougan/Must_Have_Klein_9b_loras",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
@@ -26939,7 +27195,7 @@
       "lastModified": "2026-03-26T22:03:08.000Z"
     },
     {
-      "rank": 923,
+      "rank": 931,
       "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
@@ -26966,7 +27222,7 @@
       "lastModified": "2026-04-05T16:05:28.000Z"
     },
     {
-      "rank": 924,
+      "rank": 932,
       "id": "100percentrobot/LTX-2.3-Audio-Reactive-LORA",
       "author": "100percentrobot",
       "url": "https://huggingface.co/100percentrobot/LTX-2.3-Audio-Reactive-LORA",
@@ -26990,7 +27246,7 @@
       "lastModified": "2026-04-10T15:12:18.000Z"
     },
     {
-      "rank": 925,
+      "rank": 933,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -27017,7 +27273,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 926,
+      "rank": 934,
       "id": "YJX-Xiaomi/ControlFoley",
       "author": "YJX-Xiaomi",
       "url": "https://huggingface.co/YJX-Xiaomi/ControlFoley",
@@ -27041,7 +27297,7 @@
       "lastModified": "2026-04-22T02:02:09.000Z"
     },
     {
-      "rank": 927,
+      "rank": 935,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -27081,7 +27337,7 @@
       "lastModified": "2026-04-19T00:19:49.000Z"
     },
     {
-      "rank": 928,
+      "rank": 936,
       "id": "lovis93/crt-animation-terminal-ltx-2.3-lora",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/crt-animation-terminal-ltx-2.3-lora",
@@ -27107,7 +27363,7 @@
       "lastModified": "2026-04-20T16:33:16.000Z"
     },
     {
-      "rank": 929,
+      "rank": 937,
       "id": "uva-cv-lab/OmniShotCut",
       "author": "uva-cv-lab",
       "url": "https://huggingface.co/uva-cv-lab/OmniShotCut",
@@ -27125,7 +27381,7 @@
       "lastModified": "2026-04-28T14:59:54.000Z"
     },
     {
-      "rank": 930,
+      "rank": 938,
       "id": "Yutian10/AnyRecon",
       "author": "Yutian10",
       "url": "https://huggingface.co/Yutian10/AnyRecon",
@@ -27143,7 +27399,7 @@
       "lastModified": "2026-04-27T02:17:02.000Z"
     },
     {
-      "rank": 931,
+      "rank": 939,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
@@ -27169,7 +27425,7 @@
       "lastModified": "2026-04-30T21:34:35.000Z"
     },
     {
-      "rank": 932,
+      "rank": 940,
       "id": "vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
@@ -27192,7 +27448,7 @@
       "lastModified": "2026-04-24T02:25:18.000Z"
     },
     {
-      "rank": 933,
+      "rank": 941,
       "id": "Comfy-Org/void-model",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/void-model",
@@ -27210,7 +27466,7 @@
       "lastModified": "2026-05-07T10:17:55.000Z"
     },
     {
-      "rank": 934,
+      "rank": 942,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
@@ -27240,7 +27496,7 @@
       "lastModified": "2026-04-27T23:59:16.000Z"
     },
     {
-      "rank": 935,
+      "rank": 943,
       "id": "TheBurgstall/ltx-2.3-bodypositivity-lora",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/ltx-2.3-bodypositivity-lora",
@@ -27267,7 +27523,7 @@
       "lastModified": "2026-04-26T10:38:55.000Z"
     },
     {
-      "rank": 936,
+      "rank": 944,
       "id": "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
@@ -27297,7 +27553,7 @@
       "lastModified": "2026-05-05T17:25:56.000Z"
     },
     {
-      "rank": 937,
+      "rank": 945,
       "id": "GAi92/anima-loras",
       "author": "GAi92",
       "url": "https://huggingface.co/GAi92/anima-loras",
@@ -27318,7 +27574,7 @@
       "lastModified": "2026-05-08T23:44:33.000Z"
     },
     {
-      "rank": 938,
+      "rank": 946,
       "id": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
@@ -27345,7 +27601,7 @@
       "lastModified": "2026-05-06T05:56:30.000Z"
     },
     {
-      "rank": 939,
+      "rank": 947,
       "id": "XiaomiMiMo/MiMo-V2.5-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Base",
@@ -27374,7 +27630,7 @@
       "lastModified": "2026-05-08T10:25:24.000Z"
     },
     {
-      "rank": 940,
+      "rank": 948,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit",
@@ -27403,7 +27659,7 @@
       "lastModified": "2026-04-29T04:36:33.000Z"
     },
     {
-      "rank": 941,
+      "rank": 949,
       "id": "sokann/Qwen3.6-27B-GGUF-4.256bpw",
       "author": "sokann",
       "url": "https://huggingface.co/sokann/Qwen3.6-27B-GGUF-4.256bpw",
@@ -27427,7 +27683,7 @@
       "lastModified": "2026-04-30T05:52:10.000Z"
     },
     {
-      "rank": 942,
+      "rank": 950,
       "id": "Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
@@ -27472,7 +27728,7 @@
       "lastModified": "2026-04-30T00:55:51.000Z"
     },
     {
-      "rank": 943,
+      "rank": 951,
       "id": "mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
@@ -27517,7 +27773,7 @@
       "lastModified": "2026-04-30T08:28:27.000Z"
     },
     {
-      "rank": 944,
+      "rank": 952,
       "id": "OrobasVault/Geodesic-Phantom-12B",
       "author": "OrobasVault",
       "url": "https://huggingface.co/OrobasVault/Geodesic-Phantom-12B",
@@ -27558,7 +27814,7 @@
       "lastModified": "2026-05-01T03:53:12.000Z"
     },
     {
-      "rank": 945,
+      "rank": 953,
       "id": "Egor-3926/ToxicLord",
       "author": "Egor-3926",
       "url": "https://huggingface.co/Egor-3926/ToxicLord",
@@ -27588,7 +27844,7 @@
       "lastModified": "2026-04-30T20:07:44.000Z"
     },
     {
-      "rank": 946,
+      "rank": 954,
       "id": "Playtime-AI/LTX-2.3-Jenna_Coleman",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Jenna_Coleman",
@@ -27605,7 +27861,7 @@
       "lastModified": "2026-05-01T11:07:58.000Z"
     },
     {
-      "rank": 947,
+      "rank": 955,
       "id": "abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
       "author": "abhinand",
       "url": "https://huggingface.co/abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
@@ -27635,7 +27891,7 @@
       "lastModified": "2026-05-01T15:22:45.000Z"
     },
     {
-      "rank": 948,
+      "rank": 956,
       "id": "Naphula/Salamander-24B-v1",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/Salamander-24B-v1",
@@ -27680,7 +27936,7 @@
       "lastModified": "2026-05-02T10:32:50.000Z"
     },
     {
-      "rank": 949,
+      "rank": 957,
       "id": "Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
@@ -27697,7 +27953,7 @@
       "lastModified": "2026-05-04T13:20:35.000Z"
     },
     {
-      "rank": 950,
+      "rank": 958,
       "id": "chromadb/context-1",
       "author": "chromadb",
       "url": "https://huggingface.co/chromadb/context-1",
@@ -27722,7 +27978,7 @@
       "lastModified": "2026-03-30T01:02:07.000Z"
     },
     {
-      "rank": 951,
+      "rank": 959,
       "id": "abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
       "author": "abovespec",
       "url": "https://huggingface.co/abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
@@ -27742,7 +27998,7 @@
       "lastModified": "2026-05-04T03:28:29.000Z"
     },
     {
-      "rank": 952,
+      "rank": 960,
       "id": "bond005/whisper-podlodka-turbo",
       "author": "bond005",
       "url": "https://huggingface.co/bond005/whisper-podlodka-turbo",
@@ -27777,7 +28033,7 @@
       "lastModified": "2026-01-29T10:12:53.000Z"
     },
     {
-      "rank": 953,
+      "rank": 961,
       "id": "nvidia/canary-qwen-2.5b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/canary-qwen-2.5b",
@@ -27822,7 +28078,7 @@
       "lastModified": "2026-04-21T12:31:18.000Z"
     },
     {
-      "rank": 954,
+      "rank": 962,
       "id": "lightx2v/Wan2.2-Distill-Loras",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-Distill-Loras",
@@ -27850,7 +28106,7 @@
       "lastModified": "2025-12-17T08:00:53.000Z"
     },
     {
-      "rank": 955,
+      "rank": 963,
       "id": "Qwen/Qwen3.5-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-27B",
@@ -27875,7 +28131,7 @@
       "lastModified": "2026-04-24T02:54:49.000Z"
     },
     {
-      "rank": 956,
+      "rank": 964,
       "id": "mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
@@ -27898,7 +28154,7 @@
       "lastModified": "2026-04-23T08:30:31.000Z"
     },
     {
-      "rank": 957,
+      "rank": 965,
       "id": "sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
@@ -27937,7 +28193,7 @@
       "lastModified": "2026-04-29T00:23:13.000Z"
     },
     {
-      "rank": 958,
+      "rank": 966,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit",
@@ -27965,7 +28221,7 @@
       "lastModified": "2026-04-29T06:58:31.000Z"
     },
     {
-      "rank": 959,
+      "rank": 967,
       "id": "Harley-ml/Tenete-8M",
       "author": "Harley-ml",
       "url": "https://huggingface.co/Harley-ml/Tenete-8M",
@@ -27995,12 +28251,12 @@
       "lastModified": "2026-05-05T14:34:26.000Z"
     },
     {
-      "rank": 960,
+      "rank": 968,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
-      "downloads": 1211359,
-      "likes": 781,
+      "downloads": 1191723,
+      "likes": 782,
       "trendingScore": 5,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -28032,7 +28288,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 961,
+      "rank": 969,
       "id": "nvidia/omni-embed-nemotron-3b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/omni-embed-nemotron-3b",
@@ -28068,7 +28324,7 @@
       "lastModified": "2026-05-06T18:02:16.000Z"
     },
     {
-      "rank": 962,
+      "rank": 970,
       "id": "fal/flux-2-klein-4b-spritesheet-lora",
       "author": "fal",
       "url": "https://huggingface.co/fal/flux-2-klein-4b-spritesheet-lora",
@@ -28102,7 +28358,7 @@
       "lastModified": "2026-01-21T14:44:55.000Z"
     },
     {
-      "rank": 963,
+      "rank": 971,
       "id": "DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
@@ -28147,7 +28403,7 @@
       "lastModified": "2026-03-09T07:04:55.000Z"
     },
     {
-      "rank": 964,
+      "rank": 972,
       "id": "Comfy-Org/ltx-2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/ltx-2",
@@ -28164,7 +28420,7 @@
       "lastModified": "2026-03-08T17:36:30.000Z"
     },
     {
-      "rank": 965,
+      "rank": 973,
       "id": "silveroxides/LTX-2.3-Quants",
       "author": "silveroxides",
       "url": "https://huggingface.co/silveroxides/LTX-2.3-Quants",
@@ -28208,7 +28464,7 @@
       "lastModified": "2026-05-17T22:31:52.000Z"
     },
     {
-      "rank": 966,
+      "rank": 974,
       "id": "z-lab/Qwen3.5-35B-A3B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-35B-A3B-PARO",
@@ -28237,7 +28493,7 @@
       "lastModified": "2026-05-08T06:21:10.000Z"
     },
     {
-      "rank": 967,
+      "rank": 975,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -28272,7 +28528,7 @@
       "lastModified": "2026-04-06T02:19:40.000Z"
     },
     {
-      "rank": 968,
+      "rank": 976,
       "id": "OpenMed/privacy-filter-multilingual",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-multilingual",
@@ -28317,7 +28573,7 @@
       "lastModified": "2026-05-03T21:36:31.000Z"
     },
     {
-      "rank": 969,
+      "rank": 977,
       "id": "prism-ml/Bonsai-8B-mlx-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-mlx-1bit",
@@ -28348,7 +28604,7 @@
       "lastModified": "2026-04-18T20:44:19.000Z"
     },
     {
-      "rank": 970,
+      "rank": 978,
       "id": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
@@ -28393,7 +28649,7 @@
       "lastModified": "2025-12-22T10:16:55.000Z"
     },
     {
-      "rank": 971,
+      "rank": 979,
       "id": "zai-org/GLM-5",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5",
@@ -28420,7 +28676,7 @@
       "lastModified": "2026-04-05T07:48:51.000Z"
     },
     {
-      "rank": 972,
+      "rank": 980,
       "id": "Comfy-Org/Wan_2.1_ComfyUI_repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged",
@@ -28438,7 +28694,7 @@
       "lastModified": "2026-01-28T12:44:01.000Z"
     },
     {
-      "rank": 973,
+      "rank": 981,
       "id": "sequelbox/Qwen3.6-27B-Tachibana-Agent",
       "author": "sequelbox",
       "url": "https://huggingface.co/sequelbox/Qwen3.6-27B-Tachibana-Agent",
@@ -28483,7 +28739,7 @@
       "lastModified": "2026-05-07T02:13:23.000Z"
     },
     {
-      "rank": 974,
+      "rank": 982,
       "id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
@@ -28509,7 +28765,7 @@
       "lastModified": "2024-07-03T05:16:11.000Z"
     },
     {
-      "rank": 975,
+      "rank": 983,
       "id": "lynaNSFW/LTX2.3_NSFW_motion",
       "author": "lynaNSFW",
       "url": "https://huggingface.co/lynaNSFW/LTX2.3_NSFW_motion",
@@ -28531,7 +28787,7 @@
       "lastModified": "2026-03-25T12:45:24.000Z"
     },
     {
-      "rank": 976,
+      "rank": 984,
       "id": "mlx-community/DeepSeek-V4-Flash-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit",
@@ -28554,7 +28810,7 @@
       "lastModified": "2026-04-25T00:58:58.000Z"
     },
     {
-      "rank": 977,
+      "rank": 985,
       "id": "Qwen/Qwen3-ForcedAligner-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B",
@@ -28575,7 +28831,7 @@
       "lastModified": "2026-01-30T03:00:55.000Z"
     },
     {
-      "rank": 978,
+      "rank": 986,
       "id": "nvidia/Cosmos-Reason2-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Cosmos-Reason2-8B",
@@ -28604,7 +28860,7 @@
       "lastModified": "2026-04-30T03:16:12.000Z"
     },
     {
-      "rank": 979,
+      "rank": 987,
       "id": "Qwen/Qwen3-VL-4B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct",
@@ -28633,7 +28889,7 @@
       "lastModified": "2025-10-15T16:15:55.000Z"
     },
     {
-      "rank": 980,
+      "rank": 988,
       "id": "mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
@@ -28678,7 +28934,7 @@
       "lastModified": "2026-05-03T18:58:47.000Z"
     },
     {
-      "rank": 981,
+      "rank": 989,
       "id": "SWivid/F5-TTS",
       "author": "SWivid",
       "url": "https://huggingface.co/SWivid/F5-TTS",
@@ -28699,7 +28955,7 @@
       "lastModified": "2025-03-21T05:05:00.000Z"
     },
     {
-      "rank": 982,
+      "rank": 990,
       "id": "bartowski/google_gemma-4-E4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF",
@@ -28722,7 +28978,7 @@
       "lastModified": "2026-05-03T18:32:47.000Z"
     },
     {
-      "rank": 983,
+      "rank": 991,
       "id": "Ashen3/SNOFS",
       "author": "Ashen3",
       "url": "https://huggingface.co/Ashen3/SNOFS",
@@ -28742,7 +28998,7 @@
       "lastModified": "2026-02-21T20:02:14.000Z"
     },
     {
-      "rank": 984,
+      "rank": 992,
       "id": "Prior-Labs/tabpfn_2_6",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_2_6",
@@ -28766,7 +29022,7 @@
       "lastModified": "2026-04-02T10:00:43.000Z"
     },
     {
-      "rank": 985,
+      "rank": 993,
       "id": "Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
       "author": "Sikaworld1990",
       "url": "https://huggingface.co/Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
@@ -28795,7 +29051,7 @@
       "lastModified": "2026-03-11T17:20:00.000Z"
     },
     {
-      "rank": 986,
+      "rank": 994,
       "id": "google/medgemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-4b-it",
@@ -28839,7 +29095,7 @@
       "lastModified": "2025-10-28T17:24:49.000Z"
     },
     {
-      "rank": 987,
+      "rank": 995,
       "id": "nomic-ai/nomic-embed-text-v1.5-GGUF",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF",
@@ -28862,7 +29118,7 @@
       "lastModified": "2025-04-28T20:14:53.000Z"
     },
     {
-      "rank": 988,
+      "rank": 996,
       "id": "ponpoke/flux2-klein-4b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-4b-uncensored-text-encoder",
@@ -28895,7 +29151,7 @@
       "lastModified": "2026-05-02T11:35:01.000Z"
     },
     {
-      "rank": 989,
+      "rank": 997,
       "id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
       "author": "cardiffnlp",
       "url": "https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment-latest",
@@ -28922,7 +29178,7 @@
       "lastModified": "2025-08-04T07:58:29.000Z"
     },
     {
-      "rank": 990,
+      "rank": 998,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
@@ -28967,7 +29223,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 991,
+      "rank": 999,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic",
@@ -28997,7 +29253,7 @@
       "lastModified": "2026-05-04T02:04:15.000Z"
     },
     {
-      "rank": 992,
+      "rank": 1000,
       "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
@@ -29020,225 +29276,6 @@
       ],
       "createdAt": "2025-01-20T09:18:27.000Z",
       "lastModified": "2025-02-24T03:31:45.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "microsoft/VibeVoice-Realtime-0.5B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/VibeVoice-Realtime-0.5B",
-      "downloads": 865699,
-      "likes": 1221,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "vibevoice_streaming",
-        "Realtime TTS",
-        "Streaming text input",
-        "Long-form speech generation",
-        "text-to-speech",
-        "en",
-        "arxiv:2508.19205",
-        "arxiv:2412.08635",
-        "base_model:Qwen/Qwen2.5-0.5B",
-        "base_model:finetune:Qwen/Qwen2.5-0.5B",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-12-04T05:32:08.000Z",
-      "lastModified": "2025-12-12T15:35:46.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "facebook/sam-audio-large",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam-audio-large",
-      "downloads": 10333,
-      "likes": 403,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "en",
-        "arxiv:2512.18099",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2025-12-12T21:24:20.000Z",
-      "lastModified": "2025-12-30T19:52:21.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
-      "author": "cognica",
-      "url": "https://huggingface.co/cognica/Cognica-PoE-v1.0-3B-base-continual-learning",
-      "downloads": 1408,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "cognica_poe",
-        "poe",
-        "per-stage-head",
-        "continual-learning",
-        "continual-pretraining",
-        "cyclic-lr",
-        "text-generation",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T06:41:06.000Z",
-      "lastModified": "2026-05-16T07:11:10.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
-      "author": "FireRedTeam",
-      "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1-ComfyUI",
-      "downloads": 5820,
-      "likes": 110,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "en",
-        "zh",
-        "base_model:FireRedTeam/FireRed-Image-Edit-1.1",
-        "base_model:quantized:FireRedTeam/FireRed-Image-Edit-1.1",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-04T03:29:32.000Z",
-      "lastModified": "2026-04-14T13:43:30.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "F16/z-image-turbo-flow-dpo",
-      "author": "F16",
-      "url": "https://huggingface.co/F16/z-image-turbo-flow-dpo",
-      "downloads": 0,
-      "likes": 181,
-      "trendingScore": 5,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "text-to-image",
-        "flow-matching",
-        "diffusion",
-        "lora",
-        "dpo",
-        "flow-dpo",
-        "z-image",
-        "photorealistic",
-        "lighting",
-        "feature-extraction",
-        "arxiv:2501.13918",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-02-24T21:07:28.000Z",
-      "lastModified": "2026-04-09T18:43:34.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "Jiunsong/supergemma4-e4b-abliterated",
-      "author": "Jiunsong",
-      "url": "https://huggingface.co/Jiunsong/supergemma4-e4b-abliterated",
-      "downloads": 4876,
-      "likes": 60,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "gemma",
-        "text-generation",
-        "instruction-tuned",
-        "tool-calling",
-        "structured-output",
-        "vllm",
-        "conversational",
-        "base_model:google/gemma-4-E4B-it",
-        "base_model:finetune:google/gemma-4-E4B-it",
-        "license:gemma",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T13:11:16.000Z",
-      "lastModified": "2026-04-17T13:20:56.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
-      "author": "deucebucket",
-      "url": "https://huggingface.co/deucebucket/Gemma-4-26B-A4B-it-Cerebellum-v6-GGUF",
-      "downloads": 2291,
-      "likes": 9,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "GGUF",
-        "gemma4",
-        "gemma",
-        "google",
-        "quantized",
-        "cerebellum",
-        "imatrix",
-        "moe",
-        "3-bit",
-        "conversational",
-        "multimodal",
-        "vision",
-        "image-text-to-text",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:gemma",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-01T18:29:18.000Z",
-      "lastModified": "2026-05-15T05:30:04.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
-      "author": "deepsweet",
-      "url": "https://huggingface.co/deepsweet/Qwen3.6-35B-A3B-MLX-oQ4-FP16",
-      "downloads": 5277,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5_moe",
-        "text-generation",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T07:29:14.000Z",
-      "lastModified": "2026-05-10T15:18:41.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26174176422

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.