### PR TITLE
chore(data): refresh arxiv signals 2026-05-20T20:55:29Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-20T16:18:08.510Z",
+  "ts": "2026-05-20T20:55:20.639Z",
   "count": 1,
-  "durationMs": 62849,
+  "durationMs": 62516,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T16:18:08.786Z",
+  "fetchedAt": "2026-05-20T20:55:20.862Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -8,11 +8,46 @@
   "count": 153,
   "papers": [
     {
+      "arxivId": "2605.20185v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20183v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
       "arxivId": "2605.20182v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20179v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20177v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20176v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
       "arxivId": "2605.20174v1",
@@ -22,6 +57,27 @@
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
+      "arxivId": "2605.20173v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20172v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20170v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
       "arxivId": "2605.20167v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -29,11 +85,32 @@
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
+      "arxivId": "2605.20165v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20164v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
       "arxivId": "2605.20159v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20158v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
       "arxivId": "2605.20157v1",
@@ -48,6 +125,27 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20150v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20149v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20147v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
       "arxivId": "2605.20145v1",
@@ -71,6 +169,13 @@
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
+      "arxivId": "2605.20128v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
       "arxivId": "2605.20127v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -85,11 +190,25 @@
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
+      "arxivId": "2605.20120v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
       "arxivId": "2605.20119v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20110v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
       "arxivId": "2605.20108v1",
@@ -120,363 +239,6 @@
       "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
-      "arxivId": "2605.20088v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20086v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20079v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20074v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20069v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20068v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20040v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20037v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20036v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20032v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20030v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20028v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20009v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20005v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19999v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19990v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19986v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19975v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19972v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19969v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19966v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19965v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19959v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19947v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19944v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19938v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19932v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19931v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19928v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19926v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19916v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19902v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19856v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.19847v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
-    },
-    {
-      "arxivId": "2605.20185v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20183v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20179v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20177v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20176v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20173v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20172v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20170v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20165v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20164v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20158v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20150v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20149v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20147v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20128v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20120v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
-      "arxivId": "2605.20110v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
-    },
-    {
       "arxivId": "2605.20098v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -491,11 +253,25 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.20088v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.20087v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20086v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.20085v1",
@@ -519,11 +295,25 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.20079v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.20075v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20074v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.20073v1",
@@ -538,6 +328,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20069v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20068v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.20066v1",
@@ -603,6 +407,27 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.20040v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20037v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20036v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.20035v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -615,6 +440,27 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20032v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20030v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.20028v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.20025v1",
@@ -645,11 +491,32 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.20009v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.20006v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.20005v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19999v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.19995v1",
@@ -659,11 +526,25 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.19990v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.19988v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.19986v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.19982v1",
@@ -680,11 +561,53 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.19975v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.19974v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.19972v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19969v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19966v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19965v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19959v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.19957v1",
@@ -722,11 +645,25 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.19947v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.19945v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.19944v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.19943v1",
@@ -743,11 +680,32 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.19938v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.19936v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.19932v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19931v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.19929v1",
@@ -757,11 +715,39 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.19928v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19926v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
+      "arxivId": "2605.19916v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.19908v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.19902v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.19895v1",
@@ -834,6 +820,13 @@
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
     },
     {
+      "arxivId": "2605.19856v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+    },
+    {
       "arxivId": "2605.19855v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -853,6 +846,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+    },
+    {
+      "arxivId": "2605.19847v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
     },
     {
       "arxivId": "2605.19846v1",

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T16:17:05.682Z",
+  "fetchedAt": "2026-05-20T20:54:18.139Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26189326196

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.