### PR TITLE
chore(data): refresh mcp liveness 2026-05-20T16:19:25Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T10:15:28.241Z",
+  "fetchedAt": "2026-05-20T16:19:21.712Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -1825,6 +1825,54 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "pitstop-hq/pitstop": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mrankitvish/rag-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "octen-team/octen-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "waeckerlinfederowicz66-sketch/flowspeech mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "vishaltorc/subconscious-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "michielinksee/cockpit-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rauls-kjarners/claude-to-agy": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "vassiliylakhonin/agenda intelligence": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hng2725/math addition mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pauliowest/campaign monitor mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "planit-tech/lawbster": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ai.calendarmcp/server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "mosesy5688/free2aitools": {
       "isStdio": true,
       "livenessInferred": true
@@ -1866,38 +1914,6 @@
       "livenessInferred": true
     },
     "linear": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "psufka/omnifocus mcp plus": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vvbv/pyerp mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tko85/dsr processor mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "nkarasiak/qgis mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "matthewp/lyceum": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "charliemhjeong/tableau mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hyperpolymath/boj-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "amichail-1/orbination ai desktop vision & control": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3982,22 +3998,6 @@
       "livenessInferred": true
     },
     "dazanza/mailchimp-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "lnicolaie/yapy mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jackdark425/financial modeling prep (fmp) mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "signal-found/signal found mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kakacoding1/excalidraw mcp server": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26175328743

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.