### PR TITLE
chore(data): refresh lobsters signals 2026-05-20T22:56:30Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-20T21:20:23.746Z",
+  "ts": "2026-05-20T22:56:30.304Z",
   "count": 1,
-  "durationMs": 6708,
+  "durationMs": 4325,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T21:20:17.060Z",
+  "fetchedAt": "2026-05-20T22:56:26.002Z",
   "windowDays": 7,
-  "scannedStories": 82,
+  "scannedStories": 81,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -242,7 +242,7 @@
         "score": 23,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 31.495
+        "hoursSincePosted": 33.0975
       },
       "stories": [
         {
@@ -254,8 +254,8 @@
           "score": 23,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 31.495,
-          "trendingScore": 0.11864730087243096,
+          "ageHours": 33.0975,
+          "trendingScore": 0.11061488240009948,
           "tags": [
             "plt",
             "programming"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T21:20:17.060Z",
+  "fetchedAt": "2026-05-20T22:56:26.002Z",
   "windowHours": 72,
-  "scannedTotal": 82,
+  "scannedTotal": 81,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -358,6 +358,24 @@
         "zig"
       ],
       "description": "<p>I really like the idea of accounting for newline + numbers per line! Any other similar features people have noticed and liked in other language formatters?</p>\n",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "e7lsqn",
+      "title": "Chromium publishes fixed exploit 4 years later, turns out it's actually unfixed",
+      "url": "https://infosec.exchange/@rebane2001/116606719764376414",
+      "commentsUrl": "https://lobste.rs/s/e7lsqn/chromium_publishes_fixed_exploit_4_years",
+      "by": "",
+      "score": 12,
+      "commentCount": 0,
+      "createdUtc": 1779308945,
+      "ageHours": 2.4558333333333335,
+      "trendingScore": 1.2758153967067039,
+      "tags": [
+        "browsers",
+        "security"
+      ],
+      "description": "",
       "linkedRepos": []
     },
     {
@@ -877,23 +895,6 @@
       "trendingScore": 0.9097019420546543,
       "tags": [
         "security"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "2whryd",
-      "title": "Announcing the Zulip Foundation",
-      "url": "https://blog.zulip.com/2026/05/15/announcing-zulip-foundation/",
-      "commentsUrl": "https://lobste.rs/s/2whryd/announcing_zulip_foundation",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1778876884,
-      "ageHours": 1.1477777777777778,
-      "trendingScore": 0.895290356790691,
-      "tags": [
-        "programming"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26194711752

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.