### PR TITLE
chore(data): refresh mcp liveness 2026-05-20T20:56:05Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T16:19:21.712Z",
+  "fetchedAt": "2026-05-20T20:56:01.763Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -1869,6 +1869,70 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "renanpires-tech/gpa backend test analyst mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "shdomi8599/vibie-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kapillamba4/code memory": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kapillamba4/meta-prompt-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "alikarami/mikromcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jrslyce/idelrpg": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ericm1018/skillfm beacon": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kioie/tiny-go-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tushariitr-19/patents-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aliasunder/vault-cortex": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "automatelab-tech/content distribution mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "prmbr42-bot/smartsheet mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "openaccountants/openaccountants": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "svgicons-com/svg/icons mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "alfredoizdev/contextforge-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mnemexa/mnemexa mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ai.calendarmcp/server": {
       "isStdio": true,
       "livenessInferred": true
@@ -1914,90 +1978,6 @@
       "livenessInferred": true
     },
     "linear": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tsiongk/sponge mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "daerda/mcp-audit": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aethercore-dev/token-rugcheck": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aethercore-dev/ag402-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bbdaniels/music mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "markswendsen-code/delta air lines mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "markswendsen-code/mcp-hilton": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "markswendsen-code/mcp-costco": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "markswendsen-code/mcp-southwest": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "damerakd/mcp weather server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jordan-horner/symbols": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "lvdaxianer/datetime-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "therealcoiffeur/acunetix mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jachy-h/jachy mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "the-otner/hpe aruba networking central mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "asifkabirantu/figsor": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ferodrigop/forge": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "devansh-365/infographic mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "xxo47oxx/spa-reader-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shenyunhuan/gemini_mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aboodtt404/mcp-menesesdk": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3998,6 +3978,26 @@
       "livenessInferred": true
     },
     "dazanza/mailchimp-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "lnicolaie/yapy mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jackdark425/financial modeling prep (fmp) mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "signal-found/signal found mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kakacoding1/excalidraw mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "moksh555/githubmcpserver": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26189413167

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.