### PR TITLE
chore(data): refresh bluesky signals 2026-05-20T21:10:35Z

### DIFF
--- a/data/_meta/bluesky.json
+++ b/data/_meta/bluesky.json
@@ -1,8 +1,8 @@
 {
   "source": "bluesky",
   "reason": "ok",
-  "ts": "2026-05-20T18:32:13.194Z",
+  "ts": "2026-05-20T21:10:35.396Z",
   "count": 1,
-  "durationMs": 14421,
+  "durationMs": 18378,
   "extra": {}
 }

--- a/data/bluesky-mentions.json
+++ b/data/bluesky-mentions.json
@@ -1,9 +1,9 @@
 {
-  "fetchedAt": "2026-05-20T18:31:59.035Z",
+  "fetchedAt": "2026-05-20T21:10:17.444Z",
   "windowDays": 7,
-  "scannedPosts": 197,
+  "scannedPosts": 300,
   "searchQuery": "github.com",
-  "pagesFetched": 2,
+  "pagesFetched": 3,
   "mentions": {
     "antirez/ds4": {
       "count7d": 1,
@@ -3418,7 +3418,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-20T16:27:44.000Z",
-        "hoursSincePosted": 2.07
+        "hoursSincePosted": 4.71
       },
       "posts": [
         {
@@ -3468,7 +3468,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T16:27:44.000Z",
           "createdUtc": 1779294464,
-          "ageHours": 2.07,
+          "ageHours": 4.71,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -3496,7 +3496,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T16:27:25.000Z",
           "createdUtc": 1779294445,
-          "ageHours": 2.08,
+          "ageHours": 4.71,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -3524,7 +3524,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T16:15:57.000Z",
           "createdUtc": 1779293757,
-          "ageHours": 2.27,
+          "ageHours": 4.91,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -8934,18 +8934,18 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mm66fbygf32x",
-        "cid": "bafyreieov772tglre7bm2uddq37s5mo7byt3o5j5icnfm4jkffcc7unyvy",
-        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mm66fbygf32x",
-        "text": "🟠 OpenClaw 2026.5.19-beta.1 lands with browser dialog control, typed plugin tooling, and a new Node 22.19 floor OpenClaw shipped 2026.5.19-beta.1 with several workflow-changing upgrades hiding inside a beta cut. https://github.com/openclaw/openclaw/releases/tag/v2026.5.19-beta.1 #AI #AgentWyre",
+        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmcssli32n2c",
+        "cid": "bafyreiby7qfkqartwsegvh55porzp5kiwymobywyex6zbmlfrasynpkfbi",
+        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmcssli32n2c",
+        "text": "🟠 OpenClaw v2026.5.19 raises the Node.js floor to 22.19 and adds a new image build arg OpenClaw shipped v2026.5.19 with two operator-facing changes hidden inside a routine-looking release: the minimum supported Node.js... https://github.com/openclaw/openclaw/releases/tag/v2026.5.19 #AI #AgentWyre",
         "author": {
           "handle": "agentwyre.ai"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T00:52:04.128179+00:00",
-        "hoursSincePosted": 3.69
+        "createdAt": "2026-05-20T21:08:01.240227+00:00",
+        "hoursSincePosted": 0.5
       },
       "posts": [
         {
@@ -9019,6 +9019,34 @@
           "createdUtc": 1778609979,
           "ageHours": 2.54,
           "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmcssli32n2c",
+          "cid": "bafyreiby7qfkqartwsegvh55porzp5kiwymobywyex6zbmlfrasynpkfbi",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmcssli32n2c",
+          "text": "🟠 OpenClaw v2026.5.19 raises the Node.js floor to 22.19 and adds a new image build arg OpenClaw shipped v2026.5.19 with two operator-facing changes hidden inside a routine-looking release: the minimum supported Node.js... https://github.com/openclaw/openclaw/releases/tag/v2026.5.19 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T21:08:01.240227+00:00",
+          "createdUtc": 1779311281,
+          "ageHours": 0.5,
+          "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
             "is-announcement"
@@ -11787,23 +11815,23 @@
     },
     "NousResearch/hermes-agent": {
       "count7d": 1,
-      "likesSum7d": 2,
+      "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:txfqncx66asrjzitxfur3of6/app.bsky.feed.post/3mlnnhex5uc2h",
-        "cid": "bafyreicbmrx6qyh4rsg447imtggbq7wqsjciol67knqimlldvj3na6rfy4",
-        "bskyUrl": "https://bsky.app/profile/tilmonedwards.com/post/3mlnnhex5uc2h",
-        "text": "Tried hermes for a bit, it seems like the Eclipse of coding agents. It does everything and your first session with it will be going through settings and disabling stuff. Like, it comes bundled with a skill for managing modded Minecraft servers?? github.com/NousResearch...",
+        "uri": "at://did:plc:l3ew7x4vzptgqeecfulu477l/app.bsky.feed.post/3mmcl6wkkxs2o",
+        "cid": "bafyreig2fohrb24pkew4icebvvxopz5w2cfb3yucmifczwuhhehgavxghq",
+        "bskyUrl": "https://bsky.app/profile/guillemhs.eurosky.social/post/3mmcl6wkkxs2o",
+        "text": "Necessito una màquina per posar això github.com/NousResearch...",
         "author": {
-          "handle": "tilmonedwards.com",
-          "displayName": "Tilmon Edwards (Dirigo)"
+          "handle": "guillemhs.eurosky.social",
+          "displayName": "Guillem"
         },
-        "likeCount": 2,
+        "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-12T11:06:25.885Z",
-        "hoursSincePosted": 1.22
+        "createdAt": "2026-05-20T18:51:49.379Z",
+        "hoursSincePosted": 2.31
       },
       "posts": [
         {
@@ -11827,6 +11855,34 @@
             "has-md-file"
           ],
           "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:l3ew7x4vzptgqeecfulu477l/app.bsky.feed.post/3mmcl6wkkxs2o",
+          "cid": "bafyreig2fohrb24pkew4icebvvxopz5w2cfb3yucmifczwuhhehgavxghq",
+          "bskyUrl": "https://bsky.app/profile/guillemhs.eurosky.social/post/3mmcl6wkkxs2o",
+          "text": "Necessito una màquina per posar això github.com/NousResearch...",
+          "author": {
+            "handle": "guillemhs.eurosky.social",
+            "displayName": "Guillem"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T18:51:49.379Z",
+          "createdUtc": 1779303109,
+          "ageHours": 2.31,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -13731,25 +13787,53 @@
     },
     "rohitg00/agentmemory": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:e4wr5lkpn63w5hy6iisnauqu/app.bsky.feed.post/3mmc7bqlnhh2j",
-        "cid": "bafyreifrim6qdhqjvfnjkhuo24magzsgvbwrl4ksxviqdj4q3dbh42hjp4",
-        "bskyUrl": "https://bsky.app/profile/boardwire.bsky.social/post/3mmc7bqlnhh2j",
-        "text": "Agentmemory library ships persistent memory for AI coding agents. Claims #1 benchmark for coding agent recall. Gained 1,626 GitHub stars today. #Agentmemory #CodingAgents #GitHub 🔗 https://github.com/rohitg00/agentmemory",
+        "uri": "at://did:plc:e4wr5lkpn63w5hy6iisnauqu/app.bsky.feed.post/3mmcpsfqhnt2s",
+        "cid": "bafyreigeq5dqx75jnxu5eklgbzfezyx5s3tu3kdxwh6lsveqng4neobiea",
+        "bskyUrl": "https://bsky.app/profile/boardwire.bsky.social/post/3mmcpsfqhnt2s",
+        "text": "Agent memory is becoming infrastructure for coding workflows. Agentmemory adds persistent state to AI coding agents based on real-world benchmarks. #Agentmemory #CodingAgents #AIWorkflows 🔗 https://github.com/rohitg00/agentmemory",
         "author": {
           "handle": "boardwire.bsky.social",
           "displayName": "Boardwire"
         },
-        "likeCount": 0,
+        "likeCount": 2,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-20T15:18:37.395282Z",
-        "hoursSincePosted": 3.22
+        "replyCount": 0,
+        "createdAt": "2026-05-20T20:14:16.261932Z",
+        "hoursSincePosted": 0.93
       },
       "posts": [
+        {
+          "uri": "at://did:plc:e4wr5lkpn63w5hy6iisnauqu/app.bsky.feed.post/3mmcpsfqhnt2s",
+          "cid": "bafyreigeq5dqx75jnxu5eklgbzfezyx5s3tu3kdxwh6lsveqng4neobiea",
+          "bskyUrl": "https://bsky.app/profile/boardwire.bsky.social/post/3mmcpsfqhnt2s",
+          "text": "Agent memory is becoming infrastructure for coding workflows. Agentmemory adds persistent state to AI coding agents based on real-world benchmarks. #Agentmemory #CodingAgents #AIWorkflows 🔗 https://github.com/rohitg00/agentmemory",
+          "author": {
+            "handle": "boardwire.bsky.social",
+            "displayName": "Boardwire"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T20:14:16.261932Z",
+          "createdUtc": 1779308056,
+          "ageHours": 0.93,
+          "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "rohitg00/agentmemory",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:d3p4jzrm5dpz2gdhzd5sxwwa/app.bsky.feed.post/3mluyrpisxv2z",
           "cid": "bafyreiewsbnsxbgwo5hhzlhgutfyldbylvxr5tm7kjmzjyayfsdwqjxx4e",
@@ -18573,7 +18657,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-20T17:02:53.088Z",
-        "hoursSincePosted": 1.49
+        "hoursSincePosted": 4.12
       },
       "posts": [
         {
@@ -18590,7 +18674,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T17:02:53.088Z",
           "createdUtc": 1779296573,
-          "ageHours": 1.49,
+          "ageHours": 4.12,
           "trendingScore": 1,
           "content_tags": [
             "has-github-repo"
@@ -18599,6 +18683,210 @@
           "linkedRepos": [
             {
               "fullName": "dotnet/skills",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "leejet/stable-diffusion.cpp": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 0,
+      "repliesSum7d": 1,
+      "topPost": {
+        "uri": "at://did:plc:4cb4ap6dfrm2cgfw64dpuwha/app.bsky.feed.post/3mmcq5wxv2k2s",
+        "cid": "bafyreibvckvmt2gak7y3a7anf2jmzveke5i3sxswyqzh4itfz3xar3sh4m",
+        "bskyUrl": "https://bsky.app/profile/barredspirals.comint.su/post/3mmcq5wxv2k2s",
+        "text": "okay this makes something of a difference. temporal tiling is less egregious now, down to maybe `badness 5000` github.com/leejet/stabl...",
+        "author": {
+          "handle": "barredspirals.comint.su",
+          "displayName": "lexi"
+        },
+        "likeCount": 1,
+        "repostCount": 0,
+        "replyCount": 1,
+        "createdAt": "2026-05-20T20:20:44.969Z",
+        "hoursSincePosted": 0.83
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:4cb4ap6dfrm2cgfw64dpuwha/app.bsky.feed.post/3mmcq5wxv2k2s",
+          "cid": "bafyreibvckvmt2gak7y3a7anf2jmzveke5i3sxswyqzh4itfz3xar3sh4m",
+          "bskyUrl": "https://bsky.app/profile/barredspirals.comint.su/post/3mmcq5wxv2k2s",
+          "text": "okay this makes something of a difference. temporal tiling is less egregious now, down to maybe `badness 5000` github.com/leejet/stabl...",
+          "author": {
+            "handle": "barredspirals.comint.su",
+            "displayName": "lexi"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-20T20:20:44.969Z",
+          "createdUtc": 1779308444,
+          "ageHours": 0.83,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "leejet/stable-diffusion.cpp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "ComposioHQ/awesome-codex-skills": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcpxxytld2o",
+        "cid": "bafyreibaz42i5jo7mddmukdkcva432ytujziygszzhqfgsdeu35c3dusiu",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcpxxytld2o",
+        "text": "https://github.com/ComposioHQ/awesome-codex-skills",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 1,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-20T20:17:24Z",
+        "hoursSincePosted": 0.88
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcpxxytld2o",
+          "cid": "bafyreibaz42i5jo7mddmukdkcva432ytujziygszzhqfgsdeu35c3dusiu",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcpxxytld2o",
+          "text": "https://github.com/ComposioHQ/awesome-codex-skills",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T20:17:24Z",
+          "createdUtc": 1779308244,
+          "ageHours": 0.88,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "ComposioHQ/awesome-codex-skills",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "CherryHQ/cherry-studio": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:talzg3laasdcy4cq3l5t3bg4/app.bsky.feed.post/3mmcpcpqyvm2a",
+        "cid": "bafyreidtqm5oj3dccklhgkhv42jlgw2yiexc44y7wkd3srrit7iitfvuny",
+        "bskyUrl": "https://bsky.app/profile/githubfeed.bsky.social/post/3mmcpcpqyvm2a",
+        "text": "🚀 GitHub Intelligence Drop slidev (TypeScript • 🟢) ⭐ 46.6K → https://github.com/slidevjs/slidev cherry-studio (TypeScript • 🟢) ⭐ 46K → https://github.com/CherryHQ/cherry-studio ⚡ Only signal. Zero noise.",
+        "author": {
+          "handle": "githubfeed.bsky.social",
+          "displayName": "VritraSec • GitHub Feed"
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-20T20:05:31.301653+00:00",
+        "hoursSincePosted": 1.08
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:talzg3laasdcy4cq3l5t3bg4/app.bsky.feed.post/3mmcpcpqyvm2a",
+          "cid": "bafyreidtqm5oj3dccklhgkhv42jlgw2yiexc44y7wkd3srrit7iitfvuny",
+          "bskyUrl": "https://bsky.app/profile/githubfeed.bsky.social/post/3mmcpcpqyvm2a",
+          "text": "🚀 GitHub Intelligence Drop slidev (TypeScript • 🟢) ⭐ 46.6K → https://github.com/slidevjs/slidev cherry-studio (TypeScript • 🟢) ⭐ 46K → https://github.com/CherryHQ/cherry-studio ⚡ Only signal. Zero noise.",
+          "author": {
+            "handle": "githubfeed.bsky.social",
+            "displayName": "VritraSec • GitHub Feed"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T20:05:31.301653+00:00",
+          "createdUtc": 1779307531,
+          "ageHours": 1.08,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "CherryHQ/cherry-studio",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "OpenMOSS/MOSS-TTS-Nano": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcnfj5gz72s",
+        "cid": "bafyreife6owgz7jdbe37ytso32gswxkr2hwplmpd2e3j7qmczt7kecyh3y",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcnfj5gz72s",
+        "text": "https://github.com/OpenMOSS/MOSS-TTS-Nano",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-20T19:31:17Z",
+        "hoursSincePosted": 1.65
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcnfj5gz72s",
+          "cid": "bafyreife6owgz7jdbe37ytso32gswxkr2hwplmpd2e3j7qmczt7kecyh3y",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcnfj5gz72s",
+          "text": "https://github.com/OpenMOSS/MOSS-TTS-Nano",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T19:31:17Z",
+          "createdUtc": 1779305477,
+          "ageHours": 1.65,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "OpenMOSS/MOSS-TTS-Nano",
               "matchType": "url",
               "confidence": 1
             }
@@ -22021,7 +22309,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-20T16:27:44.000Z",
-        "hoursSincePosted": 2.07
+        "hoursSincePosted": 4.71
       },
       "posts": [
         {
@@ -22071,7 +22359,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T16:27:44.000Z",
           "createdUtc": 1779294464,
-          "ageHours": 2.07,
+          "ageHours": 4.71,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -22099,7 +22387,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T16:27:25.000Z",
           "createdUtc": 1779294445,
-          "ageHours": 2.08,
+          "ageHours": 4.71,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -22127,7 +22415,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T16:15:57.000Z",
           "createdUtc": 1779293757,
-          "ageHours": 2.27,
+          "ageHours": 4.91,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -27537,18 +27825,18 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mm66fbygf32x",
-        "cid": "bafyreieov772tglre7bm2uddq37s5mo7byt3o5j5icnfm4jkffcc7unyvy",
-        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mm66fbygf32x",
-        "text": "🟠 OpenClaw 2026.5.19-beta.1 lands with browser dialog control, typed plugin tooling, and a new Node 22.19 floor OpenClaw shipped 2026.5.19-beta.1 with several workflow-changing upgrades hiding inside a beta cut. https://github.com/openclaw/openclaw/releases/tag/v2026.5.19-beta.1 #AI #AgentWyre",
+        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmcssli32n2c",
+        "cid": "bafyreiby7qfkqartwsegvh55porzp5kiwymobywyex6zbmlfrasynpkfbi",
+        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmcssli32n2c",
+        "text": "🟠 OpenClaw v2026.5.19 raises the Node.js floor to 22.19 and adds a new image build arg OpenClaw shipped v2026.5.19 with two operator-facing changes hidden inside a routine-looking release: the minimum supported Node.js... https://github.com/openclaw/openclaw/releases/tag/v2026.5.19 #AI #AgentWyre",
         "author": {
           "handle": "agentwyre.ai"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T00:52:04.128179+00:00",
-        "hoursSincePosted": 3.69
+        "createdAt": "2026-05-20T21:08:01.240227+00:00",
+        "hoursSincePosted": 0.5
       },
       "posts": [
         {
@@ -27622,6 +27910,34 @@
           "createdUtc": 1778609979,
           "ageHours": 2.54,
           "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmcssli32n2c",
+          "cid": "bafyreiby7qfkqartwsegvh55porzp5kiwymobywyex6zbmlfrasynpkfbi",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmcssli32n2c",
+          "text": "🟠 OpenClaw v2026.5.19 raises the Node.js floor to 22.19 and adds a new image build arg OpenClaw shipped v2026.5.19 with two operator-facing changes hidden inside a routine-looking release: the minimum supported Node.js... https://github.com/openclaw/openclaw/releases/tag/v2026.5.19 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T21:08:01.240227+00:00",
+          "createdUtc": 1779311281,
+          "ageHours": 0.5,
+          "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
             "is-announcement"
@@ -30390,23 +30706,23 @@
     },
     "nousresearch--hermes-agent": {
       "count7d": 1,
-      "likesSum7d": 2,
+      "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:txfqncx66asrjzitxfur3of6/app.bsky.feed.post/3mlnnhex5uc2h",
-        "cid": "bafyreicbmrx6qyh4rsg447imtggbq7wqsjciol67knqimlldvj3na6rfy4",
-        "bskyUrl": "https://bsky.app/profile/tilmonedwards.com/post/3mlnnhex5uc2h",
-        "text": "Tried hermes for a bit, it seems like the Eclipse of coding agents. It does everything and your first session with it will be going through settings and disabling stuff. Like, it comes bundled with a skill for managing modded Minecraft servers?? github.com/NousResearch...",
+        "uri": "at://did:plc:l3ew7x4vzptgqeecfulu477l/app.bsky.feed.post/3mmcl6wkkxs2o",
+        "cid": "bafyreig2fohrb24pkew4icebvvxopz5w2cfb3yucmifczwuhhehgavxghq",
+        "bskyUrl": "https://bsky.app/profile/guillemhs.eurosky.social/post/3mmcl6wkkxs2o",
+        "text": "Necessito una màquina per posar això github.com/NousResearch...",
         "author": {
-          "handle": "tilmonedwards.com",
-          "displayName": "Tilmon Edwards (Dirigo)"
+          "handle": "guillemhs.eurosky.social",
+          "displayName": "Guillem"
         },
-        "likeCount": 2,
+        "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-12T11:06:25.885Z",
-        "hoursSincePosted": 1.22
+        "createdAt": "2026-05-20T18:51:49.379Z",
+        "hoursSincePosted": 2.31
       },
       "posts": [
         {
@@ -30430,6 +30746,34 @@
             "has-md-file"
           ],
           "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:l3ew7x4vzptgqeecfulu477l/app.bsky.feed.post/3mmcl6wkkxs2o",
+          "cid": "bafyreig2fohrb24pkew4icebvvxopz5w2cfb3yucmifczwuhhehgavxghq",
+          "bskyUrl": "https://bsky.app/profile/guillemhs.eurosky.social/post/3mmcl6wkkxs2o",
+          "text": "Necessito una màquina per posar això github.com/NousResearch...",
+          "author": {
+            "handle": "guillemhs.eurosky.social",
+            "displayName": "Guillem"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T18:51:49.379Z",
+          "createdUtc": 1779303109,
+          "ageHours": 2.31,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -32334,25 +32678,53 @@
     },
     "rohitg00--agentmemory": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:e4wr5lkpn63w5hy6iisnauqu/app.bsky.feed.post/3mmc7bqlnhh2j",
-        "cid": "bafyreifrim6qdhqjvfnjkhuo24magzsgvbwrl4ksxviqdj4q3dbh42hjp4",
-        "bskyUrl": "https://bsky.app/profile/boardwire.bsky.social/post/3mmc7bqlnhh2j",
-        "text": "Agentmemory library ships persistent memory for AI coding agents. Claims #1 benchmark for coding agent recall. Gained 1,626 GitHub stars today. #Agentmemory #CodingAgents #GitHub 🔗 https://github.com/rohitg00/agentmemory",
+        "uri": "at://did:plc:e4wr5lkpn63w5hy6iisnauqu/app.bsky.feed.post/3mmcpsfqhnt2s",
+        "cid": "bafyreigeq5dqx75jnxu5eklgbzfezyx5s3tu3kdxwh6lsveqng4neobiea",
+        "bskyUrl": "https://bsky.app/profile/boardwire.bsky.social/post/3mmcpsfqhnt2s",
+        "text": "Agent memory is becoming infrastructure for coding workflows. Agentmemory adds persistent state to AI coding agents based on real-world benchmarks. #Agentmemory #CodingAgents #AIWorkflows 🔗 https://github.com/rohitg00/agentmemory",
         "author": {
           "handle": "boardwire.bsky.social",
           "displayName": "Boardwire"
         },
-        "likeCount": 0,
+        "likeCount": 2,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-20T15:18:37.395282Z",
-        "hoursSincePosted": 3.22
+        "replyCount": 0,
+        "createdAt": "2026-05-20T20:14:16.261932Z",
+        "hoursSincePosted": 0.93
       },
       "posts": [
+        {
+          "uri": "at://did:plc:e4wr5lkpn63w5hy6iisnauqu/app.bsky.feed.post/3mmcpsfqhnt2s",
+          "cid": "bafyreigeq5dqx75jnxu5eklgbzfezyx5s3tu3kdxwh6lsveqng4neobiea",
+          "bskyUrl": "https://bsky.app/profile/boardwire.bsky.social/post/3mmcpsfqhnt2s",
+          "text": "Agent memory is becoming infrastructure for coding workflows. Agentmemory adds persistent state to AI coding agents based on real-world benchmarks. #Agentmemory #CodingAgents #AIWorkflows 🔗 https://github.com/rohitg00/agentmemory",
+          "author": {
+            "handle": "boardwire.bsky.social",
+            "displayName": "Boardwire"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T20:14:16.261932Z",
+          "createdUtc": 1779308056,
+          "ageHours": 0.93,
+          "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "rohitg00/agentmemory",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:d3p4jzrm5dpz2gdhzd5sxwwa/app.bsky.feed.post/3mluyrpisxv2z",
           "cid": "bafyreiewsbnsxbgwo5hhzlhgutfyldbylvxr5tm7kjmzjyayfsdwqjxx4e",
@@ -37176,7 +37548,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-20T17:02:53.088Z",
-        "hoursSincePosted": 1.49
+        "hoursSincePosted": 4.12
       },
       "posts": [
         {
@@ -37193,7 +37565,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-20T17:02:53.088Z",
           "createdUtc": 1779296573,
-          "ageHours": 1.49,
+          "ageHours": 4.12,
           "trendingScore": 1,
           "content_tags": [
             "has-github-repo"
@@ -37208,21 +37580,220 @@
           ]
         }
       ]
+    },
+    "leejet--stable-diffusion-cpp": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 0,
+      "repliesSum7d": 1,
+      "topPost": {
+        "uri": "at://did:plc:4cb4ap6dfrm2cgfw64dpuwha/app.bsky.feed.post/3mmcq5wxv2k2s",
+        "cid": "bafyreibvckvmt2gak7y3a7anf2jmzveke5i3sxswyqzh4itfz3xar3sh4m",
+        "bskyUrl": "https://bsky.app/profile/barredspirals.comint.su/post/3mmcq5wxv2k2s",
+        "text": "okay this makes something of a difference. temporal tiling is less egregious now, down to maybe `badness 5000` github.com/leejet/stabl...",
+        "author": {
+          "handle": "barredspirals.comint.su",
+          "displayName": "lexi"
+        },
+        "likeCount": 1,
+        "repostCount": 0,
+        "replyCount": 1,
+        "createdAt": "2026-05-20T20:20:44.969Z",
+        "hoursSincePosted": 0.83
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:4cb4ap6dfrm2cgfw64dpuwha/app.bsky.feed.post/3mmcq5wxv2k2s",
+          "cid": "bafyreibvckvmt2gak7y3a7anf2jmzveke5i3sxswyqzh4itfz3xar3sh4m",
+          "bskyUrl": "https://bsky.app/profile/barredspirals.comint.su/post/3mmcq5wxv2k2s",
+          "text": "okay this makes something of a difference. temporal tiling is less egregious now, down to maybe `badness 5000` github.com/leejet/stabl...",
+          "author": {
+            "handle": "barredspirals.comint.su",
+            "displayName": "lexi"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-20T20:20:44.969Z",
+          "createdUtc": 1779308444,
+          "ageHours": 0.83,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "leejet/stable-diffusion.cpp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "composiohq--awesome-codex-skills": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcpxxytld2o",
+        "cid": "bafyreibaz42i5jo7mddmukdkcva432ytujziygszzhqfgsdeu35c3dusiu",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcpxxytld2o",
+        "text": "https://github.com/ComposioHQ/awesome-codex-skills",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 1,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-20T20:17:24Z",
+        "hoursSincePosted": 0.88
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcpxxytld2o",
+          "cid": "bafyreibaz42i5jo7mddmukdkcva432ytujziygszzhqfgsdeu35c3dusiu",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcpxxytld2o",
+          "text": "https://github.com/ComposioHQ/awesome-codex-skills",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T20:17:24Z",
+          "createdUtc": 1779308244,
+          "ageHours": 0.88,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "ComposioHQ/awesome-codex-skills",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "cherryhq--cherry-studio": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:talzg3laasdcy4cq3l5t3bg4/app.bsky.feed.post/3mmcpcpqyvm2a",
+        "cid": "bafyreidtqm5oj3dccklhgkhv42jlgw2yiexc44y7wkd3srrit7iitfvuny",
+        "bskyUrl": "https://bsky.app/profile/githubfeed.bsky.social/post/3mmcpcpqyvm2a",
+        "text": "🚀 GitHub Intelligence Drop slidev (TypeScript • 🟢) ⭐ 46.6K → https://github.com/slidevjs/slidev cherry-studio (TypeScript • 🟢) ⭐ 46K → https://github.com/CherryHQ/cherry-studio ⚡ Only signal. Zero noise.",
+        "author": {
+          "handle": "githubfeed.bsky.social",
+          "displayName": "VritraSec • GitHub Feed"
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-20T20:05:31.301653+00:00",
+        "hoursSincePosted": 1.08
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:talzg3laasdcy4cq3l5t3bg4/app.bsky.feed.post/3mmcpcpqyvm2a",
+          "cid": "bafyreidtqm5oj3dccklhgkhv42jlgw2yiexc44y7wkd3srrit7iitfvuny",
+          "bskyUrl": "https://bsky.app/profile/githubfeed.bsky.social/post/3mmcpcpqyvm2a",
+          "text": "🚀 GitHub Intelligence Drop slidev (TypeScript • 🟢) ⭐ 46.6K → https://github.com/slidevjs/slidev cherry-studio (TypeScript • 🟢) ⭐ 46K → https://github.com/CherryHQ/cherry-studio ⚡ Only signal. Zero noise.",
+          "author": {
+            "handle": "githubfeed.bsky.social",
+            "displayName": "VritraSec • GitHub Feed"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T20:05:31.301653+00:00",
+          "createdUtc": 1779307531,
+          "ageHours": 1.08,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "CherryHQ/cherry-studio",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "openmoss--moss-tts-nano": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcnfj5gz72s",
+        "cid": "bafyreife6owgz7jdbe37ytso32gswxkr2hwplmpd2e3j7qmczt7kecyh3y",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcnfj5gz72s",
+        "text": "https://github.com/OpenMOSS/MOSS-TTS-Nano",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-20T19:31:17Z",
+        "hoursSincePosted": 1.65
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmcnfj5gz72s",
+          "cid": "bafyreife6owgz7jdbe37ytso32gswxkr2hwplmpd2e3j7qmczt7kecyh3y",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmcnfj5gz72s",
+          "text": "https://github.com/OpenMOSS/MOSS-TTS-Nano",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-20T19:31:17Z",
+          "createdUtc": 1779305477,
+          "ageHours": 1.65,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "OpenMOSS/MOSS-TTS-Nano",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
     }
   },
   "leaderboard": [
     {
-      "fullName": "anthropics/claude-code",
+      "fullName": "rohitg00/agentmemory",
       "count7d": 1,
-      "likesSum7d": 1
+      "likesSum7d": 2
     },
     {
-      "fullName": "anthropics/claude-plugins-official",
-      "count7d": 1,
-      "likesSum7d": 1
-    },
-    {
-      "fullName": "colbymchenry/codegraph",
+      "fullName": "ComposioHQ/awesome-codex-skills",
       "count7d": 1,
       "likesSum7d": 1
     },
@@ -37232,27 +37803,7 @@
       "likesSum7d": 1
     },
     {
-      "fullName": "Imbad0202/academic-research-skills",
-      "count7d": 1,
-      "likesSum7d": 1
-    },
-    {
-      "fullName": "msitarzewski/agency-agents",
-      "count7d": 1,
-      "likesSum7d": 1
-    },
-    {
-      "fullName": "obra/superpowers",
-      "count7d": 1,
-      "likesSum7d": 1
-    },
-    {
-      "fullName": "rmyndharis/OpenWA",
-      "count7d": 1,
-      "likesSum7d": 1
-    },
-    {
-      "fullName": "tinyhumansai/openhuman",
+      "fullName": "leejet/stable-diffusion.cpp",
       "count7d": 1,
       "likesSum7d": 1
     },
@@ -37262,7 +37813,22 @@
       "likesSum7d": 0
     },
     {
-      "fullName": "rohitg00/agentmemory",
+      "fullName": "CherryHQ/cherry-studio",
+      "count7d": 1,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "NousResearch/hermes-agent",
+      "count7d": 1,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "openclaw/openclaw",
+      "count7d": 1,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "OpenMOSS/MOSS-TTS-Nano",
       "count7d": 1,
       "likesSum7d": 0
     }

--- a/data/bluesky-trending.json
+++ b/data/bluesky-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T18:31:59.035Z",
+  "fetchedAt": "2026-05-20T21:10:17.444Z",
   "discoveryVersion": "2026-04-21",
   "keywords": [
     "AI agents",
@@ -152,7 +152,7 @@
       ]
     }
   ],
-  "scannedPosts": 671,
+  "scannedPosts": 670,
   "posts": [
     {
       "uri": "at://did:plc:oijtzlibd7mlf56jbfohssdz/app.bsky.feed.post/3ml46o7m5rs2b",
@@ -211,13 +211,13 @@
         "handle": "tressiemcphd.bsky.social",
         "displayName": "Tressie McMillan Cottom"
       },
-      "likeCount": 2619,
-      "repostCount": 356,
-      "replyCount": 65,
+      "likeCount": 2633,
+      "repostCount": 357,
+      "replyCount": 66,
       "createdAt": "2026-05-19T11:46:20.996Z",
       "createdUtc": 1779191180,
-      "ageHours": 30.76,
-      "trendingScore": 3363.5,
+      "ageHours": 33.4,
+      "trendingScore": 3380,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -384,7 +384,7 @@
       "replyCount": 19,
       "createdAt": "2026-05-18T21:40:34.041Z",
       "createdUtc": 1779140434,
-      "ageHours": 44.86,
+      "ageHours": 47.5,
       "trendingScore": 1971.5,
       "content_tags": [],
       "value_score": 0,
@@ -547,13 +547,13 @@
         "handle": "chriswarcraft.bsky.social",
         "displayName": "Chris Kluwe"
       },
-      "likeCount": 701,
+      "likeCount": 702,
       "repostCount": 122,
       "replyCount": 16,
       "createdAt": "2026-05-19T06:36:36.432Z",
       "createdUtc": 1779172596,
-      "ageHours": 35.92,
-      "trendingScore": 953,
+      "ageHours": 38.56,
+      "trendingScore": 954,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -648,7 +648,7 @@
       "replyCount": 37,
       "createdAt": "2026-05-17T17:14:32.432Z",
       "createdUtc": 1779038072,
-      "ageHours": 73.29,
+      "ageHours": 75.93,
       "trendingScore": 800.5,
       "content_tags": [],
       "value_score": 0,
@@ -816,7 +816,7 @@
       "replyCount": 2,
       "createdAt": "2026-04-21T03:38:29.785Z",
       "createdUtc": 1776742709,
-      "ageHours": 710.89,
+      "ageHours": 713.53,
       "trendingScore": 689,
       "content_tags": [],
       "value_score": 0,
@@ -859,13 +859,37 @@
         "handle": "webdevs.firefox.com",
         "displayName": "Firefox for Web Developers"
       },
-      "likeCount": 387,
-      "repostCount": 122,
+      "likeCount": 391,
+      "repostCount": 124,
       "replyCount": 18,
       "createdAt": "2026-05-18T14:35:54.513Z",
       "createdUtc": 1779114954,
-      "ageHours": 51.93,
-      "trendingScore": 640,
+      "ageHours": 54.57,
+      "trendingScore": 648,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
+      "uri": "at://did:plc:rrjvo5jwuateqep2i7ih5ckl/app.bsky.feed.post/3mm2mt3gctk2c",
+      "cid": "bafyreih546urlctsxiosoqg6d4oh56us65pgacrokiusty6acwnxidliaq",
+      "bskyUrl": "https://bsky.app/profile/cfiesler.bsky.social/post/3mm2mt3gctk2c",
+      "text": "Particularly in the context of (appropriate) crackdowns on LLM-generated papers (e.g., on arXiv) and more and more tales of fabricated citations, two reminders: (1) LLMs do not \"cite their sources\" (2) Using an LLM to generate, complete, or fix LaTeX code can result in fabricated citations",
+      "author": {
+        "handle": "cfiesler.bsky.social",
+        "displayName": "Dr. Casey Fiesler"
+      },
+      "likeCount": 379,
+      "repostCount": 116,
+      "replyCount": 6,
+      "createdAt": "2026-05-17T14:59:41.407Z",
+      "createdUtc": 1779029981,
+      "ageHours": 78.18,
+      "trendingScore": 614,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -899,30 +923,6 @@
       "matchedTopicLabel": "Coding agents"
     },
     {
-      "uri": "at://did:plc:rrjvo5jwuateqep2i7ih5ckl/app.bsky.feed.post/3mm2mt3gctk2c",
-      "cid": "bafyreih546urlctsxiosoqg6d4oh56us65pgacrokiusty6acwnxidliaq",
-      "bskyUrl": "https://bsky.app/profile/cfiesler.bsky.social/post/3mm2mt3gctk2c",
-      "text": "Particularly in the context of (appropriate) crackdowns on LLM-generated papers (e.g., on arXiv) and more and more tales of fabricated citations, two reminders: (1) LLMs do not \"cite their sources\" (2) Using an LLM to generate, complete, or fix LaTeX code can result in fabricated citations",
-      "author": {
-        "handle": "cfiesler.bsky.social",
-        "displayName": "Dr. Casey Fiesler"
-      },
-      "likeCount": 374,
-      "repostCount": 115,
-      "replyCount": 6,
-      "createdAt": "2026-05-17T14:59:41.407Z",
-      "createdUtc": 1779029981,
-      "ageHours": 75.54,
-      "trendingScore": 607,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
-    },
-    {
       "uri": "at://did:plc:3vyl2i7k2fuk7lbnmlxh3vof/app.bsky.feed.post/3mm52ykytk22t",
       "cid": "bafyreidipr3ahloco2n67kv2isfwdzy4jhukes2rtvzfr3lj6yvtu5yyda",
       "bskyUrl": "https://bsky.app/profile/lauren.rotatingsandwiches.com/post/3mm52ykytk22t",
@@ -936,7 +936,7 @@
       "replyCount": 17,
       "createdAt": "2026-05-18T14:18:37.377Z",
       "createdUtc": 1779113917,
-      "ageHours": 52.22,
+      "ageHours": 54.86,
       "trendingScore": 602.5,
       "content_tags": [],
       "value_score": 0,
@@ -979,13 +979,13 @@
         "handle": "puppikeco.bsky.social",
         "displayName": "Pup Pike"
       },
-      "likeCount": 498,
+      "likeCount": 499,
       "repostCount": 36,
       "replyCount": 13,
       "createdAt": "2026-05-17T16:42:21.014Z",
       "createdUtc": 1779036141,
-      "ageHours": 73.83,
-      "trendingScore": 576.5,
+      "ageHours": 76.47,
+      "trendingScore": 577.5,
       "content_tags": [
         "is-question"
       ],
@@ -1021,6 +1021,30 @@
       "matchedTopicLabel": "LLMs"
     },
     {
+      "uri": "at://did:plc:unkqxy3fxjckrxrqstopn3qb/app.bsky.feed.post/3mm2ywogrec2q",
+      "cid": "bafyreifhlvm3kjszlsq74toeu6zbga6tnju4ffwq5rndahvb2y2eux64mm",
+      "bskyUrl": "https://bsky.app/profile/robdenbleyker.com/post/3mm2ywogrec2q",
+      "text": "my grandfather used to roll hotdogs at the gas station before automation replaced him",
+      "author": {
+        "handle": "robdenbleyker.com",
+        "displayName": "Rob DenBleyker"
+      },
+      "likeCount": 502,
+      "repostCount": 28,
+      "replyCount": 9,
+      "createdAt": "2026-05-17T18:36:26.909Z",
+      "createdUtc": 1779042986,
+      "ageHours": 74.56,
+      "trendingScore": 562.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en automation",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:4rndwwuyhrtlv2oufdcujjch/app.bsky.feed.post/3mluburry2c2k",
       "cid": "bafyreihqr7i5ba2ddnjp4x3apzm3e4bov7kdm6qafsancrvi5omqpbdp2i",
       "bskyUrl": "https://bsky.app/profile/srirachamander.bsky.social/post/3mluburry2c2k",
@@ -1034,7 +1058,7 @@
       "replyCount": 8,
       "createdAt": "2026-05-15T02:27:48.821Z",
       "createdUtc": 1778812068,
-      "ageHours": 136.07,
+      "ageHours": 138.71,
       "trendingScore": 562,
       "content_tags": [
         "is-question"
@@ -1045,30 +1069,6 @@
       "matchedQuery": "lang:en rag",
       "matchedTopicId": "retrieval",
       "matchedTopicLabel": "RAG and retrieval"
-    },
-    {
-      "uri": "at://did:plc:unkqxy3fxjckrxrqstopn3qb/app.bsky.feed.post/3mm2ywogrec2q",
-      "cid": "bafyreifhlvm3kjszlsq74toeu6zbga6tnju4ffwq5rndahvb2y2eux64mm",
-      "bskyUrl": "https://bsky.app/profile/robdenbleyker.com/post/3mm2ywogrec2q",
-      "text": "my grandfather used to roll hotdogs at the gas station before automation replaced him",
-      "author": {
-        "handle": "robdenbleyker.com",
-        "displayName": "Rob DenBleyker"
-      },
-      "likeCount": 501,
-      "repostCount": 28,
-      "replyCount": 9,
-      "createdAt": "2026-05-17T18:36:26.909Z",
-      "createdUtc": 1779042986,
-      "ageHours": 71.93,
-      "trendingScore": 561.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "Workflow and automation",
-      "matchedQuery": "lang:en automation",
-      "matchedTopicId": "workflow",
-      "matchedTopicLabel": "Workflow and automation"
     },
     {
       "uri": "at://did:plc:mivey63nzylfflvmmjoqcf6u/app.bsky.feed.post/3mm3e52ypys2j",
@@ -1084,7 +1084,7 @@
       "replyCount": 39,
       "createdAt": "2026-05-17T21:56:52.568Z",
       "createdUtc": 1779055012,
-      "ageHours": 68.59,
+      "ageHours": 71.22,
       "trendingScore": 550.5,
       "content_tags": [],
       "value_score": 0,
@@ -1103,13 +1103,13 @@
         "handle": "cfiesler.bsky.social",
         "displayName": "Dr. Casey Fiesler"
       },
-      "likeCount": 380,
-      "repostCount": 77,
+      "likeCount": 386,
+      "repostCount": 78,
       "replyCount": 6,
       "createdAt": "2026-05-17T15:04:35.469Z",
       "createdUtc": 1779030275,
-      "ageHours": 75.46,
-      "trendingScore": 537,
+      "ageHours": 78.1,
+      "trendingScore": 545,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1127,13 +1127,13 @@
         "handle": "naomikritzer.bsky.social",
         "displayName": "Naomi Kritzer"
       },
-      "likeCount": 252,
+      "likeCount": 253,
       "repostCount": 137,
       "replyCount": 12,
       "createdAt": "2026-05-19T17:39:30.929Z",
       "createdUtc": 1779212370,
-      "ageHours": 24.87,
-      "trendingScore": 532,
+      "ageHours": 27.51,
+      "trendingScore": 533,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1180,7 +1180,7 @@
       "replyCount": 7,
       "createdAt": "2026-05-19T18:44:40.122Z",
       "createdUtc": 1779216280,
-      "ageHours": 23.79,
+      "ageHours": 26.43,
       "trendingScore": 518.5,
       "content_tags": [],
       "value_score": 0,
@@ -1311,6 +1311,30 @@
       "matchedTopicLabel": "Coding agents"
     },
     {
+      "uri": "at://did:plc:m4fvxlyv4gqpugzszzp4cjxf/app.bsky.feed.post/3mmcdok6rmk2m",
+      "cid": "bafyreiadpptrfoxwuxwqk6gkof6hohq4ybdyal7mordhrzuzeeci6i53im",
+      "bskyUrl": "https://bsky.app/profile/alexhanna.bsky.social/post/3mmcdok6rmk2m",
+      "text": "Today @dairinstitute.bsky.social is releasing the Luddite Lab Resource Hub. The hub hosts case studies, resources, and political education for unions, labor organizations, and workers who want to fight “AI” and automation at work. labor.dair-institute.org",
+      "author": {
+        "handle": "alexhanna.bsky.social",
+        "displayName": "Alex Hanna"
+      },
+      "likeCount": 204,
+      "repostCount": 132,
+      "replyCount": 2,
+      "createdAt": "2026-05-20T16:37:23.343Z",
+      "createdUtc": 1779295043,
+      "ageHours": 4.55,
+      "trendingScore": 469,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en automation",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:tzb43fx4dkn5ux7zntskveut/app.bsky.feed.post/3ml2p5gg6g22j",
       "cid": "bafyreihkai4d7a6qnqrydrxfkcnd2yq4rzdnhyhky2kxk3ucfbrgigz4hy",
       "bskyUrl": "https://bsky.app/profile/fristart.bsky.social/post/3ml2p5gg6g22j",
@@ -1333,30 +1357,6 @@
       "matchedQuery": "lang:en cursor",
       "matchedTopicId": "coding-agents",
       "matchedTopicLabel": "Coding agents"
-    },
-    {
-      "uri": "at://did:plc:qc6xzgctorfsm35w6i3vdebx/app.bsky.feed.post/3mm36ysxkec2o",
-      "cid": "bafyreifvry2egqshhwppaaps3fkmpgjokl2ujycahpx6tuocfqdczsavgq",
-      "bskyUrl": "https://bsky.app/profile/edzitron.com/post/3mm36ysxkec2o",
-      "text": "Think of it like this. Even as a technical ceo - someone who has not written code with any seriousness in years - an LLM does an impression of a software engineer writing a lot of code, which is what you would think an SWE did if you didn’t do the job in 10+ years bsky.app/profile/zeno...",
-      "author": {
-        "handle": "edzitron.com",
-        "displayName": "Ed Zitron"
-      },
-      "likeCount": 357,
-      "repostCount": 52,
-      "replyCount": 8,
-      "createdAt": "2026-05-17T20:25:01.214Z",
-      "createdUtc": 1779049501,
-      "ageHours": 39.92,
-      "trendingScore": 465,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh Bluesky signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26190123975

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.