### PR TITLE
chore(data): refresh huggingface signals 2026-05-21T04:46:13Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-20T20:32:25.966Z",
+  "ts": "2026-05-21T04:46:12.996Z",
   "count": 1,
-  "durationMs": 8636,
+  "durationMs": 8069,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T20:32:17.332Z",
+  "fetchedAt": "2026-05-21T04:46:04.928Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -57,6 +57,34 @@
     },
     {
       "rank": 3,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/bytedance-research/Lance",
+      "downloads": 438,
+      "likes": 483,
+      "trendingScore": 475,
+      "pipelineTag": "any-to-any",
+      "libraryName": "Lance",
+      "tags": [
+        "Lance",
+        "safetensors",
+        "multimodal",
+        "image-generation",
+        "video-generation",
+        "image-editing",
+        "video-understanding",
+        "any-to-any",
+        "arxiv:2605.18678",
+        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T08:05:57.000Z",
+      "lastModified": "2026-05-20T12:40:00.000Z"
+    },
+    {
+      "rank": 4,
       "id": "Zyphra/ZAYA1-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-8B",
@@ -77,34 +105,6 @@
       ],
       "createdAt": "2026-05-04T19:45:38.000Z",
       "lastModified": "2026-05-11T22:43:52.000Z"
-    },
-    {
-      "rank": 4,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 438,
-      "likes": 449,
-      "trendingScore": 442,
-      "pipelineTag": "any-to-any",
-      "libraryName": "Lance",
-      "tags": [
-        "Lance",
-        "safetensors",
-        "multimodal",
-        "image-generation",
-        "video-generation",
-        "image-editing",
-        "video-understanding",
-        "any-to-any",
-        "arxiv:2605.18678",
-        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-20T12:40:00.000Z"
     },
     {
       "rank": 5,
@@ -287,8 +287,8 @@
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima",
       "downloads": 571087,
-      "likes": 1449,
-      "trendingScore": 208,
+      "likes": 1454,
+      "trendingScore": 210,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
       "tags": [
@@ -411,30 +411,12 @@
     },
     {
       "rank": 16,
-      "id": "TenStrip/LTX2.3-10Eros",
-      "author": "TenStrip",
-      "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
-      "downloads": 51779,
-      "likes": 190,
-      "trendingScore": 182,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "image-to-video",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T17:08:26.000Z",
-      "lastModified": "2026-05-07T01:24:09.000Z"
-    },
-    {
-      "rank": 17,
       "id": "sapientinc/HRM-Text-1B",
       "author": "sapientinc",
       "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
       "downloads": 23532,
-      "likes": 172,
-      "trendingScore": 170,
+      "likes": 186,
+      "trendingScore": 184,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -450,12 +432,31 @@
         "non-instruction-tuned",
         "custom_code",
         "en",
+        "arxiv:2605.20613",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us"
       ],
       "createdAt": "2026-05-17T15:13:02.000Z",
-      "lastModified": "2026-05-20T03:03:36.000Z"
+      "lastModified": "2026-05-21T03:33:11.000Z"
+    },
+    {
+      "rank": 17,
+      "id": "TenStrip/LTX2.3-10Eros",
+      "author": "TenStrip",
+      "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
+      "downloads": 51779,
+      "likes": 190,
+      "trendingScore": 182,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "image-to-video",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T17:08:26.000Z",
+      "lastModified": "2026-05-07T01:24:09.000Z"
     },
     {
       "rank": 18,
@@ -487,6 +488,41 @@
     },
     {
       "rank": 19,
+      "id": "NemoStation/Marlin-2B",
+      "author": "NemoStation",
+      "url": "https://huggingface.co/NemoStation/Marlin-2B",
+      "downloads": 125,
+      "likes": 148,
+      "trendingScore": 143,
+      "pipelineTag": "video-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "text-generation",
+        "video",
+        "multimodal",
+        "video-captioning",
+        "temporal-grounding",
+        "qwen",
+        "VLM",
+        "video-text-to-text",
+        "custom_code",
+        "en",
+        "arxiv:2501.00513",
+        "arxiv:2407.00634",
+        "arxiv:2512.14698",
+        "base_model:Qwen/Qwen3.5-2B",
+        "base_model:finetune:Qwen/Qwen3.5-2B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:23:12.000Z",
+      "lastModified": "2026-05-20T07:54:57.000Z"
+    },
+    {
+      "rank": 20,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -515,57 +551,13 @@
       "lastModified": "2026-04-28T07:01:37.000Z"
     },
     {
-      "rank": 20,
-      "id": "TencentARC/Pixal3D",
-      "author": "TencentARC",
-      "url": "https://huggingface.co/TencentARC/Pixal3D",
-      "downloads": 0,
-      "likes": 146,
-      "trendingScore": 137,
-      "pipelineTag": "image-to-3d",
-      "libraryName": null,
-      "tags": [
-        "image-to-3d",
-        "arxiv:2605.10922",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T10:18:49.000Z",
-      "lastModified": "2026-05-12T23:37:47.000Z"
-    },
-    {
       "rank": 21,
-      "id": "Qwen/Qwen3.6-27B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
-      "downloads": 1771851,
-      "likes": 1171,
-      "trendingScore": 133,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-21T07:50:43.000Z",
-      "lastModified": "2026-04-24T02:39:16.000Z"
-    },
-    {
-      "rank": 22,
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "downloads": 17539,
-      "likes": 134,
-      "trendingScore": 133,
+      "likes": 139,
+      "trendingScore": 138,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -602,7 +594,51 @@
       "lastModified": "2026-05-19T23:41:58.000Z"
     },
     {
+      "rank": 22,
+      "id": "TencentARC/Pixal3D",
+      "author": "TencentARC",
+      "url": "https://huggingface.co/TencentARC/Pixal3D",
+      "downloads": 0,
+      "likes": 146,
+      "trendingScore": 137,
+      "pipelineTag": "image-to-3d",
+      "libraryName": null,
+      "tags": [
+        "image-to-3d",
+        "arxiv:2605.10922",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T10:18:49.000Z",
+      "lastModified": "2026-05-12T23:37:47.000Z"
+    },
+    {
       "rank": 23,
+      "id": "Qwen/Qwen3.6-27B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
+      "downloads": 1771851,
+      "likes": 1171,
+      "trendingScore": 133,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "conversational",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-21T07:50:43.000Z",
+      "lastModified": "2026-04-24T02:39:16.000Z"
+    },
+    {
+      "rank": 24,
       "id": "mistralai/Mistral-Medium-3.5-128B",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B",
@@ -645,41 +681,6 @@
       ],
       "createdAt": "2026-03-31T09:50:20.000Z",
       "lastModified": "2026-05-04T14:16:22.000Z"
-    },
-    {
-      "rank": 24,
-      "id": "NemoStation/Marlin-2B",
-      "author": "NemoStation",
-      "url": "https://huggingface.co/NemoStation/Marlin-2B",
-      "downloads": 125,
-      "likes": 133,
-      "trendingScore": 129,
-      "pipelineTag": "video-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "text-generation",
-        "video",
-        "multimodal",
-        "video-captioning",
-        "temporal-grounding",
-        "qwen",
-        "VLM",
-        "video-text-to-text",
-        "custom_code",
-        "en",
-        "arxiv:2501.00513",
-        "arxiv:2407.00634",
-        "arxiv:2512.14698",
-        "base_model:Qwen/Qwen3.5-2B",
-        "base_model:finetune:Qwen/Qwen3.5-2B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:23:12.000Z",
-      "lastModified": "2026-05-20T07:54:57.000Z"
     },
     {
       "rank": 25,
@@ -1003,6 +1004,33 @@
     },
     {
       "rank": 36,
+      "id": "microsoft/Fara-7B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Fara-7B",
+      "downloads": 15167,
+      "likes": 588,
+      "trendingScore": 92,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_5_vl",
+        "image-text-to-text",
+        "multimodal",
+        "conversational",
+        "en",
+        "arxiv:2511.19663",
+        "license:mit",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-10-30T18:56:59.000Z",
+      "lastModified": "2026-05-19T15:37:05.000Z"
+    },
+    {
+      "rank": 37,
       "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
@@ -1028,7 +1056,7 @@
       "lastModified": "2026-04-25T21:33:07.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "unsloth/Qwen3.6-27B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
@@ -1054,33 +1082,6 @@
       ],
       "createdAt": "2026-04-22T05:43:37.000Z",
       "lastModified": "2026-04-22T16:01:39.000Z"
-    },
-    {
-      "rank": 38,
-      "id": "microsoft/Fara-7B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Fara-7B",
-      "downloads": 15167,
-      "likes": 586,
-      "trendingScore": 90,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_5_vl",
-        "image-text-to-text",
-        "multimodal",
-        "conversational",
-        "en",
-        "arxiv:2511.19663",
-        "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-10-30T18:56:59.000Z",
-      "lastModified": "2026-05-19T15:37:05.000Z"
     },
     {
       "rank": 39,
@@ -1113,8 +1114,8 @@
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
       "downloads": 3454,
-      "likes": 88,
-      "trendingScore": 87,
+      "likes": 89,
+      "trendingScore": 88,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1158,6 +1159,51 @@
     },
     {
       "rank": 42,
+      "id": "CohereLabs/command-a-plus-05-2026-w4a4",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
+      "downloads": 0,
+      "likes": 87,
+      "trendingScore": 86,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere2_vision",
+        "image-text-to-text",
+        "conversational",
+        "chat",
+        "en",
+        "ar",
+        "bg",
+        "bn",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fil",
+        "fr",
+        "ga",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "is",
+        "it",
+        "ja"
+      ],
+      "createdAt": "2026-05-18T04:51:16.000Z",
+      "lastModified": "2026-05-20T15:51:04.000Z"
+    },
+    {
+      "rank": 43,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/k2-fsa/OmniVoice",
@@ -1202,7 +1248,7 @@
       "lastModified": "2026-05-07T15:45:07.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
@@ -1229,7 +1275,7 @@
       "lastModified": "2026-05-10T15:43:51.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "antirez/deepseek-v4-gguf",
       "author": "antirez",
       "url": "https://huggingface.co/antirez/deepseek-v4-gguf",
@@ -1267,7 +1313,7 @@
       "lastModified": "2026-05-12T16:08:16.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -1295,7 +1341,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1324,7 +1370,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -1350,7 +1396,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -1379,7 +1425,7 @@
       "lastModified": "2026-04-20T12:42:25.000Z"
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -1412,7 +1458,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 50,
+      "rank": 51,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -1457,7 +1503,7 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 51,
+      "rank": 52,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -1490,7 +1536,27 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 52,
+      "rank": 53,
+      "id": "facebook/VGGT-Omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/VGGT-Omega",
+      "downloads": 0,
+      "likes": 78,
+      "trendingScore": 74,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "facebook",
+        "meta-pytorch",
+        "en",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-17T20:47:45.000Z",
+      "lastModified": "2026-05-14T21:23:21.000Z"
+    },
+    {
+      "rank": 54,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -1510,7 +1576,52 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 53,
+      "rank": 55,
+      "id": "CohereLabs/command-a-plus-05-2026-bf16",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
+      "downloads": 0,
+      "likes": 71,
+      "trendingScore": 70,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere2_vision",
+        "image-text-to-text",
+        "conversational",
+        "chat",
+        "en",
+        "ar",
+        "bg",
+        "bn",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fil",
+        "fr",
+        "ga",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "is",
+        "it",
+        "ja"
+      ],
+      "createdAt": "2026-05-11T12:31:04.000Z",
+      "lastModified": "2026-05-20T15:51:30.000Z"
+    },
+    {
+      "rank": 56,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -1533,27 +1644,32 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 54,
-      "id": "facebook/VGGT-Omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/VGGT-Omega",
+      "rank": 57,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
       "downloads": 0,
-      "likes": 73,
+      "likes": 69,
       "trendingScore": 69,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
       "tags": [
-        "facebook",
-        "meta-pytorch",
-        "en",
-        "license:cc-by-nc-4.0",
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-03-17T20:47:45.000Z",
-      "lastModified": "2026-05-14T21:23:21.000Z"
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
     },
     {
-      "rank": 55,
+      "rank": 58,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -1585,7 +1701,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 56,
+      "rank": 59,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -1610,7 +1726,7 @@
       "lastModified": "2026-05-12T14:25:54.000Z"
     },
     {
-      "rank": 57,
+      "rank": 60,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1655,32 +1771,39 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 58,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 64,
-      "trendingScore": 64,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
+      "rank": 61,
+      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
+      "downloads": 61106,
+      "likes": 69,
+      "trendingScore": 65,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
       "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
+        "gguf",
+        "uncensored",
+        "gemma4",
+        "moe",
+        "vision",
+        "multimodal",
+        "agentic",
+        "coding",
+        "image-text-to-text",
+        "en",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
         "license:apache-2.0",
-        "region:us"
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
+      "createdAt": "2026-05-14T16:24:48.000Z",
+      "lastModified": "2026-05-14T17:07:52.000Z"
     },
     {
-      "rank": 59,
+      "rank": 62,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -1707,7 +1830,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 60,
+      "rank": 63,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -1740,39 +1863,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 61,
-      "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
-      "downloads": 61106,
-      "likes": 65,
-      "trendingScore": 62,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "moe",
-        "vision",
-        "multimodal",
-        "agentic",
-        "coding",
-        "image-text-to-text",
-        "en",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-14T16:24:48.000Z",
-      "lastModified": "2026-05-14T17:07:52.000Z"
-    },
-    {
-      "rank": 62,
+      "rank": 64,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -1804,7 +1895,7 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 63,
+      "rank": 65,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -1833,7 +1924,7 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 64,
+      "rank": 66,
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
@@ -1858,7 +1949,7 @@
       "lastModified": "2026-05-14T08:44:07.000Z"
     },
     {
-      "rank": 65,
+      "rank": 67,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -1886,7 +1977,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 66,
+      "rank": 68,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -1913,7 +2004,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 67,
+      "rank": 69,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -1940,7 +2031,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 68,
+      "rank": 70,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -1963,7 +2054,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 69,
+      "rank": 71,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -1994,7 +2085,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 70,
+      "rank": 72,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -2024,7 +2115,7 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 71,
+      "rank": 73,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2068,7 +2159,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 72,
+      "rank": 74,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -2086,7 +2177,34 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 73,
+      "rank": 75,
+      "id": "Lakonik/AsymFLUX.2-klein-9B",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
+      "downloads": 2316,
+      "likes": 55,
+      "trendingScore": 54,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "flow-matching",
+        "pixel-diffusion",
+        "pixel-generation",
+        "flux2",
+        "text-to-image",
+        "arxiv:2605.12964",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T20:19:24.000Z",
+      "lastModified": "2026-05-14T02:37:15.000Z"
+    },
+    {
+      "rank": 76,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -2113,7 +2231,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 74,
+      "rank": 77,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2146,34 +2264,51 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 75,
-      "id": "Lakonik/AsymFLUX.2-klein-9B",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
-      "downloads": 2316,
-      "likes": 53,
+      "rank": 78,
+      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "downloads": 6680,
+      "likes": 55,
       "trendingScore": 53,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
-        "safetensors",
-        "flow-matching",
-        "pixel-diffusion",
-        "pixel-generation",
-        "flux2",
-        "text-to-image",
-        "arxiv:2605.12964",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:other",
-        "region:us"
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_5",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-05-12T20:19:24.000Z",
-      "lastModified": "2026-05-14T02:37:15.000Z"
+      "createdAt": "2026-05-18T05:48:32.000Z",
+      "lastModified": "2026-05-19T23:43:59.000Z"
     },
     {
-      "rank": 76,
+      "rank": 79,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2218,7 +2353,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 77,
+      "rank": 80,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2245,7 +2380,7 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 78,
+      "rank": 81,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2273,7 +2408,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 79,
+      "rank": 82,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2307,7 +2442,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 80,
+      "rank": 83,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2337,7 +2472,7 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 81,
+      "rank": 84,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -2357,96 +2492,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 82,
-      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "downloads": 6680,
-      "likes": 50,
-      "trendingScore": 48,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_5",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "coder",
-        "text-generation",
-        "en",
-        "zh",
-        "ko",
-        "ru",
-        "ja",
-        "es",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-18T05:48:32.000Z",
-      "lastModified": "2026-05-19T23:43:59.000Z"
-    },
-    {
-      "rank": 83,
-      "id": "CohereLabs/command-a-plus-05-2026-bf16",
-      "author": "CohereLabs",
-      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
-      "downloads": 0,
-      "likes": 49,
-      "trendingScore": 48,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere2_vision",
-        "image-text-to-text",
-        "conversational",
-        "chat",
-        "en",
-        "ar",
-        "bg",
-        "bn",
-        "ca",
-        "cs",
-        "da",
-        "de",
-        "el",
-        "es",
-        "et",
-        "fa",
-        "fi",
-        "fil",
-        "fr",
-        "ga",
-        "he",
-        "hi",
-        "hr",
-        "hu",
-        "id",
-        "is",
-        "it",
-        "ja"
-      ],
-      "createdAt": "2026-05-11T12:31:04.000Z",
-      "lastModified": "2026-05-20T15:51:30.000Z"
-    },
-    {
-      "rank": 84,
+      "rank": 85,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -2477,7 +2523,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 85,
+      "rank": 86,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -2502,7 +2548,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -2539,7 +2585,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -2574,51 +2620,6 @@
       ],
       "createdAt": "2026-04-01T22:06:52.000Z",
       "lastModified": "2026-05-17T10:58:37.000Z"
-    },
-    {
-      "rank": 88,
-      "id": "CohereLabs/command-a-plus-05-2026-w4a4",
-      "author": "CohereLabs",
-      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
-      "downloads": 0,
-      "likes": 48,
-      "trendingScore": 47,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere2_vision",
-        "image-text-to-text",
-        "conversational",
-        "chat",
-        "en",
-        "ar",
-        "bg",
-        "bn",
-        "ca",
-        "cs",
-        "da",
-        "de",
-        "el",
-        "es",
-        "et",
-        "fa",
-        "fi",
-        "fil",
-        "fr",
-        "ga",
-        "he",
-        "hi",
-        "hr",
-        "hu",
-        "id",
-        "is",
-        "it",
-        "ja"
-      ],
-      "createdAt": "2026-05-18T04:51:16.000Z",
-      "lastModified": "2026-05-20T15:51:04.000Z"
     },
     {
       "rank": 89,
@@ -2674,6 +2675,32 @@
     },
     {
       "rank": 91,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 65,
+      "likes": 46,
+      "trendingScore": 46,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 92,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -2696,12 +2723,12 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 92,
+      "rank": 93,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
       "downloads": 53048,
-      "likes": 46,
+      "likes": 47,
       "trendingScore": 45,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -2723,7 +2750,44 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 1720,
+      "likes": 46,
+      "trendingScore": 45,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 95,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -2756,7 +2820,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 94,
+      "rank": 96,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -2787,7 +2851,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 95,
+      "rank": 97,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -2803,33 +2867,7 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 96,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 65,
-      "likes": 42,
-      "trendingScore": 42,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
-    },
-    {
-      "rank": 97,
+      "rank": 98,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -2846,43 +2884,6 @@
       ],
       "createdAt": "2026-05-05T23:12:08.000Z",
       "lastModified": "2026-05-08T23:21:12.000Z"
-    },
-    {
-      "rank": 98,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 1720,
-      "likes": 39,
-      "trendingScore": 38,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "image-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
       "rank": 99,
@@ -3107,6 +3108,25 @@
     },
     {
       "rank": 107,
+      "id": "Kijai/LTX2.3_comfy",
+      "author": "Kijai",
+      "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
+      "downloads": 1189089,
+      "likes": 380,
+      "trendingScore": 35,
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
+      "tags": [
+        "diffusion-single-file",
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-05T15:20:18.000Z",
+      "lastModified": "2026-05-20T20:31:07.000Z"
+    },
+    {
+      "rank": 108,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -3130,7 +3150,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 108,
+      "rank": 109,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -3147,7 +3167,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 109,
+      "rank": 110,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -3171,7 +3191,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 110,
+      "rank": 111,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3197,7 +3217,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 111,
+      "rank": 112,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -3213,7 +3233,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 112,
+      "rank": 113,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -3240,7 +3260,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 113,
+      "rank": 114,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -3267,25 +3287,6 @@
       ],
       "createdAt": "2026-04-15T01:22:42.000Z",
       "lastModified": "2026-04-19T21:43:06.000Z"
-    },
-    {
-      "rank": 114,
-      "id": "Kijai/LTX2.3_comfy",
-      "author": "Kijai",
-      "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
-      "downloads": 1189089,
-      "likes": 376,
-      "trendingScore": 34,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
-      "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-05T15:20:18.000Z",
-      "lastModified": "2026-05-19T22:46:11.000Z"
     },
     {
       "rank": 115,
@@ -3789,6 +3790,57 @@
     },
     {
       "rank": 129,
+      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "downloads": 16599,
+      "likes": 33,
+      "trendingScore": 31,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:11:26.000Z",
+      "lastModified": "2026-05-21T03:18:01.000Z"
+    },
+    {
+      "rank": 130,
+      "id": "kohya-ss/Anima-LLLite",
+      "author": "kohya-ss",
+      "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
+      "downloads": 0,
+      "likes": 77,
+      "trendingScore": 31,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "base_model:circlestone-labs/Anima",
+        "base_model:adapter:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T12:32:06.000Z",
+      "lastModified": "2026-05-20T13:33:56.000Z"
+    },
+    {
+      "rank": 131,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -3814,7 +3866,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 130,
+      "rank": 132,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -3846,7 +3898,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 131,
+      "rank": 133,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -3873,7 +3925,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 132,
+      "rank": 134,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -3907,7 +3959,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 133,
+      "rank": 135,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -3929,7 +3981,7 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 134,
+      "rank": 136,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -3960,7 +4012,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 135,
+      "rank": 137,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -3985,7 +4037,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 136,
+      "rank": 138,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -4008,7 +4060,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 137,
+      "rank": 139,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -4035,7 +4087,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 138,
+      "rank": 140,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -4066,12 +4118,12 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 139,
+      "rank": 141,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
       "downloads": 4925733,
-      "likes": 5710,
+      "likes": 5711,
       "trendingScore": 29,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
@@ -4111,39 +4163,7 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 140,
-      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 16599,
-      "likes": 31,
-      "trendingScore": 29,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:11:26.000Z",
-      "lastModified": "2026-05-16T21:22:27.000Z"
-    },
-    {
-      "rank": 141,
+      "rank": 142,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -4165,7 +4185,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 142,
+      "rank": 143,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -4202,7 +4222,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 143,
+      "rank": 144,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -4224,7 +4244,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 144,
+      "rank": 145,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -4257,26 +4277,65 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 145,
-      "id": "kohya-ss/Anima-LLLite",
-      "author": "kohya-ss",
-      "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
+      "rank": 146,
+      "id": "ByteDance-Seed/Cola-DLM",
+      "author": "ByteDance-Seed",
+      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
       "downloads": 0,
-      "likes": 74,
+      "likes": 28,
       "trendingScore": 28,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "base_model:circlestone-labs/Anima",
-        "base_model:adapter:circlestone-labs/Anima",
+        "transformers",
+        "safetensors",
+        "text-generation",
+        "language-model",
+        "diffusion",
+        "latent-diffusion",
+        "flow-matching",
+        "text-vae",
+        "pytorch",
+        "research",
+        "en",
+        "arxiv:2605.06548",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T07:55:26.000Z",
+      "lastModified": "2026-05-15T09:38:05.000Z"
+    },
+    {
+      "rank": 147,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 28,
+      "trendingScore": 28,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
         "license:other",
         "region:us"
       ],
-      "createdAt": "2026-04-27T12:32:06.000Z",
-      "lastModified": "2026-05-20T13:33:56.000Z"
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
     },
     {
-      "rank": 146,
+      "rank": 148,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -4316,7 +4375,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 147,
+      "rank": 149,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -4353,7 +4412,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 148,
+      "rank": 150,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -4396,7 +4455,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 149,
+      "rank": 151,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -4416,7 +4475,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 150,
+      "rank": 152,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -4441,37 +4500,33 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 151,
-      "id": "ByteDance-Seed/Cola-DLM",
-      "author": "ByteDance-Seed",
-      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
-      "downloads": 0,
-      "likes": 27,
+      "rank": 153,
+      "id": "HuggingFaceBio/Carbon-3B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
+      "downloads": 2184,
+      "likes": 28,
       "trendingScore": 27,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
+        "llama",
         "text-generation",
-        "language-model",
-        "diffusion",
-        "latent-diffusion",
-        "flow-matching",
-        "text-vae",
-        "pytorch",
-        "research",
-        "en",
-        "arxiv:2605.06548",
+        "dna",
+        "genomic",
+        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
         "license:apache-2.0",
+        "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-15T07:55:26.000Z",
-      "lastModified": "2026-05-15T09:38:05.000Z"
+      "createdAt": "2026-05-12T11:05:49.000Z",
+      "lastModified": "2026-05-20T13:39:48.000Z"
     },
     {
-      "rank": 152,
+      "rank": 154,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -4516,7 +4571,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 153,
+      "rank": 155,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -4543,7 +4598,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 154,
+      "rank": 156,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -4588,7 +4643,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 155,
+      "rank": 157,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -4614,7 +4669,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 156,
+      "rank": 158,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -4636,7 +4691,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 157,
+      "rank": 159,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -4652,7 +4707,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 158,
+      "rank": 160,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -4688,7 +4743,25 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 159,
+      "rank": 161,
+      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
+      "downloads": 65,
+      "likes": 27,
+      "trendingScore": 26,
+      "pipelineTag": null,
+      "libraryName": "nemo",
+      "tags": [
+        "nemo",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T21:52:25.000Z",
+      "lastModified": "2026-05-16T05:35:07.000Z"
+    },
+    {
+      "rank": 162,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -4726,7 +4799,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 160,
+      "rank": 163,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -4744,7 +4817,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 161,
+      "rank": 164,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -4770,7 +4843,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 162,
+      "rank": 165,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -4790,7 +4863,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 163,
+      "rank": 166,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -4817,7 +4890,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 164,
+      "rank": 167,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -4843,7 +4916,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 165,
+      "rank": 168,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -4869,7 +4942,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 166,
+      "rank": 169,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -4906,7 +4979,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 167,
+      "rank": 170,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -4922,7 +4995,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 168,
+      "rank": 171,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -4945,7 +5018,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 169,
+      "rank": 172,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -4987,7 +5060,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 170,
+      "rank": 173,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -5026,25 +5099,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 171,
-      "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
-      "downloads": 65,
-      "likes": 26,
-      "trendingScore": 25,
-      "pipelineTag": null,
-      "libraryName": "nemo",
-      "tags": [
-        "nemo",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T21:52:25.000Z",
-      "lastModified": "2026-05-16T05:35:07.000Z"
-    },
-    {
-      "rank": 172,
+      "rank": 174,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -5076,7 +5131,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 173,
+      "rank": 175,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -5100,7 +5155,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 174,
+      "rank": 176,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
@@ -5145,7 +5200,7 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 175,
+      "rank": 177,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -5172,7 +5227,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 176,
+      "rank": 178,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -5197,7 +5252,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 177,
+      "rank": 179,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -5233,7 +5288,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 178,
+      "rank": 180,
       "id": "pyannote/speaker-diarization-3.1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
@@ -5265,7 +5320,7 @@
       "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 179,
+      "rank": 181,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -5281,7 +5336,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 180,
+      "rank": 182,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -5302,12 +5357,41 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 181,
-      "id": "HuggingFaceBio/Carbon-3B",
+      "rank": 183,
+      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "author": "sensenova",
+      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
+      "downloads": 421,
+      "likes": 31,
+      "trendingScore": 24,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "neo_chat",
+        "feature-extraction",
+        "multimodal",
+        "text-to-image",
+        "image-to-text",
+        "image-editing",
+        "interleaved-generation",
+        "custom_code",
+        "any-to-any",
+        "arxiv:2502.01522",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T09:54:29.000Z",
+      "lastModified": "2026-05-16T06:48:11.000Z"
+    },
+    {
+      "rank": 184,
+      "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 2184,
-      "likes": 25,
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
+      "downloads": 1107,
+      "likes": 24,
       "trendingScore": 24,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -5318,17 +5402,16 @@
         "text-generation",
         "dna",
         "genomic",
-        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
         "license:apache-2.0",
         "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-12T11:05:49.000Z",
-      "lastModified": "2026-05-20T13:39:48.000Z"
+      "createdAt": "2026-05-17T23:30:49.000Z",
+      "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 182,
+      "rank": 185,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -5355,7 +5438,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 183,
+      "rank": 186,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -5384,7 +5467,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 184,
+      "rank": 187,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -5401,7 +5484,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 185,
+      "rank": 188,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -5422,7 +5505,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 186,
+      "rank": 189,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -5443,7 +5526,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 187,
+      "rank": 190,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -5475,7 +5558,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 188,
+      "rank": 191,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -5496,7 +5579,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 189,
+      "rank": 192,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -5528,7 +5611,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 190,
+      "rank": 193,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -5559,7 +5642,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 191,
+      "rank": 194,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -5588,7 +5671,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 192,
+      "rank": 195,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -5633,7 +5716,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 193,
+      "rank": 196,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -5660,7 +5743,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 194,
+      "rank": 197,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5686,7 +5769,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 195,
+      "rank": 198,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -5710,7 +5793,80 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 196,
+      "rank": 199,
+      "id": "FINAL-Bench/Darwin-28B-REASON",
+      "author": "FINAL-Bench",
+      "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
+      "downloads": 264,
+      "likes": 25,
+      "trendingScore": 22,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "darwin",
+        "darwin-reason",
+        "reasoning",
+        "advanced-reasoning",
+        "chain-of-thought",
+        "thinking",
+        "reasoning-trace-distillation",
+        "rtd",
+        "darwin-delphi",
+        "test-time-compute",
+        "qwen3.6",
+        "qwen",
+        "gpqa",
+        "benchmark",
+        "open-source",
+        "apache-2.0",
+        "proto-agi",
+        "vidraft",
+        "eval-results",
+        "text-generation",
+        "conversational",
+        "en",
+        "zh",
+        "ko",
+        "ja",
+        "multilingual"
+      ],
+      "createdAt": "2026-05-17T08:52:00.000Z",
+      "lastModified": "2026-05-17T09:32:18.000Z"
+    },
+    {
+      "rank": 200,
+      "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
+      "author": "Ex0bit",
+      "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
+      "downloads": 243,
+      "likes": 22,
+      "trendingScore": 22,
+      "pipelineTag": "text-generation",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "quantized",
+        "dynamic-quant",
+        "qwen3",
+        "llama.cpp",
+        "speculative-decoding",
+        "text-generation",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:19:08.000Z",
+      "lastModified": "2026-05-19T21:32:32.000Z"
+    },
+    {
+      "rank": 201,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -5755,7 +5911,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 197,
+      "rank": 202,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -5783,7 +5939,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 198,
+      "rank": 203,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -5810,7 +5966,7 @@
       "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 199,
+      "rank": 204,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -5846,7 +6002,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 200,
+      "rank": 205,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -5863,52 +6019,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 201,
-      "id": "FINAL-Bench/Darwin-28B-REASON",
-      "author": "FINAL-Bench",
-      "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
-      "downloads": 264,
-      "likes": 24,
-      "trendingScore": 21,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "darwin",
-        "darwin-reason",
-        "reasoning",
-        "advanced-reasoning",
-        "chain-of-thought",
-        "thinking",
-        "reasoning-trace-distillation",
-        "rtd",
-        "darwin-delphi",
-        "test-time-compute",
-        "qwen3.6",
-        "qwen",
-        "gpqa",
-        "benchmark",
-        "open-source",
-        "apache-2.0",
-        "proto-agi",
-        "vidraft",
-        "eval-results",
-        "text-generation",
-        "conversational",
-        "en",
-        "zh",
-        "ko",
-        "ja",
-        "multilingual"
-      ],
-      "createdAt": "2026-05-17T08:52:00.000Z",
-      "lastModified": "2026-05-17T09:32:18.000Z"
-    },
-    {
-      "rank": 202,
+      "rank": 206,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -5946,41 +6057,12 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 203,
-      "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "author": "sensenova",
-      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
-      "downloads": 421,
-      "likes": 28,
-      "trendingScore": 21,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "neo_chat",
-        "feature-extraction",
-        "multimodal",
-        "text-to-image",
-        "image-to-text",
-        "image-editing",
-        "interleaved-generation",
-        "custom_code",
-        "any-to-any",
-        "arxiv:2502.01522",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T09:54:29.000Z",
-      "lastModified": "2026-05-16T06:48:11.000Z"
-    },
-    {
-      "rank": 204,
+      "rank": 207,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
       "downloads": 20652,
-      "likes": 21,
+      "likes": 22,
       "trendingScore": 21,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -6002,35 +6084,77 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 205,
-      "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "author": "Ex0bit",
-      "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "downloads": 243,
-      "likes": 21,
+      "rank": 208,
+      "id": "CohereLabs/command-a-plus-05-2026-fp8",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
+      "downloads": 0,
+      "likes": 22,
       "trendingScore": 21,
-      "pipelineTag": "text-generation",
-      "libraryName": "gguf",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "gguf",
-        "quantized",
-        "dynamic-quant",
-        "qwen3",
-        "llama.cpp",
-        "speculative-decoding",
-        "text-generation",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "transformers",
+        "safetensors",
+        "cohere2_vision",
+        "image-text-to-text",
+        "conversational",
+        "chat",
+        "en",
+        "ar",
+        "bg",
+        "bn",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fil",
+        "fr",
+        "ga",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "is",
+        "it",
+        "ja"
       ],
-      "createdAt": "2026-05-19T21:19:08.000Z",
-      "lastModified": "2026-05-19T21:32:32.000Z"
+      "createdAt": "2026-05-18T04:50:57.000Z",
+      "lastModified": "2026-05-20T15:51:46.000Z"
     },
     {
-      "rank": 206,
+      "rank": 209,
+      "id": "kjanh/KhanhTTS-OmniVoice",
+      "author": "kjanh",
+      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
+      "downloads": 3154,
+      "likes": 24,
+      "trendingScore": 21,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "omnivoice",
+        "text-to-speech",
+        "vi",
+        "en",
+        "arxiv:2604.00688",
+        "base_model:k2-fsa/OmniVoice",
+        "base_model:finetune:k2-fsa/OmniVoice",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T02:00:22.000Z",
+      "lastModified": "2026-05-16T04:32:12.000Z"
+    },
+    {
+      "rank": 210,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -6058,7 +6182,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 207,
+      "rank": 211,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -6091,7 +6215,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 208,
+      "rank": 212,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -6116,7 +6240,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 209,
+      "rank": 213,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -6153,7 +6277,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 210,
+      "rank": 214,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -6196,7 +6320,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 211,
+      "rank": 215,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -6220,7 +6344,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 212,
+      "rank": 216,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -6244,7 +6368,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 213,
+      "rank": 217,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -6276,7 +6400,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 214,
+      "rank": 218,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -6305,7 +6429,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 215,
+      "rank": 219,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -6336,7 +6460,7 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 216,
+      "rank": 220,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -6354,7 +6478,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 217,
+      "rank": 221,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -6399,12 +6523,12 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 218,
-      "id": "HuggingFaceBio/Carbon-8B",
+      "rank": 222,
+      "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
-      "downloads": 1107,
-      "likes": 20,
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
+      "downloads": 706,
+      "likes": 21,
       "trendingScore": 20,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -6415,16 +6539,17 @@
         "text-generation",
         "dna",
         "genomic",
+        "speculative-decoding",
         "license:apache-2.0",
         "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-17T23:30:49.000Z",
-      "lastModified": "2026-05-20T13:40:10.000Z"
+      "createdAt": "2026-05-12T16:09:33.000Z",
+      "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 219,
+      "rank": 223,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -6469,7 +6594,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 220,
+      "rank": 224,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -6502,7 +6627,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 221,
+      "rank": 225,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -6524,7 +6649,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 222,
+      "rank": 226,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -6551,7 +6676,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 223,
+      "rank": 227,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -6567,7 +6692,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 224,
+      "rank": 228,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -6584,7 +6709,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 225,
+      "rank": 229,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -6607,7 +6732,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 226,
+      "rank": 230,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -6632,7 +6757,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 227,
+      "rank": 231,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -6668,7 +6793,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 228,
+      "rank": 232,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -6697,7 +6822,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 229,
+      "rank": 233,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -6727,7 +6852,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 230,
+      "rank": 234,
       "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
       "author": "fal",
       "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
@@ -6759,7 +6884,7 @@
       "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
-      "rank": 231,
+      "rank": 235,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -6804,7 +6929,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 232,
+      "rank": 236,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -6831,7 +6956,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 233,
+      "rank": 237,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6862,7 +6987,7 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 234,
+      "rank": 238,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -6888,7 +7013,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 235,
+      "rank": 239,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -6916,7 +7041,87 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 236,
+      "rank": 240,
+      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "downloads": 22423,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-122B-A10B",
+        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T19:03:18.000Z",
+      "lastModified": "2026-05-18T03:29:50.000Z"
+    },
+    {
+      "rank": 241,
+      "id": "chiennv/Orthrus-Qwen3-8B",
+      "author": "chiennv",
+      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
+      "downloads": 1860,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "diffusion",
+        "parallel-decoding",
+        "orthrus",
+        "conversational",
+        "custom_code",
+        "arxiv:2605.12825",
+        "license:cc-by-4.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T17:59:34.000Z",
+      "lastModified": "2026-05-16T22:44:53.000Z"
+    },
+    {
+      "rank": 242,
+      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "author": "vrgamedevgirl84",
+      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
+      "downloads": 2029,
+      "likes": 22,
+      "trendingScore": 19,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ltx-video",
+        "text-to-video",
+        "safetensors",
+        "base_model:Lightricks/LTX-Video",
+        "base_model:adapter:Lightricks/LTX-Video",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T00:29:34.000Z",
+      "lastModified": "2026-04-24T02:26:47.000Z"
+    },
+    {
+      "rank": 243,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -6938,7 +7143,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 237,
+      "rank": 244,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -6972,7 +7177,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 238,
+      "rank": 245,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -6996,7 +7201,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 239,
+      "rank": 246,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7022,7 +7227,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 240,
+      "rank": 247,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -7044,7 +7249,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 241,
+      "rank": 248,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -7073,7 +7278,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 242,
+      "rank": 249,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -7105,7 +7310,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 243,
+      "rank": 250,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -7134,7 +7339,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 244,
+      "rank": 251,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -7156,7 +7361,7 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 245,
+      "rank": 252,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -7174,35 +7379,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 246,
-      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "downloads": 22423,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-122B-A10B",
-        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T19:03:18.000Z",
-      "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 247,
+      "rank": 253,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -7231,7 +7408,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 248,
+      "rank": 254,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7258,7 +7435,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 249,
+      "rank": 255,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -7276,62 +7453,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 250,
-      "id": "HuggingFaceBio/Carbon-500M",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
-      "downloads": 706,
-      "likes": 19,
-      "trendingScore": 18,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "speculative-decoding",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T16:09:33.000Z",
-      "lastModified": "2026-05-20T13:40:43.000Z"
-    },
-    {
-      "rank": 251,
-      "id": "chiennv/Orthrus-Qwen3-8B",
-      "author": "chiennv",
-      "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
-      "downloads": 1860,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "diffusion",
-        "parallel-decoding",
-        "orthrus",
-        "conversational",
-        "custom_code",
-        "arxiv:2605.12825",
-        "license:cc-by-4.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T17:59:34.000Z",
-      "lastModified": "2026-05-16T22:44:53.000Z"
-    },
-    {
-      "rank": 252,
+      "rank": 256,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7376,75 +7498,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 253,
-      "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "author": "vrgamedevgirl84",
-      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "downloads": 2029,
-      "likes": 21,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ltx-video",
-        "text-to-video",
-        "safetensors",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T00:29:34.000Z",
-      "lastModified": "2026-04-24T02:26:47.000Z"
-    },
-    {
-      "rank": 254,
-      "id": "CohereLabs/command-a-plus-05-2026-fp8",
-      "author": "CohereLabs",
-      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
-      "downloads": 0,
-      "likes": 19,
-      "trendingScore": 18,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere2_vision",
-        "image-text-to-text",
-        "conversational",
-        "chat",
-        "en",
-        "ar",
-        "bg",
-        "bn",
-        "ca",
-        "cs",
-        "da",
-        "de",
-        "el",
-        "es",
-        "et",
-        "fa",
-        "fi",
-        "fil",
-        "fr",
-        "ga",
-        "he",
-        "hi",
-        "hr",
-        "hu",
-        "id",
-        "is",
-        "it",
-        "ja"
-      ],
-      "createdAt": "2026-05-18T04:50:57.000Z",
-      "lastModified": "2026-05-20T15:51:46.000Z"
-    },
-    {
-      "rank": 255,
+      "rank": 257,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -7489,7 +7543,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 256,
+      "rank": 258,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -7518,7 +7572,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 257,
+      "rank": 259,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -7547,7 +7601,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 258,
+      "rank": 260,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -7579,7 +7633,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 259,
+      "rank": 261,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -7609,7 +7663,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 260,
+      "rank": 262,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -7630,7 +7684,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 261,
+      "rank": 263,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -7675,7 +7729,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 262,
+      "rank": 264,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -7704,7 +7758,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 263,
+      "rank": 265,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -7732,12 +7786,12 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 264,
+      "rank": 266,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
-      "downloads": 65614,
-      "likes": 835,
+      "downloads": 78127,
+      "likes": 841,
       "trendingScore": 17,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -7757,7 +7811,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 265,
+      "rank": 267,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -7780,7 +7834,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 266,
+      "rank": 268,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -7807,7 +7861,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 267,
+      "rank": 269,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -7833,7 +7887,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 268,
+      "rank": 270,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -7862,12 +7916,12 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 269,
+      "rank": 271,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
       "downloads": 1940583,
-      "likes": 7726,
+      "likes": 7731,
       "trendingScore": 17,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -7891,7 +7945,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 270,
+      "rank": 272,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -7916,7 +7970,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 271,
+      "rank": 273,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -7951,7 +8005,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 272,
+      "rank": 274,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -7996,7 +8050,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 273,
+      "rank": 275,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -8023,7 +8077,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 274,
+      "rank": 276,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -8052,7 +8106,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 275,
+      "rank": 277,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -8075,7 +8129,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 276,
+      "rank": 278,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -8119,7 +8173,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 277,
+      "rank": 279,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -8164,7 +8218,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 278,
+      "rank": 280,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -8182,7 +8236,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 279,
+      "rank": 281,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -8227,7 +8281,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 280,
+      "rank": 282,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -8265,7 +8319,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 281,
+      "rank": 283,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -8285,7 +8339,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 282,
+      "rank": 284,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -8318,7 +8372,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 283,
+      "rank": 285,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -8348,7 +8402,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 284,
+      "rank": 286,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -8380,7 +8434,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 285,
+      "rank": 287,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -8405,32 +8459,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 286,
-      "id": "kjanh/KhanhTTS-OmniVoice",
-      "author": "kjanh",
-      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
-      "downloads": 3154,
-      "likes": 17,
-      "trendingScore": 16,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "omnivoice",
-        "text-to-speech",
-        "vi",
-        "en",
-        "arxiv:2604.00688",
-        "base_model:k2-fsa/OmniVoice",
-        "base_model:finetune:k2-fsa/OmniVoice",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T02:00:22.000Z",
-      "lastModified": "2026-05-16T04:32:12.000Z"
-    },
-    {
-      "rank": 287,
+      "rank": 288,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -8457,7 +8486,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 288,
+      "rank": 289,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -8502,7 +8531,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 289,
+      "rank": 290,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -8532,7 +8561,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 290,
+      "rank": 291,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -8562,7 +8591,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 291,
+      "rank": 292,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -8607,7 +8636,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 292,
+      "rank": 293,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -8642,7 +8671,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 293,
+      "rank": 294,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -8670,7 +8699,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 294,
+      "rank": 295,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -8699,7 +8728,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 295,
+      "rank": 296,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -8724,7 +8753,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 296,
+      "rank": 297,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -8752,7 +8781,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 297,
+      "rank": 298,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -8780,7 +8809,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 298,
+      "rank": 299,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -8811,7 +8840,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 299,
+      "rank": 300,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -8856,7 +8885,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 300,
+      "rank": 301,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -8888,7 +8917,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 301,
+      "rank": 302,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -8915,7 +8944,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 302,
+      "rank": 303,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -8938,7 +8967,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 303,
+      "rank": 304,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -8971,7 +9000,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 304,
+      "rank": 305,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -8998,7 +9027,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 305,
+      "rank": 306,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9017,7 +9046,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 306,
+      "rank": 307,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -9040,7 +9069,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 307,
+      "rank": 308,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -9066,7 +9095,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 308,
+      "rank": 309,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -9096,7 +9125,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 309,
+      "rank": 310,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -9123,7 +9152,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 310,
+      "rank": 311,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9153,7 +9182,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 311,
+      "rank": 312,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -9184,7 +9213,59 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 312,
+      "rank": 313,
+      "id": "Efficient-Large-Model/LongLive-2.0-5B",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
+      "downloads": 0,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "text-to-video",
+        "multi-shot",
+        "video-generation",
+        "diffusion",
+        "long-video",
+        "longlive2",
+        "arxiv:2605.18739",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:10:14.000Z",
+      "lastModified": "2026-05-19T02:54:48.000Z"
+    },
+    {
+      "rank": 314,
+      "id": "stabilityai/stable-audio-3-small-music",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "downloads": 0,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-music-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:33.000Z",
+      "lastModified": "2026-05-19T20:02:42.000Z"
+    },
+    {
+      "rank": 315,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -9208,7 +9289,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 313,
+      "rank": 316,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -9235,7 +9316,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 314,
+      "rank": 317,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -9263,7 +9344,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 315,
+      "rank": 318,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -9291,7 +9372,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 316,
+      "rank": 319,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -9310,7 +9391,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 317,
+      "rank": 320,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -9342,7 +9423,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 318,
+      "rank": 321,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -9371,7 +9452,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 319,
+      "rank": 322,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -9398,7 +9479,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 320,
+      "rank": 323,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -9422,7 +9503,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 321,
+      "rank": 324,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -9448,7 +9529,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 322,
+      "rank": 325,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -9479,7 +9560,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 323,
+      "rank": 326,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -9507,7 +9588,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 324,
+      "rank": 327,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -9530,7 +9611,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 325,
+      "rank": 328,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -9564,7 +9645,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 326,
+      "rank": 329,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -9590,7 +9671,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 327,
+      "rank": 330,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -9632,7 +9713,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 328,
+      "rank": 331,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -9670,7 +9751,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 329,
+      "rank": 332,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -9689,7 +9770,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 330,
+      "rank": 333,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -9709,7 +9790,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 331,
+      "rank": 334,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -9736,7 +9817,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 332,
+      "rank": 335,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -9762,7 +9843,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 333,
+      "rank": 336,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -9787,7 +9868,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 334,
+      "rank": 337,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -9816,7 +9897,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 335,
+      "rank": 338,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -9861,7 +9942,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -9885,32 +9966,93 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 337,
-      "id": "Efficient-Large-Model/LongLive-2.0-5B",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
+      "rank": 340,
+      "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
+      "downloads": 4890,
+      "likes": 17,
+      "trendingScore": 14,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.5",
+        "reasoning",
+        "chain-of-thought",
+        "evolutionary-merge",
+        "darwin",
+        "base_model:FINAL-Bench/Darwin-36B-Opus",
+        "base_model:quantized:FINAL-Bench/Darwin-36B-Opus",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T09:29:30.000Z",
+      "lastModified": "2026-05-15T12:12:22.000Z"
+    },
+    {
+      "rank": 341,
+      "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
+      "author": "ibm-research",
+      "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
+      "downloads": 2010,
+      "likes": 43,
+      "trendingScore": 14,
+      "pipelineTag": null,
+      "libraryName": "biomed-multi-alignment",
+      "tags": [
+        "biomed-multi-alignment",
+        "safetensors",
+        "biology",
+        "small-molecules",
+        "single-cell-genes",
+        "drug-discovery",
+        "ibm",
+        "mammal",
+        "pytorch",
+        "arxiv:2410.22367",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2024-10-08T12:22:46.000Z",
+      "lastModified": "2024-12-19T17:04:32.000Z"
+    },
+    {
+      "rank": 342,
+      "id": "oron1208/OOO_Anima",
+      "author": "oron1208",
+      "url": "https://huggingface.co/oron1208/OOO_Anima",
       "downloads": 0,
       "likes": 14,
       "trendingScore": 14,
-      "pipelineTag": "text-to-video",
-      "libraryName": "wan2.2",
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
       "tags": [
-        "wan2.2",
-        "text-to-video",
-        "multi-shot",
-        "video-generation",
-        "diffusion",
-        "long-video",
-        "longlive2",
-        "arxiv:2605.18739",
+        "text-to-image",
+        "image-generation",
+        "anime",
+        "illustration",
+        "anima",
+        "safetensors",
+        "ja",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
         "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-17T23:10:14.000Z",
-      "lastModified": "2026-05-19T02:54:48.000Z"
+      "createdAt": "2026-05-20T09:41:37.000Z",
+      "lastModified": "2026-05-20T13:37:45.000Z"
     },
     {
-      "rank": 338,
+      "rank": 343,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -9939,7 +10081,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 339,
+      "rank": 344,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -9984,7 +10126,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 340,
+      "rank": 345,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -10013,7 +10155,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 341,
+      "rank": 346,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -10040,7 +10182,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 342,
+      "rank": 347,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10085,7 +10227,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 343,
+      "rank": 348,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -10112,7 +10254,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 344,
+      "rank": 349,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -10143,7 +10285,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 345,
+      "rank": 350,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -10167,7 +10309,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 346,
+      "rank": 351,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -10191,7 +10333,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 347,
+      "rank": 352,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -10236,7 +10378,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 348,
+      "rank": 353,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -10263,7 +10405,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 349,
+      "rank": 354,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -10299,7 +10441,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 350,
+      "rank": 355,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -10330,7 +10472,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 351,
+      "rank": 356,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -10361,7 +10503,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 352,
+      "rank": 357,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -10394,7 +10536,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 353,
+      "rank": 358,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -10423,12 +10565,12 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 354,
+      "rank": 359,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
-      "downloads": 198079,
-      "likes": 76,
+      "downloads": 157382,
+      "likes": 90,
       "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -10440,14 +10582,13 @@
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
-        "imatrix",
         "conversational"
       ],
       "createdAt": "2026-04-16T14:23:44.000Z",
-      "lastModified": "2026-04-16T18:11:27.000Z"
+      "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 355,
+      "rank": 360,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -10473,7 +10614,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 356,
+      "rank": 361,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -10503,7 +10644,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 357,
+      "rank": 362,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -10521,7 +10662,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 358,
+      "rank": 363,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -10552,7 +10693,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 359,
+      "rank": 364,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -10573,7 +10714,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 360,
+      "rank": 365,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -10593,7 +10734,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 361,
+      "rank": 366,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -10621,7 +10762,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 362,
+      "rank": 367,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -10648,7 +10789,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 363,
+      "rank": 368,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -10678,7 +10819,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 364,
+      "rank": 369,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -10695,7 +10836,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 365,
+      "rank": 370,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -10722,7 +10863,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 366,
+      "rank": 371,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -10753,66 +10894,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 367,
-      "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
-      "downloads": 4890,
-      "likes": 16,
-      "trendingScore": 13,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "evolutionary-merge",
-        "darwin",
-        "base_model:FINAL-Bench/Darwin-36B-Opus",
-        "base_model:quantized:FINAL-Bench/Darwin-36B-Opus",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T09:29:30.000Z",
-      "lastModified": "2026-05-15T12:12:22.000Z"
-    },
-    {
-      "rank": 368,
-      "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
-      "author": "ibm-research",
-      "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
-      "downloads": 2010,
-      "likes": 42,
-      "trendingScore": 13,
-      "pipelineTag": null,
-      "libraryName": "biomed-multi-alignment",
-      "tags": [
-        "biomed-multi-alignment",
-        "safetensors",
-        "biology",
-        "small-molecules",
-        "single-cell-genes",
-        "drug-discovery",
-        "ibm",
-        "mammal",
-        "pytorch",
-        "arxiv:2410.22367",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2024-10-08T12:22:46.000Z",
-      "lastModified": "2024-12-19T17:04:32.000Z"
-    },
-    {
-      "rank": 369,
+      "rank": 372,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -10840,10 +10922,10 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 370,
-      "id": "stabilityai/stable-audio-3-medium",
+      "rank": 373,
+      "id": "stabilityai/stable-audio-3-small-sfx",
       "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
       "downloads": 0,
       "likes": 13,
       "trendingScore": 13,
@@ -10853,22 +10935,21 @@
         "stable-audio-3",
         "safetensors",
         "audio-generation",
-        "music",
         "sound-effects",
         "diffusion",
         "text-to-audio",
         "en",
         "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "base_model:stabilityai/stable-audio-3-small-sfx-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
         "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
+      "createdAt": "2026-05-17T01:51:16.000Z",
+      "lastModified": "2026-05-19T20:02:45.000Z"
     },
     {
-      "rank": 371,
+      "rank": 374,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10913,7 +10994,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 372,
+      "rank": 375,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -10940,7 +11021,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 373,
+      "rank": 376,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -10968,7 +11049,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 374,
+      "rank": 377,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -11001,7 +11082,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 375,
+      "rank": 378,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -11017,7 +11098,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 376,
+      "rank": 379,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -11040,7 +11121,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 377,
+      "rank": 380,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -11074,7 +11155,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 378,
+      "rank": 381,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -11094,7 +11175,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 379,
+      "rank": 382,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -11129,7 +11210,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 380,
+      "rank": 383,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -11159,7 +11240,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 381,
+      "rank": 384,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -11180,7 +11261,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 382,
+      "rank": 385,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -11209,7 +11290,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 383,
+      "rank": 386,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -11239,7 +11320,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 384,
+      "rank": 387,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -11267,7 +11348,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 385,
+      "rank": 388,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -11296,7 +11377,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 386,
+      "rank": 389,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -11328,7 +11409,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 387,
+      "rank": 390,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -11357,7 +11438,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 388,
+      "rank": 391,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -11392,7 +11473,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 389,
+      "rank": 392,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -11414,7 +11495,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 390,
+      "rank": 393,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -11452,7 +11533,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 391,
+      "rank": 394,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -11491,7 +11572,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 392,
+      "rank": 395,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -11528,7 +11609,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 393,
+      "rank": 396,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -11552,7 +11633,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 394,
+      "rank": 397,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -11570,7 +11651,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 395,
+      "rank": 398,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -11589,7 +11670,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 396,
+      "rank": 399,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -11617,7 +11698,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 397,
+      "rank": 400,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -11658,7 +11739,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 398,
+      "rank": 401,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -11680,7 +11761,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 399,
+      "rank": 402,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -11717,7 +11798,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 400,
+      "rank": 403,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -11747,7 +11828,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 401,
+      "rank": 404,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -11776,7 +11857,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 402,
+      "rank": 405,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -11804,7 +11885,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 403,
+      "rank": 406,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -11844,7 +11925,33 @@
       "lastModified": "2026-05-18T20:11:08.000Z"
     },
     {
-      "rank": 404,
+      "rank": 407,
+      "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
+      "downloads": 6,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:47:29.000Z",
+      "lastModified": "2026-05-19T22:23:34.000Z"
+    },
+    {
+      "rank": 408,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -11889,7 +11996,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 405,
+      "rank": 409,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -11931,7 +12038,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 406,
+      "rank": 410,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -11957,7 +12064,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 407,
+      "rank": 411,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -11982,7 +12089,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 408,
+      "rank": 412,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -11999,7 +12106,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 409,
+      "rank": 413,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -12027,7 +12134,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 410,
+      "rank": 414,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -12053,7 +12160,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 411,
+      "rank": 415,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -12080,7 +12187,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 412,
+      "rank": 416,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -12108,7 +12215,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 413,
+      "rank": 417,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -12141,7 +12248,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 414,
+      "rank": 418,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -12175,7 +12282,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 415,
+      "rank": 419,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -12204,7 +12311,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 416,
+      "rank": 420,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -12233,7 +12340,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 417,
+      "rank": 421,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -12266,7 +12373,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 418,
+      "rank": 422,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -12293,7 +12400,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 419,
+      "rank": 423,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -12323,7 +12430,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 420,
+      "rank": 424,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -12346,7 +12453,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 421,
+      "rank": 425,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -12372,7 +12479,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 422,
+      "rank": 426,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -12396,7 +12503,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 423,
+      "rank": 427,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -12423,7 +12530,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 424,
+      "rank": 428,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -12453,7 +12560,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 425,
+      "rank": 429,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -12487,7 +12594,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 426,
+      "rank": 430,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -12503,7 +12610,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 427,
+      "rank": 431,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -12534,7 +12641,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 428,
+      "rank": 432,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -12556,7 +12663,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 429,
+      "rank": 433,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -12576,7 +12683,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 430,
+      "rank": 434,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -12598,7 +12705,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 431,
+      "rank": 435,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -12627,7 +12734,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 432,
+      "rank": 436,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -12652,7 +12759,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 433,
+      "rank": 437,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -12677,7 +12784,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 434,
+      "rank": 438,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -12712,7 +12819,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 435,
+      "rank": 439,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -12736,7 +12843,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 436,
+      "rank": 440,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -12767,7 +12874,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 437,
+      "rank": 441,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -12794,7 +12901,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 438,
+      "rank": 442,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -12820,7 +12927,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 439,
+      "rank": 443,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -12850,7 +12957,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 440,
+      "rank": 444,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -12876,7 +12983,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 441,
+      "rank": 445,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -12901,7 +13008,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 442,
+      "rank": 446,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -12927,7 +13034,7 @@
       "lastModified": "2026-05-19T18:52:44.000Z"
     },
     {
-      "rank": 443,
+      "rank": 447,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -12972,7 +13079,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 444,
+      "rank": 448,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -12999,7 +13106,39 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 445,
+      "rank": 449,
+      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "downloads": 6742,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T04:50:12.000Z",
+      "lastModified": "2026-05-17T06:57:22.000Z"
+    },
+    {
+      "rank": 450,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -13028,7 +13167,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 446,
+      "rank": 451,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -13062,7 +13201,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 447,
+      "rank": 452,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -13107,7 +13246,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 448,
+      "rank": 453,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -13136,7 +13275,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 449,
+      "rank": 454,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -13161,7 +13300,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 450,
+      "rank": 455,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -13196,7 +13335,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 451,
+      "rank": 456,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -13223,7 +13362,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 452,
+      "rank": 457,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -13268,7 +13407,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 453,
+      "rank": 458,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -13290,7 +13429,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 454,
+      "rank": 459,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -13322,7 +13461,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 455,
+      "rank": 460,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -13347,7 +13486,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 456,
+      "rank": 461,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -13371,7 +13510,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 457,
+      "rank": 462,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -13399,7 +13538,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 458,
+      "rank": 463,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -13442,7 +13581,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 459,
+      "rank": 464,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -13466,7 +13605,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 460,
+      "rank": 465,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -13511,7 +13650,7 @@
       "lastModified": "2026-04-07T16:23:12.000Z"
     },
     {
-      "rank": 461,
+      "rank": 466,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -13540,7 +13679,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 462,
+      "rank": 467,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -13572,7 +13711,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 463,
+      "rank": 468,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -13596,7 +13735,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 464,
+      "rank": 469,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -13618,7 +13757,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 465,
+      "rank": 470,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -13643,7 +13782,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 466,
+      "rank": 471,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -13671,7 +13810,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 467,
+      "rank": 472,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -13695,7 +13834,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 468,
+      "rank": 473,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -13722,7 +13861,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 469,
+      "rank": 474,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -13747,7 +13886,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 470,
+      "rank": 475,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -13764,7 +13903,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 471,
+      "rank": 476,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -13788,7 +13927,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 472,
+      "rank": 477,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -13812,7 +13951,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 473,
+      "rank": 478,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -13845,7 +13984,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 474,
+      "rank": 479,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -13879,7 +14018,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 475,
+      "rank": 480,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -13901,7 +14040,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 476,
+      "rank": 481,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -13924,7 +14063,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 477,
+      "rank": 482,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -13944,7 +14083,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 478,
+      "rank": 483,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -13976,7 +14115,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 479,
+      "rank": 484,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -14015,7 +14154,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 480,
+      "rank": 485,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -14049,7 +14188,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 481,
+      "rank": 486,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -14073,7 +14212,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 482,
+      "rank": 487,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -14106,7 +14245,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 483,
+      "rank": 488,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -14126,7 +14265,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 484,
+      "rank": 489,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -14155,7 +14294,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 485,
+      "rank": 490,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -14177,7 +14316,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 486,
+      "rank": 491,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -14209,7 +14348,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 487,
+      "rank": 492,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -14236,7 +14375,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 488,
+      "rank": 493,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -14280,7 +14419,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 489,
+      "rank": 494,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -14298,7 +14437,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 490,
+      "rank": 495,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -14337,7 +14476,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 491,
+      "rank": 496,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -14376,7 +14515,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 492,
+      "rank": 497,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -14410,7 +14549,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 493,
+      "rank": 498,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -14438,7 +14577,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 494,
+      "rank": 499,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -14460,7 +14599,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 495,
+      "rank": 500,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -14488,7 +14627,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 496,
+      "rank": 501,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -14506,7 +14645,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 497,
+      "rank": 502,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -14534,12 +14673,12 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 498,
+      "rank": 503,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
-      "downloads": 4569750,
-      "likes": 1538,
+      "downloads": 4552869,
+      "likes": 1540,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -14565,7 +14704,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 499,
+      "rank": 504,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -14581,7 +14720,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 500,
+      "rank": 505,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -14608,7 +14747,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 501,
+      "rank": 506,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -14637,7 +14776,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 502,
+      "rank": 507,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -14665,7 +14804,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 503,
+      "rank": 508,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -14694,12 +14833,12 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 504,
+      "rank": 509,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
-      "downloads": 79298,
-      "likes": 2625,
+      "downloads": 79292,
+      "likes": 2628,
       "trendingScore": 10,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -14720,7 +14859,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 505,
+      "rank": 510,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -14749,7 +14888,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 506,
+      "rank": 511,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -14778,12 +14917,12 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 507,
+      "rank": 512,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
       "downloads": 215339,
-      "likes": 430,
+      "likes": 432,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -14819,7 +14958,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 508,
+      "rank": 513,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -14862,39 +15001,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 509,
-      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "downloads": 6742,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T04:50:12.000Z",
-      "lastModified": "2026-05-17T06:57:22.000Z"
-    },
-    {
-      "rank": 510,
+      "rank": 514,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -14915,7 +15022,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 511,
+      "rank": 515,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -14936,7 +15043,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 512,
+      "rank": 516,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -14962,7 +15069,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 513,
+      "rank": 517,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -15007,7 +15114,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 514,
+      "rank": 518,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
@@ -15033,7 +15140,86 @@
       "lastModified": "2026-05-19T18:52:45.000Z"
     },
     {
-      "rank": 515,
+      "rank": 519,
+      "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
+      "author": "noctrex",
+      "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
+      "downloads": 3284,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen",
+        "qwen3_5_moe",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Jackrong/Qwopus3.5-9B-Coder",
+        "base_model:quantized:Jackrong/Qwopus3.5-9B-Coder",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:52:39.000Z",
+      "lastModified": "2026-05-17T12:48:32.000Z"
+    },
+    {
+      "rank": 520,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 0,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
+      "rank": 521,
+      "id": "stabilityai/stable-audio-3-medium-base",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
+      "downloads": 0,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:44:44.000Z",
+      "lastModified": "2026-05-19T20:02:40.000Z"
+    },
+    {
+      "rank": 522,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -15060,7 +15246,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 516,
+      "rank": 523,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -15086,7 +15272,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 517,
+      "rank": 524,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -15114,7 +15300,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 518,
+      "rank": 525,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -15140,7 +15326,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 519,
+      "rank": 526,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -15184,7 +15370,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 520,
+      "rank": 527,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -15224,7 +15410,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 521,
+      "rank": 528,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -15260,7 +15446,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 522,
+      "rank": 529,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -15304,7 +15490,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 523,
+      "rank": 530,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -15329,7 +15515,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 524,
+      "rank": 531,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -15374,7 +15560,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 525,
+      "rank": 532,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -15393,7 +15579,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 526,
+      "rank": 533,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -15418,7 +15604,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 527,
+      "rank": 534,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -15457,7 +15643,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 528,
+      "rank": 535,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -15474,7 +15660,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 529,
+      "rank": 536,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -15502,7 +15688,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 530,
+      "rank": 537,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -15531,7 +15717,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 531,
+      "rank": 538,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -15556,7 +15742,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 532,
+      "rank": 539,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -15591,7 +15777,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 533,
+      "rank": 540,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -15621,7 +15807,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 534,
+      "rank": 541,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -15657,7 +15843,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 535,
+      "rank": 542,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -15680,7 +15866,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 536,
+      "rank": 543,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -15697,7 +15883,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 537,
+      "rank": 544,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -15717,7 +15903,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 538,
+      "rank": 545,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -15744,7 +15930,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 539,
+      "rank": 546,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -15768,7 +15954,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 540,
+      "rank": 547,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -15790,7 +15976,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 541,
+      "rank": 548,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -15822,7 +16008,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 542,
+      "rank": 549,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -15850,7 +16036,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 543,
+      "rank": 550,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -15868,7 +16054,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 544,
+      "rank": 551,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -15893,7 +16079,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 545,
+      "rank": 552,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -15916,7 +16102,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 546,
+      "rank": 553,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -15934,7 +16120,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 547,
+      "rank": 554,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -15969,7 +16155,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 548,
+      "rank": 555,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -15997,7 +16183,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 549,
+      "rank": 556,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -16019,7 +16205,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 550,
+      "rank": 557,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -16046,7 +16232,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 551,
+      "rank": 558,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -16071,7 +16257,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 552,
+      "rank": 559,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -16105,7 +16291,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 553,
+      "rank": 560,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -16132,7 +16318,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 554,
+      "rank": 561,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -16159,7 +16345,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 555,
+      "rank": 562,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -16200,7 +16386,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 556,
+      "rank": 563,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -16230,7 +16416,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 557,
+      "rank": 564,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -16267,7 +16453,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 558,
+      "rank": 565,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -16299,7 +16485,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 559,
+      "rank": 566,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -16341,7 +16527,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 560,
+      "rank": 567,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -16371,7 +16557,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 561,
+      "rank": 568,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -16416,7 +16602,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 562,
+      "rank": 569,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -16443,7 +16629,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 563,
+      "rank": 570,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -16475,7 +16661,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 564,
+      "rank": 571,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -16509,7 +16695,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 565,
+      "rank": 572,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -16539,7 +16725,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 566,
+      "rank": 573,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -16564,7 +16750,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 567,
+      "rank": 574,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -16591,7 +16777,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 568,
+      "rank": 575,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -16623,33 +16809,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 569,
-      "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
-      "author": "noctrex",
-      "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
-      "downloads": 3284,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen",
-        "qwen3_5_moe",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Jackrong/Qwopus3.5-9B-Coder",
-        "base_model:quantized:Jackrong/Qwopus3.5-9B-Coder",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:52:39.000Z",
-      "lastModified": "2026-05-17T12:48:32.000Z"
-    },
-    {
-      "rank": 570,
+      "rank": 576,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -16694,7 +16854,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 571,
+      "rank": 577,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -16722,7 +16882,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 572,
+      "rank": 578,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -16747,7 +16907,7 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 573,
+      "rank": 579,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -16779,7 +16939,7 @@
       "lastModified": "2026-05-17T15:23:22.000Z"
     },
     {
-      "rank": 574,
+      "rank": 580,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -16818,7 +16978,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 575,
+      "rank": 581,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -16844,7 +17004,7 @@
       "lastModified": "2026-05-20T19:06:32.000Z"
     },
     {
-      "rank": 576,
+      "rank": 582,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -16864,7 +17024,151 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 577,
+      "rank": 583,
+      "id": "Qwen/Qwen3-VL-Embedding-2B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
+      "downloads": 1631256,
+      "likes": 410,
+      "trendingScore": 9,
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "transformers",
+        "multimodal embedding",
+        "qwen",
+        "embedding",
+        "sentence-similarity",
+        "arxiv:2601.04720",
+        "base_model:Qwen/Qwen3-VL-2B-Instruct",
+        "base_model:finetune:Qwen/Qwen3-VL-2B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T03:03:25.000Z",
+      "lastModified": "2026-04-16T08:54:25.000Z"
+    },
+    {
+      "rank": 584,
+      "id": "LiquidAI/LFM2.5-Audio-1.5B",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
+      "downloads": 974,
+      "likes": 405,
+      "trendingScore": 9,
+      "pipelineTag": "audio-to-audio",
+      "libraryName": "liquid-audio",
+      "tags": [
+        "liquid-audio",
+        "safetensors",
+        "liquid",
+        "lfm2",
+        "audio",
+        "lfm2-audio",
+        "speech-to-speech",
+        "audio-to-audio",
+        "en",
+        "arxiv:2511.23404",
+        "base_model:LiquidAI/LFM2-1.2B",
+        "base_model:finetune:LiquidAI/LFM2-1.2B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2025-12-18T10:21:11.000Z",
+      "lastModified": "2026-03-30T14:43:52.000Z"
+    },
+    {
+      "rank": 585,
+      "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
+      "downloads": 6559,
+      "likes": 15,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3.5",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "competitive-programming",
+        "trace-inversion",
+        "negentropy",
+        "distillation",
+        "claude-opus-4.7",
+        "qwen3",
+        "synthetic-data",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "ko",
+        "ja",
+        "ru",
+        "arxiv:2603.07267",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:adapter:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-07T17:15:51.000Z",
+      "lastModified": "2026-05-07T17:23:36.000Z"
+    },
+    {
+      "rank": 586,
+      "id": "Comfy-Org/stable-audio-3",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
+      "downloads": 0,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T23:23:44.000Z",
+      "lastModified": "2026-05-20T15:19:38.000Z"
+    },
+    {
+      "rank": 587,
+      "id": "stabilityai/SAME-L",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/SAME-L",
+      "downloads": 0,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "music",
+        "sound-effects",
+        "audio",
+        "autoencoder",
+        "en",
+        "arxiv:2605.18613",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T02:18:14.000Z",
+      "lastModified": "2026-05-19T20:11:14.000Z"
+    },
+    {
+      "rank": 588,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -16891,7 +17195,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 578,
+      "rank": 589,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -16915,7 +17219,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 579,
+      "rank": 590,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -16935,12 +17239,12 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 580,
+      "rank": 591,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
-      "downloads": 3425126,
-      "likes": 1423,
+      "downloads": 3097524,
+      "likes": 1429,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -16962,7 +17266,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 581,
+      "rank": 592,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -16981,7 +17285,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 582,
+      "rank": 593,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -17015,7 +17319,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 583,
+      "rank": 594,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -17047,7 +17351,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 584,
+      "rank": 595,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -17069,7 +17373,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 585,
+      "rank": 596,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -17114,7 +17418,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 586,
+      "rank": 597,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -17133,7 +17437,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 587,
+      "rank": 598,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -17167,7 +17471,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 588,
+      "rank": 599,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -17195,7 +17499,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 589,
+      "rank": 600,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -17223,7 +17527,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 590,
+      "rank": 601,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -17246,7 +17550,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 591,
+      "rank": 602,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -17273,7 +17577,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 592,
+      "rank": 603,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -17318,7 +17622,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 593,
+      "rank": 604,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -17354,7 +17658,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 594,
+      "rank": 605,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -17394,7 +17698,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 595,
+      "rank": 606,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -17423,7 +17727,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 596,
+      "rank": 607,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -17451,7 +17755,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 597,
+      "rank": 608,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -17470,7 +17774,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 598,
+      "rank": 609,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -17489,7 +17793,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 599,
+      "rank": 610,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -17521,12 +17825,12 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 600,
+      "rank": 611,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
-      "downloads": 231868,
-      "likes": 803,
+      "downloads": 293121,
+      "likes": 811,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -17548,7 +17852,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 601,
+      "rank": 612,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -17570,7 +17874,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 602,
+      "rank": 613,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -17588,7 +17892,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 603,
+      "rank": 614,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -17617,7 +17921,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 604,
+      "rank": 615,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -17638,7 +17942,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 605,
+      "rank": 616,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -17666,7 +17970,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 606,
+      "rank": 617,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -17687,7 +17991,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 607,
+      "rank": 618,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -17723,7 +18027,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 608,
+      "rank": 619,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -17768,7 +18072,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 609,
+      "rank": 620,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -17794,7 +18098,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 610,
+      "rank": 621,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -17817,7 +18121,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 611,
+      "rank": 622,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -17842,7 +18146,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 612,
+      "rank": 623,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -17877,7 +18181,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 613,
+      "rank": 624,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -17922,7 +18226,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 614,
+      "rank": 625,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -17949,7 +18253,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 615,
+      "rank": 626,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -17978,7 +18282,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 616,
+      "rank": 627,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -17997,7 +18301,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 617,
+      "rank": 628,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -18018,7 +18322,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 618,
+      "rank": 629,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -18044,7 +18348,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 619,
+      "rank": 630,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -18070,7 +18374,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 620,
+      "rank": 631,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -18107,7 +18411,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 621,
+      "rank": 632,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -18152,7 +18456,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 622,
+      "rank": 633,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -18177,7 +18481,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 623,
+      "rank": 634,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -18194,7 +18498,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 624,
+      "rank": 635,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -18221,7 +18525,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 625,
+      "rank": 636,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -18239,7 +18543,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 626,
+      "rank": 637,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -18264,7 +18568,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 627,
+      "rank": 638,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -18296,7 +18600,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 628,
+      "rank": 639,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -18317,7 +18621,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 629,
+      "rank": 640,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -18336,7 +18640,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 630,
+      "rank": 641,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -18367,7 +18671,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 631,
+      "rank": 642,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -18390,7 +18694,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 632,
+      "rank": 643,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -18428,7 +18732,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 633,
+      "rank": 644,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -18445,7 +18749,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 634,
+      "rank": 645,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -18473,7 +18777,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 635,
+      "rank": 646,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -18490,7 +18794,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 636,
+      "rank": 647,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -18526,7 +18830,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 637,
+      "rank": 648,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -18556,7 +18860,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 638,
+      "rank": 649,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -18585,7 +18889,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 639,
+      "rank": 650,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -18623,7 +18927,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 640,
+      "rank": 651,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -18650,7 +18954,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 641,
+      "rank": 652,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -18673,7 +18977,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 642,
+      "rank": 653,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -18706,37 +19010,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 643,
-      "id": "Qwen/Qwen3-VL-Embedding-2B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
-      "downloads": 1631256,
-      "likes": 409,
-      "trendingScore": 8,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "transformers",
-        "multimodal embedding",
-        "qwen",
-        "embedding",
-        "sentence-similarity",
-        "arxiv:2601.04720",
-        "base_model:Qwen/Qwen3-VL-2B-Instruct",
-        "base_model:finetune:Qwen/Qwen3-VL-2B-Instruct",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-01-07T03:03:25.000Z",
-      "lastModified": "2026-04-16T08:54:25.000Z"
-    },
-    {
-      "rank": 644,
+      "rank": 654,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -18767,7 +19041,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 645,
+      "rank": 655,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -18790,7 +19064,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 646,
+      "rank": 656,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -18823,7 +19097,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 647,
+      "rank": 657,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -18846,7 +19120,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 648,
+      "rank": 658,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -18876,7 +19150,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 649,
+      "rank": 659,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -18903,7 +19177,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 650,
+      "rank": 660,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -18932,7 +19206,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 651,
+      "rank": 661,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -18961,7 +19235,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 652,
+      "rank": 662,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -18996,7 +19270,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 653,
+      "rank": 663,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -19032,7 +19306,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 654,
+      "rank": 664,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -19055,7 +19329,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 655,
+      "rank": 665,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -19080,7 +19354,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 656,
+      "rank": 666,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -19107,7 +19381,7 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 657,
+      "rank": 667,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -19136,36 +19410,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 658,
-      "id": "LiquidAI/LFM2.5-Audio-1.5B",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
-      "downloads": 974,
-      "likes": 404,
-      "trendingScore": 8,
-      "pipelineTag": "audio-to-audio",
-      "libraryName": "liquid-audio",
-      "tags": [
-        "liquid-audio",
-        "safetensors",
-        "liquid",
-        "lfm2",
-        "audio",
-        "lfm2-audio",
-        "speech-to-speech",
-        "audio-to-audio",
-        "en",
-        "arxiv:2511.23404",
-        "base_model:LiquidAI/LFM2-1.2B",
-        "base_model:finetune:LiquidAI/LFM2-1.2B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2025-12-18T10:21:11.000Z",
-      "lastModified": "2026-03-30T14:43:52.000Z"
-    },
-    {
-      "rank": 659,
+      "rank": 668,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -19195,7 +19440,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 660,
+      "rank": 669,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -19223,49 +19468,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 661,
-      "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
-      "downloads": 6559,
-      "likes": 14,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "competitive-programming",
-        "trace-inversion",
-        "negentropy",
-        "distillation",
-        "claude-opus-4.7",
-        "qwen3",
-        "synthetic-data",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "ko",
-        "ja",
-        "ru",
-        "arxiv:2603.07267",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:adapter:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-07T17:15:51.000Z",
-      "lastModified": "2026-05-07T17:23:36.000Z"
-    },
-    {
-      "rank": 662,
+      "rank": 670,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -19294,7 +19497,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 663,
+      "rank": 671,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -19323,7 +19526,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 664,
+      "rank": 672,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -19353,7 +19556,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 665,
+      "rank": 673,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -19383,11 +19586,84 @@
       "lastModified": "2026-05-19T07:20:08.000Z"
     },
     {
-      "rank": 666,
-      "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
-      "downloads": 6,
+      "rank": 674,
+      "id": "AxiomicLabs/GPT-X2-125M",
+      "author": "AxiomicLabs",
+      "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
+      "downloads": 1091,
+      "likes": 12,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gptx2",
+        "text-generation",
+        "language-model",
+        "transformer",
+        "rope",
+        "swiglu",
+        "gqa",
+        "custom-architecture",
+        "custom-tokenizer",
+        "curriculum-learning",
+        "code-normalization",
+        "custom_code",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "dataset:AxiomicLabs/NPset-python",
+        "dataset:HuggingFaceTB/finemath",
+        "dataset:mlfoundations/dclm-baseline-1.0",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-25T02:56:06.000Z",
+      "lastModified": "2026-05-19T03:58:06.000Z"
+    },
+    {
+      "rank": 675,
+      "id": "meta-llama/Llama-Prompt-Guard-2-86M",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
+      "downloads": 142246,
+      "likes": 127,
+      "trendingScore": 8,
+      "pipelineTag": "text-classification",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "deberta-v2",
+        "text-classification",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama",
+        "llama4",
+        "safety",
+        "en",
+        "fr",
+        "de",
+        "hi",
+        "it",
+        "pt",
+        "es",
+        "th",
+        "license:other",
+        "text-embeddings-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-04-28T07:16:35.000Z",
+      "lastModified": "2025-04-29T15:59:55.000Z"
+    },
+    {
+      "rank": 676,
+      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
+      "downloads": 769,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -19395,21 +19671,23 @@
       "tags": [
         "transformers",
         "gguf",
-        "qwen3.6",
-        "byteshape",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
         "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-19T21:47:29.000Z",
-      "lastModified": "2026-05-19T22:23:34.000Z"
+      "createdAt": "2026-05-19T16:01:21.000Z",
+      "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 667,
+      "rank": 677,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -19435,7 +19713,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 668,
+      "rank": 678,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -19452,7 +19730,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 669,
+      "rank": 679,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -19480,7 +19758,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 670,
+      "rank": 680,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -19523,7 +19801,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 671,
+      "rank": 681,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -19558,7 +19836,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 672,
+      "rank": 682,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -19583,7 +19861,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 673,
+      "rank": 683,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -19613,7 +19891,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 674,
+      "rank": 684,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -19642,7 +19920,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 675,
+      "rank": 685,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -19669,7 +19947,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 676,
+      "rank": 686,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -19695,7 +19973,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 677,
+      "rank": 687,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -19726,7 +20004,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 678,
+      "rank": 688,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -19744,7 +20022,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 679,
+      "rank": 689,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -19773,7 +20051,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 680,
+      "rank": 690,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -19796,7 +20074,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 681,
+      "rank": 691,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -19841,7 +20119,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 682,
+      "rank": 692,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -19867,7 +20145,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 683,
+      "rank": 693,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -19895,7 +20173,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 684,
+      "rank": 694,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -19933,7 +20211,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 685,
+      "rank": 695,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -19960,7 +20238,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 686,
+      "rank": 696,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -19986,7 +20264,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 687,
+      "rank": 697,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -20004,7 +20282,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 688,
+      "rank": 698,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -20030,7 +20308,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 689,
+      "rank": 699,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -20054,7 +20332,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 690,
+      "rank": 700,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -20095,7 +20373,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 691,
+      "rank": 701,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -20112,7 +20390,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 692,
+      "rank": 702,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -20145,7 +20423,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 693,
+      "rank": 703,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -20179,7 +20457,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 694,
+      "rank": 704,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -20218,7 +20496,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 695,
+      "rank": 705,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -20248,7 +20526,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 696,
+      "rank": 706,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -20284,7 +20562,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 697,
+      "rank": 707,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -20310,7 +20588,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 698,
+      "rank": 708,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -20346,7 +20624,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 699,
+      "rank": 709,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -20376,7 +20654,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 700,
+      "rank": 710,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -20414,7 +20692,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 701,
+      "rank": 711,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -20449,7 +20727,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 702,
+      "rank": 712,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -20474,7 +20752,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 703,
+      "rank": 713,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -20491,7 +20769,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 704,
+      "rank": 714,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -20533,7 +20811,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 705,
+      "rank": 715,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -20563,7 +20841,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 706,
+      "rank": 716,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -20588,7 +20866,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 707,
+      "rank": 717,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -20616,7 +20894,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 708,
+      "rank": 718,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -20633,7 +20911,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 709,
+      "rank": 719,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -20660,7 +20938,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 710,
+      "rank": 720,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -20703,7 +20981,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 711,
+      "rank": 721,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -20743,7 +21021,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 712,
+      "rank": 722,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -20767,7 +21045,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 713,
+      "rank": 723,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -20796,7 +21074,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 714,
+      "rank": 724,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -20822,7 +21100,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 715,
+      "rank": 725,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -20850,7 +21128,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 716,
+      "rank": 726,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -20889,7 +21167,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 717,
+      "rank": 727,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -20913,7 +21191,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 718,
+      "rank": 728,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -20941,7 +21219,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 719,
+      "rank": 729,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -20973,7 +21251,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 720,
+      "rank": 730,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -21003,7 +21281,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 721,
+      "rank": 731,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -21032,7 +21310,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 722,
+      "rank": 732,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -21065,7 +21343,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 723,
+      "rank": 733,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -21094,7 +21372,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 724,
+      "rank": 734,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -21114,7 +21392,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 725,
+      "rank": 735,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -21143,7 +21421,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 726,
+      "rank": 736,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -21167,7 +21445,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 727,
+      "rank": 737,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -21197,7 +21475,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 728,
+      "rank": 738,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -21227,7 +21505,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 729,
+      "rank": 739,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -21245,7 +21523,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 730,
+      "rank": 740,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -21262,7 +21540,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 731,
+      "rank": 741,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -21298,7 +21576,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 732,
+      "rank": 742,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -21329,7 +21607,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 733,
+      "rank": 743,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -21360,7 +21638,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 734,
+      "rank": 744,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -21393,7 +21671,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 735,
+      "rank": 745,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -21421,7 +21699,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 736,
+      "rank": 746,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -21446,7 +21724,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 737,
+      "rank": 747,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -21469,7 +21747,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 738,
+      "rank": 748,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -21497,7 +21775,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 739,
+      "rank": 749,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -21530,7 +21808,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 740,
+      "rank": 750,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -21560,7 +21838,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 741,
+      "rank": 751,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -21595,7 +21873,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 742,
+      "rank": 752,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -21627,7 +21905,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 743,
+      "rank": 753,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -21652,7 +21930,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 744,
+      "rank": 754,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -21675,7 +21953,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 745,
+      "rank": 755,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -21702,7 +21980,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 746,
+      "rank": 756,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -21725,7 +22003,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 747,
+      "rank": 757,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -21770,7 +22048,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 748,
+      "rank": 758,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -21802,7 +22080,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 749,
+      "rank": 759,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -21829,7 +22107,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 750,
+      "rank": 760,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -21855,7 +22133,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 751,
+      "rank": 761,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -21887,7 +22165,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 752,
+      "rank": 762,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -21916,7 +22194,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 753,
+      "rank": 763,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -21948,7 +22226,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 754,
+      "rank": 764,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -21978,7 +22256,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 755,
+      "rank": 765,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -21995,7 +22273,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 756,
+      "rank": 766,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -22015,7 +22293,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 757,
+      "rank": 767,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -22054,7 +22332,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 758,
+      "rank": 768,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -22092,7 +22370,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 759,
+      "rank": 769,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -22120,7 +22398,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 760,
+      "rank": 770,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -22165,7 +22443,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 761,
+      "rank": 771,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -22192,7 +22470,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 762,
+      "rank": 772,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -22216,7 +22494,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 763,
+      "rank": 773,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -22246,7 +22524,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 764,
+      "rank": 774,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -22273,7 +22551,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 765,
+      "rank": 775,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -22306,7 +22584,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 766,
+      "rank": 776,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -22332,7 +22610,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 767,
+      "rank": 777,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -22360,7 +22638,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 768,
+      "rank": 778,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -22384,7 +22662,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 769,
+      "rank": 779,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -22410,46 +22688,10 @@
         "conversational"
       ],
       "createdAt": "2026-05-14T14:13:15.000Z",
-      "lastModified": "2026-05-18T22:20:53.000Z"
+      "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 770,
-      "id": "AxiomicLabs/GPT-X2-125M",
-      "author": "AxiomicLabs",
-      "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
-      "downloads": 1091,
-      "likes": 11,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gptx2",
-        "text-generation",
-        "language-model",
-        "transformer",
-        "rope",
-        "swiglu",
-        "gqa",
-        "custom-architecture",
-        "custom-tokenizer",
-        "curriculum-learning",
-        "code-normalization",
-        "custom_code",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "dataset:AxiomicLabs/NPset-python",
-        "dataset:HuggingFaceTB/finemath",
-        "dataset:mlfoundations/dclm-baseline-1.0",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-25T02:56:06.000Z",
-      "lastModified": "2026-05-19T03:58:06.000Z"
-    },
-    {
-      "rank": 771,
+      "rank": 780,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -22467,7 +22709,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 772,
+      "rank": 781,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -22487,7 +22729,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 773,
+      "rank": 782,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -22519,7 +22761,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 774,
+      "rank": 783,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -22546,44 +22788,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 775,
-      "id": "meta-llama/Llama-Prompt-Guard-2-86M",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
-      "downloads": 142246,
-      "likes": 126,
-      "trendingScore": 7,
-      "pipelineTag": "text-classification",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "deberta-v2",
-        "text-classification",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama",
-        "llama4",
-        "safety",
-        "en",
-        "fr",
-        "de",
-        "hi",
-        "it",
-        "pt",
-        "es",
-        "th",
-        "license:other",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-04-28T07:16:35.000Z",
-      "lastModified": "2025-04-29T15:59:55.000Z"
-    },
-    {
-      "rank": 776,
+      "rank": 784,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -22599,10 +22804,184 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 777,
-      "id": "stabilityai/stable-audio-3-small-music",
+      "rank": 785,
+      "id": "Qwen/Qwen3-VL-Embedding-8B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
+      "downloads": 1614778,
+      "likes": 411,
+      "trendingScore": 7,
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "transformers",
+        "multimodal embedding",
+        "qwen",
+        "embedding",
+        "sentence-similarity",
+        "arxiv:2601.04720",
+        "base_model:Qwen/Qwen3-VL-8B-Instruct",
+        "base_model:finetune:Qwen/Qwen3-VL-8B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T03:02:55.000Z",
+      "lastModified": "2026-04-16T08:55:18.000Z"
+    },
+    {
+      "rank": 786,
+      "id": "Comfy-Org/gemma-4",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/gemma-4",
+      "downloads": 4079,
+      "likes": 32,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-12T14:13:09.000Z",
+      "lastModified": "2026-05-06T13:44:48.000Z"
+    },
+    {
+      "rank": 787,
+      "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
+      "downloads": 10311,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-397B-A17B",
+        "base_model:quantized:Qwen/Qwen3.5-397B-A17B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T14:25:43.000Z",
+      "lastModified": "2026-05-18T03:34:48.000Z"
+    },
+    {
+      "rank": 788,
+      "id": "MLXBits/sulphur-2-distill-mlx-q4",
+      "author": "MLXBits",
+      "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
+      "downloads": 717,
+      "likes": 8,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-video",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "AudioVideo",
+        "quantized",
+        "4bit",
+        "q4",
+        "image-text-to-video",
+        "base_model:SulphurAI/Sulphur-2-base",
+        "base_model:quantized:SulphurAI/Sulphur-2-base",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T18:23:21.000Z",
+      "lastModified": "2026-05-12T20:32:15.000Z"
+    },
+    {
+      "rank": 789,
+      "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
+      "author": "KevinJK51",
+      "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
+      "downloads": 4497,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen",
+        "uncensored",
+        "thinking",
+        "qwen3.5",
+        "heretic",
+        "text-generation",
+        "en",
+        "zh",
+        "base_model:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+        "base_model:quantized:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T14:55:59.000Z",
+      "lastModified": "2026-05-17T15:14:46.000Z"
+    },
+    {
+      "rank": 790,
+      "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
+      "author": "mradermacher",
+      "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
+      "downloads": 15496,
+      "likes": 8,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "darwin",
+        "darwin-v7",
+        "evolutionary-merge",
+        "reasoning",
+        "advanced-reasoning",
+        "chain-of-thought",
+        "thinking",
+        "qwen3.6",
+        "qwen",
+        "moe",
+        "mixture-of-experts",
+        "claude-opus",
+        "distillation",
+        "multilingual",
+        "gpqa",
+        "benchmark",
+        "open-source",
+        "apache-2.0",
+        "hybrid-vigor",
+        "proto-agi",
+        "vidraft",
+        "eval-results",
+        "en",
+        "zh",
+        "ko",
+        "ja",
+        "de",
+        "fr"
+      ],
+      "createdAt": "2026-05-16T00:40:28.000Z",
+      "lastModified": "2026-05-16T16:36:57.000Z"
+    },
+    {
+      "rank": 791,
+      "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
       "downloads": 0,
       "likes": 7,
       "trendingScore": 7,
@@ -22617,44 +22996,41 @@
         "text-to-audio",
         "en",
         "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-music-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
         "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-17T01:51:33.000Z",
-      "lastModified": "2026-05-19T20:02:42.000Z"
+      "createdAt": "2026-05-16T23:40:30.000Z",
+      "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 778,
-      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
-      "downloads": 769,
+      "rank": 792,
+      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "author": "opendatalab",
+      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "downloads": 0,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
+        "safetensors",
+        "qwen2_vl",
         "image-text-to-text",
-        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "conversational",
+        "zh",
+        "en",
+        "arxiv:2604.04771",
         "license:apache-2.0",
+        "text-generation-inference",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "region:us"
       ],
-      "createdAt": "2026-05-19T16:01:21.000Z",
-      "lastModified": "2026-05-19T16:22:18.000Z"
+      "createdAt": "2026-05-20T11:00:43.000Z",
+      "lastModified": "2026-05-21T02:10:38.000Z"
     },
     {
-      "rank": 779,
+      "rank": 793,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -22682,7 +23058,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 780,
+      "rank": 794,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -22721,7 +23097,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 781,
+      "rank": 795,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -22754,7 +23130,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 782,
+      "rank": 796,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -22783,37 +23159,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 783,
-      "id": "Qwen/Qwen3-VL-Embedding-8B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
-      "downloads": 1614778,
-      "likes": 410,
-      "trendingScore": 6,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "transformers",
-        "multimodal embedding",
-        "qwen",
-        "embedding",
-        "sentence-similarity",
-        "arxiv:2601.04720",
-        "base_model:Qwen/Qwen3-VL-8B-Instruct",
-        "base_model:finetune:Qwen/Qwen3-VL-8B-Instruct",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-01-07T03:02:55.000Z",
-      "lastModified": "2026-04-16T08:55:18.000Z"
-    },
-    {
-      "rank": 784,
+      "rank": 797,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -22858,7 +23204,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 785,
+      "rank": 798,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -22887,7 +23233,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 786,
+      "rank": 799,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -22932,7 +23278,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 787,
+      "rank": 800,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -22976,7 +23322,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 788,
+      "rank": 801,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -23002,7 +23348,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 789,
+      "rank": 802,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -23028,7 +23374,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 790,
+      "rank": 803,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -23060,7 +23406,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 791,
+      "rank": 804,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -23083,7 +23429,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 792,
+      "rank": 805,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -23126,7 +23472,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 793,
+      "rank": 806,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -23171,7 +23517,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 794,
+      "rank": 807,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -23216,7 +23562,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 795,
+      "rank": 808,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -23243,7 +23589,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 796,
+      "rank": 809,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -23270,7 +23616,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 797,
+      "rank": 810,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -23295,7 +23641,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 798,
+      "rank": 811,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -23334,7 +23680,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 799,
+      "rank": 812,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -23359,7 +23705,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 800,
+      "rank": 813,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -23387,7 +23733,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 801,
+      "rank": 814,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -23412,7 +23758,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 802,
+      "rank": 815,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -23428,7 +23774,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 803,
+      "rank": 816,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -23455,7 +23801,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 804,
+      "rank": 817,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -23487,7 +23833,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 805,
+      "rank": 818,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -23517,7 +23863,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 806,
+      "rank": 819,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -23549,7 +23895,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 807,
+      "rank": 820,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -23577,7 +23923,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 808,
+      "rank": 821,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -23603,7 +23949,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 809,
+      "rank": 822,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -23628,7 +23974,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 810,
+      "rank": 823,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -23657,7 +24003,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 811,
+      "rank": 824,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -23699,7 +24045,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 812,
+      "rank": 825,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -23726,7 +24072,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 813,
+      "rank": 826,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -23771,7 +24117,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 814,
+      "rank": 827,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -23797,7 +24143,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 815,
+      "rank": 828,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -23817,7 +24163,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 816,
+      "rank": 829,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -23844,7 +24190,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 817,
+      "rank": 830,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -23886,7 +24232,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 818,
+      "rank": 831,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -23913,7 +24259,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 819,
+      "rank": 832,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -23947,7 +24293,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 820,
+      "rank": 833,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -23976,7 +24322,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 821,
+      "rank": 834,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -24003,7 +24349,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 822,
+      "rank": 835,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -24030,7 +24376,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 823,
+      "rank": 836,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -24057,7 +24403,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 824,
+      "rank": 837,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -24085,7 +24431,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 825,
+      "rank": 838,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -24108,7 +24454,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 826,
+      "rank": 839,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -24139,7 +24485,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 827,
+      "rank": 840,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -24184,7 +24530,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 828,
+      "rank": 841,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -24206,7 +24552,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 829,
+      "rank": 842,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -24232,7 +24578,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 830,
+      "rank": 843,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -24258,7 +24604,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 831,
+      "rank": 844,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -24289,7 +24635,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 832,
+      "rank": 845,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -24312,7 +24658,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 833,
+      "rank": 846,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -24342,7 +24688,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 834,
+      "rank": 847,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -24374,7 +24720,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 835,
+      "rank": 848,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -24403,7 +24749,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 836,
+      "rank": 849,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -24435,7 +24781,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 837,
+      "rank": 850,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -24467,7 +24813,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 838,
+      "rank": 851,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -24498,7 +24844,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 839,
+      "rank": 852,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -24529,7 +24875,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 840,
+      "rank": 853,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -24552,7 +24898,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 841,
+      "rank": 854,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -24579,7 +24925,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 842,
+      "rank": 855,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -24624,7 +24970,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 843,
+      "rank": 856,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -24642,7 +24988,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 844,
+      "rank": 857,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -24665,7 +25011,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 845,
+      "rank": 858,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -24695,7 +25041,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 846,
+      "rank": 859,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -24734,7 +25080,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 847,
+      "rank": 860,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -24772,7 +25118,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 848,
+      "rank": 861,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -24817,7 +25163,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 849,
+      "rank": 862,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -24842,7 +25188,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 850,
+      "rank": 863,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -24876,7 +25222,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 851,
+      "rank": 864,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -24901,7 +25247,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 852,
+      "rank": 865,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -24934,7 +25280,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 853,
+      "rank": 866,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -24961,7 +25307,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 854,
+      "rank": 867,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -24991,7 +25337,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 855,
+      "rank": 868,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -25023,7 +25369,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 856,
+      "rank": 869,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -25056,7 +25402,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 857,
+      "rank": 870,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -25074,7 +25420,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 858,
+      "rank": 871,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -25097,7 +25443,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 859,
+      "rank": 872,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -25129,7 +25475,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 860,
+      "rank": 873,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -25174,7 +25520,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 861,
+      "rank": 874,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -25215,7 +25561,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 862,
+      "rank": 875,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -25254,7 +25600,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 863,
+      "rank": 876,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -25281,7 +25627,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 864,
+      "rank": 877,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -25318,7 +25664,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 865,
+      "rank": 878,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -25354,7 +25700,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 866,
+      "rank": 879,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -25372,7 +25718,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 867,
+      "rank": 880,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -25411,7 +25757,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 868,
+      "rank": 881,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -25440,7 +25786,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 869,
+      "rank": 882,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -25467,7 +25813,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 870,
+      "rank": 883,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -25494,7 +25840,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 871,
+      "rank": 884,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -25524,7 +25870,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 872,
+      "rank": 885,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -25551,7 +25897,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 873,
+      "rank": 886,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -25582,25 +25928,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 874,
-      "id": "Comfy-Org/gemma-4",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/gemma-4",
-      "downloads": 4079,
-      "likes": 31,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-12T14:13:09.000Z",
-      "lastModified": "2026-05-06T13:44:48.000Z"
-    },
-    {
-      "rank": 875,
+      "rank": 887,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -25619,7 +25947,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 876,
+      "rank": 888,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -25646,7 +25974,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 877,
+      "rank": 889,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -25671,7 +25999,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 878,
+      "rank": 890,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -25701,7 +26029,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 879,
+      "rank": 891,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -25732,7 +26060,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 880,
+      "rank": 892,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -25754,7 +26082,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 881,
+      "rank": 893,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -25775,7 +26103,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 882,
+      "rank": 894,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -25811,7 +26139,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 883,
+      "rank": 895,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -25834,7 +26162,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 884,
+      "rank": 896,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -25879,7 +26207,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 885,
+      "rank": 897,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -25901,7 +26229,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 886,
+      "rank": 898,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -25931,7 +26259,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 887,
+      "rank": 899,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -25956,7 +26284,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 888,
+      "rank": 900,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -25989,7 +26317,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 889,
+      "rank": 901,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -26012,7 +26340,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 890,
+      "rank": 902,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -26032,7 +26360,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 891,
+      "rank": 903,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -26077,7 +26405,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 892,
+      "rank": 904,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -26098,7 +26426,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 893,
+      "rank": 905,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -26131,7 +26459,7 @@
       "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 894,
+      "rank": 906,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -26159,34 +26487,7 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 895,
-      "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
-      "downloads": 10311,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-397B-A17B",
-        "base_model:quantized:Qwen/Qwen3.5-397B-A17B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T14:25:43.000Z",
-      "lastModified": "2026-05-18T03:34:48.000Z"
-    },
-    {
-      "rank": 896,
+      "rank": 907,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -26231,7 +26532,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 897,
+      "rank": 908,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -26256,7 +26557,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 898,
+      "rank": 909,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -26284,7 +26585,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 899,
+      "rank": 910,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -26309,7 +26610,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 900,
+      "rank": 911,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -26334,7 +26635,7 @@
       "lastModified": "2026-05-18T05:58:18.000Z"
     },
     {
-      "rank": 901,
+      "rank": 912,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
@@ -26365,7 +26666,7 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 902,
+      "rank": 913,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
@@ -26384,7 +26685,7 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 903,
+      "rank": 914,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -26410,7 +26711,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 904,
+      "rank": 915,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -26437,7 +26738,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 905,
+      "rank": 916,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
@@ -26469,7 +26770,7 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 906,
+      "rank": 917,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -26487,31 +26788,7 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 907,
-      "id": "MLXBits/sulphur-2-distill-mlx-q4",
-      "author": "MLXBits",
-      "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
-      "downloads": 717,
-      "likes": 7,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-video",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "AudioVideo",
-        "quantized",
-        "4bit",
-        "q4",
-        "image-text-to-video",
-        "base_model:SulphurAI/Sulphur-2-base",
-        "base_model:quantized:SulphurAI/Sulphur-2-base",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T18:23:21.000Z",
-      "lastModified": "2026-05-12T20:32:15.000Z"
-    },
-    {
-      "rank": 908,
+      "rank": 918,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -26534,7 +26811,7 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 909,
+      "rank": 919,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
@@ -26561,7 +26838,7 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 910,
+      "rank": 920,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
@@ -26593,7 +26870,7 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 911,
+      "rank": 921,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
@@ -26611,7 +26888,7 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 912,
+      "rank": 922,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -26651,7 +26928,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 913,
+      "rank": 923,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
@@ -26684,7 +26961,7 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 914,
+      "rank": 924,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -26716,7 +26993,7 @@
       "lastModified": "2026-05-17T11:23:09.000Z"
     },
     {
-      "rank": 915,
+      "rank": 925,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -26761,7 +27038,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 916,
+      "rank": 926,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -26786,7 +27063,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 917,
+      "rank": 927,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -26813,7 +27090,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 918,
+      "rank": 928,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -26831,82 +27108,270 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 919,
-      "id": "Comfy-Org/stable-audio-3",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T23:23:44.000Z",
-      "lastModified": "2026-05-20T15:19:38.000Z"
-    },
-    {
-      "rank": 920,
-      "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
-      "author": "KevinJK51",
-      "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
-      "downloads": 4497,
-      "likes": 6,
+      "rank": 929,
+      "id": "meta-llama/Llama-3.2-3B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
+      "downloads": 1191723,
+      "likes": 783,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
-      "libraryName": null,
+      "libraryName": "transformers",
       "tags": [
-        "gguf",
-        "qwen",
-        "uncensored",
-        "thinking",
-        "qwen3.5",
-        "heretic",
+        "transformers",
+        "safetensors",
+        "llama",
         "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
         "en",
-        "zh",
-        "base_model:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-        "base_model:quantized:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-        "license:apache-2.0",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
         "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:23:48.000Z",
+      "lastModified": "2024-10-24T15:07:40.000Z"
+    },
+    {
+      "rank": 930,
+      "id": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
+      "author": "Ttimofeyka",
+      "url": "https://huggingface.co/Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
+      "downloads": 39823,
+      "likes": 98,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "mistral",
+        "text-generation",
+        "mergekit",
+        "merge",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-02-07T14:19:28.000Z",
+      "lastModified": "2024-02-10T11:41:00.000Z"
+    },
+    {
+      "rank": 931,
+      "id": "HuggingFaceTB/SmolLM2-135M-Instruct",
+      "author": "HuggingFaceTB",
+      "url": "https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct",
+      "downloads": 1742823,
+      "likes": 323,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "tensorboard",
+        "onnx",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "transformers.js",
+        "conversational",
+        "en",
+        "arxiv:2502.02737",
+        "base_model:HuggingFaceTB/SmolLM2-135M",
+        "base_model:quantized:HuggingFaceTB/SmolLM2-135M",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-10-31T13:41:10.000Z",
+      "lastModified": "2025-09-22T20:43:15.000Z"
+    },
+    {
+      "rank": 932,
+      "id": "mistralai/Ministral-3-8B-Instruct-2512-GGUF",
+      "author": "mistralai",
+      "url": "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF",
+      "downloads": 10139,
+      "likes": 49,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": "vllm",
+      "tags": [
+        "vllm",
+        "gguf",
+        "mistral-common",
+        "en",
+        "fr",
+        "es",
+        "de",
+        "it",
+        "pt",
+        "nl",
+        "zh",
+        "ja",
+        "ko",
+        "ar",
+        "arxiv:2601.08584",
+        "base_model:mistralai/Ministral-3-8B-Instruct-2512",
+        "base_model:quantized:mistralai/Ministral-3-8B-Instruct-2512",
+        "license:apache-2.0",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-17T14:55:59.000Z",
-      "lastModified": "2026-05-17T15:14:46.000Z"
+      "createdAt": "2025-10-31T08:46:24.000Z",
+      "lastModified": "2026-01-15T11:18:05.000Z"
     },
     {
-      "rank": 921,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 0,
-      "likes": 6,
+      "rank": 933,
+      "id": "nvidia/nemotron-speech-streaming-en-0.6b",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
+      "downloads": 8558,
+      "likes": 543,
+      "trendingScore": 6,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "nemo",
+      "tags": [
+        "nemo",
+        "speech-recognition",
+        "cache-aware ASR",
+        "automatic-speech-recognition",
+        "streaming-asr",
+        "speech",
+        "audio",
+        "FastConformer",
+        "RNNT",
+        "Parakeet",
+        "ASR",
+        "pytorch",
+        "NeMo",
+        "dataset:nvidia/Granary",
+        "dataset:YTC",
+        "dataset:Yodas2",
+        "dataset:LibriLight",
+        "dataset:librispeech_asr",
+        "dataset:fisher_corpus",
+        "dataset:Switchboard-1",
+        "dataset:WSJ-0",
+        "dataset:WSJ-1",
+        "dataset:National-Singapore-Corpus-Part-1",
+        "dataset:National-Singapore-Corpus-Part-6",
+        "dataset:vctk",
+        "dataset:voxpopuli",
+        "dataset:europarl",
+        "dataset:multilingual_librispeech",
+        "dataset:fleurs",
+        "dataset:mozilla-foundation/common_voice_8_0"
+      ],
+      "createdAt": "2025-12-17T01:07:38.000Z",
+      "lastModified": "2026-05-03T15:17:33.000Z"
+    },
+    {
+      "rank": 934,
+      "id": "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
+      "author": "hampsonw",
+      "url": "https://huggingface.co/hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
+      "downloads": 11737,
+      "likes": 14,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
+        "safetensors",
+        "qwen3_5",
         "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "compressed-tensors",
+        "region:us"
       ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
+      "createdAt": "2026-04-23T20:58:33.000Z",
+      "lastModified": "2026-05-14T19:42:51.000Z"
     },
     {
-      "rank": 922,
+      "rank": 935,
+      "id": "Vortex5/Elysian-Sunrise-12B",
+      "author": "Vortex5",
+      "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
+      "downloads": 29,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "mistral",
+        "text-generation",
+        "mergekit",
+        "merge",
+        "roleplay",
+        "conversational",
+        "base_model:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
+        "base_model:merge:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
+        "base_model:AuriAetherwiing/MN-12B-Starcannon-v3",
+        "base_model:merge:AuriAetherwiing/MN-12B-Starcannon-v3",
+        "base_model:LatitudeGames/Muse-12B",
+        "base_model:merge:LatitudeGames/Muse-12B",
+        "base_model:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
+        "base_model:merge:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
+        "base_model:elinas/Chronos-Gold-12B-1.0",
+        "base_model:merge:elinas/Chronos-Gold-12B-1.0",
+        "base_model:yamatazen/EtherealAurora-12B-Lorablated",
+        "base_model:merge:yamatazen/EtherealAurora-12B-Lorablated",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T02:14:17.000Z",
+      "lastModified": "2026-05-17T12:38:01.000Z"
+    },
+    {
+      "rank": 936,
+      "id": "stabilityai/SAME-S",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/SAME-S",
+      "downloads": 0,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "music",
+        "sound-effects",
+        "audio",
+        "autoencoder",
+        "en",
+        "arxiv:2605.18613",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T02:17:58.000Z",
+      "lastModified": "2026-05-19T20:11:16.000Z"
+    },
+    {
+      "rank": 937,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -26933,7 +27398,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 923,
+      "rank": 938,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -26969,7 +27434,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 924,
+      "rank": 939,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -27014,7 +27479,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 925,
+      "rank": 940,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -27059,7 +27524,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 926,
+      "rank": 941,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -27094,7 +27559,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 927,
+      "rank": 942,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -27122,7 +27587,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 928,
+      "rank": 943,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -27148,7 +27613,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 929,
+      "rank": 944,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -27174,7 +27639,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 930,
+      "rank": 945,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -27200,7 +27665,7 @@
       "lastModified": "2026-05-06T20:09:03.000Z"
     },
     {
-      "rank": 931,
+      "rank": 946,
       "id": "TheDrummer/Skyfall-31B-v4.2",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
@@ -27220,7 +27685,7 @@
       "lastModified": "2026-04-03T20:52:19.000Z"
     },
     {
-      "rank": 932,
+      "rank": 947,
       "id": "LiquidAI/LFM2-24B-A2B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
@@ -27258,7 +27723,7 @@
       "lastModified": "2026-03-30T12:54:26.000Z"
     },
     {
-      "rank": 933,
+      "rank": 948,
       "id": "nvidia/GR00T-N1.7-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
@@ -27278,7 +27743,7 @@
       "lastModified": "2026-04-23T19:09:30.000Z"
     },
     {
-      "rank": 934,
+      "rank": 949,
       "id": "Aratako/Irodori-TTS-500M",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
@@ -27301,7 +27766,7 @@
       "lastModified": "2026-03-18T11:03:56.000Z"
     },
     {
-      "rank": 935,
+      "rank": 950,
       "id": "Qwen/Qwen3.5-0.8B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
@@ -27324,7 +27789,7 @@
       "lastModified": "2026-04-23T11:14:09.000Z"
     },
     {
-      "rank": 936,
+      "rank": 951,
       "id": "z-lab/Qwen3.5-9B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
@@ -27357,7 +27822,7 @@
       "lastModified": "2026-04-07T14:29:47.000Z"
     },
     {
-      "rank": 937,
+      "rank": 952,
       "id": "Winnougan/Must_Have_Klein_9b_loras",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
@@ -27379,7 +27844,7 @@
       "lastModified": "2026-03-26T22:03:08.000Z"
     },
     {
-      "rank": 938,
+      "rank": 953,
       "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
@@ -27406,7 +27871,7 @@
       "lastModified": "2026-04-05T16:05:28.000Z"
     },
     {
-      "rank": 939,
+      "rank": 954,
       "id": "100percentrobot/LTX-2.3-Audio-Reactive-LORA",
       "author": "100percentrobot",
       "url": "https://huggingface.co/100percentrobot/LTX-2.3-Audio-Reactive-LORA",
@@ -27430,7 +27895,7 @@
       "lastModified": "2026-04-10T15:12:18.000Z"
     },
     {
-      "rank": 940,
+      "rank": 955,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -27457,7 +27922,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 941,
+      "rank": 956,
       "id": "YJX-Xiaomi/ControlFoley",
       "author": "YJX-Xiaomi",
       "url": "https://huggingface.co/YJX-Xiaomi/ControlFoley",
@@ -27481,7 +27946,7 @@
       "lastModified": "2026-04-22T02:02:09.000Z"
     },
     {
-      "rank": 942,
+      "rank": 957,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -27521,7 +27986,7 @@
       "lastModified": "2026-04-19T00:19:49.000Z"
     },
     {
-      "rank": 943,
+      "rank": 958,
       "id": "lovis93/crt-animation-terminal-ltx-2.3-lora",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/crt-animation-terminal-ltx-2.3-lora",
@@ -27547,7 +28012,7 @@
       "lastModified": "2026-04-20T16:33:16.000Z"
     },
     {
-      "rank": 944,
+      "rank": 959,
       "id": "uva-cv-lab/OmniShotCut",
       "author": "uva-cv-lab",
       "url": "https://huggingface.co/uva-cv-lab/OmniShotCut",
@@ -27565,7 +28030,7 @@
       "lastModified": "2026-04-28T14:59:54.000Z"
     },
     {
-      "rank": 945,
+      "rank": 960,
       "id": "Yutian10/AnyRecon",
       "author": "Yutian10",
       "url": "https://huggingface.co/Yutian10/AnyRecon",
@@ -27583,7 +28048,7 @@
       "lastModified": "2026-04-27T02:17:02.000Z"
     },
     {
-      "rank": 946,
+      "rank": 961,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
@@ -27609,7 +28074,7 @@
       "lastModified": "2026-04-30T21:34:35.000Z"
     },
     {
-      "rank": 947,
+      "rank": 962,
       "id": "vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
@@ -27632,7 +28097,7 @@
       "lastModified": "2026-04-24T02:25:18.000Z"
     },
     {
-      "rank": 948,
+      "rank": 963,
       "id": "Comfy-Org/void-model",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/void-model",
@@ -27650,7 +28115,7 @@
       "lastModified": "2026-05-07T10:17:55.000Z"
     },
     {
-      "rank": 949,
+      "rank": 964,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
@@ -27680,7 +28145,7 @@
       "lastModified": "2026-04-27T23:59:16.000Z"
     },
     {
-      "rank": 950,
+      "rank": 965,
       "id": "TheBurgstall/ltx-2.3-bodypositivity-lora",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/ltx-2.3-bodypositivity-lora",
@@ -27707,7 +28172,7 @@
       "lastModified": "2026-04-26T10:38:55.000Z"
     },
     {
-      "rank": 951,
+      "rank": 966,
       "id": "llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E2B-it-ultra-uncensored-heretic",
@@ -27737,7 +28202,7 @@
       "lastModified": "2026-05-05T17:25:56.000Z"
     },
     {
-      "rank": 952,
+      "rank": 967,
       "id": "GAi92/anima-loras",
       "author": "GAi92",
       "url": "https://huggingface.co/GAi92/anima-loras",
@@ -27758,7 +28223,7 @@
       "lastModified": "2026-05-08T23:44:33.000Z"
     },
     {
-      "rank": 953,
+      "rank": 968,
       "id": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
@@ -27785,7 +28250,7 @@
       "lastModified": "2026-05-06T05:56:30.000Z"
     },
     {
-      "rank": 954,
+      "rank": 969,
       "id": "XiaomiMiMo/MiMo-V2.5-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Base",
@@ -27814,7 +28279,7 @@
       "lastModified": "2026-05-08T10:25:24.000Z"
     },
     {
-      "rank": 955,
+      "rank": 970,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit",
@@ -27843,7 +28308,7 @@
       "lastModified": "2026-04-29T04:36:33.000Z"
     },
     {
-      "rank": 956,
+      "rank": 971,
       "id": "sokann/Qwen3.6-27B-GGUF-4.256bpw",
       "author": "sokann",
       "url": "https://huggingface.co/sokann/Qwen3.6-27B-GGUF-4.256bpw",
@@ -27867,7 +28332,7 @@
       "lastModified": "2026-04-30T05:52:10.000Z"
     },
     {
-      "rank": 957,
+      "rank": 972,
       "id": "Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/MLX-Qwen3.5-9B-DeepSeek-V4-Flash-4bit",
@@ -27912,7 +28377,7 @@
       "lastModified": "2026-04-30T00:55:51.000Z"
     },
     {
-      "rank": 958,
+      "rank": 973,
       "id": "mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16-mlx-2Bit",
@@ -27957,7 +28422,7 @@
       "lastModified": "2026-04-30T08:28:27.000Z"
     },
     {
-      "rank": 959,
+      "rank": 974,
       "id": "OrobasVault/Geodesic-Phantom-12B",
       "author": "OrobasVault",
       "url": "https://huggingface.co/OrobasVault/Geodesic-Phantom-12B",
@@ -27998,7 +28463,7 @@
       "lastModified": "2026-05-01T03:53:12.000Z"
     },
     {
-      "rank": 960,
+      "rank": 975,
       "id": "Egor-3926/ToxicLord",
       "author": "Egor-3926",
       "url": "https://huggingface.co/Egor-3926/ToxicLord",
@@ -28028,7 +28493,7 @@
       "lastModified": "2026-04-30T20:07:44.000Z"
     },
     {
-      "rank": 961,
+      "rank": 976,
       "id": "Playtime-AI/LTX-2.3-Jenna_Coleman",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Jenna_Coleman",
@@ -28045,7 +28510,7 @@
       "lastModified": "2026-05-01T11:07:58.000Z"
     },
     {
-      "rank": 962,
+      "rank": 977,
       "id": "abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
       "author": "abhinand",
       "url": "https://huggingface.co/abhinand/Qwen3.6-35B-A3B-DFlash-GGUF",
@@ -28075,7 +28540,7 @@
       "lastModified": "2026-05-01T15:22:45.000Z"
     },
     {
-      "rank": 963,
+      "rank": 978,
       "id": "Naphula/Salamander-24B-v1",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/Salamander-24B-v1",
@@ -28120,7 +28585,7 @@
       "lastModified": "2026-05-02T10:32:50.000Z"
     },
     {
-      "rank": 964,
+      "rank": 979,
       "id": "Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Doggy_Style_Sex_v2.1",
@@ -28137,7 +28602,7 @@
       "lastModified": "2026-05-04T13:20:35.000Z"
     },
     {
-      "rank": 965,
+      "rank": 980,
       "id": "chromadb/context-1",
       "author": "chromadb",
       "url": "https://huggingface.co/chromadb/context-1",
@@ -28162,7 +28627,7 @@
       "lastModified": "2026-03-30T01:02:07.000Z"
     },
     {
-      "rank": 966,
+      "rank": 981,
       "id": "abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
       "author": "abovespec",
       "url": "https://huggingface.co/abovespec/Qwen3.6-35B-A3B-IQ3_K_R4-GGUF",
@@ -28182,7 +28647,7 @@
       "lastModified": "2026-05-04T03:28:29.000Z"
     },
     {
-      "rank": 967,
+      "rank": 982,
       "id": "bond005/whisper-podlodka-turbo",
       "author": "bond005",
       "url": "https://huggingface.co/bond005/whisper-podlodka-turbo",
@@ -28217,7 +28682,7 @@
       "lastModified": "2026-01-29T10:12:53.000Z"
     },
     {
-      "rank": 968,
+      "rank": 983,
       "id": "nvidia/canary-qwen-2.5b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/canary-qwen-2.5b",
@@ -28262,7 +28727,7 @@
       "lastModified": "2026-04-21T12:31:18.000Z"
     },
     {
-      "rank": 969,
+      "rank": 984,
       "id": "lightx2v/Wan2.2-Distill-Loras",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-Distill-Loras",
@@ -28290,12 +28755,12 @@
       "lastModified": "2025-12-17T08:00:53.000Z"
     },
     {
-      "rank": 970,
+      "rank": 985,
       "id": "Qwen/Qwen3.5-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-27B",
-      "downloads": 3339625,
-      "likes": 970,
+      "downloads": 3346870,
+      "likes": 975,
       "trendingScore": 5,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -28315,7 +28780,7 @@
       "lastModified": "2026-04-24T02:54:49.000Z"
     },
     {
-      "rank": 971,
+      "rank": 986,
       "id": "mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-mlx-8bit",
@@ -28338,7 +28803,7 @@
       "lastModified": "2026-04-23T08:30:31.000Z"
     },
     {
-      "rank": 972,
+      "rank": 987,
       "id": "sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Carnice-V2-27b-NVFP4-TEXT-MTP",
@@ -28377,7 +28842,7 @@
       "lastModified": "2026-04-29T00:23:13.000Z"
     },
     {
-      "rank": 973,
+      "rank": 988,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit",
@@ -28405,7 +28870,7 @@
       "lastModified": "2026-04-29T06:58:31.000Z"
     },
     {
-      "rank": 974,
+      "rank": 989,
       "id": "Harley-ml/Tenete-8M",
       "author": "Harley-ml",
       "url": "https://huggingface.co/Harley-ml/Tenete-8M",
@@ -28435,44 +28900,7 @@
       "lastModified": "2026-05-05T14:34:26.000Z"
     },
     {
-      "rank": 975,
-      "id": "meta-llama/Llama-3.2-3B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
-      "downloads": 1191723,
-      "likes": 782,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:23:48.000Z",
-      "lastModified": "2024-10-24T15:07:40.000Z"
-    },
-    {
-      "rank": 976,
+      "rank": 990,
       "id": "nvidia/omni-embed-nemotron-3b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/omni-embed-nemotron-3b",
@@ -28508,7 +28936,7 @@
       "lastModified": "2026-05-06T18:02:16.000Z"
     },
     {
-      "rank": 977,
+      "rank": 991,
       "id": "fal/flux-2-klein-4b-spritesheet-lora",
       "author": "fal",
       "url": "https://huggingface.co/fal/flux-2-klein-4b-spritesheet-lora",
@@ -28542,7 +28970,7 @@
       "lastModified": "2026-01-21T14:44:55.000Z"
     },
     {
-      "rank": 978,
+      "rank": 992,
       "id": "DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-9B-Claude-4.6-OS-Auto-Variable-HERETIC-UNCENSORED-THINKING-MAX-NEOCODE-Imatrix-GGUF",
@@ -28587,7 +29015,7 @@
       "lastModified": "2026-03-09T07:04:55.000Z"
     },
     {
-      "rank": 979,
+      "rank": 993,
       "id": "Comfy-Org/ltx-2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/ltx-2",
@@ -28604,7 +29032,7 @@
       "lastModified": "2026-03-08T17:36:30.000Z"
     },
     {
-      "rank": 980,
+      "rank": 994,
       "id": "silveroxides/LTX-2.3-Quants",
       "author": "silveroxides",
       "url": "https://huggingface.co/silveroxides/LTX-2.3-Quants",
@@ -28648,7 +29076,7 @@
       "lastModified": "2026-05-17T22:31:52.000Z"
     },
     {
-      "rank": 981,
+      "rank": 995,
       "id": "z-lab/Qwen3.5-35B-A3B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-35B-A3B-PARO",
@@ -28677,7 +29105,7 @@
       "lastModified": "2026-05-08T06:21:10.000Z"
     },
     {
-      "rank": 982,
+      "rank": 996,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -28712,7 +29140,7 @@
       "lastModified": "2026-04-06T02:19:40.000Z"
     },
     {
-      "rank": 983,
+      "rank": 997,
       "id": "OpenMed/privacy-filter-multilingual",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-multilingual",
@@ -28757,7 +29185,7 @@
       "lastModified": "2026-05-03T21:36:31.000Z"
     },
     {
-      "rank": 984,
+      "rank": 998,
       "id": "prism-ml/Bonsai-8B-mlx-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-mlx-1bit",
@@ -28788,7 +29216,7 @@
       "lastModified": "2026-04-18T20:44:19.000Z"
     },
     {
-      "rank": 985,
+      "rank": 999,
       "id": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
@@ -28833,7 +29261,7 @@
       "lastModified": "2025-12-22T10:16:55.000Z"
     },
     {
-      "rank": 986,
+      "rank": 1000,
       "id": "zai-org/GLM-5",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5",
@@ -28858,381 +29286,6 @@
       ],
       "createdAt": "2026-02-11T04:55:46.000Z",
       "lastModified": "2026-04-05T07:48:51.000Z"
-    },
-    {
-      "rank": 987,
-      "id": "Comfy-Org/Wan_2.1_ComfyUI_repackaged",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged",
-      "downloads": 3533804,
-      "likes": 888,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
-      "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "region:us"
-      ],
-      "createdAt": "2025-02-25T21:27:12.000Z",
-      "lastModified": "2026-01-28T12:44:01.000Z"
-    },
-    {
-      "rank": 988,
-      "id": "sequelbox/Qwen3.6-27B-Tachibana-Agent",
-      "author": "sequelbox",
-      "url": "https://huggingface.co/sequelbox/Qwen3.6-27B-Tachibana-Agent",
-      "downloads": 71,
-      "likes": 5,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_text",
-        "text-generation",
-        "tachibana",
-        "valiant",
-        "valiant-labs",
-        "qwen",
-        "qwen-3.6",
-        "qwen-3.6-27b",
-        "27b",
-        "reasoning",
-        "code",
-        "code-instruct",
-        "python",
-        "typescript",
-        "javascript",
-        "java",
-        "c++",
-        "c",
-        "c#",
-        "rust",
-        "go",
-        "haskell",
-        "shell",
-        "bash",
-        "azure",
-        "aws",
-        "gcp",
-        "cloud"
-      ],
-      "createdAt": "2026-05-07T02:02:02.000Z",
-      "lastModified": "2026-05-07T02:13:23.000Z"
-    },
-    {
-      "rank": 989,
-      "id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
-      "author": "deepseek-ai",
-      "url": "https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
-      "downloads": 1150580,
-      "likes": 595,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "deepseek_v2",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "arxiv:2401.06066",
-        "license:other",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-06-14T06:23:33.000Z",
-      "lastModified": "2024-07-03T05:16:11.000Z"
-    },
-    {
-      "rank": 990,
-      "id": "lynaNSFW/LTX2.3_NSFW_motion",
-      "author": "lynaNSFW",
-      "url": "https://huggingface.co/lynaNSFW/LTX2.3_NSFW_motion",
-      "downloads": 2043,
-      "likes": 8,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "text-to-image",
-        "lora",
-        "template:diffusion-lora",
-        "base_model:lynaNSFW/LTX2BFN",
-        "base_model:adapter:lynaNSFW/LTX2BFN",
-        "region:us"
-      ],
-      "createdAt": "2026-03-25T12:45:03.000Z",
-      "lastModified": "2026-03-25T12:45:24.000Z"
-    },
-    {
-      "rank": 991,
-      "id": "mlx-community/DeepSeek-V4-Flash-4bit",
-      "author": "mlx-community",
-      "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-4bit",
-      "downloads": 23082,
-      "likes": 13,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "deepseek_v4",
-        "text-generation",
-        "conversational",
-        "en",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T08:02:27.000Z",
-      "lastModified": "2026-04-25T00:58:58.000Z"
-    },
-    {
-      "rank": 992,
-      "id": "Qwen/Qwen3-ForcedAligner-0.6B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B",
-      "downloads": 451135,
-      "likes": 130,
-      "trendingScore": 5,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_asr",
-        "automatic-speech-recognition",
-        "arxiv:2601.21337",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-28T03:29:54.000Z",
-      "lastModified": "2026-01-30T03:00:55.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "nvidia/Cosmos-Reason2-8B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Cosmos-Reason2-8B",
-      "downloads": 225631,
-      "likes": 178,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "cosmos",
-      "tags": [
-        "cosmos",
-        "safetensors",
-        "qwen3_vl",
-        "nvidia",
-        "conversational",
-        "image-text-to-text",
-        "arxiv:2503.06800",
-        "arxiv:2406.10721",
-        "arxiv:2603.18178",
-        "arxiv:2312.14115",
-        "base_model:Qwen/Qwen3-VL-8B-Instruct",
-        "base_model:finetune:Qwen/Qwen3-VL-8B-Instruct",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2025-12-12T17:50:27.000Z",
-      "lastModified": "2026-04-30T03:16:12.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "Qwen/Qwen3-VL-4B-Instruct",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct",
-      "downloads": 2859913,
-      "likes": 389,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "conversational",
-        "arxiv:2505.09388",
-        "arxiv:2502.13923",
-        "arxiv:2409.12191",
-        "arxiv:2308.12966",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-10-11T07:23:22.000Z",
-      "lastModified": "2025-10-15T16:15:55.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
-      "author": "mlx-community",
-      "url": "https://huggingface.co/mlx-community/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-8bit",
-      "downloads": 7647,
-      "likes": 6,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5",
-        "unsloth",
-        "fine tune",
-        "heretic",
-        "uncensored",
-        "abliterated",
-        "multi-stage tuned.",
-        "all use cases",
-        "coder",
-        "creative",
-        "creative writing",
-        "fiction writing",
-        "plot generation",
-        "sub-plot generation",
-        "story generation",
-        "scene continue",
-        "storytelling",
-        "fiction story",
-        "science fiction",
-        "romance",
-        "all genres",
-        "story",
-        "writing",
-        "vivid prosing",
-        "vivid writing",
-        "fiction",
-        "roleplaying",
-        "bfloat16"
-      ],
-      "createdAt": "2026-05-02T22:17:41.000Z",
-      "lastModified": "2026-05-03T18:58:47.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "SWivid/F5-TTS",
-      "author": "SWivid",
-      "url": "https://huggingface.co/SWivid/F5-TTS",
-      "downloads": 478527,
-      "likes": 1169,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "f5-tts",
-      "tags": [
-        "f5-tts",
-        "text-to-speech",
-        "dataset:amphion/Emilia-Dataset",
-        "arxiv:2410.06885",
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2024-10-07T14:37:58.000Z",
-      "lastModified": "2025-03-21T05:05:00.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "bartowski/google_gemma-4-E4B-it-GGUF",
-      "author": "bartowski",
-      "url": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF",
-      "downloads": 130794,
-      "likes": 55,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "image-text-to-text",
-        "base_model:google/gemma-4-E4B-it",
-        "base_model:quantized:google/gemma-4-E4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-02T16:00:37.000Z",
-      "lastModified": "2026-05-03T18:32:47.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "Ashen3/SNOFS",
-      "author": "Ashen3",
-      "url": "https://huggingface.co/Ashen3/SNOFS",
-      "downloads": 0,
-      "likes": 24,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "snofs",
-        "base_model:black-forest-labs/FLUX.2-klein-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-9B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-02-21T19:24:31.000Z",
-      "lastModified": "2026-02-21T20:02:14.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "Prior-Labs/tabpfn_2_6",
-      "author": "Prior-Labs",
-      "url": "https://huggingface.co/Prior-Labs/tabpfn_2_6",
-      "downloads": 14741,
-      "likes": 23,
-      "trendingScore": 5,
-      "pipelineTag": "tabular-classification",
-      "libraryName": null,
-      "tags": [
-        "chemistry",
-        "biology",
-        "finance",
-        "legal",
-        "climate",
-        "medical",
-        "tabular-classification",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-24T08:13:33.000Z",
-      "lastModified": "2026-04-02T10:00:43.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
-      "author": "Sikaworld1990",
-      "url": "https://huggingface.co/Sikaworld1990/gemma-3-12b-qat-abliterated-sikaworld-fp4-ltx2",
-      "downloads": 0,
-      "likes": 27,
-      "trendingScore": 5,
-      "pipelineTag": "feature-extraction",
-      "libraryName": null,
-      "tags": [
-        "nvfp4",
-        "gemma-3",
-        "comfyui",
-        "abliterated",
-        "qat",
-        "ltx-2",
-        "ltx-2.3",
-        "uncensored",
-        "feature-extraction",
-        "en",
-        "base_model:mlabonne/gemma-3-12b-it-qat-abliterated",
-        "base_model:finetune:mlabonne/gemma-3-12b-it-qat-abliterated",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-11T15:38:21.000Z",
-      "lastModified": "2026-03-11T17:20:00.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26205956616

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.