### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-21T00:16:37Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-20T21:07:29.202Z",
+  "ts": "2026-05-21T00:16:36.795Z",
   "count": 1,
-  "durationMs": 11057,
+  "durationMs": 9939,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-20T21:07:26.135Z",
+  "lastFetchedAt": "2026-05-21T00:16:34.014Z",
   "windowDays": 7,
   "launches": [
     {
@@ -9,8 +9,8 @@
       "description": "StoreClaw is the first AI commerce platform with agents that know how to sell, so you can make more money with less effort and less stress. Connect StoreClaw to your existing store and it will study your numbers, current sales figures, and growth trajectory, and then offer proactive suggestions that it can execute on your behalf — once you give it your approval. Ask StoreClaw how your business is doing any time, anywhere. Sell more with less stress: StoreClaw.",
       "url": "https://www.producthunt.com/products/storeclaw?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
       "website": "https://www.producthunt.com/r/PVXOOJINEBKKUA",
-      "votesCount": 487,
-      "commentsCount": 202,
+      "votesCount": 496,
+      "commentsCount": 206,
       "createdAt": "2026-05-20T07:01:00Z",
       "thumbnail": "https://ph-files.imgix.net/407049a2-0be3-4b8d-a7c0-4fc5b9754db2.png?auto=format",
       "topics": [
@@ -147,19 +147,19 @@
       "aiAdjacent": true
     },
     {
-      "id": "1140630",
-      "name": "Naptick AI",
-      "tagline": "Al sleep companion that helps fall asleep without struggle",
-      "description": "Naptick is a smart bedside AI sleep companion designed for founders, professionals, light sleepers, and anyone struggling with nighttime stress or doomscrolling. It combines circadian light therapy, 1000+ adaptive soundscapes, room condition intelligence, app-locking, and an on-device AI sleep coach to help users fall asleep faster and wake up refreshed. Unlike passive sleep trackers, Naptick is built phone-free by design and actively helps improve sleep before the night begins.",
-      "url": "https://www.producthunt.com/products/naptick-ai-sleep-companion?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/OT2VX5IW7L4F7E",
-      "votesCount": 426,
-      "commentsCount": 94,
-      "createdAt": "2026-05-14T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/768542e3-e0be-44b7-8547-cde9ad144423.jpeg?auto=format",
+      "id": "1134267",
+      "name": "mailX by mailwarm",
+      "tagline": "Email deliverability toolkit for humans and AI agents",
+      "description": "Your emails go to spam. mailX shows you why, and how to fix it in seconds with clear answers and exact steps. Built for humans and AI agents. API and MCP ready.",
+      "url": "https://www.producthunt.com/products/mailx-by-mailwarm-yc-s20?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/H2XLXASAORMP7Z",
+      "votesCount": 438,
+      "commentsCount": 233,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/9d9e986f-969d-4a67-9a15-e6733097da14.gif?auto=format",
       "topics": [
-        "health-fitness",
-        "hardware",
+        "email",
+        "email-marketing",
         "artificial-intelligence"
       ],
       "makers": [
@@ -213,19 +213,19 @@
       "aiAdjacent": true
     },
     {
-      "id": "1134267",
-      "name": "mailX by mailwarm",
-      "tagline": "Email deliverability toolkit for humans and AI agents",
-      "description": "Your emails go to spam. mailX shows you why, and how to fix it in seconds with clear answers and exact steps. Built for humans and AI agents. API and MCP ready.",
-      "url": "https://www.producthunt.com/products/mailx-by-mailwarm-yc-s20?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/H2XLXASAORMP7Z",
-      "votesCount": 417,
-      "commentsCount": 232,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/9d9e986f-969d-4a67-9a15-e6733097da14.gif?auto=format",
+      "id": "1140630",
+      "name": "Naptick AI",
+      "tagline": "Al sleep companion that helps fall asleep without struggle",
+      "description": "Naptick is a smart bedside AI sleep companion designed for founders, professionals, light sleepers, and anyone struggling with nighttime stress or doomscrolling. It combines circadian light therapy, 1000+ adaptive soundscapes, room condition intelligence, app-locking, and an on-device AI sleep coach to help users fall asleep faster and wake up refreshed. Unlike passive sleep trackers, Naptick is built phone-free by design and actively helps improve sleep before the night begins.",
+      "url": "https://www.producthunt.com/products/naptick-ai-sleep-companion?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/OT2VX5IW7L4F7E",
+      "votesCount": 426,
+      "commentsCount": 94,
+      "createdAt": "2026-05-14T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/768542e3-e0be-44b7-8547-cde9ad144423.jpeg?auto=format",
       "topics": [
-        "email",
-        "email-marketing",
+        "health-fitness",
+        "hardware",
         "artificial-intelligence"
       ],
       "makers": [
@@ -1078,6 +1078,35 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151095",
+      "name": "Gemini Omni",
+      "tagline": "Create anything from any input – starting with video",
+      "description": "Create anything from anything, starting with video. Gemini Omni is where Gemini’s ability to reason meets the ability to create. It delivers a leap in world understanding, multimodality, and editing.",
+      "url": "https://www.producthunt.com/products/gemini-omni-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/ENOAWGG27PYBQE",
+      "votesCount": 286,
+      "commentsCount": 7,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/d0081810-ee52-41d6-b33e-163838981bc6.svg?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "video"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1052099",
       "name": "Graphbit PRFlow",
       "tagline": "AI code reviewer that catches what others miss",
@@ -1138,21 +1167,29 @@
       "aiAdjacent": false
     },
     {
-      "id": "1151095",
-      "name": "Gemini Omni",
-      "tagline": "Create anything from any input – starting with video",
-      "description": "Create anything from anything, starting with video. Gemini Omni is where Gemini’s ability to reason meets the ability to create. It delivers a leap in world understanding, multimodality, and editing.",
-      "url": "https://www.producthunt.com/products/gemini-omni-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/ENOAWGG27PYBQE",
-      "votesCount": 276,
-      "commentsCount": 6,
+      "id": "1150124",
+      "name": "Emdash",
+      "tagline": "One app. Every coding agent. Open-source.",
+      "description": "Emdash is an open-source desktop app for running multiple coding agents in parallel; one place to monitor sessions, review diffs, and turn issues into PRs.",
+      "url": "https://www.producthunt.com/products/emdash?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/U7NUCTTEX6BM3I",
+      "votesCount": 279,
+      "commentsCount": 69,
       "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/d0081810-ee52-41d6-b33e-163838981bc6.svg?auto=format",
+      "thumbnail": "https://ph-files.imgix.net/4b4feac9-ff8d-4091-aecb-78859d285f91.x-icon?auto=format",
       "topics": [
-        "artificial-intelligence",
-        "video"
+        "productivity",
+        "open-source",
+        "developer-tools",
+        "github"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1496,43 +1533,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1150124",
-      "name": "Emdash",
-      "tagline": "One app. Every coding agent. Open-source.",
-      "description": "Emdash is an open-source desktop app for running multiple coding agents in parallel; one place to monitor sessions, review diffs, and turn issues into PRs.",
-      "url": "https://www.producthunt.com/products/emdash?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/U7NUCTTEX6BM3I",
-      "votesCount": 250,
-      "commentsCount": 66,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/4b4feac9-ff8d-4091-aecb-78859d285f91.x-icon?auto=format",
-      "topics": [
-        "productivity",
-        "open-source",
-        "developer-tools",
-        "github"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1140851",
       "name": "Tendem by Toloka",
       "tagline": "AI platform to hand off any task to a human expert",
@@ -1736,6 +1736,48 @@
         "yc-application"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1151120",
+      "name": "Runtime",
+      "tagline": "Sandboxed coding agents for everyone on your team",
+      "description": "Turn coding agents into teammates anyone can use from Slack, Linear, CLI, API or your browser. Ship features, query data, build dashboards, automate workflows. All within your company's context, skills, integrations, and security guardrails.",
+      "url": "https://www.producthunt.com/products/runtime?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/TOZOGOJYMEHTNQ",
+      "votesCount": 206,
+      "commentsCount": 46,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/67ea30b8-1bf6-44ba-99db-09c8498841d9.png?auto=format",
+      "topics": [
+        "slack",
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2083,48 +2125,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1151120",
-      "name": "Runtime",
-      "tagline": "Sandboxed coding agents for everyone on your team",
-      "description": "Turn coding agents into teammates anyone can use from Slack, Linear, CLI, API or your browser. Ship features, query data, build dashboards, automate workflows. All within your company's context, skills, integrations, and security guardrails.",
-      "url": "https://www.producthunt.com/products/runtime?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/TOZOGOJYMEHTNQ",
-      "votesCount": 183,
-      "commentsCount": 34,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/67ea30b8-1bf6-44ba-99db-09c8498841d9.png?auto=format",
-      "topics": [
-        "slack",
-        "developer-tools",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     },
     {
       "id": "1139758",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26197579451

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.