### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T01:33:10Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-20T22:56:30.304Z",
+  "ts": "2026-05-21T01:33:09.988Z",
   "count": 1,
-  "durationMs": 4325,
+  "durationMs": 3820,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T22:56:26.002Z",
+  "fetchedAt": "2026-05-21T01:33:06.187Z",
   "windowDays": 7,
-  "scannedStories": 81,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -242,7 +242,7 @@
         "score": 23,
         "url": "https://github.com/tomekw/stcc",
         "commentsUrl": "https://lobste.rs/s/pk139i/super_tiny_compiler_ada",
-        "hoursSincePosted": 33.0975
+        "hoursSincePosted": 35.70861111111111
       },
       "stories": [
         {
@@ -254,8 +254,8 @@
           "score": 23,
           "commentCount": 3,
           "createdUtc": 1779198635,
-          "ageHours": 33.0975,
-          "trendingScore": 0.11061488240009948,
+          "ageHours": 35.70861111111111,
+          "trendingScore": 0.09932693422418028,
           "tags": [
             "plt",
             "programming"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-20T22:56:26.002Z",
+  "fetchedAt": "2026-05-21T01:33:06.187Z",
   "windowHours": 72,
-  "scannedTotal": 81,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -361,16 +361,33 @@
       "linkedRepos": []
     },
     {
+      "shortId": "rwu7ah",
+      "title": "The Mislabeled Bricks of Utopia",
+      "url": "https://orib.dev/nexus.html",
+      "commentsUrl": "https://lobste.rs/s/rwu7ah/mislabeled_bricks_utopia",
+      "by": "",
+      "score": 5,
+      "commentCount": 0,
+      "createdUtc": 1779325628,
+      "ageHours": 0.43277777777777776,
+      "trendingScore": 1.3176993879144157,
+      "tags": [
+        "philosophy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "e7lsqn",
       "title": "Chromium publishes fixed exploit 4 years later, turns out it's actually unfixed",
       "url": "https://infosec.exchange/@rebane2001/116606719764376414",
       "commentsUrl": "https://lobste.rs/s/e7lsqn/chromium_publishes_fixed_exploit_4_years",
       "by": "",
-      "score": 12,
-      "commentCount": 0,
+      "score": 24,
+      "commentCount": 2,
       "createdUtc": 1779308945,
-      "ageHours": 2.4558333333333335,
-      "trendingScore": 1.2758153967067039,
+      "ageHours": 5.066944444444444,
+      "trendingScore": 1.2775082866993916,
       "tags": [
         "browsers",
         "security"
@@ -878,23 +895,6 @@
       "trendingScore": 0.9131510131737931,
       "tags": [
         "css"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "tvhqam",
-      "title": "\"six CVEs for serious security vulnerabilities in dnsmasq\"",
-      "url": "https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2026q2/018471.html",
-      "commentsUrl": "https://lobste.rs/s/tvhqam/six_cves_for_serious_security",
-      "by": "",
-      "score": 5,
-      "commentCount": 1,
-      "createdUtc": 1778613035,
-      "ageHours": 1.1144444444444443,
-      "trendingScore": 0.9097019420546543,
-      "tags": [
-        "security"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26200080857

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.