### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-20T17:59:20Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-20T13:46:21.741Z",
+  "ts": "2026-05-20T17:59:20.340Z",
   "count": 1,
-  "durationMs": 10285,
+  "durationMs": 14422,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-20T13:46:18.936Z",
+  "lastFetchedAt": "2026-05-20T17:59:17.194Z",
   "windowDays": 7,
   "launches": [
     {
@@ -109,6 +109,66 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1144771",
+      "name": "StoreClaw",
+      "tagline": "Grow your store profits with agents that know how to sell",
+      "description": "StoreClaw is the first AI commerce platform with agents that know how to sell, so you can make more money with less effort and less stress. Connect StoreClaw to your existing store and it will study your numbers, current sales figures, and growth trajectory, and then offer proactive suggestions that it can execute on your behalf — once you give it your approval. Ask StoreClaw how your business is doing any time, anywhere. Sell more with less stress: StoreClaw.",
+      "url": "https://www.producthunt.com/products/storeclaw?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/PVXOOJINEBKKUA",
+      "votesCount": 423,
+      "commentsCount": 191,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/407049a2-0be3-4b8d-a7c0-4fc5b9754db2.png?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "e-commerce",
+        "marketing-automation"
+      ],
+      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -327,6 +387,72 @@
       "aiAdjacent": false
     },
     {
+      "id": "1134267",
+      "name": "mailX by mailwarm",
+      "tagline": "Email deliverability toolkit for humans and AI agents",
+      "description": "Your emails go to spam. mailX shows you why, and how to fix it in seconds with clear answers and exact steps. Built for humans and AI agents. API and MCP ready.",
+      "url": "https://www.producthunt.com/products/mailx-by-mailwarm-yc-s20?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/H2XLXASAORMP7Z",
+      "votesCount": 366,
+      "commentsCount": 210,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/9d9e986f-969d-4a67-9a15-e6733097da14.gif?auto=format",
+      "topics": [
+        "email",
+        "email-marketing",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1141978",
       "name": "Monid 2.0",
       "tagline": "OpenRouter for agent tools",
@@ -491,66 +617,6 @@
       "topics": [
         "productivity",
         "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1144771",
-      "name": "StoreClaw",
-      "tagline": "Grow your store profits with agents that know how to sell",
-      "description": "StoreClaw is the first AI commerce platform with agents that know how to sell, so you can make more money with less effort and less stress. Connect StoreClaw to your existing store and it will study your numbers, current sales figures, and growth trajectory, and then offer proactive suggestions that it can execute on your behalf — once you give it your approval. Ask StoreClaw how your business is doing any time, anywhere. Sell more with less stress: StoreClaw.",
-      "url": "https://www.producthunt.com/products/storeclaw?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/PVXOOJINEBKKUA",
-      "votesCount": 325,
-      "commentsCount": 147,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/407049a2-0be3-4b8d-a7c0-4fc5b9754db2.png?auto=format",
-      "topics": [
-        "artificial-intelligence",
-        "e-commerce",
-        "marketing-automation"
       ],
       "makers": [
         {
@@ -1072,72 +1138,6 @@
       "aiAdjacent": false
     },
     {
-      "id": "1134267",
-      "name": "mailX by mailwarm",
-      "tagline": "Email deliverability toolkit for humans and AI agents",
-      "description": "Your emails go to spam. mailX shows you why, and how to fix it in seconds with clear answers and exact steps. Built for humans and AI agents. API and MCP ready.",
-      "url": "https://www.producthunt.com/products/mailx-by-mailwarm-yc-s20?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/H2XLXASAORMP7Z",
-      "votesCount": 280,
-      "commentsCount": 135,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/9d9e986f-969d-4a67-9a15-e6733097da14.gif?auto=format",
-      "topics": [
-        "email",
-        "email-marketing",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1137008",
       "name": "OpenJobs AI",
       "tagline": "End-to-End Autonomous AI Recruiter",
@@ -1401,6 +1401,35 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151095",
+      "name": "Gemini Omni",
+      "tagline": "Create anything from any input – starting with video",
+      "description": "Create anything from anything, starting with video. Gemini Omni is where Gemini’s ability to reason meets the ability to create. It delivers a leap in world understanding, multimodality, and editing.",
+      "url": "https://www.producthunt.com/products/gemini-omni-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ENOAWGG27PYBQE",
+      "votesCount": 253,
+      "commentsCount": 5,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d0081810-ee52-41d6-b33e-163838981bc6.svg?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "video"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1050396",
       "name": "Genpire",
       "tagline": "Make Real Products with AI, literally.",
@@ -1554,6 +1583,43 @@
         "saas",
         "github",
         "vibe-coding"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1150124",
+      "name": "Emdash",
+      "tagline": "One app. Every coding agent. Open-source.",
+      "description": "Emdash is an open-source desktop app for running multiple coding agents in parallel; one place to monitor sessions, review diffs, and turn issues into PRs.",
+      "url": "https://www.producthunt.com/products/emdash?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/U7NUCTTEX6BM3I",
+      "votesCount": 226,
+      "commentsCount": 50,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/4b4feac9-ff8d-4091-aecb-78859d285f91.x-icon?auto=format",
+      "topics": [
+        "productivity",
+        "open-source",
+        "developer-tools",
+        "github"
       ],
       "makers": [
         {
@@ -2169,158 +2235,6 @@
         "productivity",
         "venture-capital",
         "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1141439",
-      "name": "Warp Open-Source",
-      "tagline": "Agentic development environment built with the community",
-      "description": "The best, longest-lasting software is built with the people who use it, so we've opened up Warp to the community. To make this possible, Oz-managed agents do the heavy lifting (coding, planning, testing), letting community members focus on ideas, direction, and verification. 25K+ stars added and 500+ contributors in week one.",
-      "url": "https://www.producthunt.com/products/warp?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/RXPBBH5AYSU33A",
-      "votesCount": 168,
-      "commentsCount": 10,
-      "createdAt": "2026-05-11T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/d3217cf2-1f51-4772-aa0d-497d8737ad9a.png?auto=format",
-      "topics": [
-        "open-source",
-        "developer-tools",
-        "artificial-intelligence",
-        "github"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1150124",
-      "name": "Emdash",
-      "tagline": "One app. Every coding agent. Open-source.",
-      "description": "Emdash is an open-source desktop app for running multiple coding agents in parallel; one place to monitor sessions, review diffs, and turn issues into PRs.",
-      "url": "https://www.producthunt.com/products/emdash?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/U7NUCTTEX6BM3I",
-      "votesCount": 167,
-      "commentsCount": 28,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/4b4feac9-ff8d-4091-aecb-78859d285f91.x-icon?auto=format",
-      "topics": [
-        "productivity",
-        "open-source",
-        "developer-tools",
-        "github"
       ],
       "makers": [
         {


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26180418928

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.