### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-20T21:07:29Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-20T17:59:20.340Z",
+  "ts": "2026-05-20T21:07:29.202Z",
   "count": 1,
-  "durationMs": 14422,
+  "durationMs": 11057,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,7 +1,67 @@
 {
-  "lastFetchedAt": "2026-05-20T17:59:17.194Z",
+  "lastFetchedAt": "2026-05-20T21:07:26.135Z",
   "windowDays": 7,
   "launches": [
+    {
+      "id": "1144771",
+      "name": "StoreClaw",
+      "tagline": "Grow your store profits with agents that know how to sell",
+      "description": "StoreClaw is the first AI commerce platform with agents that know how to sell, so you can make more money with less effort and less stress. Connect StoreClaw to your existing store and it will study your numbers, current sales figures, and growth trajectory, and then offer proactive suggestions that it can execute on your behalf — once you give it your approval. Ask StoreClaw how your business is doing any time, anywhere. Sell more with less stress: StoreClaw.",
+      "url": "https://www.producthunt.com/products/storeclaw?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/PVXOOJINEBKKUA",
+      "votesCount": 487,
+      "commentsCount": 202,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/407049a2-0be3-4b8d-a7c0-4fc5b9754db2.png?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "e-commerce",
+        "marketing-automation"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
     {
       "id": "1058199",
       "name": "Spellar 3.0",
@@ -153,22 +213,28 @@
       "aiAdjacent": true
     },
     {
-      "id": "1144771",
-      "name": "StoreClaw",
-      "tagline": "Grow your store profits with agents that know how to sell",
-      "description": "StoreClaw is the first AI commerce platform with agents that know how to sell, so you can make more money with less effort and less stress. Connect StoreClaw to your existing store and it will study your numbers, current sales figures, and growth trajectory, and then offer proactive suggestions that it can execute on your behalf — once you give it your approval. Ask StoreClaw how your business is doing any time, anywhere. Sell more with less stress: StoreClaw.",
-      "url": "https://www.producthunt.com/products/storeclaw?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/PVXOOJINEBKKUA",
-      "votesCount": 423,
-      "commentsCount": 191,
+      "id": "1134267",
+      "name": "mailX by mailwarm",
+      "tagline": "Email deliverability toolkit for humans and AI agents",
+      "description": "Your emails go to spam. mailX shows you why, and how to fix it in seconds with clear answers and exact steps. Built for humans and AI agents. API and MCP ready.",
+      "url": "https://www.producthunt.com/products/mailx-by-mailwarm-yc-s20?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/H2XLXASAORMP7Z",
+      "votesCount": 417,
+      "commentsCount": 232,
       "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/407049a2-0be3-4b8d-a7c0-4fc5b9754db2.png?auto=format",
+      "thumbnail": "https://ph-files.imgix.net/9d9e986f-969d-4a67-9a15-e6733097da14.gif?auto=format",
       "topics": [
-        "artificial-intelligence",
-        "e-commerce",
-        "marketing-automation"
+        "email",
+        "email-marketing",
+        "artificial-intelligence"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -385,72 +451,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1134267",
-      "name": "mailX by mailwarm",
-      "tagline": "Email deliverability toolkit for humans and AI agents",
-      "description": "Your emails go to spam. mailX shows you why, and how to fix it in seconds with clear answers and exact steps. Built for humans and AI agents. API and MCP ready.",
-      "url": "https://www.producthunt.com/products/mailx-by-mailwarm-yc-s20?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/H2XLXASAORMP7Z",
-      "votesCount": 366,
-      "commentsCount": 210,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/9d9e986f-969d-4a67-9a15-e6733097da14.gif?auto=format",
-      "topics": [
-        "email",
-        "email-marketing",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     },
     {
       "id": "1141978",
@@ -1138,6 +1138,35 @@
       "aiAdjacent": false
     },
     {
+      "id": "1151095",
+      "name": "Gemini Omni",
+      "tagline": "Create anything from any input – starting with video",
+      "description": "Create anything from anything, starting with video. Gemini Omni is where Gemini’s ability to reason meets the ability to create. It delivers a leap in world understanding, multimodality, and editing.",
+      "url": "https://www.producthunt.com/products/gemini-omni-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ENOAWGG27PYBQE",
+      "votesCount": 276,
+      "commentsCount": 6,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d0081810-ee52-41d6-b33e-163838981bc6.svg?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "video"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1137008",
       "name": "OpenJobs AI",
       "tagline": "End-to-End Autonomous AI Recruiter",
@@ -1401,35 +1430,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1151095",
-      "name": "Gemini Omni",
-      "tagline": "Create anything from any input – starting with video",
-      "description": "Create anything from anything, starting with video. Gemini Omni is where Gemini’s ability to reason meets the ability to create. It delivers a leap in world understanding, multimodality, and editing.",
-      "url": "https://www.producthunt.com/products/gemini-omni-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/ENOAWGG27PYBQE",
-      "votesCount": 253,
-      "commentsCount": 5,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/d0081810-ee52-41d6-b33e-163838981bc6.svg?auto=format",
-      "topics": [
-        "artificial-intelligence",
-        "video"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1050396",
       "name": "Genpire",
       "tagline": "Make Real Products with AI, literally.",
@@ -1476,6 +1476,43 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1150124",
+      "name": "Emdash",
+      "tagline": "One app. Every coding agent. Open-source.",
+      "description": "Emdash is an open-source desktop app for running multiple coding agents in parallel; one place to monitor sessions, review diffs, and turn issues into PRs.",
+      "url": "https://www.producthunt.com/products/emdash?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/U7NUCTTEX6BM3I",
+      "votesCount": 250,
+      "commentsCount": 66,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/4b4feac9-ff8d-4091-aecb-78859d285f91.x-icon?auto=format",
+      "topics": [
+        "productivity",
+        "open-source",
+        "developer-tools",
+        "github"
+      ],
+      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1583,43 +1620,6 @@
         "saas",
         "github",
         "vibe-coding"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1150124",
-      "name": "Emdash",
-      "tagline": "One app. Every coding agent. Open-source.",
-      "description": "Emdash is an open-source desktop app for running multiple coding agents in parallel; one place to monitor sessions, review diffs, and turn issues into PRs.",
-      "url": "https://www.producthunt.com/products/emdash?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/U7NUCTTEX6BM3I",
-      "votesCount": 226,
-      "commentsCount": 50,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/4b4feac9-ff8d-4091-aecb-78859d285f91.x-icon?auto=format",
-      "topics": [
-        "productivity",
-        "open-source",
-        "developer-tools",
-        "github"
       ],
       "makers": [
         {
@@ -2085,6 +2085,48 @@
       "aiAdjacent": false
     },
     {
+      "id": "1151120",
+      "name": "Runtime",
+      "tagline": "Sandboxed coding agents for everyone on your team",
+      "description": "Turn coding agents into teammates anyone can use from Slack, Linear, CLI, API or your browser. Ship features, query data, build dashboards, automate workflows. All within your company's context, skills, integrations, and security guardrails.",
+      "url": "https://www.producthunt.com/products/runtime?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/TOZOGOJYMEHTNQ",
+      "votesCount": 183,
+      "commentsCount": 34,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/67ea30b8-1bf6-44ba-99db-09c8498841d9.png?auto=format",
+      "topics": [
+        "slack",
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1139758",
       "name": "GPT‑5.5 Instant",
       "tagline": "Smarter, more personal answers as ChatGPT's new default",
@@ -2198,42 +2240,6 @@
       "createdAt": "2026-05-09T07:01:00Z",
       "thumbnail": "https://ph-files.imgix.net/e7e6aade-0ffd-4cce-a202-e014aba72c18.png?auto=format",
       "topics": [
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1140478",
-      "name": "Causo for Fundraising",
-      "tagline": "Pitch the right VCs, skip the grind",
-      "description": "90% of startups die from no money, not bad products. Causo's AI agents find matching investors and email them for you while you ship. Upload your deck or website, get matched with specific partners at relevant VC funds, send your pitch. All on autopilot. Let our raccoons do the work while you ship product and talk to customers.",
-      "url": "https://www.producthunt.com/products/causo-hub-free-tools-for-fundraising?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/FVNJIU4JR4VBWS",
-      "votesCount": 171,
-      "commentsCount": 53,
-      "createdAt": "2026-05-14T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/a9fa067d-d885-40aa-8913-5579b75c422f.png?auto=format",
-      "topics": [
-        "productivity",
-        "venture-capital",
         "artificial-intelligence"
       ],
       "makers": [


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26189979748

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.