### PR TITLE
chore(data): refresh huggingface space signals 2026-05-20T20:37:26Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-20T16:09:56.065Z",
+  "ts": "2026-05-20T20:37:26.035Z",
   "count": 1,
-  "durationMs": 5557,
+  "durationMs": 6771,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T16:09:50.510Z",
+  "fetchedAt": "2026-05-20T20:37:19.266Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -177,6 +177,23 @@
     },
     {
       "rank": 11,
+      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
+      "author": "cbensimon",
+      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
+      "likes": 84,
+      "trendingScore": 72,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:08:17.000Z",
+      "lastModified": "2026-05-14T11:52:10.000Z",
+      "models": []
+    },
+    {
+      "rank": 12,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
@@ -192,7 +209,7 @@
       "models": []
     },
     {
-      "rank": 12,
+      "rank": 13,
       "id": "r3gm/wan2-2-fp8da-aoti-preview",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview",
@@ -209,7 +226,7 @@
       "models": []
     },
     {
-      "rank": 13,
+      "rank": 14,
       "id": "kulkas2pintu/wan222",
       "author": "kulkas2pintu",
       "url": "https://huggingface.co/spaces/kulkas2pintu/wan222",
@@ -223,23 +240,6 @@
       ],
       "createdAt": "2026-03-27T08:57:40.000Z",
       "lastModified": "2026-03-26T22:35:15.000Z",
-      "models": []
-    },
-    {
-      "rank": 14,
-      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
-      "author": "cbensimon",
-      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 81,
-      "trendingScore": 69,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:08:17.000Z",
-      "lastModified": "2026-05-14T11:52:10.000Z",
       "models": []
     },
     {
@@ -313,8 +313,8 @@
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 51,
-      "trendingScore": 50,
+      "likes": 55,
+      "trendingScore": 54,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -409,8 +409,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 50,
-      "trendingScore": 37,
+      "likes": 53,
+      "trendingScore": 38,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -506,6 +506,23 @@
     },
     {
       "rank": 31,
+      "id": "mteb/leaderboard",
+      "author": "mteb",
+      "url": "https://huggingface.co/spaces/mteb/leaderboard",
+      "likes": 7395,
+      "trendingScore": 32,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "leaderboard",
+        "region:us"
+      ],
+      "createdAt": "2022-09-29T11:29:23.000Z",
+      "lastModified": "2026-05-20T15:09:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 32,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -519,23 +536,6 @@
       ],
       "createdAt": "2026-02-09T13:55:04.000Z",
       "lastModified": "2026-05-13T07:34:37.000Z",
-      "models": []
-    },
-    {
-      "rank": 32,
-      "id": "mteb/leaderboard",
-      "author": "mteb",
-      "url": "https://huggingface.co/spaces/mteb/leaderboard",
-      "likes": 7394,
-      "trendingScore": 31,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "leaderboard",
-        "region:us"
-      ],
-      "createdAt": "2022-09-29T11:29:23.000Z",
-      "lastModified": "2026-05-20T15:09:57.000Z",
       "models": []
     },
     {
@@ -707,6 +707,22 @@
     },
     {
       "rank": 43,
+      "id": "multimodalart/scenema-audio",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
+      "likes": 24,
+      "trendingScore": 22,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T10:12:08.000Z",
+      "lastModified": "2026-05-16T00:07:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 44,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -722,7 +738,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "Overworld/waypoint-1-5",
       "author": "Overworld",
       "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
@@ -738,7 +754,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
@@ -754,7 +770,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "carlofkl/DreamLite",
       "author": "carlofkl",
       "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
@@ -774,7 +790,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "huggingface/physics-intern",
       "author": "huggingface",
       "url": "https://huggingface.co/spaces/huggingface/physics-intern",
@@ -788,22 +804,6 @@
       ],
       "createdAt": "2026-04-09T06:56:52.000Z",
       "lastModified": "2026-05-12T14:59:53.000Z",
-      "models": []
-    },
-    {
-      "rank": 48,
-      "id": "multimodalart/scenema-audio",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 23,
-      "trendingScore": 21,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T10:12:08.000Z",
-      "lastModified": "2026-05-16T00:07:35.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26188463871

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.