### PR TITLE
chore(data): refresh huggingface space signals 2026-05-21T04:56:41Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-20T20:37:26.035Z",
+  "ts": "2026-05-21T04:56:41.327Z",
   "count": 1,
-  "durationMs": 6771,
+  "durationMs": 5551,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T20:37:19.266Z",
+  "fetchedAt": "2026-05-21T04:56:35.778Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -95,7 +95,7 @@
       "id": "mikeee/qwen-7b-chat",
       "author": "mikeee",
       "url": "https://huggingface.co/spaces/mikeee/qwen-7b-chat",
-      "likes": 269,
+      "likes": 319,
       "trendingScore": 106,
       "sdk": "docker",
       "tags": [
@@ -128,6 +128,23 @@
     },
     {
       "rank": 8,
+      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
+      "author": "cbensimon",
+      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
+      "likes": 94,
+      "trendingScore": 82,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:08:17.000Z",
+      "lastModified": "2026-05-14T11:52:10.000Z",
+      "models": []
+    },
+    {
+      "rank": 9,
       "id": "prithivMLmods/FireRed-Image-Edit-1.0-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/FireRed-Image-Edit-1.0-Fast",
@@ -144,7 +161,7 @@
       "models": []
     },
     {
-      "rank": 9,
+      "rank": 10,
       "id": "HiDream-ai/HiDream-O1-Image",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image",
@@ -160,7 +177,7 @@
       "models": []
     },
     {
-      "rank": 10,
+      "rank": 11,
       "id": "techfreakworm/LTX2.3-Studio",
       "author": "techfreakworm",
       "url": "https://huggingface.co/spaces/techfreakworm/LTX2.3-Studio",
@@ -173,23 +190,6 @@
       ],
       "createdAt": "2026-05-01T05:41:26.000Z",
       "lastModified": "2026-05-13T18:07:02.000Z",
-      "models": []
-    },
-    {
-      "rank": 11,
-      "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
-      "author": "cbensimon",
-      "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 84,
-      "trendingScore": 72,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:08:17.000Z",
-      "lastModified": "2026-05-14T11:52:10.000Z",
       "models": []
     },
     {
@@ -276,6 +276,22 @@
     },
     {
       "rank": 17,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 59,
+      "trendingScore": 58,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-20T10:03:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 18,
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
@@ -292,7 +308,7 @@
       "models": []
     },
     {
-      "rank": 18,
+      "rank": 19,
       "id": "zerogpu-aoti/wan2-2-fp8da-aoti-faster",
       "author": "zerogpu-aoti",
       "url": "https://huggingface.co/spaces/zerogpu-aoti/wan2-2-fp8da-aoti-faster",
@@ -306,22 +322,6 @@
       ],
       "createdAt": "2025-07-30T19:03:28.000Z",
       "lastModified": "2025-12-16T14:37:58.000Z",
-      "models": []
-    },
-    {
-      "rank": 19,
-      "id": "HuggingFaceBio/carbon-demo",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 55,
-      "trendingScore": 54,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T14:18:55.000Z",
-      "lastModified": "2026-05-20T10:03:33.000Z",
       "models": []
     },
     {
@@ -409,7 +409,7 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 53,
+      "likes": 54,
       "trendingScore": 38,
       "sdk": "gradio",
       "tags": [
@@ -518,7 +518,7 @@
         "region:us"
       ],
       "createdAt": "2022-09-29T11:29:23.000Z",
-      "lastModified": "2026-05-20T15:09:57.000Z",
+      "lastModified": "2026-05-20T23:55:58.000Z",
       "models": []
     },
     {
@@ -572,6 +572,22 @@
     },
     {
       "rank": 35,
+      "id": "Lakonik/AsymFLUX.2-klein",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
+      "likes": 31,
+      "trendingScore": 31,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:06:55.000Z",
+      "lastModified": "2026-05-19T00:50:26.000Z",
+      "models": []
+    },
+    {
+      "rank": 36,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -587,7 +603,7 @@
       "models": []
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -601,22 +617,6 @@
       ],
       "createdAt": "2026-03-28T19:57:45.000Z",
       "lastModified": "2026-05-15T03:44:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 37,
-      "id": "Lakonik/AsymFLUX.2-klein",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
-      "likes": 29,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:06:55.000Z",
-      "lastModified": "2026-05-19T00:50:26.000Z",
       "models": []
     },
     {
@@ -658,6 +658,22 @@
     },
     {
       "rank": 40,
+      "id": "multimodalart/scenema-audio",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
+      "likes": 26,
+      "trendingScore": 24,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T10:12:08.000Z",
+      "lastModified": "2026-05-16T00:07:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 41,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -674,7 +690,7 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -690,7 +706,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -703,22 +719,6 @@
       ],
       "createdAt": "2026-02-03T14:43:29.000Z",
       "lastModified": "2026-03-10T10:33:23.000Z",
-      "models": []
-    },
-    {
-      "rank": 43,
-      "id": "multimodalart/scenema-audio",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 24,
-      "trendingScore": 22,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T10:12:08.000Z",
-      "lastModified": "2026-05-16T00:07:35.000Z",
       "models": []
     },
     {
@@ -758,7 +758,7 @@
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 30,
+      "likes": 31,
       "trendingScore": 21,
       "sdk": "gradio",
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26206292581

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.