### PR TITLE
chore(data): refresh huggingface space signals 2026-05-20T16:09:56Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-20T10:03:03.725Z",
+  "ts": "2026-05-20T16:09:56.065Z",
   "count": 1,
-  "durationMs": 6002,
+  "durationMs": 5557,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T10:02:57.726Z",
+  "fetchedAt": "2026-05-20T16:09:50.510Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -177,6 +177,22 @@
     },
     {
       "rank": 11,
+      "id": "ResembleAI/Dramabox",
+      "author": "ResembleAI",
+      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
+      "likes": 72,
+      "trendingScore": 72,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T05:09:42.000Z",
+      "lastModified": "2026-05-20T05:14:48.000Z",
+      "models": []
+    },
+    {
+      "rank": 12,
       "id": "r3gm/wan2-2-fp8da-aoti-preview",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview",
@@ -193,7 +209,7 @@
       "models": []
     },
     {
-      "rank": 12,
+      "rank": 13,
       "id": "kulkas2pintu/wan222",
       "author": "kulkas2pintu",
       "url": "https://huggingface.co/spaces/kulkas2pintu/wan222",
@@ -210,28 +226,12 @@
       "models": []
     },
     {
-      "rank": 13,
-      "id": "ResembleAI/Dramabox",
-      "author": "ResembleAI",
-      "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
-      "likes": 69,
-      "trendingScore": 69,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T05:09:42.000Z",
-      "lastModified": "2026-05-20T05:14:48.000Z",
-      "models": []
-    },
-    {
       "rank": 14,
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 75,
-      "trendingScore": 66,
+      "likes": 81,
+      "trendingScore": 69,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -310,6 +310,22 @@
     },
     {
       "rank": 19,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 51,
+      "trendingScore": 50,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-20T10:03:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 20,
       "id": "smolagents/ml-intern",
       "author": "smolagents",
       "url": "https://huggingface.co/spaces/smolagents/ml-intern",
@@ -322,22 +338,6 @@
       ],
       "createdAt": "2026-01-27T14:05:13.000Z",
       "lastModified": "2026-05-08T10:48:11.000Z",
-      "models": []
-    },
-    {
-      "rank": 20,
-      "id": "HuggingFaceBio/carbon-demo",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 45,
-      "trendingScore": 45,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T14:18:55.000Z",
-      "lastModified": "2026-05-20T09:15:09.000Z",
       "models": []
     },
     {
@@ -406,6 +406,23 @@
     },
     {
       "rank": 25,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 50,
+      "trendingScore": 37,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 26,
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
@@ -419,23 +436,6 @@
       ],
       "createdAt": "2025-11-26T19:54:05.000Z",
       "lastModified": "2026-02-02T16:51:24.000Z",
-      "models": []
-    },
-    {
-      "rank": 26,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 45,
-      "trendingScore": 35,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -523,6 +523,23 @@
     },
     {
       "rank": 32,
+      "id": "mteb/leaderboard",
+      "author": "mteb",
+      "url": "https://huggingface.co/spaces/mteb/leaderboard",
+      "likes": 7394,
+      "trendingScore": 31,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "leaderboard",
+        "region:us"
+      ],
+      "createdAt": "2022-09-29T11:29:23.000Z",
+      "lastModified": "2026-05-20T15:09:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 33,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -538,7 +555,7 @@
       "models": []
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -551,23 +568,6 @@
       ],
       "createdAt": "2026-04-23T14:39:25.000Z",
       "lastModified": "2026-05-06T11:59:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 34,
-      "id": "mteb/leaderboard",
-      "author": "mteb",
-      "url": "https://huggingface.co/spaces/mteb/leaderboard",
-      "likes": 7387,
-      "trendingScore": 29,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "leaderboard",
-        "region:us"
-      ],
-      "createdAt": "2022-09-29T11:29:23.000Z",
-      "lastModified": "2026-05-18T15:44:09.000Z",
       "models": []
     },
     {
@@ -792,6 +792,22 @@
     },
     {
       "rank": 48,
+      "id": "multimodalart/scenema-audio",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
+      "likes": 23,
+      "trendingScore": 21,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T10:12:08.000Z",
+      "lastModified": "2026-05-16T00:07:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 49,
       "id": "BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
       "author": "BoobyBoobs",
       "url": "https://huggingface.co/spaces/BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
@@ -807,7 +823,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "NucleusAI/nucleus-image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/spaces/NucleusAI/nucleus-image",
@@ -820,22 +836,6 @@
       ],
       "createdAt": "2026-04-15T22:24:04.000Z",
       "lastModified": "2026-04-30T12:41:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "multimodalart/scenema-audio",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 22,
-      "trendingScore": 20,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T10:12:08.000Z",
-      "lastModified": "2026-05-16T00:07:35.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26174844934

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.