### PR TITLE
chore(data): refresh lobsters signals 2026-05-20T18:42:35Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-20T16:09:08.154Z",
+  "ts": "2026-05-20T18:42:34.859Z",
   "count": 1,
-  "durationMs": 4589,
+  "durationMs": 4552,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T16:09:03.590Z",
+  "fetchedAt": "2026-05-20T18:42:30.327Z",
   "windowDays": 7,
-  "scannedStories": 81,
+  "scannedStories": 82,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -235,14 +235,14 @@
     },
     "tomekw/stcc": {
       "count7d": 1,
-      "scoreSum7d": 22,
+      "scoreSum7d": 23,
       "topStory": {
         "shortId": "pk139i",
         "title": "The Super Tiny Compiler, but in Ada",
-        "score": 22,
+        "score": 23,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 26.307777777777776
+        "hoursSincePosted": 28.865277777777777
       },
       "stories": [
         {
@@ -251,11 +251,11 @@
           "url": "https://github.com/tomekw/stcc",
           "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
           "by": "",
-          "score": 22,
+          "score": 23,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 26.307777777777776,
-          "trendingScore": 0.1460710040065351,
+          "ageHours": 28.865277777777777,
+          "trendingScore": 0.13412895816808107,
           "tags": [
             "plt",
             "programming"
@@ -492,7 +492,7 @@
     {
       "fullName": "tomekw/stcc",
       "count7d": 1,
-      "scoreSum7d": 22
+      "scoreSum7d": 23
     },
     {
       "fullName": "0xdeadbeefnetwork/Copy_Fail2-Electric_Boogaloo",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T16:09:03.590Z",
+  "fetchedAt": "2026-05-20T18:42:30.327Z",
   "windowHours": 72,
-  "scannedTotal": 81,
+  "scannedTotal": 82,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -673,6 +673,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "asu0u9",
+      "title": "Erasing Existentials",
+      "url": "https://wolfgirl.dev/blog/2026-05-20-erasing-existentials/",
+      "commentsUrl": "https://lobste.rs/s/asu0u9/erasing_existentials",
+      "by": "",
+      "score": 18,
+      "commentCount": 1,
+      "createdUtc": 1779284705,
+      "ageHours": 4.956944444444445,
+      "trendingScore": 0.9809451001573645,
+      "tags": [
+        "rust"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "5pjoom",
       "title": "Introducing Casuarina Linux: A glibc-Based Chimera Linux Derivative",
       "url": "https://casuarina.org/news/introducing-casuarina-linux/",
@@ -878,26 +895,6 @@
       "tags": [
         "security",
         "vibecoding"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "sjbrlg",
-      "title": "Yggdrasil Network as an Embedded Go Library",
-      "url": "https://dev.to/asciimoth/yggdrasil-network-as-an-embedded-go-library-9h",
-      "commentsUrl": "https://lobste.rs/s/sjbrlg/yggdrasil_network_as_embedded_go_library",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1778347459,
-      "ageHours": 1.1588888888888889,
-      "trendingScore": 0.8905708565168265,
-      "tags": [
-        "distributed",
-        "go",
-        "networking",
-        "programming"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26182642739

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.