### PR TITLE
chore(data): refresh lobsters signals 2026-05-20T21:20:23Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-20T18:42:34.859Z",
+  "ts": "2026-05-20T21:20:23.746Z",
   "count": 1,
-  "durationMs": 4552,
+  "durationMs": 6708,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T18:42:30.327Z",
+  "fetchedAt": "2026-05-20T21:20:17.060Z",
   "windowDays": 7,
   "scannedStories": 82,
   "mentions": {
@@ -242,7 +242,7 @@
         "score": 23,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 28.865277777777777
+        "hoursSincePosted": 31.495
       },
       "stories": [
         {
@@ -254,8 +254,8 @@
           "score": 23,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 28.865277777777777,
-          "trendingScore": 0.13412895816808107,
+          "ageHours": 31.495,
+          "trendingScore": 0.11864730087243096,
           "tags": [
             "plt",
             "programming"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T18:42:30.327Z",
+  "fetchedAt": "2026-05-20T21:20:17.060Z",
   "windowHours": 72,
   "scannedTotal": 82,
   "stories": [
@@ -602,6 +602,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "k8mkgs",
+      "title": "XSS Is Deadly for Passkeys: The Hidden Risk of Attestation None",
+      "url": "https://scotthelme.co.uk/xss-is-deadly-for-passkeys-the-hidden-risk-of-attestation-none/",
+      "commentsUrl": "https://lobste.rs/s/k8mkgs/xss_is_deadly_for_passkeys_hidden_risk",
+      "by": "",
+      "score": 8,
+      "commentCount": 1,
+      "createdUtc": 1779304832,
+      "ageHours": 1.9958333333333333,
+      "trendingScore": 1.001564536980598,
+      "tags": [
+        "security"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "b8gee9",
       "title": "taken",
       "url": "https://sinceyouarrived.world/taken",
@@ -877,24 +894,6 @@
       "trendingScore": 0.895290356790691,
       "tags": [
         "programming"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "duyp69",
-      "title": "The CTF scene is dead",
-      "url": "https://kabir.au/blog/the-ctf-scene-is-dead",
-      "commentsUrl": "https://lobste.rs/s/duyp69/ctf_scene_is_dead",
-      "by": "",
-      "score": 7,
-      "commentCount": 3,
-      "createdUtc": 1778921464,
-      "ageHours": 1.951111111111111,
-      "trendingScore": 0.891290291065429,
-      "tags": [
-        "security",
-        "vibecoding"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26190605236

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.