### PR TITLE
chore(data): refresh lobsters signals 2026-05-20T16:09:08Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-20T12:10:00.726Z",
+  "ts": "2026-05-20T16:09:08.154Z",
   "count": 1,
-  "durationMs": 7903,
+  "durationMs": 4589,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T12:09:52.843Z",
+  "fetchedAt": "2026-05-20T16:09:03.590Z",
   "windowDays": 7,
-  "scannedStories": 82,
+  "scannedStories": 81,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -235,14 +235,14 @@
     },
     "tomekw/stcc": {
       "count7d": 1,
-      "scoreSum7d": 21,
+      "scoreSum7d": 22,
       "topStory": {
         "shortId": "pk139i",
         "title": "The Super Tiny Compiler, but in Ada",
-        "score": 21,
+        "score": 22,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 22.32138888888889
+        "hoursSincePosted": 26.307777777777776
       },
       "stories": [
         {
@@ -251,11 +251,11 @@
           "url": "https://github.com/tomekw/stcc",
           "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
           "by": "",
-          "score": 21,
+          "score": 22,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 22.32138888888889,
-          "trendingScore": 0.17508008015246546,
+          "ageHours": 26.307777777777776,
+          "trendingScore": 0.1460710040065351,
           "tags": [
             "plt",
             "programming"
@@ -492,7 +492,7 @@
     {
       "fullName": "tomekw/stcc",
       "count7d": 1,
-      "scoreSum7d": 21
+      "scoreSum7d": 22
     },
     {
       "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T12:09:52.843Z",
+  "fetchedAt": "2026-05-20T16:09:03.590Z",
   "windowHours": 72,
-  "scannedTotal": 82,
+  "scannedTotal": 81,
   "stories": [
     {
       "shortId": "29pm2f",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26174791676

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.