### PR TITLE
chore(data): refresh arxiv signals 2026-05-21T05:14:30Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-20T20:55:20.639Z",
+  "ts": "2026-05-21T05:01:37.754Z",
   "count": 1,
-  "durationMs": 62516,
+  "durationMs": 79162,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,1082 +1,1117 @@
 {
-  "fetchedAt": "2026-05-20T20:55:20.862Z",
+  "fetchedAt": "2026-05-21T05:01:38.021Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
     "reddit"
   ],
-  "count": 153,
+  "count": 158,
   "papers": [
     {
-      "arxivId": "2605.20185v1",
+      "arxivId": "2605.21489v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20183v1",
+      "arxivId": "2605.21488v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20182v1",
+      "arxivId": "2605.21487v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20179v1",
+      "arxivId": "2605.21486v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20177v1",
+      "arxivId": "2605.21485v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20176v1",
+      "arxivId": "2605.21484v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20174v1",
+      "arxivId": "2605.21483v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20173v1",
+      "arxivId": "2605.21482v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20172v1",
+      "arxivId": "2605.21481v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20170v1",
+      "arxivId": "2605.21479v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20167v1",
+      "arxivId": "2605.21478v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20165v1",
+      "arxivId": "2605.21475v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20164v1",
+      "arxivId": "2605.21472v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20159v1",
+      "arxivId": "2605.21470v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20158v1",
+      "arxivId": "2605.21468v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20157v1",
+      "arxivId": "2605.21467v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20151v1",
+      "arxivId": "2605.21466v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20150v1",
+      "arxivId": "2605.21465v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20149v1",
+      "arxivId": "2605.21463v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20147v1",
+      "arxivId": "2605.21461v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20145v1",
+      "arxivId": "2605.21460v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20134v1",
+      "arxivId": "2605.21458v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20132v1",
+      "arxivId": "2605.21455v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20128v1",
+      "arxivId": "2605.21454v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20127v1",
+      "arxivId": "2605.21453v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20122v1",
+      "arxivId": "2605.21451v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20120v1",
+      "arxivId": "2605.21446v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20119v1",
+      "arxivId": "2605.21443v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20110v1",
+      "arxivId": "2605.21442v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20108v1",
+      "arxivId": "2605.21440v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20107v1",
+      "arxivId": "2605.21437v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20105v1",
+      "arxivId": "2605.21435v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20104v1",
+      "arxivId": "2605.21431v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20098v1",
+      "arxivId": "2605.21429v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20090v1",
+      "arxivId": "2605.21428v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20088v1",
+      "arxivId": "2605.21427v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20087v1",
+      "arxivId": "2605.21426v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20086v1",
+      "arxivId": "2605.21422v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20085v1",
+      "arxivId": "2605.21421v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20084v1",
+      "arxivId": "2605.21420v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20082v1",
+      "arxivId": "2605.21418v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20079v1",
+      "arxivId": "2605.21417v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20075v1",
+      "arxivId": "2605.21414v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20074v1",
+      "arxivId": "2605.21413v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20073v1",
+      "arxivId": "2605.21411v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20072v1",
+      "arxivId": "2605.21405v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20069v1",
+      "arxivId": "2605.21404v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20068v1",
+      "arxivId": "2605.21403v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20066v1",
+      "arxivId": "2605.21402v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20064v1",
+      "arxivId": "2605.21401v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20061v1",
+      "arxivId": "2605.21395v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20055v1",
+      "arxivId": "2605.21391v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20052v1",
+      "arxivId": "2605.21390v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20050v1",
+      "arxivId": "2605.21388v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20049v1",
+      "arxivId": "2605.21384v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20044v1",
+      "arxivId": "2605.21381v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20043v1",
+      "arxivId": "2605.21379v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20040v1",
+      "arxivId": "2605.21372v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20037v1",
+      "arxivId": "2605.21371v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20036v1",
+      "arxivId": "2605.21369v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20035v1",
+      "arxivId": "2605.21363v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20033v1",
+      "arxivId": "2605.21362v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20032v1",
+      "arxivId": "2605.21352v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20030v1",
+      "arxivId": "2605.21347v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20028v1",
+      "arxivId": "2605.21348v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20025v1",
+      "arxivId": "2605.21343v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20023v1",
+      "arxivId": "2605.21341v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20022v1",
+      "arxivId": "2605.21338v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20016v1",
+      "arxivId": "2605.21333v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20009v1",
+      "arxivId": "2605.21325v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20006v1",
+      "arxivId": "2605.21324v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.20005v1",
+      "arxivId": "2605.21322v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19999v1",
+      "arxivId": "2605.21318v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19995v1",
+      "arxivId": "2605.21317v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19990v1",
+      "arxivId": "2605.21313v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19988v1",
+      "arxivId": "2605.21312v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19986v1",
+      "arxivId": "2605.21311v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19982v1",
+      "arxivId": "2605.21309v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19976v1",
+      "arxivId": "2605.21308v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19975v1",
+      "arxivId": "2605.21303v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19974v1",
+      "arxivId": "2605.21301v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19972v1",
+      "arxivId": "2605.21300v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19969v1",
+      "arxivId": "2605.21299v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19966v1",
+      "arxivId": "2605.21295v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19965v1",
+      "arxivId": "2605.21292v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19959v1",
+      "arxivId": "2605.21288v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19957v1",
+      "arxivId": "2605.21282v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19956v1",
+      "arxivId": "2605.21280v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19952v1",
+      "arxivId": "2605.21273v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19950v1",
+      "arxivId": "2605.21272v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19949v1",
+      "arxivId": "2605.21268v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19947v1",
+      "arxivId": "2605.21266v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19945v1",
+      "arxivId": "2605.21264v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19944v1",
+      "arxivId": "2605.21263v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19943v1",
+      "arxivId": "2605.21261v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19940v1",
+      "arxivId": "2605.21258v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19938v1",
+      "arxivId": "2605.21256v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19936v1",
+      "arxivId": "2605.21251v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19932v1",
+      "arxivId": "2605.21244v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19931v1",
+      "arxivId": "2605.21240v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19929v1",
+      "arxivId": "2605.21237v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19928v1",
+      "arxivId": "2605.21235v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19926v1",
+      "arxivId": "2605.21227v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19916v1",
+      "arxivId": "2605.21226v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19908v1",
+      "arxivId": "2605.21225v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19902v1",
+      "arxivId": "2605.21224v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19895v1",
+      "arxivId": "2605.21214v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19892v1",
+      "arxivId": "2605.21213v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19890v1",
+      "arxivId": "2605.21207v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19889v1",
+      "arxivId": "2605.21198v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19876v1",
+      "arxivId": "2605.21195v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19869v1",
+      "arxivId": "2605.21190v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19868v1",
+      "arxivId": "2605.21186v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19866v1",
+      "arxivId": "2605.21182v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19865v1",
+      "arxivId": "2605.21178v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19859v1",
+      "arxivId": "2605.21177v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19856v1",
+      "arxivId": "2605.21171v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19855v1",
+      "arxivId": "2605.21157v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19852v1",
+      "arxivId": "2605.21154v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19848v1",
+      "arxivId": "2605.21147v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19847v1",
+      "arxivId": "2605.21139v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T04:57:33.309Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19846v1",
+      "arxivId": "2605.21135v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19839v1",
+      "arxivId": "2605.21132v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19837v1",
+      "arxivId": "2605.21131v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19833v1",
+      "arxivId": "2605.21130v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19824v1",
+      "arxivId": "2605.21123v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19821v1",
+      "arxivId": "2605.21121v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19815v1",
+      "arxivId": "2605.21112v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19806v1",
+      "arxivId": "2605.21102v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19804v1",
+      "arxivId": "2605.21099v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19799v1",
+      "arxivId": "2605.21097v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19798v1",
+      "arxivId": "2605.21090v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19797v1",
+      "arxivId": "2605.21086v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19792v1",
+      "arxivId": "2605.21079v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19766v1",
+      "arxivId": "2605.21076v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19762v1",
+      "arxivId": "2605.21075v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19738v1",
+      "arxivId": "2605.21071v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19735v1",
+      "arxivId": "2605.21063v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19723v1",
+      "arxivId": "2605.21049v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19718v1",
+      "arxivId": "2605.21029v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19714v1",
+      "arxivId": "2605.21027v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19711v1",
+      "arxivId": "2605.21006v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19660v1",
+      "arxivId": "2605.20998v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19645v1",
+      "arxivId": "2605.20994v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19633v1",
+      "arxivId": "2605.20967v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19597v1",
+      "arxivId": "2605.20960v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19577v1",
+      "arxivId": "2605.20948v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19576v1",
+      "arxivId": "2605.20946v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19575v1",
+      "arxivId": "2605.20936v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19568v1",
+      "arxivId": "2605.20924v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19523v1",
+      "arxivId": "2605.20920v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19516v1",
+      "arxivId": "2605.20916v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     },
     {
-      "arxivId": "2605.19514v1",
+      "arxivId": "2605.20915v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-20T16:18:08.786Z"
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
+    },
+    {
+      "arxivId": "2605.20912v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
+    },
+    {
+      "arxivId": "2605.20876v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
+    },
+    {
+      "arxivId": "2605.20833v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
+    },
+    {
+      "arxivId": "2605.20815v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
+    },
+    {
+      "arxivId": "2605.20813v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-21T05:01:38.021Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-20T20:54:18.139Z",
+  "fetchedAt": "2026-05-21T05:00:18.615Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",
@@ -8,2202 +8,3106 @@
     "cs.CV"
   ],
   "failedCategories": [],
-  "count": 153,
+  "count": 158,
   "linkedRepoCount": 0,
   "papers": [
     {
-      "arxivId": "2605.20185v1",
-      "title": "PiG-Avatar: Hierarchical Neural-Field-Guided Gaussian Avatars",
-      "summary": "Existing Gaussian avatar methods typically parameterize geometry on a body-template surface, which entangles the avatar's representation space with the template's deformation space and limits the capture of layered, off-body, and non-rigid clothing geometry. We present PiG-Avatar, which addresses this limitation by using the parametric body model solely for kinematic transport, while representing the avatar as Gaussians anchored in a volumetric canonical space governed by a continuous neural field. This decouples representation from template topology, avoiding the geometric constraints of surface-based parameterizations. Kinematic coherence is maintained through 3D barycentric anchor transport, which guides motion without constraining geometry and allows anchors to deviate freely from the template surface, yielding dense, stable temporal surface correspondences by construction. To make this unconstrained formulation tractable, we introduce dual-level spatially coherent optimization, combining Sobolev-preconditioned neural-field updates with a novel KNN-based preconditioning of canonical anchor geometry. Together, these mechanisms induce an emergent self-organization of anchor density: anchors migrate toward regions of high curvature, appearance variation, and non-coherent motion without explicit heuristics. As a result, complex clothing geometry and layered surfaces emerge as natural, high-fidelity outputs. This single representation further supports hierarchical reconstruction across multiple levels of detail, with coarse-level supervision propagating to finer levels through the shared field and coupled anchor graph. On established benchmarks featuring subjects with complex clothing and challenging non-rigid motion, PiG-Avatar achieves state-of-the-art rendering quality, generalizes robustly to imperfect body model initialization, and renders in real time across all detail levels.",
+      "arxivId": "2605.21489v1",
+      "title": "Variance Reduction for Expectations with Diffusion Teachers",
+      "summary": "Pretrained diffusion models serve as frozen teachers feeding downstream pipelines such as text-to-3D, single-step distillation, and data attribution. The teacher gradients these pipelines consume are Monte Carlo (MC) expectations over noise levels and Gaussian noise samples; their estimator variance dominates compute cost because each draw requires expensive upstream work (rendering, simulation, encoding). We introduce CARV, a compute-aware variance-accounting framework that motivates a hierarchical MC estimator: amortize the expensive upstream computation over cheap diffusion-noise resamples, sharpened by timestep importance sampling and a stratified-inverse-CDF construction. In our text-to-3D distillation and attribution experiments, CARV delivers 2-3x effective compute multipliers (most from amortized reuse; ~25% additional from IS+stratification) without changing the objective; in single-step distillation, the same techniques cut gradient variance by an order of magnitude but do not improve downstream FID, marking the regime where MC variance is no longer the bottleneck.",
       "authors": [
-        "Julian Kaltheuner",
-        "Jan Spindler",
-        "Sina Kitz",
-        "Patrick Stotko",
-        "Reinhard Klein"
+        "Jesse Bettencourt",
+        "Xindi Wu",
+        "Matan Atzmon",
+        "James Lucas",
+        "Jonathan Lorraine"
       ],
       "categories": [
-        "cs.GR",
-        "cs.CV"
+        "cs.LG",
+        "cs.AI",
+        "cs.CV",
+        "stat.CO",
+        "stat.ML"
       ],
-      "primaryCategory": "cs.GR",
-      "absUrl": "https://arxiv.org/abs/2605.20185v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20185v1",
-      "publishedAt": "2026-05-19T17:59:54.000Z",
-      "updatedAt": "2026-05-19T17:59:54.000Z",
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21489v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21489v1",
+      "publishedAt": "2026-05-20T17:59:52.000Z",
+      "updatedAt": "2026-05-20T17:59:52.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20183v1",
-      "title": "MSAVBench: Towards Comprehensive and Reliable Evaluation of Multi-Shot Audio-Video Generation",
-      "summary": "Video generation is rapidly evolving from single-shot synthesis to complex multi-shot audio-video (MSAV) narratives to meet real-world demands. However, evaluating such frontier models remains a fundamental challenge. Existing benchmarks are limited in scope and data diversity, and rely on rigid evaluation pipelines, preventing systematic and reliable assessment of modern MSAV models. To bridge these gaps, we introduce MSAVBench, the first comprehensive benchmark and adaptive hybrid evaluation framework for multi-shot audio-video generation. Our benchmark spans four key dimensions, video, audio, shot, and reference, covering diverse task settings, varying shot counts of up to 15, and challenging non-realistic scenarios. Our evaluation framework improves robustness through an adaptive self-correction mechanism for shot segmentation, instance-wise rubrics for subjective metrics, and tool-grounded evidence extraction for complex judgments. Furthermore, MSAVBench achieves high alignment with human judgments, reaching a Spearman rank correlation of 91.5%. Our systematic evaluation of 19 state-of-the-art closed- and open-source models shows that current systems still struggle with director-level control and fine-grained audio-visual synchronization, while modular or agentic generation pipelines offer a promising path toward narrowing the gap between open- and closed-source models. We will release the benchmark data and evaluation code to facilitate future research.",
+      "arxivId": "2605.21488v1",
+      "title": "Equilibrium Reasoners: Learning Attractors Enables Scalable Reasoning",
+      "summary": "Scaling test-time compute by iteratively updating a latent state has emerged as a powerful paradigm for reasoning. Yet the internal mechanisms that enable these iterative models to generalize beyond memorized patterns remain unclear. We hypothesize that generalizable reasoning arises from learning task-conditioned attractors: latent dynamical systems whose stable fixed points correspond to valid solutions. We formalize this process through Equilibrium Reasoners (EqR), which enable test-time scaling without external verifiers or task-specific priors. EqR scales internal dynamics along two axes: depth, by running more iterations, and breadth, by aggregating stochastic trajectories from multiple initializations. Empirically, gains from test-time scaling are tightly coupled with stronger convergence toward solution-aligned attractors. This attractor perspective allows neural networks to adaptively allocate test-time compute based on task difficulty. While simple cases converge within 1 to 5 iteration steps, harder cases benefit from massive test-time scaling. By unrolling up to the equivalent of 40,000 layers, scalable latent reasoning boosts accuracy from 2.6% for feedforward models to over 99% on Sudoku-Extreme. These results suggest that learned attractor landscapes provide a useful mechanistic lens for understanding scalable reasoning in iterative latent models.",
       "authors": [
-        "Yujie Wei",
-        "Yujin Han",
-        "Zhekai Chen",
-        "Yongming Li",
-        "Kaixun Jiang",
-        "Zhihang Liu",
-        "Quanhao Li",
-        "Zhiwu Qing",
-        "Xiang Wang",
-        "Zhen Xing",
-        "Ruihang Chu",
-        "Lingyi Hong",
-        "Yefei He",
-        "Junjie Zhou",
-        "Junqiu Yu",
-        "Yang Shi",
-        "Difan Zou",
-        "Kai Zhu",
-        "Shiwei Zhang",
-        "Yingya Zhang",
-        "Yu Liu",
-        "Xihui Liu",
-        "Hongming Shan"
+        "Benhao Huang",
+        "Zhengyang Geng",
+        "Zico Kolter"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21488v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21488v1",
+      "publishedAt": "2026-05-20T17:59:48.000Z",
+      "updatedAt": "2026-05-20T17:59:48.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21487v1",
+      "title": "Uni-Edit: Intelligent Editing Is A General Task For Unified Model Tuning",
+      "summary": "Currently, enhancing Unified Multimodal Models (UMMs) with image understanding, generation, and editing capabilities mainly relies on mixed multi-task training. Due to inherent task conflicts, such strategy requires complex multi-stage pipelines, massive data mixing, and balancing tricks, merely resulting in a performance trade-off rather than true mutual reinforcement. To break this paradigm, we propose Uni-Edit, an intelligent image editing task that serves as the first general task for UMM tuning. Unlike complex mixed pipelines, Uni-Edit improves performance across all three abilities at once using only one task, one training stage, and one dataset. Specifically, we first identify image editing as an inherently ideal general task, as it naturally demands both visual understanding and generation. However, existing editing data relies on simplistic instructions that severely underutilize a model's understanding capacity. To address this, we introduce the first automated and scalable data synthesis pipeline for intelligent editing, transforming diverse VQA data into complex and effective editing instructions with embedded questions and nested logic. This yields Uni-Edit-148k, pairing diverse reasoning-intensive instructions with high-quality edited images. Extensive experiments on BAGEL and Janus-Pro demonstrate that tuning solely on Uni-Edit achieves comprehensive enhancements across all three capabilities without any auxiliary operations.",
+      "authors": [
+        "Dian Zheng",
+        "Manyuan Zhang",
+        "Hongyu Li",
+        "Hongbo Liu",
+        "Kai Zou",
+        "Kaituo Feng",
+        "Hongsheng Li"
       ],
       "categories": [
         "cs.CV"
       ],
       "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20183v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20183v1",
-      "publishedAt": "2026-05-19T17:59:33.000Z",
-      "updatedAt": "2026-05-19T17:59:33.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21487v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21487v1",
+      "publishedAt": "2026-05-20T17:59:42.000Z",
+      "updatedAt": "2026-05-20T17:59:42.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20182v1",
-      "title": "Atoms of Thought: Universal EEG Representation Learning with Microstates",
-      "summary": "Learning universal representations from electroencephalogram (EEG) signals is a cutting-edge approach in the field of neuroinformatics and brain-computer interfaces (BCIs). Conventionally, EEG is treated as a multivariate temporal signal, where time- or frequency-domain features are extracted for representation learning. This paper investigates a simple yet effective EEG representation, i.e., microstates. Microstates represent the building blocks of brain activity patterns at a microscopic time scale. We build a universal microstate tokenizer from a large medical EEG dataset by clustering continuous EEG signals into sequences of discrete microstates. The microstate tokenizer is then adopted universally across a series of downstream tasks, including sleep staging, emotion recognition, and motor imagery classification. Experimental results show that EEG representation learning with microstates outperforms traditional time-domain and frequency-domain features under different models and across different tasks. Further analysis shows that microstates offer greater interpretability and scalability, thereby opening up applications in both cognitive neuroscience and clinical research.",
+      "arxivId": "2605.21486v1",
+      "title": "Quantifying Hyperparameter Transfer and the Importance of Embedding Layer Learning Rate",
+      "summary": "Hyperparameter transfer allows extrapolating optimal optimization hyperparameters from small to large scales, making it critical for training large language models (LLMs). This is done either by fitting a scaling law to the hyperparameters or by a judicious choice of parameterization, such as Maximal Update ($μ$P), that renders optimal hyperparameters approximately scale invariant. In this paper, we first develop a framework to quantify hyperparameter transfer through three metrics: (1) the quality of the scaling law fit, (2) the robustness to extrapolation errors, and (3) the asymptotic loss penalty due to choice of parameterization. Next, we investigate through a comprehensive series of ablations why $μ$P appears to offer high-quality learning rate transfer relative to standard parameterization (SP), as existing theory is inadequate. We find that the overwhelming benefit of $μ$P relative to SP when training with AdamW arises simply from maximizing the learning rate of the embedding layer. In SP, the embedding layer learning rate acts as a bottleneck that induces training instabilities; increasing it by a factor of width to match $μ$P dramatically smooths out training while improving hyperparameter transfer. We also find that weight decay improves the scaling law fits, while, in the fixed token-per-parameter setting, it hurts the robustness of the extrapolation.",
       "authors": [
-        "Xinyang Tian",
-        "Ruitao Liu",
-        "Ziyi Ye",
-        "Siyang Xue",
-        "Xin Wang",
-        "Xuesong Chen"
+        "Dayal Singh Kalra",
+        "Maissam Barkeshli"
+      ],
+      "categories": [
+        "cs.LG",
+        "cond-mat.dis-nn",
+        "cs.AI",
+        "stat.ML"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21486v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21486v1",
+      "publishedAt": "2026-05-20T17:59:40.000Z",
+      "updatedAt": "2026-05-20T17:59:40.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21485v1",
+      "title": "EvoStruct: Bridging Evolutionary and Structural Priors for Antibody CDR Design via Protein Language Model Adaptation",
+      "summary": "Equivariant graph neural network (GNN) methods for antibody complementarity-determining region (CDR) design achieve the highest sequence recovery but suffer from severe vocabulary collapse. The current best GNN methods over-predict very few amino acids, such as tyrosine and glycine, while ignoring functionally important residues. We trace this failure to GNN encoders learning amino acid distributions de novo from limited structural data, discarding substitution patterns encoded in evolutionary databases. To resolve this, we propose EvoStruct, which bridges a frozen protein language model (PLM) with 3D structural context from an E(3)-equivariant GNN via a cross-attention adapter. Unlike prior PLM-structure adapters for general protein design, EvoStruct targets the vocabulary collapse problem specific to CDR design through progressive PLM unfreezing and R-Drop consistency regularization. On the CHIMERA-Bench dataset, EvoStruct achieves the highest amino acid recovery and lowest perplexity among several antibody design methods, improving sequence recovery by 16% and reducing perplexity by 43% relative to the best GNN baselines, while recovering 2.3x greater amino acid diversity and the highest binding-pair correlation with ground truth.",
+      "authors": [
+        "Mansoor Ahmed",
+        "Sujin Lee",
+        "Umar Khayaz",
+        "Murray Patterson"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21485v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21485v1",
+      "publishedAt": "2026-05-20T17:59:16.000Z",
+      "updatedAt": "2026-05-20T17:59:16.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21484v1",
+      "title": "One-Step Distillation of Discrete Diffusion Image Generators via Fixed-Point Iteration",
+      "summary": "Discrete diffusion models excel at visual synthesis but rely on slow, iterative decoding. Existing single-step distillation methods attempt to bypass this bottleneck, either by training auxiliary score networks that effectively double compute, or by introducing specialized parameterizations and multi-stage pipelines that fragment optimization. In this paper, we introduce Fixed-Point Distillation (FPD), an end-to-end framework that constructs local correction targets by partially corrupting the student's one-step draft and refining it with a single teacher step. To compute the training objective in a semantically meaningful space, we lift discrete tokens into continuous features and apply a multi-bandwidth drift loss that iteratively accumulates these corrections. To backpropagate through the discrete bottleneck, we employ a straight-through estimator that feeds exact hard-sampled tokens to the teacher and decoder during the forward pass, ensuring that training and inference operate on the same codebook manifold, while routing continuous gradients back to the student logits. This fully differentiable pathway additionally accommodates an optional unconditional adversarial objective to enhance perceptual realism. Evaluations on both class- and text-conditional generation validate the effectiveness of our framework. FPD achieves competitive visual fidelity and structural alignment within a single inference step, narrowing the gap to multi-step teachers while outperforming existing discrete distillation baselines.",
+      "authors": [
+        "Chaoyang Wang",
+        "Yunhai Tong"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21484v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21484v1",
+      "publishedAt": "2026-05-20T17:59:10.000Z",
+      "updatedAt": "2026-05-20T17:59:10.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21483v1",
+      "title": "Velocityformer: Broken-Symmetry-Matched Equivariant Graph Transformers for Cosmological Velocity Reconstruction",
+      "summary": "Precise measurement of the kinematic Sunyaev-Zel'dovich (kSZ) effect - a probe of the large-scale distribution of baryonic matter, a key observable for cosmological inference - requires accurate reconstruction of galaxy velocities from spectroscopic surveys. The signal-to-noise ratio (SNR) of kSZ measurements scales directly with the correlation coefficient $r$ between reconstructed and true velocities. We introduce Velocityformer, an equivariant graph transformer architecture designed to match the specific symmetry of the observational data. While the underlying physics is equivariant with respect to translations and rotations, observational effects break this symmetry due to the preferred line-of-sight direction. Matching the model's inductive bias to the data's broken symmetry consistently improves performance across all model sizes and training volumes, with Velocityformer improving $r$ by 35% over the standard linear theory baseline and outperforming ML baselines at every data volume. By matching the model's inductive bias to the data and conditioning on the physics-based long-wavelength solution, Velocityformer is highly data-efficient, training to high accuracy on as few as 4 low-fidelity simulations, and generalises zero-shot across input geometry, cosmological parameters, and galaxy sample. On high-fidelity simulated galaxy catalogues, this yields a 30% improvement in $r$ over the physical baseline, directly translating to the same SNR gain on observational data.",
+      "authors": [
+        "Tilman Tröster",
+        "David Mirkovic",
+        "Veronika Oehl",
+        "Arne Thomsen"
+      ],
+      "categories": [
+        "astro-ph.CO",
+        "cs.LG"
+      ],
+      "primaryCategory": "astro-ph.CO",
+      "absUrl": "https://arxiv.org/abs/2605.21483v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21483v1",
+      "publishedAt": "2026-05-20T17:59:05.000Z",
+      "updatedAt": "2026-05-20T17:59:05.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21482v1",
+      "title": "DeepWeb-Bench: A Deep Research Benchmark Demanding Massive Cross-Source Evidence and Long-Horizon Derivation",
+      "summary": "Deep research, in which an agent searches the open web, collects evidence, and derives an answer through extended reasoning, is a prominent use case for frontier language models. Frontier deep research products score high on existing benchmarks, making it difficult to distinguish their capabilities from current evaluation data alone. We introduce DeepWeb-Bench, a deep research benchmark that is substantially harder than existing benchmarks for the current frontier. Difficulty comes from three properties of the data itself: each task requires massive evidence collection, cross-source reconciliation, and long-horizon multi-step derivation. We represent these three sources of difficulty as four capability families (Retrieval, Derivation, Reasoning, and Calibration) and report results sliced by family. Every reference answer is accompanied by a source-provenance record with four disclosure levels and cross-source checks where available, making scores easier to audit against the underlying evidence. We evaluate DeepWeb-Bench on nine frontier models and report three findings: (1) retrieval is not the bottleneck, as retrieval failures account for only 12-14% of errors while derivation and calibration failures account for over 70%; (2) strong and weak models fail in qualitatively different ways, with strong models' errors dominated by incomplete derivation and weak models' by hallucinated precision; and (3) models exhibit genuine specialization across domains, with cross-model agreement of only rho = 0.61 and per-case disagreement reaching 18.8 percentage points. The public benchmark release includes the data, rubrics, and evaluation code.",
+      "authors": [
+        "Sixiong Xie",
+        "Zhuofan Shi",
+        "Haiyang Shen",
+        "Jiuzheng Wang",
+        "Siqi Zhong",
+        "Mugeng Liu",
+        "Chongyang Pan",
+        "Peilun Jia",
+        "Baoqing Sun",
+        "Xiang Jing",
+        "Yun Ma"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.21482v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21482v1",
+      "publishedAt": "2026-05-20T17:59:03.000Z",
+      "updatedAt": "2026-05-20T17:59:03.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21481v1",
+      "title": "AiraXiv: An AI-Driven Open-Access Platform for Human and AI Scientists",
+      "summary": "Recent advances in artificial intelligence (AI) have accelerated the growth of both human-authored and AI-generated research outputs, placing increasing strain on traditional academic publishing systems and challenging the scalability of conference- and journal-centered paradigms amid rising submission volumes, reviewer workload, and venue size. To address these challenges, we explore an AI-era publishing paradigm in which both human and AI scientists participate as authors and readers, and papers evolve through continuous, feedback-driven iteration. We propose AiraXiv, an AI-driven open-access platform built on open preprints, AI-augmented analysis and review, and reader feedback. AiraXiv supports human scientists through an interactive UI and AI scientists through Model Context Protocol (MCP)-based interactions. We validate AiraXiv through real-world deployments, including serving as the submission platform for ICAIS 2025, demonstrating its potential as a fast, inclusive, and scalable research infrastructure for the AI era. AiraXiv is publicly available at https://airaxiv.com.",
+      "authors": [
+        "Junshu Pan",
+        "Panzhong Lu",
+        "Yixuan Weng",
+        "Qiyao Sun",
+        "Fang Guo",
+        "Zijie Yang",
+        "Qiji Zhou",
+        "Yue Zhang"
+      ],
+      "categories": [
+        "cs.AI",
+        "cs.CL",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.21481v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21481v1",
+      "publishedAt": "2026-05-20T17:59:03.000Z",
+      "updatedAt": "2026-05-20T17:59:03.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21479v1",
+      "title": "WikiVQABench: A Knowledge-Grounded Visual Question Answering Benchmark from Wikipedia and Wikidata",
+      "summary": "Visual Question Answering (VQA) benchmarks have largely emphasized perception-based tasks that can be solved from visual content alone. In contrast, many real-world scenarios require external knowledge that is not directly observable in the image to answer correctly. We introduce WikiVQABench, a human-curated knowledge-grounded VQA benchmark constructed by systematically combining Wikipedia images, their associated article captions, and structured knowledge from Wikidata. Our pipeline uses large language models (LLMs) to generate candidate multiple-choice image-question-answer sets. All generated instances are subsequently reviewed and curated by human annotators to ensure factual correctness, visual-text consistency, and that each question requires external knowledge in addition to visual evidence for correct resolution. WikiVQABench comprises a substantial collection of Wikipedia images with curated multiple-choice questions designed to benchmark knowledge-aware vision-language models (VLMs). Evaluation of fifteen VLMs (256M-90B parameters) reveals a wide performance range (24.7%-75.6% accuracy), demonstrating that the benchmark effectively discriminates model capabilities on knowledge-intensive reasoning. The dataset and benchmarking code are publicly available.",
+      "authors": [
+        "Basel Shbita",
+        "Pengyuan Li",
+        "Anna Lisa Gentile"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21479v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21479v1",
+      "publishedAt": "2026-05-20T17:58:24.000Z",
+      "updatedAt": "2026-05-20T17:58:24.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21478v1",
+      "title": "Latent Dynamics for Full Body Avatar Animation",
+      "summary": "Pose-driven full-body avatars built on neural rendering produce high-quality novel views of a captured subject. Yet loose clothing and other dynamic elements deform in ways pose alone cannot explain: the same pose can correspond to many different states, because their motion depends on history, inertia, and contact. Explicit simulation and layered-garment methods can model such dynamics, but they require either a dedicated garment template, which raw multi-view capture does not naturally provide, or a test-time physics simulator with non-trivial runtime cost. A parallel line of work learns data-driven clothing avatars that avoid explicit garment layers. These methods add an auxiliary latent for variation beyond pose; at inference, they fix it, regress it from pose, or retrieve it from training data, without explicitly modeling how the latent evolves with its own dynamics. Additionally, even in everyday motion with loose clothing, existing architectures often struggle to capture fine-grained detail, producing blurry renderings and temporal artifacts. We augment a pose-conditioned 3D Gaussian avatar with a transformer-based decoder and a dynamics residual latent that captures temporal appearance and geometry variation beyond the driving signals. At inference, a learned latent dynamics model evolves the residual latent from a short pose history and the previous latent state. The model decomposes each update into driving, restoring, and dissipative forces, producing temporally coherent, history-dependent rollouts with negligible added cost. Different initial conditions yield diverse yet plausible motion trajectories, and the force decomposition exposes controls such as stiffness. Across nine captured sequences of everyday motion with diverse loose garments, quantitative metrics and a perceptual user study show improved animation quality over recent data-driven baselines.",
+      "authors": [
+        "Shichong Peng",
+        "Chengxiang Yin",
+        "Fei Jiang",
+        "Zhongshi Jiang",
+        "Lingchen Yang",
+        "Qingyang Tan",
+        "Amin Jourabloo",
+        "Jason Saragih",
+        "Ke Li",
+        "Christian Häne"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.GR"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21478v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21478v1",
+      "publishedAt": "2026-05-20T17:58:03.000Z",
+      "updatedAt": "2026-05-20T17:58:03.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21475v1",
+      "title": "Is Fixing Schema Graphs Necessary? Full-Resolution Graph Structure Learning for Relational Deep Learning",
+      "summary": "Relational prediction tasks are fundamental in many real-world applications, where data are naturally stored in relational databases (RDBs). Relational Deep Learning (RDL) addresses this problem by modeling RDBs as graphs and applying graph neural networks (GNNs) for end-to-end learning. However, the full-resolution property is commonly adopted as a design principle in graph construction for RDBs to preserve relational semantics, which leads most existing methods to rely on fixed graph structures. In this paper, we propose FROG, a Full-Resolution and Optimizable Graph Structure Learning} framework for RDL that formulates relational structure learning as a learnable table role modeling problem, allowing tables to contribute as nodes and edges in message passing. We further design role-driven message passing mechanisms to capture relational semantics, enabling joint optimization of graph structure and GNN representations. To ensure semantic consistency, we introduce functional dependency constraints that regularize representations across table and entity levels. Extensive experiments demonstrate that our method outperforms existing approaches and reveal how table roles impact downstream tasks, offering new insights into graph construction for RDL",
+      "authors": [
+        "Yi Huang",
+        "Qingyun Sun",
+        "Jia Li",
+        "Xingcheng Fu",
+        "Jianxin Li"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21475v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21475v1",
+      "publishedAt": "2026-05-20T17:56:09.000Z",
+      "updatedAt": "2026-05-20T17:56:09.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21472v1",
+      "title": "Stream3D: Sequential Multi-View 3D Generation via Evidential Memory",
+      "summary": "View-conditioned 3D generators such as SAM 3D, TRELLIS and Hunyuan3D produce high-quality object reconstructions from a single view, but real-world visual observation often arrives as long monocular streams. Naively applying these generators to each streaming frame independently leads to severe temporal inconsistency in the generated results. To address this problem, we propose Stream3D, the first training-free streaming mechanism that turns a frozen view-conditioned 3D generator into a streaming generator with constant cross-chunk memory. Stream3D achieves this by maintaining a compact evidential memory, which selectively caches the most informative historical frames based on a proposed evidence score mechanism. As the stream progresses, the memory dynamically updates to retain a fixed number of informative frames, preventing the memory footprint from growing linearly with sequence length. This also prevents degradation over long sequences and keeps the underlying generator completely unchanged without retraining, architectural modifications, or auxiliary losses. Evaluated on both realistic and synthetic streaming benchmarks, Stream3D outperforms latent-transport baselines, including KV-cache reuse and flow-based feature editing, across both photometric and geometric metrics. More details can be found at: https://anonymous-submission-20.github.io/streaming3D.github.io/.",
+      "authors": [
+        "Kaichen Zhou",
+        "Zeyang Bai",
+        "Xinhai Chang",
+        "Mengyu Wang",
+        "Paul Liang",
+        "Fangneng Zhan"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21472v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21472v1",
+      "publishedAt": "2026-05-20T17:55:16.000Z",
+      "updatedAt": "2026-05-20T17:55:16.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21470v1",
+      "title": "Agent JIT Compilation for Latency-Optimizing Web Agent Planning and Scheduling",
+      "summary": "Computer-use agents (CUA) automate tasks specified with natural language such as \"order the cheapest item from Taco Bell\" by generating sequences of calls to tools such as click, type, and scroll on a browser. Current implementations follow a sequential fetch-screenshot-execute loop where each iteration requires an LLM call, resulting in high latency and frequent errors from incorrect tool use. We present agent just-in-time (JIT) compilation, an alternative that compiles task descriptions directly into executable code that is free to include LLM calls, tool calls, and parallelization. Our approach comprises three components: (1) JIT-Planner, which generates multiple code plans, validates each against tool specifications, and selects the minimum-cost candidate; (2) JIT-Scheduler, which explores parallelization strategies via Monte Carlo cost estimation from learned latency distributions; and (3) an invariant-enforcing tool protocol specifying precondition and postcondition state requirements that reduce the rate of generating plans with incorrect tool use. Across 5 web applications, JIT-Planner achieves $10.4\\times$ speedup and $+28\\%$ accuracy over Browser-Use, while JIT-Scheduler achieves $2.4\\times$ speedup and $+9\\%$ accuracy over OpenAI CUA.",
+      "authors": [
+        "Caleb Winston",
+        "Ron Yifeng Wang",
+        "Azalia Mirhoseini",
+        "Christos Kozyrakis"
       ],
       "categories": [
         "cs.LG",
         "cs.AI"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20182v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20182v1",
-      "publishedAt": "2026-05-19T17:59:31.000Z",
-      "updatedAt": "2026-05-19T17:59:31.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21470v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21470v1",
+      "publishedAt": "2026-05-20T17:54:27.000Z",
+      "updatedAt": "2026-05-20T17:54:27.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20179v1",
-      "title": "TIDE: Efficient and Lossless MoE Diffusion LLM Inference with I/O-aware Expert Offload",
-      "summary": "Diffusion Large Language Models (dLLMs) have emerged as a competitive alternative to autoregressive (AR) models, offering better hardware utilization and bidirectional context through parallel block-level decoding. However, as dLLMs continue to scale up with mixture-of-experts (MoE) architectures, their deployment on resource-constrained devices remains an open challenge. Existing AR-based methods often incur either prohibitive I/O overhead or significant compute bottlenecks. In this work, we propose TIDE, a novel resource-efficient inference system that leverages the temporal stability of expert activations during the diffusion process within the block. Specifically, we leverage the temporal stability of expert activations during the diffusion process within the block and introduce an interval-based expert refresh strategy that updates the expert placement in an I/O-aware fashion. To ensure optimal performance, we formulate the inference scheduling as a mathematical programming problem, solving for the optimal interval that minimizes I/O traffic and CPU computation. Most importantly, TIDE is a lossless optimization that requires no model training, providing a \"free lunch\" acceleration for dLLM inference. In a single GPU-CPU system, we demonstrate that TIDE achieves up to 1.4$\\times$ and 1.5$\\times$ throughput improvements over prior baselines on LLaDA2.0-mini and LLaDA2.0-flash models, respectively.",
+      "arxivId": "2605.21468v1",
+      "title": "You Only Need Minimal RLVR Training: Extrapolating LLMs via Rank-1 Trajectories",
+      "summary": "Reinforcement learning with verifiable rewards (RLVR) has become a dominant paradigm for improving reasoning in large language models (LLMs), yet the underlying geometry of the resulting parameter trajectories remains underexplored. In this work, we demonstrate that RLVR weight trajectories are extremely low-rank and highly predictable. Specifically, we find that the majority of downstream performance gains are captured by a rank-1 approximation of the parameter deltas, where the magnitude of this projection evolves near-linearly with training steps. Motivated by this, we propose a simple and compute-efficient method RELEX (REinforcement Learning EXtrapolation), which estimates the rank-1 subspace from a short observation window and extrapolates future checkpoints via linear regression, with no learned model required. Across three models (i.e., Qwen2.5-Math-1.5B, Qwen3-4B-Base, and Qwen3-8B-Base), RELEX produces checkpoints that match or exceed RLVR performance on both in-domain and out-of-domain benchmarks, requiring as few as 15% steps of full RLVR training. Remarkably, RELEX is able to extrapolate far beyond the observation window at no training cost, predicting checkpoints up to 10-20$\\times$ beyond the observed prefix with continued improvement (e.g., observe only the first 50 steps and extrapolate to 1000 steps). Our ablation analysis confirms the minimalist sufficiency of RELEX: neither increasing the subspace rank nor employing non-linear modeling yields further gains in extrapolation. Finally, we show that RELEX's success stems from a \"denoising\" effect: by projecting updates onto the rank-1 subspace, the model discards stochastic optimization noise that would otherwise degrade performance during extrapolation. Our code is available at https://github.com/weizhepei/RELEX.",
       "authors": [
-        "Zhiben Chen",
-        "Youpeng Zhao",
-        "Yang Sui",
-        "Jun Wang",
-        "Yuzhang Shang"
+        "Zhepei Wei",
+        "Xinyu Zhu",
+        "Wei-Lin Chen",
+        "Chengsong Huang",
+        "Jiaxin Huang",
+        "Yu Meng"
       ],
       "categories": [
+        "cs.LG",
         "cs.CL"
       ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20179v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20179v1",
-      "publishedAt": "2026-05-19T17:59:08.000Z",
-      "updatedAt": "2026-05-19T17:59:08.000Z",
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21468v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21468v1",
+      "publishedAt": "2026-05-20T17:53:20.000Z",
+      "updatedAt": "2026-05-20T17:53:20.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20177v1",
-      "title": "From Seeing to Thinking: Decoupling Perception and Reasoning Improves Post-Training of Vision-Language Models",
-      "summary": "Recent advances in vision-language models (VLMs) emphasize long chain-of-thought reasoning; yet, we find that their performance on visual tasks is primarily limited by a lack of visual perception as opposed to reasoning itself. In this work, we systematically study the interplay between perception and reasoning in VLM post-training by decomposing their capabilities into three separate training stages: visual perception, visual reasoning, and textual reasoning, incorporating specialized training data. We demonstrate that visual perception (a) requires targeted optimization with specialized data; (b) serves as a fundamental scaffold that should be solidified through staged training before refining visual reasoning; and (c) is more effectively learned via RL than caption-based SFT. Our experiments across multiple VLMs demonstrate that staged training consistently improves both visual perception and reasoning performance over merged training. Notably, models trained with our approach achieve 1.5% higher reasoning accuracy with 20.8% shorter reasoning traces, suggesting that superior perception reduces the need for excessive reasoning. Furthermore, we show that this capability-based staging represents a new curriculum dimension orthogonal to traditional difficulty-based curricula, and combining both yields further additive gains. Our staged-training models achieve superior performance among open-weight VLMs, establishing advanced results on several visual math and perception (e.g., +5.2% on WeMath and +3.7% on RealWorldQA) tasks compared with the base counterpart.",
+      "arxivId": "2605.21467v1",
+      "title": "DelTA: Discriminative Token Credit Assignment for Reinforcement Learning from Verifiable Rewards",
+      "summary": "Reinforcement learning from verifiable rewards (RLVR) has emerged as a central technique for improving the reasoning capabilities of large language models. Despite its effectiveness, how response-level rewards translate into token-level probability changes remains poorly understood. We introduce a discriminator view of RLVR updates, showing that the policy-gradient update direction implicitly acts as a linear discriminator over token-gradient vectors and thereby determines which token probabilities are increased or decreased during learning. Under standard sequence-level RLVR, this discriminator is constructed from positive- and negative-side centroids formed by advantage-weighted averaging of token-gradient vectors. However, such centroid construction can be dominated by shared high-frequency patterns, such as formatting tokens, diluting sparse yet discriminative directions that better distinguish high-reward responses from low-reward ones. To address this limitation, we propose $\\textbf{DelTA}$, a discriminative token credit assignment method that estimates token coefficients to amplify side-specific token-gradient directions and downweight shared or weakly discriminative ones. These coefficients reweight a self-normalized RLVR surrogate, making the effective side-wise centroids more contrastive and thereby reshaping the RLVR update direction. On seven mathematical benchmarks, DelTA outperforms the strongest same-scale baselines by 3.26 and 2.62 average points on Qwen3-8B-Base and Qwen3-14B-Base, respectively. Additional results on code generation, a different backbone, and out-of-domain evaluations further demonstrate the generalization ability of DelTA.",
       "authors": [
-        "Juncheng Wu",
-        "Hardy Chen",
-        "Haoqin Tu",
-        "Xianfeng Tang",
-        "Freda Shi",
-        "Hui Liu",
-        "Hanqing Lu",
-        "Cihang Xie",
-        "Yuyin Zhou"
+        "Kaiyi Zhang",
+        "Wei Wu",
+        "Yankai Lin"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21467v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21467v1",
+      "publishedAt": "2026-05-20T17:53:09.000Z",
+      "updatedAt": "2026-05-20T17:53:09.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21466v1",
+      "title": "StreamGVE: Training-Free Video Editing via Few-Step Streaming Video Generation",
+      "summary": "Although existing video editing methods are generally feasible, they often require many costly iterations and still struggle to deliver high-quality yet satisfying editing results. We attribute this limitation to the prevalent data-to-data paradigm, which is less compatible with modern generative models than noise-to-data generation. To address this gap, we revisit video editing from a noise-to-data perspective and propose Streaming-Generation-based Video Editing (StreamGVE), which preserves few-step sampling while seamlessly injecting source-video conditions. Built on pre-trained streaming generation models, StreamGVE introduces dual-branch fast sampling with a self-attention bridge and cross-attention grounding/boosting to satisfy both sampling and conditioning requirements. We further propose source-oriented guidance to improve target-generation quality, and a visual prompting strategy to enhance editing flexibility and practicality. The method is effective, robust, and generalizable across different models. Extensive experiments on diverse video editing tasks show that StreamGVE consistently outperforms existing approaches, even in few-step settings with minimal time cost.",
+      "authors": [
+        "Guanlong Jiao",
+        "Chenyangguang Zhang",
+        "Jia Jun Cheng Xian",
+        "Zewei Zhang",
+        "Renjie Liao"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21466v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21466v1",
+      "publishedAt": "2026-05-20T17:52:10.000Z",
+      "updatedAt": "2026-05-20T17:52:10.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21465v1",
+      "title": "Leveraging LLMs for Grammar Adaptation: A Study on Metamodel-Grammar Co-Evolution",
+      "summary": "In model-driven engineering, metamodel evolution leads to the need to adapt corresponding grammars to maintain consistency, which typically requires tedious manual work. Existing rule-based methods can achieve partial automation but have limitations when handling complex grammar scenarios. This paper proposes a Large Language Model-based approach that automatically applies adaptations to new grammars after evolution by learning grammar adaptations from previous versions. We evaluated this approach on six real-world Xtext domain-specific languages, using four DSLs as a training set to develop prompting strategies, two DSLs as a test set for validation, and conducting a longitudinal case study on QVTo. The evaluation used three Large Language Models (Claude Sonnet 4.5, ChatGPT 5.1, Gemini 3) and measured grammar adaptation quality from three dimensions: grammar rule-level adaptation consistency, output similarity, and metamodel conformance. Results show that on the test set, all three LLMs achieved 100% adaptation consistency and output similarity, while the rule-based approach achieved only 84.21% on DOT and 62.50% on Xcore. In the QVTo longitudinal study, the LLM-based approach successfully reused learned adaptations across all three evolution steps without manual grammar editing, while the rule-based approach required manual adjustments in two of three transitions. However, on large-scale grammars (EAST-ADL, 297 rules), LLMs' adaptation consistency was far below 90%. This study demonstrates the advantages of LLM-based approaches in handling complex grammar scenarios, while revealing their limitations in large-scale grammar adaptation.",
+      "authors": [
+        "Weixing Zhang",
+        "Bowen Jiang",
+        "Rahul Sharma",
+        "Regina Hebig",
+        "Daniel Strüber"
       ],
       "categories": [
         "cs.CL",
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20177v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20177v1",
-      "publishedAt": "2026-05-19T17:58:40.000Z",
-      "updatedAt": "2026-05-19T17:58:40.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20176v1",
-      "title": "ClinSeekAgent: Automating Multimodal Evidence Seeking for Agentic Clinical Reasoning",
-      "summary": "Large language models (LLMs) and agentic systems have shown promise for clinical decision support, but existing works largely assume that evidence has already been curated and handed to the model. Real-world clinical workflows instead require agents to actively seek, iteratively plan, and synthesize multimodal evidence from heterogeneous sources. In this paper, we introduce ClinSeekAgent, an automated agentic framework for dynamic multimodal evidence seeking that shifts the paradigm from passive evidence consumption to active evidence acquisition. Given only a clinical query and access to raw data sources, ClinSeekAgent gathers evidence by querying medical knowledge bases, navigating raw EHRs, and invoking medical imaging tools; refines its hypotheses as new information emerges; and integrates the collected evidence into grounded clinical decisions. ClinSeekAgent serves both as an inference-time agent for frontier LLMs and as a training-time pipeline for distilling high-quality agent trajectories into compact open-source models. To validate its inference-time effectiveness, we construct ClinSeek-Bench, which pairs Curated Input reasoning from fixed pre-selected evidence with Automated Evidence-Seeking over raw clinical data. On text-only EHR tasks, ClinSeekAgent improves Claude Opus 4.6 from 60.0 to 63.2 overall F1 and MiniMax M2.5 from 43.1 to 47.3, with positive risk-prediction gains in 7 out of 9 evaluated host models. On multimodal tasks, ClinSeekAgent improves Claude Opus 4.6 from 47.5 to 62.6 (+15.1); all evaluated models improve across the three CXR-related task groups. We further validate ClinSeekAgent as a training pipeline by distilling agentic evidence-seeking trajectories into ClinSeek-35B-A3B, which achieves 34.0 average F1 on existing AgentEHR-Bench, improving over its Qwen3.5-35B-A3B baseline by +11.9 points and approaching Claude Opus 4.6.",
-      "authors": [
-        "Juncheng Wu",
-        "Letian Zhang",
-        "Yuhan Wang",
-        "Haoqin Tu",
-        "Hardy Chen",
-        "Zijun Wang",
-        "Cihang Xie",
-        "Yuyin Zhou"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20176v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20176v1",
-      "publishedAt": "2026-05-19T17:58:37.000Z",
-      "updatedAt": "2026-05-19T17:58:37.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20174v1",
-      "title": "Multi-axis Analysis of Image Manipulation Localization",
-      "summary": "Advanced image editing software enables easy creation of highly convincing image manipulations, which has been made even more accessible in recent years due to advances in generative AI. Manipulated images, while often harmless, could spread misinformation, create false narratives, and influence people's opinions on important issues. Despite this growing threat, there is limited research on detecting advanced manipulations across different visual domains. Thus, we introduce Analysis Under Domain-shifts, qualIty, Type, and Size (AUDITS), a comprehensive benchmark designed for studying axes of analysis in image manipulation detection. AUDITS comprises over 530K images from two distinct sources (user and news photos). We curate our dataset to support analysis across multiple axes using recent diffusion-based inpaintings, spanning a diverse range of manipulation types and sizes. We conduct experiments under different types of domain shift to evaluate robustness of existing image manipulation detection methods. Our goal is to drive further research in this area by offering new insights that would help develop more reliable and generalizable image manipulation detection methods.",
-      "authors": [
-        "Keanu Nichols",
-        "Divya Appapogu",
-        "Giscard Biamby",
-        "Dina Bashkirova",
-        "Anna Rohrbach",
-        "Bryan A. Plummer"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20174v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20174v1",
-      "publishedAt": "2026-05-19T17:54:33.000Z",
-      "updatedAt": "2026-05-19T17:54:33.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20173v1",
-      "title": "A Methodology for Selecting and Composing Runtime Architecture Patterns for Production LLM Agents",
-      "summary": "Production LLM agents combine stochastic model outputs with deterministic software systems, yet the boundary between the two is rarely treated as a first-class architectural object. This paper names that boundary the stochastic-deterministic boundary (SDB): a four-part contract among a proposer, verifier, commit step, and reject signal that specifies how an LLM output becomes a system action. We argue that the SDB is the load-bearing primitive of production agent runtimes. Around this primitive, we organize agent runtime design into three concerns: Coordination, State, and Control. We present a catalog of six runtime patterns that compose the SDB differently across conversational, autonomous, and long-horizon agents: hierarchical delegation, scatter-gather plus saga, event-driven sequencing, shared state machine, supervisor plus gate, and human in the loop. For each pattern, we trace its lineage to distributed-systems concepts and identify what changes when the worker is stochastic. The paper contributes a five-step methodology for selecting runtime patterns, a diagnostic procedure that maps production failures to pattern weaknesses, and a failure mode called replay divergence, in which LLM-based consumers of a deterministic event log produce different downstream outputs under model-version or prompt changes. A stylized reliability decomposition separates per-call model variance from architectural momentum, motivating the claim that as model variance decreases, pattern choice and SDB strength become increasingly important levers for long-run reliability. We apply the methodology to five workloads and provide one runnable reference implementation for a 90-day contract-renewal agent.",
-      "authors": [
-        "Vasundra Srinivasan"
-      ],
-      "categories": [
-        "cs.AI",
         "cs.SE"
       ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20173v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20173v1",
-      "publishedAt": "2026-05-19T17:54:21.000Z",
-      "updatedAt": "2026-05-19T17:54:21.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20172v1",
-      "title": "Long-term Power Grid Planning via Answer Set Programming",
-      "summary": "The Power grid is a critical infrastructure underpinning all aspects of modern society and its services. Maintaining its effectiveness requires continuous adaptations. In particular, addressing sustainability targets, demand patterns, and urbanisation trends requires implementing changes to the network. Actual developments can potentially span over a decade, with supply continuity and service quality that must be preserved throughout by ensuring conformance to several topological and combinatorial invariants. Long-term power grid planning deals with the above process, and although planning languages could be a natural choice, the kind of properties and invariants needed are cumbersome to express in such languages; on the contrary, they can be elegantly and succinctly encoded in Answer Set Programming (ASP). In this paper, we propose the first approach to automate and optimise the long-term power grid planning process using ASP. Experimental evaluations conducted on synthetic and real-world grid data confirm the expressive power of the proposed ASP-based approach and demonstrate its effectiveness.",
-      "authors": [
-        "Antonio Ielo",
-        "Francesco Doria",
-        "Sandra Castellanos-Paez",
-        "Marco Maratea",
-        "Francesco Percassi",
-        "Mauro Vallati"
-      ],
-      "categories": [
-        "cs.LO",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.LO",
-      "absUrl": "https://arxiv.org/abs/2605.20172v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20172v1",
-      "publishedAt": "2026-05-19T17:54:15.000Z",
-      "updatedAt": "2026-05-19T17:54:15.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20170v1",
-      "title": "KoRe: Compact Knowledge Representations for Large Language Models",
-      "summary": "Modern Large Language Models (LLMs) have shown impressive performances in user-facing tasks such as question answering, as well as consistent improvements in reasoning capabilities. Still, the way these models encode knowledge seems inherently flawed: by design, LLMs encode world-knowledge within their parameters. This way of representing knowledge is inherently opaque, difficult to debug and update, and prone to hallucinations. On the other hand, Knowledge Graphs can provide human-readable and easily editable world knowledge representations, and their application in knowledge-intensive tasks has consistently proven beneficial to downstream performance. Nonetheless, current integration techniques require extensive retraining or finetuning. To overcome this issue, we introduce KoRe, a methodology to encode 1-hop sub-graphs into compact discrete knowledge tokens and inject them into a LLM backbone. We test the proposed approach on three established benchmarks, and report competitive performances coupled with a significant reduction (up to 10x) in token usage. Our results show that compact discrete KG representations can efficiently and effectively be used to ground modern LLMs.",
-      "authors": [
-        "Davide Cavicchini",
-        "Fausto Giunchiglia",
-        "Jacopo Staiano"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20170v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20170v1",
-      "publishedAt": "2026-05-19T17:53:29.000Z",
-      "updatedAt": "2026-05-19T17:53:29.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21465v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21465v1",
+      "publishedAt": "2026-05-20T17:51:51.000Z",
+      "updatedAt": "2026-05-20T17:51:51.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20167v1",
-      "title": "HaorFloodAlert: Deseasonalized ML Ensemble for 72-Hour Flood Prediction in Bangladesh Haor Wetlands",
-      "summary": "Flash floods in Bangladesh's haor wetlands show up with almost no warning. They wreck the annual boro rice harvest. Current setups, built for riverine floods, miss backwater dynamics entirely. These basins are flat. Water does not behave like it does on the Brahmaputra. We built HaorFloodAlert, a deseasonalized machine learning ensemble that forecasts 72-hour flood probability for the Sunamganj Haor (approximately 8,000 km2). Temperature was acting as a seasonal cheat code - it inflated accuracy by 6.9 pp just because floods happen in warm months. We caught that. We also built an upstream Barak River Sentinel-1 SAR proxy from Silchar, Assam, giving about 36 hours of lead time. Otsu-thresholded SAR change detection validates at 84-91 percent spatial match. The operational ensemble (RF 0.5625 + XGBoost 0.4375) hits 89.6 percent LOOCV accuracy, 87.5 percent recall, and 0.943 AUC-ROC on 77 real Sentinel-1 events. A three-tier alert pipeline and a BRRI-calibrated boro rice damage estimator are included.",
+      "arxivId": "2605.21463v1",
+      "title": "Mem-$π$: Adaptive Memory through Learning When and What to Generate",
+      "summary": "We present Mem-$π$, a framework for adaptive memory in large language model (LLM) agents, where useful guidance is generated on demand rather than retrieved from external memory stores. Existing memory-augmented agents typically rely on similarity-based retrieval from episodic memory banks or skill libraries, returning static entries that often misalign with the current context. In contrast, Mem-$π$ uses a dedicated language or vision-language model with its own parameters, separate from the downstream agent, to generate context-specific guidance for complex tasks. Conditioned on the current agent context, the model jointly decides when to produce guidance and what guidance to produce. We train it with a decision-content decoupled reinforcement learning (RL) objective, enabling it to abstain when generation would not help and otherwise produce concise, useful guidance. Across diverse agentic benchmarks spanning web navigation, terminal-based tool use, and text-based embodied interaction, Mem-$π$ consistently outperforms retrieval-based and prior RL-optimized memory baselines, achieving over 30% relative improvement on web navigation tasks.",
       "authors": [
-        "Salma Hoque Talukdar Koli",
-        "Fahima Haque Talukder Jely",
-        "Md. Samiul Alim",
-        "Md. Zakir Hossen"
-      ],
-      "categories": [
-        "cs.AI",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20167v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20167v1",
-      "publishedAt": "2026-05-19T17:51:46.000Z",
-      "updatedAt": "2026-05-19T17:51:46.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20165v1",
-      "title": "CaMo: Camera Motion Grounded Evaluation and Training for Vision-Language Models",
-      "summary": "Vision-Language Models (VLMs) achieve strong performance on spatial question answering benchmarks, yet it remains unclear whether such gains reflect genuine spatial intelligence. We show that existing spatial VLMs lack basic camera motion understanding, a key component of spatial cognition. We propose the Spatial Narrative Score (SNS), an evaluation framework that requires VLMs to generate explicit spatial narratives capturing both scene semantics and camera motion, followed by reasoning with a frozen proxy LLM. Under SNS, state-of-the-art spatial VLMs exhibit significant performance degradation despite high direct question answering accuracy. To address this gap, we introduce CaMo, a camera motion grounded VLM that achieves consistent performance across SNS evaluation and direct spatial question answering accuracy. Our results highlight the importance of explicit spatial narrative externalization for evaluating VLMs with transferable 3D spatial understanding. Our code, data, and model is available at https://github.com/hsiangwei0903/CaMo",
-      "authors": [
-        "Hsiang-Wei Huang",
-        "Junbin Lu",
-        "Kuang-Ming Chen",
-        "Jianxu Shangguan",
-        "Cheng-Yen Yang",
-        "Jenq-Neng Hwang"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20165v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20165v1",
-      "publishedAt": "2026-05-19T17:50:25.000Z",
-      "updatedAt": "2026-05-19T17:50:25.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20164v1",
-      "title": "Not Every Rubric Teaches Equally: Policy-Aware Rubric Rewards for RLVR",
-      "summary": "Reinforcement learning with verifiable rewards has made post-training highly effective when correctness can be checked automatically. However, many important model behaviors require satisfying several qualitative criteria at once. Rubric-based rewards address this setting by grading prompt-specific criteria and aggregating them into a scalar reward. Yet standard static aggregations conflate a criterion's human-assigned importance with its current usefulness as an optimization signal. We show that this assumption breaks down in rubric RL: many important criteria are already saturated or currently unreachable, while criteria that distinguish rollouts are not necessarily those with the largest human weights. We introduce POW3R, a policy-aware rubric reward framework that preserves human weights and category balance as the rubric objective while adapting criterion-level reward weights during training. POW3R uses rollout-level contrast to emphasize criteria that currently separate the policy's outputs, making the GRPO reward more informative without changing the underlying evaluation target. Across three base policies on two datasets spanning multimodal and text-only settings, POW3R wins $24$ of $30$ base-policy/metric comparisons, improving both mean rubric reward and strict completion (the fraction of prompts whose response satisfies every required rubric criterion) over vanilla GRPO with rubric rewards, and reaches the same plateau in $2.5$--$4\\times$ fewer training steps. Rubric rewards should therefore distinguish what should matter in the final answer from what can teach the current policy.",
-      "authors": [
-        "Utkarsh Tyagi",
-        "Xingang Guo",
-        "MohammadHossein Rezaei",
-        "Daniel George",
-        "Anas Mahmoud",
-        "Jackson Lee",
-        "Bing Liu",
-        "Yunzhong He"
-      ],
-      "categories": [
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20164v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20164v1",
-      "publishedAt": "2026-05-19T17:50:18.000Z",
-      "updatedAt": "2026-05-19T17:50:18.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20159v1",
-      "title": "Interpretable Computer Vision for Defect Detection in X-ray Tomography of Aerospace SiC/SiC Composites",
-      "summary": "Non-destructive testing of aerospace SiC/SiC composites via X-ray computed tomography (XCT) relies on expert visual assessment, with current workflows offering limited traceability for accept/reject decisions. Deep convolutional networks can automate defect detection, yet their black-box nature conflicts with the transparency that industrial inspection practice demands. To close this gap, we introduce p-ResNet-50, a convolutional framework extended with a prototype layer that couples high detection accuracy with case-based explanations. Six learned prototypes are explicitly aligned with expert-defined semantic categories-healthy matrix, matrix--air interfaces, pores, line-like defects, and mixed morphologies-so that every classification is traceable to a physically meaningful reference. Two novel regularisation terms, anchor-based and medoid-based, tether prototypes to expert-selected patches and prevent prototype collapse, addressing a known limitation of prototype networks. Latent-space analysis via UMAP delineates semantically coherent sub-domains and maps zones of uncertainty where misclassifications concentrate, giving inspectors an explicit picture of where the model is-and is not-reliable. The framework is validated on an XCT patch dataset of approximately 12,000 patches extracted from four defect-rich SiC/SiC laboratory specimens. Taking a black-box ResNet-50 as a baseline (ROC-AUC = 0.991), the prototype extension achieves comparable performance (accuracy 0.957 vs. 0.959; ROC-AUC 0.994 vs. 0.993) while trading a slight reduction in sensitivity for higher precision and specificity. Each decision is backed by representative evidence patches, and the model explicitly flags its uncertainty regions. Beyond defect mapping, the framework establishes a reusable methodology for embedding domain-expert knowledge into prototype networks, applicable to other XCT inspection scenarios requiring traceable, auditable decisions.",
-      "authors": [
-        "Antonio Peña Corredor",
-        "Julien Lesseur",
-        "Romain Nunez",
-        "Paul Rivalland",
-        "Thomas Philippe"
-      ],
-      "categories": [
-        "cs.CV",
-        "cond-mat.mtrl-sci",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20159v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20159v1",
-      "publishedAt": "2026-05-19T17:46:49.000Z",
-      "updatedAt": "2026-05-19T17:46:49.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20158v1",
-      "title": "Rethinking Visual Attribution for Chest X-ray Reasoning in Large Vision Language Models",
-      "summary": "Large Vision Language Models (LVLMs) show promise in medical applications, but their inability to faithfully ground responses in visual evidence raises serious concerns about clinical trustworthiness. While visual attribution methods are widely used to explain LVLM predictions, whether these explanations actually reflect the visual evidence underlying the model's decision is largely unverified, since ground-truth annotations for internal model reasoning are typically unavailable. We address this question for chest X-ray (CXR) reasoning by developing a causal evaluation framework that retains only CXR-VQA samples for which the expert-annotated region is verified, via counterfactual editing, to be causally responsible for the model's prediction. Using this framework across 11 attribution methods, six open-source LVLMs, and two output modes (direct answer and step-by-step reasoning), we find that existing attribution methods often fail to identify the evidence used by LVLMs. To address this failure, we propose MedFocus, a concept-based attribution method that localizes clinically meaningful anatomical regions via unbalanced optimal transport and measures their causal effect on model outputs through targeted interventions. MedFocus produces spatial, concept-level, and token-level attributions and substantially outperforms prior methods, taking a step toward more trustworthy attribution for medical LVLMs. Our data and code are available at https://github.com/gzxiong/medfocus/.",
-      "authors": [
-        "Guangzhi Xiong",
-        "Qiao Jin",
-        "Sanchit Sinha",
-        "Zhiyong Lu",
-        "Aidong Zhang"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.AI",
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20158v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20158v1",
-      "publishedAt": "2026-05-19T17:46:40.000Z",
-      "updatedAt": "2026-05-19T17:46:40.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20157v1",
-      "title": "SAGE: Scalable Automatic Gating Ensemble for Confident Negative Harvesting in Fraud Detection",
-      "summary": "Music streaming fraud, where bad actors artificially inflate stream counts to manipulate chart rankings and royalty payments, poses a significant threat to streaming services and legitimate content creators. Traditional fraud detection approaches struggle with a critical challenge: many legitimate edge cases, including super-fans and sleep-music sessions, exhibit activity patterns that closely mimic those of coordinated fraud. We present SAGE, a novel counterfactual-aware negative harvesting approach that combines SimHash-based stratified sampling with a modular gating ensemble for confident negative identification from unlabeled data. Our ensemble architecture employs pluggable statistical gates (currently instantiated with Mahalanobis distance and k-NN density) with configurable voting thresholds enabling adaptive precision-recall trade-offs. This addresses the representation bias problem in Positive-Unlabeled learning by ensuring comprehensive coverage of rare behavioral cohorts through floor-constrained sampling. Evaluation demonstrates strong precision and recall on held-out data. The approach generalizes across fraud detection domains, achieving strong performance on both customer-level and artist-level fraud without modification to the core methodology.",
-      "authors": [
-        "Sudheer Tubati",
-        "Amit Goyal"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.CR",
-        "cs.IR"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20157v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20157v1",
-      "publishedAt": "2026-05-19T17:46:31.000Z",
-      "updatedAt": "2026-05-19T17:46:31.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20151v1",
-      "title": "When Does Model Collapse Occur in Structured Interactive Learning?",
-      "summary": "The proliferation of generative artificial intelligence has given rise to an interactive learning environment, where model parameters are continuously updated using not only data generated by natural processes, but also synthetic outputs produced by other models. This paradigm introduces two major challenges: (1) training data are no longer drawn exclusively from the target population, undermining a core assumption of classical statistical learning, and (2) model training processes become inherently correlated, as models interact with one another through repeated exposure to each other's synthetic outputs in a potentially complex manner. Establishing reliable statistical inference in such structured interactive learning environments therefore remains an important open problem. In particular, there is growing concern about model collapse, a phenomenon in which the performance of generative models progressively degrades as they are trained on synthetic data produced by earlier model generations. Prior work on model collapse primarily focuses on a single model trained on its own output, failing to capture model performance in multi-model interactive settings. In this work, we fill this gap by investigating the performance of generative models in an interactive learning environment with general interaction patterns. In particular, we formalize model interactions using directed graphs and show that the occurrence of model collapse depends critically on the topology of the interaction graph. We further derive an explicit necessary and sufficient condition characterizing when model collapse occurs, and establish finite-sample results for linear regression and asymptotic guarantees for general M-estimators. We support our theoretical findings through extensive numerical experiments.",
-      "authors": [
-        "Yuchen Wu",
-        "Kangjie Zhou",
-        "Weijie Su"
-      ],
-      "categories": [
-        "cs.LG",
-        "math.ST"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20151v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20151v1",
-      "publishedAt": "2026-05-19T17:41:09.000Z",
-      "updatedAt": "2026-05-19T17:41:09.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20150v1",
-      "title": "TideGS: Scalable Training of Over One Billion 3D Gaussian Splatting Primitives via Out-of-Core Optimization",
-      "summary": "Training 3D Gaussian Splatting (3DGS) at billion-primitive scale is fundamentally memory-bound: each Gaussian primitive carries a large attribute vector, and the aggregate parameter table quickly exceeds GPU capacity, limiting prior systems to tens of millions of Gaussians on commodity single-GPU hardware. We observe that 3DGS training is inherently sparse and trajectory-conditioned: each iteration activates only the Gaussians visible from the current camera batch, so GPU memory can serve as a working-set cache rather than a persistent parameter store. Building on this insight, we introduce TideGS, an out-of-core training framework that manages parameters across an SSD-CPU-GPU hierarchy via three synergistic techniques: block-virtualized geometry for SSD-aligned spatial locality, a hierarchical asynchronous pipeline to overlap I/O with computation, and trajectory-adaptive differential streaming that transfers only incremental working-set deltas between iterations. Experiments show that TideGS enables training with over one billion Gaussians on a single 24 GB GPU while achieving the best reconstruction quality among evaluated single-GPU baselines on large-scale scenes, scaling beyond prior out-of-core baselines (e.g., approximately 100M Gaussians) and standard in-memory training (e.g., approximately 11M Gaussians).",
-      "authors": [
-        "Chonghao Zhong",
-        "Linfeng Shi",
-        "Hua Chen",
-        "Tiecheng Sun",
-        "Hao Zhao",
-        "Binhang Yuan",
-        "Chaojian Li"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.PF"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20150v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20150v1",
-      "publishedAt": "2026-05-19T17:40:59.000Z",
-      "updatedAt": "2026-05-19T17:40:59.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20149v1",
-      "title": "Less Back-and-Forth: A Comparative Study of Structured Prompting",
-      "summary": "Large language models (LLMs) are widely used for open-ended tasks, but underspecified prompts can lead to low-quality answers and additional interaction. This paper studies whether structured prompt design improves response quality while reducing user effort. We compare three prompt conditions: a raw prompt, a checklist-improved prompt, and a clarifying-question prompt. We evaluate these conditions across four task types--summarization, planning, explanation, and coding--using three LLM systems: ChatGPT, Claude, and Grok. Each output is scored with a unified rubric covering task completion, correctness, compliance, and clarity. Checklist-improved prompts achieved the highest mean rubric score, 7.50 out of 8, compared with 5.67 for raw prompts and 6.67 for clarifying-question prompts. Checklist prompts also produced the best quality-effort tradeoff, using fewer average tokens than both raw and clarifying prompts. These results suggest that a simple prompt checklist can improve LLM responses while reducing unnecessary interaction.",
-      "authors": [
-        "Saurav Ghosh",
-        "Gabriella Polach",
-        "Abdou Sow"
+        "Xiaoqiang Wang",
+        "Chao Wang",
+        "Hadi Nekoei",
+        "Christopher Pal",
+        "Alexandre Lacoste",
+        "Spandana Gella",
+        "Bang Liu",
+        "Perouz Taslakian"
       ],
       "categories": [
         "cs.CL",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21463v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21463v1",
+      "publishedAt": "2026-05-20T17:51:05.000Z",
+      "updatedAt": "2026-05-20T17:51:05.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21461v1",
+      "title": "A Machine Learning Framework for Weighted Least Squares GNSS Positioning based on Activation Functions",
+      "summary": "Global Navigation Satellite Systems (GNSS) are widely used to provide position, velocity, and timing (PVT) information for various applications, including transportation, location-based communication services, and intelligent agriculture. In urban canyons, high-rise buildings and narrow streets can cause signal obstruction, non-line-of-sight (NLOS) reception, and multipath effects that introduce errors in GNSS pseudorange measurements. Although multi-constellations GNSS effectively increase the number of available satellites, the inclusion of degraded signals can lead to severe positioning errors. This study proposes a machine learning framework for the weighted least squares (WLS) algorithm incorporating activation functions to enhance positioning accuracy. Several signal quality indicators are employed as training features for ensemble learning algorithms to identify poor quality signals by providing quality scores. Then, activation functions are employed to transform the machine learning predicted scores to appropriate weights for WLS positioning. To evaluate the performance of our approach, experiments are conducted using real-world datasets from Hong Kong and Tokyo urban areas. Comparative analysis of activation functions reveals that sigmoid functions consistently yield the greatest improvements with different machine learning algorithms and GNSS constellation configurations. The proposed algorithm demonstrates substantial reductions in positioning errors for both single- and multiconstellation scenarios. Furthermore, our results indicate that the proposed algorithm exhibits strong geographical transferability. The proposed algorithm maintains comparable level of performance when trained on data from other regions with similar levels of urbanization.",
+      "authors": [
+        "Pin-Hsun Lee",
+        "Harry Leib"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21461v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21461v1",
+      "publishedAt": "2026-05-20T17:50:14.000Z",
+      "updatedAt": "2026-05-20T17:50:14.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21460v1",
+      "title": "HITL-D: Human In The Loop Diffusion Assisted Shared Control",
+      "summary": "Autonomous manipulation systems have achieved remarkable capabilities, yet the integration of human expertise with diffusion-based policies in shared control remains relatively unexplored. In this paper, we propose Human-In-The-Loop Diffusion (HITL-D), a shared control framework that enhances user performance in multi-step, insertion, and fine manipulation tasks. HITL-D leverages a novel combination of diffusion-based policies and human control to provide autonomous end effector orientation updates conditioned on a scene point cloud and the Cartesian position of the end effector. This approach reduces the number of joystick control axes required, thereby lowering mental workload. In a multi-task user study with 12 participants, HITL-D reduced average task completion times by 40%, decreased perceived workload by 37%, and improved Likert-scale ratings for independence, intuitiveness, and confidence compared to traditional teleoperation methods. These results demonstrate that HITL-D effectively integrates human expertise with autonomous assistance, improving both objective and subjective aspects of teleoperation.",
+      "authors": [
+        "Riley Zilka",
+        "Sergey Khlynovskiy",
+        "Allie Wang",
+        "Martin Jagersand"
+      ],
+      "categories": [
+        "cs.RO",
         "cs.AI",
         "cs.HC"
       ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20149v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20149v1",
-      "publishedAt": "2026-05-19T17:40:14.000Z",
-      "updatedAt": "2026-05-19T17:40:14.000Z",
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.21460v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21460v1",
+      "publishedAt": "2026-05-20T17:49:56.000Z",
+      "updatedAt": "2026-05-20T17:49:56.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20147v1",
-      "title": "PixVerve: Advancing Native UHR Image Generation to 100MP with a Large-Scale High-Quality Dataset",
-      "summary": "Text-to-Image (T2I) models have recently seen notable progress around 1K and 2K resolution. With the extreme desire for better visual experience and the rapid development of imaging technology, the demand for Ultra-High-Resolution (UHR) image generation has grown significantly. However, UHR image generation poses great challenges due to the scarcity and complexity of high-resolution content. In this paper, we first introduce PixVerve-95K, a high-quality, open-source UHR T2I dataset curated with a carefully designed data pipeline, which contains 95K images across diverse scenarios (each image has a minimum pixel-count of 100M) and seven-dimensional annotations. Based on our large-scale image-text dataset, we take a pioneering step to extend various T2I foundation models to native 100MP generation with three training schemes. Finally, leveraging both conventional metrics and multimodal large language model-based assessments, our proposed PixVerve-Bench benchmark establishes a comprehensive evaluation protocol for UHR images encompassing visual quality and semantic alignment. Extensive experimental results on our benchmark and the constructive exploration of training strategies collaboratively provide valuable insights for future breakthroughs.",
+      "arxivId": "2605.21458v1",
+      "title": "Mind the Sim-to-Real Gap & Think Like a Scientist",
+      "summary": "Suppose a planner has a pre-trained simulator of a sequential decision problem and the option to run real experiments in the field. The simulator is cheap to query but inherits confounding and drift from its calibration data. Experimentation is unbiased but consumes one real unit per trial. We study when, and how, the planner should supplement the simulator with experiments. We give three results. First, an extended simulation lemma decomposes the simulator's value error into a calibration--deployment shift that randomization can identify and a parametric residual that no further interaction can reduce. Second, the value gap between the simulator-optimal policy and the optimum splits into a local component, on states the deployed policy already visits, and a reachability component, on states it does not. The reachability component stays bounded away from zero at any horizon under purely passive learning. Third, we propose Fisher-SEP, a simulation-aided experimental policy (SEP) that minimizes the posterior predictive variance of a target policy's value, with reward-only and transition-only specializations. Two case studies illustrate the regimes. In a vending-machine supply chain, front-loaded experimentation overtakes posterior updating once the horizon is long enough to amortize the pilot. In an HIV mobile-testing example with a corridor that separates a well-surveilled region from a poorly-surveilled one, only designed exploration reaches the poorly-surveilled region.",
       "authors": [
-        "Haojun Chen",
-        "Haoyang He",
-        "Chengming Xu",
-        "Qingdong He",
-        "Junwei Zhu",
-        "Yabiao Wang",
-        "Zhucun Xue",
-        "Xianfang Zeng",
-        "Zhennan Chen",
-        "Xiaobin Hu",
-        "Hao Zhao",
-        "Yong Liu",
-        "Jiangning Zhang",
-        "Dacheng Tao"
+        "Harsh Parikh",
+        "Gabriel Levin-Konigsberg",
+        "Dominique Perrault-Joncas",
+        "Alexander Volfovsky"
       ],
       "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20147v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20147v1",
-      "publishedAt": "2026-05-19T17:35:09.000Z",
-      "updatedAt": "2026-05-19T17:35:09.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20145v1",
-      "title": "Goal-Oriented Lower-Tail Calibration of Gaussian Processes for Bayesian Optimization",
-      "summary": "Bayesian optimization (BO) selects evaluation points for expensive black-box objectives using Gaussian process (GP) predictive distributions. Kernel choice and hyperparameter selection can lead to miscalibrated predictive distributions and an inappropriate exploration-exploitation trade-off. For minimization, sampling criteria such as expected improvement (EI) depend on the predictive distribution below the current best value, so lower-tail miscalibration directly affects the sampling decision. This article studies goal-oriented calibration of GP predictive distributions below a low threshold $t$ in the noiseless setting, for standard GP models with hyperparameters selected by maximum likelihood. A framework for predictive reliability below $t$ is introduced, based on two notions of spatial calibration: occurrence calibration over the design space and thresholded $μ$-calibration on sublevel sets of the form $\\{x\\in\\mathbb{X}, f(x)\\le t\\}$. Building on this framework, we propose tcGP, a post-hoc method that calibrates GP predictive distributions below~$t$, and we show that the resulting EI-based global optimization algorithm remains dense in the design space. Experiments on standard benchmarks show improved lower-tail calibration and BO performance relative to standard GP models and globally calibrated GP models.",
-      "authors": [
-        "Aurélien Pion",
-        "Emmanuel Vazquez"
-      ],
-      "categories": [
-        "stat.ML",
+        "cs.AI",
         "cs.LG",
         "stat.ME"
       ],
-      "primaryCategory": "stat.ML",
-      "absUrl": "https://arxiv.org/abs/2605.20145v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20145v1",
-      "publishedAt": "2026-05-19T17:32:25.000Z",
-      "updatedAt": "2026-05-19T17:32:25.000Z",
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.21458v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21458v1",
+      "publishedAt": "2026-05-20T17:48:14.000Z",
+      "updatedAt": "2026-05-20T17:48:14.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20134v1",
-      "title": "TrajTok: Adaptive Spatial Tokenization for Trajectory Representation Learning",
-      "summary": "Learning generalizable trajectory representations from raw GPS traces remains difficult because the data is continuous, noisy, and irregularly sampled. Spatial tokenization is also challenging: fine grids yield sparse cells with weak embeddings, while coarse grids merge heterogeneous movement patterns into the same token. We present TrajTok, a trajectory encoder with a simple pretraining recipe for transferable trajectory embeddings. TrajTok first learns a multi-resolution hexagonal cell partition from the spatial distribution of GPS points, converting noisy GPS sequences into discrete cell tokens. To capture both geometry and kinematics, it uses a factorized transformer encoder with early per-modality self-attention blocks, cross-attention fusion layers, and spatiotemporal rotary position embeddings, ST-RoPE, to encode where and when each token occurs. TrajTok is pretrained with masked-token modeling that recovers both geometric structure and kinematic patterns from partial trajectory observations. On the Porto dataset, a frozen TrajTok encoder with lightweight task adapters achieves strong performance across trajectory similarity search, classification, estimated time of arrival, and full travel-time regression, outperforming multiple task-specific methods. The same frozen encoder supports both geometry-dominated and kinematics-dominated tasks, suggesting that TrajTok learns transferable trajectory structure rather than task-specific shortcuts. These results indicate that learned multi-resolution spatial tokenization combined with masked-token pretraining is a promising direction for general-purpose trajectory foundation models.",
+      "arxivId": "2605.21455v1",
+      "title": "Mitigating Label Bias with Interpretable Rubric Embeddings",
+      "summary": "Statistical decision algorithms are increasingly deployed in domains where ground-truth labels are hard to obtain, such as hiring, university admissions, and content moderation. In these settings, models are typically trained on historical human evaluations -- for example, using past hiring decisions as a proxy for true applicant quality. However, if past evaluations unjustly favor certain groups, models trained on these labels may inherit those biases. To address this problem, we propose basing predictions on rubric embeddings, a representation framework that replaces standard black-box embeddings with features derived from expert-defined criteria that align with the underlying construct of interest. By anchoring predictions to semantically meaningful dimensions, this approach guards against biased proxy signals. We provide both theoretical and empirical evidence that rubric embeddings mitigate label bias under plausible conditions. Empirically, we evaluate our method on a novel dataset of applications to a large master's program. We find that models trained on rubric embeddings reduce group disparities while improving measures of cohort quality. Our results suggest that basing predictions on interpretable, domain-grounded representations offers a practical approach to learning in the presence of biased labels.",
       "authors": [
-        "Zhen Xiong",
-        "Shang-Ling Hsu",
-        "Cyrus Shahabi"
+        "Calvin Isley",
+        "Johann D. Gaebler",
+        "Sharad Goel"
       ],
       "categories": [
         "cs.LG"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20134v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20134v1",
-      "publishedAt": "2026-05-19T17:18:32.000Z",
-      "updatedAt": "2026-05-19T17:18:32.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21455v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21455v1",
+      "publishedAt": "2026-05-20T17:46:08.000Z",
+      "updatedAt": "2026-05-20T17:46:08.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20132v1",
-      "title": "FiLark: a streaming-first software framework for end-to-end exploration, annotation, and algorithm integration in distributed acoustic sensing",
-      "summary": "Distributed acoustic sensing (DAS) systems generate continuous, ultra-high-channel-count data streams at rates that exceed the capabilities of conventional batch-oriented analysis frameworks. As a result, essential tasks such as interactive exploration of long-duration recordings, scalable event annotation, and real-time algorithm-in-the-loop monitoring remain inadequately supported by workflows built around manually selected data segments and offline processing. This paper presents FiLark (Fiber Lark), a Python framework that applies a \\emph{streaming-first} principle uniformly across data access, signal processing, visualization and monitoring for DAS. Instead of operating on manually selected data segments, FiLark presents any DAS sources-including continuous multi-file recordings-as a unified stream and builds all system components around that abstraction. An OpenGL-based ring-buffer renderer enables interactive browsing and visualization of arbitrarily long recordings with constant memory usage. An integrated annotation interface supports event labeling directly within continuous data streams, facilitating the creation of reproducible machine-learning-ready labeled datasets without offline preprocessing. The signal processing library includes temporal, spatial, spectral, and decomposition-based operators, with both CPU implementations and GPU-accelerated variants via PyTorch, alongside stateful chunked execution that preserves processing continuity and application semantics across segment boundaries. A standardized monitor interface further integrates streaming detectors and learning-based models into the visualization workflow. By sharing a common streaming abstraction across all layers, FiLark allows processing configurations and workflows developed interactively to transfer directly to scalable production pipelines without modification.",
+      "arxivId": "2605.21454v1",
+      "title": "ProtoPathway: Biologically Structured Prototype-Pathway Fusion for Multimodal Cancer Survival Prediction",
+      "summary": "We introduce ProtoPathway, an interpretable-by-design multimodal framework for cancer survival prediction that unifies whole slide imaging and transcriptomics through encoders producing biologically grounded representations on both sides of the fusion. On the histopathology side, $K$ learnable morphological prototypes, trained end-to-end with the survival objective, serve as the slide representation itself: patches flow into prototype tokens via soft assignment, compressing variable-length patch sets into fixed task-adaptive tokens. On the genomic side, a bipartite graph neural network encodes gene expression within the Reactome pathway hierarchy, producing pathway embeddings that reflect both constituent genes and their broader biological context through bidirectional message passing over a shared gene--pathway graph. Cross-modal attention then operates over a compact prototype $\\times$ pathway matrix in which prototypes query pathways, modeling the biological direction in which molecular programs give rise to tissue morphology. Because both axes carry stable task-learned identity, the attention matrix is itself an interpretability output, yielding native inference-time attribution across the full biological hierarchy, from genes through pathways and prototypes to spatial tissue maps. We evaluate on five TCGA cancer cohorts, demonstrating competitive or superior survival prediction with substantially improved biological interpretability and reduced computational cost, with interpretability claims validated through fold-stratified rank-based population-level analysis. Our source code, model weights, and Reactome pathways, together with a unified codebase reimplementing all multimodal survival baselines under identical preprocessing and evaluation, are available at: https://github.com/AmayaGS/ProtoPathway.",
       "authors": [
-        "Jintao Li",
-        "Weichang Li",
-        "Kai Tong",
-        "Xaingyu Guo"
+        "Amaya Gallagher-Syed",
+        "Costantino Pitzalis",
+        "Myles J. Lewis",
+        "Michael R. Barnes",
+        "Gregory Slabaugh"
+      ],
+      "categories": [
+        "cs.CV",
+        "q-bio.QM",
+        "q-bio.TO"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21454v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21454v1",
+      "publishedAt": "2026-05-20T17:43:43.000Z",
+      "updatedAt": "2026-05-20T17:43:43.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21453v1",
+      "title": "Quality and Security Signals in AI-Generated Python Refactoring Pull Requests",
+      "summary": "As AI agents increasingly contribute to code development and maintenance, there is still limited empirical evidence on the quality and risk characteristics of their changes in real-world projects, particularly for refactoring-oriented contributions. It remains unclear how agent-authored refactoring edits affect maintainability, code quality, and security once merged into GitHub repositories. To address this gap, we conduct an empirical study of Python refactoring pull requests (PRs) from the AIDev dataset. We analyze agentic refactoring PRs using PyQu, an ML-based quality assessment tool for Python, to quantify changes across five quality attributes, and we complement PyQu with domain-independent static analysis (Pylint and Bandit) to measure code quality and security issues before and after each change. Our results show that, on average, agentic commits improve a quality attribute in 22.5% of the studied changes, with usability improving most frequently (36.5%). At the same time, 24.17% of modified files introduce new Pylint issues predominantly convention level violations such as long lines-while 4.7% introduce new Bandit findings. From the observed diffs, we derive a taxonomy of 24 recurring change operations and map them to the lint and security findings they most commonly affect. Despite these mixed outcomes, developer acceptance is high: 73.5% of the analyzed PRs are merged, including cases that introduce new lint or security findings, often alongside the removal of existing issues. Overall, these findings highlight both the promise and current limitations of agentic refactoring, and motivate stronger tool-in-the-loop quality and security gating for AI-driven development workflows.",
+      "authors": [
+        "Mohamed Almukhtar",
+        "Anwar Ghammam",
+        "Hua Ming"
+      ],
+      "categories": [
+        "cs.SE",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.SE",
+      "absUrl": "https://arxiv.org/abs/2605.21453v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21453v1",
+      "publishedAt": "2026-05-20T17:43:36.000Z",
+      "updatedAt": "2026-05-20T17:43:36.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21451v1",
+      "title": "Approximation Theory for Neural Networks: Old and New",
+      "summary": "Universal approximation theorems provide a mathematical explanation for the expressive power of neural networks. They assert that, under mild conditions on the activation function, feedforward neural networks are dense in broad function classes, such as continuous functions on compact subsets of $\\mathbb{R}^d$, $L^p$ spaces, or Sobolev spaces. Over the past four decades, these qualitative universality results have evolved into a rich quantitative theory addressing approximation rates, parameter efficiency, and the role of architectural features such as depth and width. This survey presents several glimpses into this theory. We review classical density results for single-hidden-layer networks, as well as quantitative bounds that relate approximation error to network size and smoothness assumptions on target functions. Particular emphasis is placed on depth--width trade-offs and on results demonstrating that deeper architectures can achieve superior parameter efficiency for structured function classes. In addition to standard feedforward neural networks, we also review recent developments on Kolmogorov--Arnold Networks (KANs), which offer an alternative architectural paradigm and whose approximation-theoretic properties have begun to attract significant theoretical attention.",
+      "authors": [
+        "Soumendu Sundar Mukherjee",
+        "Himasish Talukdar"
+      ],
+      "categories": [
+        "cs.LG",
+        "cond-mat.dis-nn",
+        "cs.AI",
+        "cs.NE"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21451v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21451v1",
+      "publishedAt": "2026-05-20T17:42:34.000Z",
+      "updatedAt": "2026-05-20T17:42:34.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21446v1",
+      "title": "Lost in Fog: Sensor Perturbations Expose Reasoning Fragility in Driving VLAs",
+      "summary": "Interpretable autonomous driving planners depend not only on generating explanations, but also on those explanations remaining reliable under real-world sensor degradation. In this paper we present a controlled perturbation study of Vision-Language-Action (VLA) robustness in autonomous driving, evaluating Alpamayo R1 (10B parameters) across 1,996 scenarios under eight sensor perturbations (Gaussian noise at four intensities, two lighting extremes, and two fog levels; ${\\sim}18{,}000$ inference trials). We find that reasoning consistency is a high-fidelity indicator of trajectory reliability: when Chain-of-Causation (CoC) explanations change after perturbation, trajectory deviation spikes $5.3{\\times}$ (21.8m vs 4.1m), with $r\\!=\\!0.99$ across attack types and $r_{pb}\\!=\\!0.53$ per-sample (Cohen's $d\\!=\\!1.12$). A controlled ablation provides evidence that enabling CoC generation is associated with improved trajectory accuracy (11.8% on average across conditions; $p < 0.0001$) under matched inference settings. Over the tested noise range ($σ\\in \\{10, 30, 50, 70\\}$), degradation is approximately linear ($R^2\\!=\\!0.957$), while standard input preprocessing defenses provide only marginal relief. Together, these results establish CoC consistency as a quantitative proxy for planning safety and motivate reasoning-based runtime monitoring for safer VLA deployment.",
+      "authors": [
+        "Abhinaw Priyadershi",
+        "Jelena Frtunikj"
+      ],
+      "categories": [
+        "cs.RO",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.21446v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21446v1",
+      "publishedAt": "2026-05-20T17:34:02.000Z",
+      "updatedAt": "2026-05-20T17:34:02.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21443v1",
+      "title": "TempGlitch: Evaluating Vision-Language Models for Temporal Glitch Detection in Gameplay Videos",
+      "summary": "Vision-language models (VLMs) are increasingly being explored for video game quality assurance, especially gameplay glitch detection. Most existing evaluations, however, treat glitches as static visual anomalies, asking models to detect failures from a single frame. We argue that this framing misses a key distinction: some glitches are spatial and visible in an isolated frame, whereas others are temporal and become evident only through changes across ordered frames. A preliminary study confirms this gap, showing that temporal glitches are substantially harder for VLMs to detect than spatial ones. To enable systematic evaluation of this underexplored setting, we introduce TempGlitch, a controlled gameplay video benchmark for temporal glitch detection. TempGlitch covers five temporal glitch types with balanced per-category samples, together with paired glitch-free videos that enable reliable binary evaluation. We evaluate 12 proprietary and open-weight VLMs across multiple frame-sampling settings. Our results show that current VLMs remain near chance on TempGlitch, often collapsing into either overly conservative behavior that misses most glitches or overly sensitive behavior that flags clean videos as glitchy. Moreover, denser frame sampling and larger model size do not reliably resolve these failures. TempGlitch provides a focused testbed for temporal reasoning, robust gameplay understanding, and automated glitch detection with VLMs. Code and data are available at the project website.",
+      "authors": [
+        "Yakun Yu",
+        "Ashley Wiens",
+        "Adrián Barahona-Ríos",
+        "Benedict Wilkins",
+        "Saman Zadtootaghaj",
+        "Nabajeet Barman",
+        "Cor-Paul Bezemer"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21443v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21443v1",
+      "publishedAt": "2026-05-20T17:32:26.000Z",
+      "updatedAt": "2026-05-20T17:32:26.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21442v1",
+      "title": "torchtune: PyTorch native post-training library",
+      "summary": "Modern LLMs typically require multistage training pipelines to achieve strong downstream performance, with post-training serving as the main interface for adapting open-weight models. We introduce torchtune, a PyTorch-native library designed to streamline the post-training lifecycle of LLMs, enabling efficient fine-tuning, experimentation, and deployment-oriented workflows. Unlike many existing fine-tuning frameworks, which often optimize for ease of use, specialized recipes, or hardware efficiency at the cost of transparency and extensibility, torchtune emphasizes modularity, hackability, and direct access to the underlying PyTorch components. In this paper, we present the design principles behind torchtune, describe how they are reflected in its model builders, training recipes, and distributed training stack, and evaluate the library across representative post-training settings. We compare against popular fine-tuning frameworks, including Axolotl and Unsloth, and show that torchtune provides strong performance and memory efficiency across many settings while remaining flexible enough for rapid research iteration. These results position torchtune as a practical foundation for reproducible LLMs post-training research.",
+      "authors": [
+        "Mark Obozov",
+        "Maxime Griot",
+        "Joseph Cummings",
+        "Evan Smothers",
+        "Felipe Mello",
+        "Rafi Ayub",
+        "Philip John Bontrager",
+        "Salman Mohammadi",
+        "Ariel Kwiatkowski",
+        "Nathan Azrak",
+        "Mircea Mironenco"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21442v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21442v1",
+      "publishedAt": "2026-05-20T17:32:08.000Z",
+      "updatedAt": "2026-05-20T17:32:08.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21440v1",
+      "title": "ReMATF: Recurrent Motion-Adaptive Multi-scale Turbulence Mitigation for Dynamic Scenes",
+      "summary": "Atmospheric turbulence severely degrades video quality by introducing distortions such as geometric warping, blur, and temporal flickering, posing significant challenges to both visual clarity and temporal consistency. Current state-of-the-art methods are based on transformer, 3D architectures and require multi-frame input, but their large computational cost and memory usage limit real-time deployment, especially in resource-constrained scenarios. In this work, we propose ReMATF, a lightweight recurrent framework that restores videos using only two frames at a time while preserving spatial detail and temporal stability. ReMATF combines a multi-scale encoder-decoder with temporal warping and a motion-adaptive temporal fusion module that performs per-pixel fusion between the warped previous output and the current prediction to enhance coherence without enlarging the temporal window. This design reduces flicker, sharpens details, and remains efficient. Experiments on synthetic and real turbulence datasets show consistent improvements in PSNR/SSIM and perceptual quality (LPIPS), along with substantially faster inference than multi-frame transformer baselines, making ReMATF suitable turbulence mitigation in resource-constrained scenarios.",
+      "authors": [
+        "Zhiming Liu",
+        "Zhicheng Zou",
+        "Nantheera Anantrasirichai"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21440v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21440v1",
+      "publishedAt": "2026-05-20T17:28:49.000Z",
+      "updatedAt": "2026-05-20T17:28:49.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21437v1",
+      "title": "Neural Negative Binomial Regression for Weekly Seismicity Forecasting: Per-Cell Dispersion Estimation and Tail Risk Assessment",
+      "summary": "Standard approaches to forecasting the weekly number of earthquakes on a spatial grid rely on the Poisson distribution with a single global dispersion assumption. We show that this assumption is systematically violated in seismic data from Central Asia (2010-2024), where a likelihood-ratio test with boundary correction strongly rejects the Poisson hypothesis (p < 10^{-179}). The main contribution of this work is the EarthquakeNet architecture, which provides an endogenous per-cell estimate of the overdispersion parameter alpha via a neural network (spatial embeddings + MLP), without explicit spatial covariance specification. In contrast to existing negative binomial regression approaches in seismological forecasting, which typically assume a single global alpha, the proposed per-cell formulation allows the model to identify spatial heterogeneity in seismic clustering and to construct probabilistic risk-aware alerts via quantiles of the predicted distribution. A walk-forward evaluation (2018-2023) over four systems shows an 8.6 percent reduction in mean pinball deviation (MPD) relative to a negative binomial GLM baseline. The strongest improvements are observed in the tail regime (Y >= 5), where the continuous ranked probability score (CRPS) of the proposed model is 12.5 percent lower than that of the baseline, indicating improved calibration in extreme-event forecasting.",
+      "authors": [
+        "Alim Igilik"
       ],
       "categories": [
         "physics.geo-ph",
         "cs.LG",
-        "eess.SP"
+        "stat.ML"
       ],
       "primaryCategory": "physics.geo-ph",
-      "absUrl": "https://arxiv.org/abs/2605.20132v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20132v1",
-      "publishedAt": "2026-05-19T17:17:02.000Z",
-      "updatedAt": "2026-05-19T17:17:02.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21437v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21437v1",
+      "publishedAt": "2026-05-20T17:27:27.000Z",
+      "updatedAt": "2026-05-20T17:27:27.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20128v1",
-      "title": "MixRea: Benchmarking Explicit-Implicit Reasoning in Large Language Models",
-      "summary": "Large language models (LLMs) are increasingly integrated into high-stakes decision-making. Inspired by the theory of \\emph{inattentional blindness} in human cognition, we investigate whether LLMs, trained on human-preferred corpora that embed attentional biases, exhibit a similar limitation: \\emph{failing to attend to subtle yet important contextual cues under explicit task instructions}. To evaluate this, we introduce the task of \\textbf{explicit-implicit reasoning} and present \\textbf{MixRea}, a benchmark of 2,246 multiple-choice questions across 9 reasoning types with varying distributions of explicit and implicit information. Evaluation of 21 advanced LLMs shows that even the best-performing reasoning model (Gemini 2.5 Pro) achieves only 42.8\\% consistency, revealing widespread inattentional blindness. To mitigate this, we propose \\textbf{Potential Relation Completion Prompting (PRCP)}, a prompting method that improves reasoning by recovering overlooked causal relations. Further analysis shows that this limitation persists across diverse multi-source reasoning tasks, highlighting the need for more cognitively aligned models.",
+      "arxivId": "2605.21435v1",
+      "title": "Gaussian Sheaf Neural Networks",
+      "summary": "Graph Neural Networks (GNNs) have become the de facto standard for learning on relational data. While traditional GNNs' message passing is well suited for vector-valued node features, there are cases in which node features are better represented by probability distributions than real vectors. Concretely, when node features are Gaussians, characterized by a mean and a covariance matrix, naively concatenating their parameters into a single vector and applying standard message passing discards the geometric and algebraic structure that governs means and covariances. We propose Gaussian Sheaf Neural Networks (GSNNs), a principled framework that incorporates these inductive biases into graph-based learning. Building on the theory of cellular sheaves, we derive a new Laplacian operator that generalizes the sheaf Laplacian to this setting and preserves its key properties. We complement our theoretical contributions with experiments on synthetic and real-world data that illustrate the practical relevance of GSNNs.",
       "authors": [
-        "Yuanqing Cai",
-        "Ziyi Huang",
-        "Minhao Liu",
-        "Lixin Duan",
-        "Wen Li",
-        "Yanru Zhang"
+        "André Ribeiro",
+        "Ana Luiza Tenório",
+        "Tiago da Silva",
+        "Diego Mesquita"
+      ],
+      "categories": [
+        "cs.LG",
+        "math.AT",
+        "math.CT"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21435v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21435v1",
+      "publishedAt": "2026-05-20T17:26:32.000Z",
+      "updatedAt": "2026-05-20T17:26:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21431v1",
+      "title": "iTryOn: Mastering Interactive Video Virtual Try-On with Spatial-Semantic Guidance",
+      "summary": "Video Virtual Try-On (VVT) aims to seamlessly replace a garment on a person in a video with a new one. While existing methods have made significant strides in maintaining temporal consistency, they are predominantly confined to non-interactive scenarios where models merely showcase garments. This limitation overlooks a crucial aspect of real-world apparel presentation: active human-garment interaction. To bridge this gap, we introduce and formalize a new challenging task: Interactive Video Virtual Try-On (Interactive VVT), where subjects in the video actively engage with their clothing. This task introduces unique challenges beyond simple texture preservation, including: (1) resolving the semantic ambiguity of interactions from standard pose information, and (2) learning complex garment deformations from video where interactive moments are sparse and brief. To address these challenges, we propose iTryOn, a novel framework built upon a large-scale video diffusion Transformer. iTryOn pioneers a multi-level interaction injection mechanism to guide the generation of complex dynamics. At the spatial level, we introduce a garment-agnostic 3D hand prior to provide fine-grained guidance for precise hand-garment contact, effectively resolving spatial ambiguity. At the semantic level, iTryOn leverages global captions for overall context and time-stamped action captions for localized interactions, synchronized via our novel Action-aware Rotational Position Embedding (A-RoPE). Extensive experiments demonstrate that iTryOn not only achieves state-of-the-art performance on traditional VVT benchmarks but also establishes a commanding lead in the new interactive setting, marking a significant step towards more dynamic and controllable virtual try-on experiences.",
+      "authors": [
+        "Jun Zheng",
+        "Zhengze Xu",
+        "Mengting Chen",
+        "Jing Wang",
+        "Jinsong Lan",
+        "Xiaoyong Zhu",
+        "Kaifu Zhang",
+        "Bo Zheng",
+        "Xiaodan Liang"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21431v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21431v1",
+      "publishedAt": "2026-05-20T17:23:32.000Z",
+      "updatedAt": "2026-05-20T17:23:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21429v1",
+      "title": "roto 2.0: The Robot Tactile Olympiad",
+      "summary": "Tactile-based reinforcement learning (RL) is currently hindered by fragmented research and a focus on over-saturated orientation tasks. We introduce v2 of the Robot Tactile Olympiad (\\texttt{roto 2.0}), a GPU-parallelised benchmark designed to standardise tactile-based RL across four distinct robotic morphologies (16-DOF to 24-DOF). Unlike prior benchmarks, roto focuses on end-to-end \"blind\" manipulation, utilising only proprioception and tactile sensing without state information or distillation. We demonstrate a significant performance leap, with our blind agents achieving 13 Baoding ball rotations in 10 seconds, an order of magnitude faster than current state-of-the-art speeds. By open-sourcing our environments and robustly tuned baselines, we reduce the barrier to entry and enable researchers to prioritise fundamental algorithmic challenges over tedious RL tuning. Website: https://elle-miller.github.io/roto/",
+      "authors": [
+        "Elle Miller",
+        "Jayaram Reddy",
+        "Ayush Deshmukh",
+        "Trevor McInroe",
+        "David Abel",
+        "Oisin Mac Aodha",
+        "Sethu Vijayakumar"
+      ],
+      "categories": [
+        "cs.RO",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.21429v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21429v1",
+      "publishedAt": "2026-05-20T17:22:33.000Z",
+      "updatedAt": "2026-05-20T17:22:33.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21428v1",
+      "title": "Polynomial-Time Robust Multiclass Linear Classification under Gaussian Marginals",
+      "summary": "We study the task of agnostic learning of multiclass linear classifiers under the Gaussian distribution. Given labeled examples $(x, y)$ from a distribution over $\\mathbb{R}^d \\times [k]$, with Gaussian $x$-marginal, the goal is to output a hypothesis whose error is comparable to that of the best $k$-class linear classifier. While the binary case $k=2$ has a well-developed algorithmic theory, much less is known for $k \\ge 3$. Even for $k=3$, prior robust algorithms incur exponential dependence on the inverse of the desired accuracy in both complexity and representation size. In this work, we develop new structural results for multiclass linear classifiers and use them to design fully polynomial-time robust learners with dimension-independent error guarantees. Our first result shows that the standard multiclass perceptron algorithm requires super-polynomially many samples and updates, even with clean labels and Gaussian marginals, revealing a basic obstruction absent in the binary case. Our main positive result is a pairwise improper-learning framework which yields an efficient learner with error $\\widetilde O(k^{3/2}\\sqrt{\\mathrm{opt}})+ε$ for general $k$. Additionally, we develop a sharper localization-based framework which leads to error $O(\\mathrm{opt})+ε$ for $k=3$, and error $\\mathrm{poly}(k)\\mathrm{opt}+ε$ for geometrically regular $k$-class linear classifiers.",
+      "authors": [
+        "Ilias Diakonikolas",
+        "Giannis Iakovidis",
+        "Mingchen Ma"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.DS"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21428v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21428v1",
+      "publishedAt": "2026-05-20T17:19:30.000Z",
+      "updatedAt": "2026-05-20T17:19:30.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21427v1",
+      "title": "PALS: Power-Aware LLM Serving for Mixture-of-Experts Models",
+      "summary": "Large language model (LLM) inference has become a dominant workload in modern data centers, driving significant GPU utilization and energy consumption. While prior systems optimize throughput and latency by batching, scheduling, and parallelism, they largely treat GPU power as a static constraint rather than a controllable resource. In this paper, we present a power-aware runtime for LLM serving, PALS, that treats GPU power caps as a first-class control knob and jointly optimizes them with software parameters such as batch size. The system combines lightweight offline power-performance models with a feedback-driven controller to select configurations that satisfy throughput targets while maximizing energy efficiency. We implement PALS within an existing LLM serving framework, vLLM, demonstrating that it requires no model retraining or API changes. Across multi-GPU systems and both dense and mixture-of-experts (MoE) models, PALS improves energy efficiency by up to 26.3%, reduces QoS violations by 4x to 7x under power constraints, and tracks dynamic power budgets. These results highlight the potential of integrating power control directly into LLM inference runtimes, enabling energy-proportional and grid-interactive AI systems.",
+      "authors": [
+        "Can Hankendi",
+        "Rana Shahout",
+        "Minlan Yu",
+        "Ayse K. Coskun"
+      ],
+      "categories": [
+        "cs.AI",
+        "cs.DC"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.21427v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21427v1",
+      "publishedAt": "2026-05-20T17:19:20.000Z",
+      "updatedAt": "2026-05-20T17:19:20.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21426v1",
+      "title": "Adaptive Signal Resuscitation: Channel-wise Post-Pruning Repair for Sparse Vision Networks",
+      "summary": "One-shot magnitude pruning can cause severe accuracy collapse in the high-sparsity regime, even when the pruning mask preserves the largest weights. We argue that this failure reflects a granularity mismatch in post-pruning repair. Under global magnitude pruning, nearly collapsed channels can coexist with channels that retain informative activation variance within the same layer. Existing layer-wise activation repair methods apply a single correction to the whole layer, and can therefore over-amplify damaged channels while trying to restore the layer-level signal. We propose Adaptive Signal Resuscitation (ASR), a training-free channel-wise repair method that matches the granularity of repair to the granularity of damage. ASR estimates a variance-matching correction for each output channel and stabilizes it with a data-driven shrinkage rule, suppressing unreliable corrections for channels with weak post-pruning signal while preserving corrections for healthier channels. Applied before BatchNorm recalibration, ASR requires only forward passes on a small calibration set and no retraining. Across three datasets, four convolutional architectures, and both unstructured and structured sparsity settings, ASR generally improves over layer-wise repair, with the clearest gains in high-sparsity regimes. On ResNet-50 at 90% sparsity, ASR recovers 55.6% top-1 accuracy on CIFAR-10, compared with 41.0% for layer-wise repair and 28.0% for BatchNorm-only recalibration. Ablations show that naive channel-wise variance matching is insufficient, and that shrinkage stabilizes post-pruning repair.",
+      "authors": [
+        "Qishi Zhan",
+        "Ziheng Chen",
+        "Minxuan Hu"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21426v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21426v1",
+      "publishedAt": "2026-05-20T17:19:01.000Z",
+      "updatedAt": "2026-05-20T17:19:01.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21422v1",
+      "title": "Preference-aware Influence-function-based Data Selection Method for Efficient Fine-Tuning",
+      "summary": "As LLMs continue to scale, improving training efficiency increasingly depends on using data more effectively. Data selection addresses this problem by allocating a limited training budget to samples that best promote a target behavior. Existing methods usually represent the target behavior with a set of target examples, but often treat these examples as equally important. This can be inefficient because target examples may differ in their relevance to the current model: examples closer to the model's current behavior provide more actionable guidance than those farther away. We propose PRISM (PReference-aware Influence-function-based Data Selection Method for Efficient Fine-Tuning), which uses the current model's preference to weight target examples and construct a preference-aware target representation. PRISM then scores candidate training samples by their alignment with this representation, concentrating the data budget on samples more likely to move the model toward the target behavior. Theoretical analysis shows that this preference weighting yields a more effective first-order direction for increasing target-behavior preference. Experiments across model families and scales show that PRISM improves both efficient fine-tuning and safety-oriented SFT repair, demonstrating that precise target-behavior characterization is key to budget-efficient data selection.",
+      "authors": [
+        "Qihao Lin",
+        "Guanxu Chen",
+        "Dongrui Liu",
+        "Jing Shao"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21422v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21422v1",
+      "publishedAt": "2026-05-20T17:15:43.000Z",
+      "updatedAt": "2026-05-20T17:15:43.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21421v1",
+      "title": "AIGaitor: Privacy-preserving and cloud-free motion analysis for everyone, using edge computing",
+      "summary": "Motion capture is the gold standard for measuring human movement, but clinical use remains limited by cost, technical complexity, and privacy concerns. AIGaitor is a privacy-preserving, cloud-free motion analysis system that runs markerless monocular motion-capture pipelines and downstream deep-learning analysis entirely on a consumer smartphone using on-device neural accelerators. To motivate its design, we surveyed 74 rehabilitation clinicians: 92 percent said they would adopt an accurate, cost-effective, easy-to-use AI gait analysis tool, while 79.7 percent cited operating cost, 68.9 percent insufficient training, and 64.9 percent privacy concerns as leading barriers. We then optimized and benchmarked mobile iOS implementations of current monocular pipeline components, including 2D and 3D pose estimation, pose optimization, skeleton-based deep-learning analysis, and a vision-language model. A Time-Priority end-to-end on-device pipeline processes a 10 s 4K 60 fps video clip in 77 s on an iPhone 14, matching or beating the same pipeline on a high-end NVIDIA H200 cloud server when network transfer is included: 94 s at global mobile-average uplink and 66 s at developed-world Wi-Fi. Lightweight models such as ViTPose-s achieve real-time keypoint extraction, and skeleton-based action-recognition models provide sub-millisecond gait classification on the same clip. To our knowledge, AIGaitor is the first monocular system to demonstrate end-to-end on-device motion capture and downstream deep-learning analysis, supporting clinically applicable movement analysis that is low-cost, private, and accessible to smartphone users.",
+      "authors": [
+        "Lauhitya Reddy",
+        "Trisha M. Kesar",
+        "Hyeokhyen Kwon"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21421v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21421v1",
+      "publishedAt": "2026-05-20T17:14:57.000Z",
+      "updatedAt": "2026-05-20T17:14:57.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21420v1",
+      "title": "HiRes: Inspectable Precedent Memory for Reaction Condition Recommendation",
+      "summary": "Reaction condition recommendation sits immediately after retrosynthetic disconnection selection, and in practice, chemists require both accurate predictions and the precedents that justify them. We present HiRes (Hierarchical Reaction Representations), a retrieval-augmented condition recommendation system whose learned reaction space serves as both a classifier feature and an inspectable precedent memory. The model combines a graph encoder, transformation-aware cross-attention, multi-stream reaction fusion, and a k-NN retrieval layer. HiRes achieves state-of-the-art performance among primary-slot USPTO-Condition models, reaching Catalyst, Solvent, and Reagent top-1 accuracies (Acc@1) of 0.929, 0.534, and 0.530 respectively. It ties the best reported baseline on Catalyst while outperforming models such as REACON on Solvent and Reagent. Furthermore, paired bootstrap analysis demonstrates that integrating retrieval with learned condition heads provides statistically significant gains for solvent and reagent selection over purely parametric approaches. Ultimately, HiRes bridges the gap between predictive accuracy and chemical interpretability, offering a single representation that supplies both competitive recommendations and the concrete chemical precedents necessary for practical synthesis planning.",
+      "authors": [
+        "Shreyas Vinaya Sathyanarayana",
+        "Raja Sekhar Pappala",
+        "Deepak Warrier"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI",
+        "q-bio.MN"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21420v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21420v1",
+      "publishedAt": "2026-05-20T17:14:46.000Z",
+      "updatedAt": "2026-05-20T17:14:46.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21418v1",
+      "title": "FedCritic: Serverless Federated Critic Learning-based Resource Allocation for Multi-Cell OFDMA in 6G",
+      "summary": "In sixth-generation (6G) ultra-dense networks, aggressive frequency reuse amplifies inter-cell interference (ICI), making multi-cell orthogonal frequency-division multiple access (OFDMA) scheduling and power control strongly coupled across neighboring cells. We study distributed downlink resource management -- joint subcarrier scheduling and power allocation -- under interference coupling and long-term per-user quality-of-service (QoS) minimum-rate constraints. By using virtual-queue deficit weights to enforce long-term QoS, we develop FedCritic, a serverless federated multi-agent actor-critic framework with decentralized execution. Unlike centralized training with decentralized execution (CTDE) approaches that require centralized critic learning and joint trajectory aggregation, FedCritic federates the critic through lightweight gossip-based parameter averaging over the interference graph, enabling stable value estimation without a central coordinator while keeping policies local. Simulations in an interference-rich reuse-1 setting show that FedCritic improves mean signal-to-interference-plus-noise ratio (SINR) and cell-edge rate, increases network-wide average sum-rate and fairness relative to non-coordinated and CTDE baselines, and achieves more stable training with lower coordination overhead.",
+      "authors": [
+        "Amin Farajzadeh",
+        "Melike Erol-Kantarci"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI",
+        "cs.CV",
+        "cs.NI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21418v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21418v1",
+      "publishedAt": "2026-05-20T17:13:09.000Z",
+      "updatedAt": "2026-05-20T17:13:09.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21417v1",
+      "title": "Ordering Matters: Rank-Aware Selective Fusion for Blended Emotion Recognition",
+      "summary": "Blended emotion recognition is challenging because emotions are often expressed as mixtures of subtle and overlapping multimodal cues rather than a single dominant signal. We propose a rank-aware multi-encoder framework that selectively combines complementary representations from diverse pre-extracted video and audio encoders. Our method projects heterogeneous encoder features into a shared latent space, estimates sample-wise encoder importance through an attention-based gating module, and fuses only the top-n most informative encoders. To better model blended emotions, we decouple prediction into presence and salience heads and align them through probability-level fusion. We further incorporate feature-level unsupervised domain adaptation without pseudo-labeling to improve robustness under distribution shift. Experiments on the BlEmoRE challenge show that the proposed framework outperforms strong individual encoders and naïve multi-encoder fusion baselines. Our final system ranked 2nd in the competition, supporting the effectiveness of rank-aware selective fusion for fine-grained blended emotion recognition.",
+      "authors": [
+        "Junghyun Lee",
+        "Hyunseo Kim",
+        "Hanna Jang",
+        "Junhyug Noh"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21417v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21417v1",
+      "publishedAt": "2026-05-20T17:12:55.000Z",
+      "updatedAt": "2026-05-20T17:12:55.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21414v1",
+      "title": "PointACT: Vision-Language-Action Models with Multi-Scale Point-Action Interaction",
+      "summary": "Vision-Language-Action (VLA) models have shown strong potential for general-purpose robotic manipulation by leveraging large pretrained vision-language backbones. However, most existing VLAs rely primarily on 2D visual representations, which limit their ability to reason about fine-grained geometry and spatial grounding - capabilities that are essential for precise and robust manipulation in 3D environments. In this paper, we propose PointACT, a dual-system 3D-aware VLA policy that integrates hierarchical 3D point cloud representations directly into the action decoding process. PointACT employs a multi-scale point-action interaction mechanism with efficient bottleneck window self-attention, enabling evolving action tokens to densely attend to both local geometric detail and global scene structure. We evaluate PointACT on the LIBERO and RLBench benchmarks and systematically compare it against monolithic and dual-system VLA baselines, including variants augmented with point cloud inputs. PointACT achieves consistent improvements across both benchmarks, increasing success rates by 10% on the challenging RLBench-10Tasks suite over state-of-the-art pretrained VLAs, with even larger gains when the vision-language backbone is frozen and the action expert is trained from scratch. Extensive ablation studies demonstrate that tightly coupling hierarchical 3D geometry with pretrained 2D semantic representations is critical for robust and spatially grounded robot control. Our results also highlight the promise of pretrained 3D representations for 3D-aware VLA policies.",
+      "authors": [
+        "Shizhe Chen",
+        "Paul Pacaud",
+        "Cordelia Schmid"
+      ],
+      "categories": [
+        "cs.RO",
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.21414v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21414v1",
+      "publishedAt": "2026-05-20T17:10:31.000Z",
+      "updatedAt": "2026-05-20T17:10:31.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21413v1",
+      "title": "Teaching AI Through Benchmark Construction: QuestBench as a Course-Based Practice for Accountable Knowledge Work",
+      "summary": "As AI becomes part of everyday learning, many courses teach students to use it mainly as a productivity tool: how to prompt, search, summarize, write, code, and use tools more efficiently. We argue that AI education also needs a setting in which students learn to test AI and understand their own role in judging machine-produced knowledge. To this end, we introduce a course-based practice that teaches AI through benchmark construction, using deep research systems as a concrete example of AI-era knowledge work. Students turn disciplinary knowledge into verifiable expert-level questions, review one another's designs for ambiguity and shortcuts, and evaluate AI systems on the resulting tasks. This activity gives students direct exposure to a powerful tool while asking them to specify what a trustworthy answer would require. The produced benchmark, QuestBench, consists of 256 questions across 14 humanities and social-science domains. Evaluation on QuestBench shows that student-designed tasks reveal hidden failures in current deep research systems: across thirteen evaluated systems, the mean question-level pass rate is only 16.85%, and the best-performing system, GPT-5.5, reaches a 57.58% pass rate. The failures are educationally useful because they show how fluent, source-backed answers can still miss the right query, source, term, or evidence standard. Reflections from five student contributors suggest that benchmark construction can help students see professional knowledge not only as content AI may retrieve, but as the basis for judging AI outputs. We present QuestBench as a benchmark artifact and as a reusable classroom setting for a larger educational question: how students can remain responsible knowledge actors as AI enters learning and professional work. The dataset is available at https://huggingface.co/datasets/PKUAIWeb/QuestBench/tree/main.",
+      "authors": [
+        "Haiyang Shen",
+        "Jiuzheng Wang",
+        "Taian Guo",
+        "Mugeng Liu",
+        "Wenchun Jing",
+        "Chongyang Pan",
+        "Siqi Zhong",
+        "Zhiyang Chen",
+        "Weichen Bi",
+        "Yudong Han",
+        "Xiaoying Bai",
+        "Yun Ma"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.21413v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21413v1",
+      "publishedAt": "2026-05-20T17:09:56.000Z",
+      "updatedAt": "2026-05-20T17:09:56.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21411v1",
+      "title": "RoadTones: Tone Controllable Text Generation from Road Event Videos",
+      "summary": "Existing video-language models can generate factual descriptions of road events but lack control over how these events are expressed: their tone, urgency, or style. This limits deployment in communication-critical settings where the effectiveness of a message depends on both content and presentation, not just factual accuracy. To mitigate this, we introduce a comprehensive dataset-model-evaluation suite for tone-controllable road video captioning. Our human-validated data generation pipeline expands road-video corpora with diverse tonal annotations and multi-tone captions, yielding the RoadTones-51K dataset. We propose RoadTones-VL-CoT, a controllable video-to-text model that also generates tone-conditioned Chain-of-Thought intermediate drafts for interpretability. We also introduce RoadTones-Eval, a new evaluation suite that jointly measures factual consistency and tone adherence. In addition, we conducted a user study whose results validate caption quality, tone control, and factual consistency. Together, these contributions lay the foundation for context-sensitive tone-controllable video captioning.",
+      "authors": [
+        "Chirag Parikh",
+        "Siddhi Pravin Lipare",
+        "Ravi Kiran Sarvadevabhatla"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21411v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21411v1",
+      "publishedAt": "2026-05-20T17:08:18.000Z",
+      "updatedAt": "2026-05-20T17:08:18.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21405v1",
+      "title": "Stdlib or Third-Party? Empirical Performance and Correctness of LLM-Assisted Zero-Dependency Python Libraries",
+      "summary": "Third-party Python libraries introduce dependency management overhead, supply chain risk, and deployment friction in constrained environments. A natural question is how much of this ecosystem can be replicated using only Python's standard library -- and at what correctness and performance cost. We address this empirically through zerodep, a growing collection of single-file Python modules, each a stdlib-only reimplementation of a popular third-party library, developed with LLM assistance under strict constraints: no external imports, single file, drop-in API compatibility, and mandatory correctness validation against the reference library. Spanning over 40 modules across 12 categories -- including serialization, networking, cryptography, agent protocols, and text processing -- zerodep provides a controlled testbed for two interrelated questions: (1) Where does the stdlib suffice? and (2) Can LLMs effectively generate correct, performant code under tight symbolic constraints? Systematic benchmarking shows that stdlib-only implementations achieve performance parity (within 2x of the reference) in the majority of cases. The primary performance cliff is C-extension-backed computation (image processing, binary serialization, low-level crypto), not the inherent overhead of pure-Python third-party libraries. Conversely, many widely-used libraries carry architectural overhead that LLM-generated stdlib reimplementations avoid, yielding 5--115x speedups in several categories. We characterize the stdlib capability boundary across complexity tiers and library categories, discuss where LLM-assisted development succeeds and where it requires iterative human correction, and examine implications for dependency-free software engineering at scale. zerodep is open-source at https://github.com/Oaklight/zerodep.",
+      "authors": [
+        "Peng Ding",
+        "Rick Stevens"
+      ],
+      "categories": [
+        "cs.SE",
+        "cs.AI",
+        "cs.PL"
+      ],
+      "primaryCategory": "cs.SE",
+      "absUrl": "https://arxiv.org/abs/2605.21405v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21405v1",
+      "publishedAt": "2026-05-20T17:02:54.000Z",
+      "updatedAt": "2026-05-20T17:02:54.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21404v1",
+      "title": "What Twelve LLM Agent Benchmark Papers Disclose About Themselves: A Pilot Audit and an Open Scoring Schema",
+      "summary": "We read twelve well-known LLM agent benchmark papers and recorded, dimension by dimension, what each paper actually says about how its evaluation was run. The motivation came from a familiar frustration: two papers will report results on the same benchmark with the same model name and disagree, and you cannot tell why -- the scaffold, the sampling settings, the subset, or the evaluator version. In many cases the published artifact does not let you answer. This paper is an implementation report on the attempt. We designed a small audit schema (five fields: benchmark identity, harness specification, inference settings, cost reporting, failure breakdown), wrote a scoring codebook with the boundary cases we hit during pilot scoring, applied it to twelve canonical papers (eight agent, four classical static), and recorded what we saw. We score the disclosure of an agent run, not its correctness, and make no claim that disclosure implies a trustworthy result. The mean audit score across the eight agent-benchmark papers is 0.38 (out of 1.0), and across the four classical static benchmarks 0.66; the largest gap is on cost (none of the eight agent benchmark papers disclose inference cost in any form) and on harness specification (none fully disclose a content-addressed container image of the evaluation environment). We release the schema as a JSON Schema file, the codebook as a Markdown document, and the raw scoring sheet as a CSV. The scoring was performed by a single auditor in one pass; a multi-rater audit is the natural next step, and we discuss what we think it would change.",
+      "authors": [
+        "Mahdi Naser Moghadasi",
+        "Faezeh Ghaderi"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21404v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21404v1",
+      "publishedAt": "2026-05-20T17:02:36.000Z",
+      "updatedAt": "2026-05-20T17:02:36.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21403v1",
+      "title": "Quantifying the cross-linguistic effects of syncretism on agreement attraction",
+      "summary": "Agreement attraction errors, in which a verb erroneously agrees with an intervening noun rather than its grammatical head, are amplified by morphological syncretism in some languages (English, German, Russian) but not others (Turkish, Armenian), a cross-linguistic pattern without a principled account. We use surprisal and attention entropy from large language models as processing proxies to investigate this variation across four languages. LLM-derived measures replicate behavioral findings in English and German (syncretism modulates attraction), align with Turkish null results (no modulation), and partially capture Russian patterns. We discuss further directions for better understanding why syncretism affects agreement attraction differently across languages.",
+      "authors": [
+        "Utku Turk",
+        "Eva Neu"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20128v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20128v1",
-      "publishedAt": "2026-05-19T17:15:08.000Z",
-      "updatedAt": "2026-05-19T17:15:08.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21403v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21403v1",
+      "publishedAt": "2026-05-20T17:02:17.000Z",
+      "updatedAt": "2026-05-20T17:02:17.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20127v1",
-      "title": "Beyond Prediction Accuracy: Target-Space Recovery Profiles for Evaluating Model-Brain Alignment",
-      "summary": "Artificial vision models are often evaluated against the human visual cortex by measuring how accurately their internal representations predict brain responses. However, prediction accuracy alone does not indicate which dimensions of the target brain's response space are recovered. Here, we introduce a unified framework for evaluating both model-brain and brain-brain alignment by identifying the response dimensions recovered by prediction. Using repeated fMRI measurements, we first identify target-brain response dimensions that can be reproducibly predicted across independent trial splits. We then predict target-brain responses from either another subject's brain responses or a vision model's internal representations, and quantify how strongly each of these reproducible response dimensions is recovered. Applying this framework to a subset of the Natural Scenes Dataset, in which eight subjects viewed the same natural images during fMRI, we find that the early-to-intermediate visual-cortex responses contain a low-dimensional set of reproducible dimensions. Brain-to-brain comparisons identify which of these dimensions are consistently recoverable from other subjects' brains, providing a diagnostic human reference rather than only a scalar benchmark. In some cases, pretrained and randomly initialized models achieve similar prediction accuracy while showing distinct recovery profiles across these response dimensions. These results show that prediction accuracy alone can mask model-brain mismatches. By making explicit which reproducible brain response dimensions are recovered by prediction, our framework provides a more diagnostic evaluation of alignment between artificial vision models and the human visual cortex.",
+      "arxivId": "2605.21402v1",
+      "title": "Memorisation, convergence and generalisation in generative models",
+      "summary": "Generative neural networks learn how to produce highly realistic images from a large, but finite number of examples - or do they simply memorise their training set? To settle this question, Kadkhodaie, Guth, Simoncelli and Mallat (ICLR '24) trained diffusion models independently on disjoint subsets of a dataset and showed that they converge to nearly the same density when the number of training images is large enough. This result raises two basic questions: how much data do you need for convergence, and what does convergence capture about learning the data distribution? Here, we address these questions by providing an exact analytical characterisation of the transition from memorisation to generalisation in linear generative models. We find that these models memorise at small load, while convergence emerges continuously when the number of samples is linear in the input dimension. Strikingly, we find that convergence is insensitive to recovery of the principal latent factors of the data, which are recovered in a sharp transition. After extending our approach to data with power-law spectra, we find the same distinction between convergence and latent recovery in our experiments with convolutional denoisers and in the data of Kadkhodaie et al. We thus show that generalisation in generative models decomposes into at least two distinct objectives: matching the bulk of the data distribution and recovering the principal latent factors. These objectives correspond to two different distances between true and learnt data distribution, and only the first one is captured by convergence.",
       "authors": [
-        "Ken Nakamura",
-        "Tomoya Nakai",
-        "Ryuto Yashiro",
-        "Ayumu Yamashita",
-        "Kaoru Amano"
-      ],
-      "categories": [
-        "q-bio.NC",
-        "cs.AI",
-        "cs.LG"
-      ],
-      "primaryCategory": "q-bio.NC",
-      "absUrl": "https://arxiv.org/abs/2605.20127v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20127v1",
-      "publishedAt": "2026-05-19T17:14:27.000Z",
-      "updatedAt": "2026-05-19T17:14:27.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20122v1",
-      "title": "Optimizing Computational-Statistical Runtime for Wasserstein Distance Estimation",
-      "summary": "Squared Wasserstein distance is a frequently used tool to measure discrepancy between probability distributions. This distance is typically computed between empirical measures of size $n$ from two underlying random samples. Unfortunately, even in lower dimensional Euclidean space problems $\\left( d \\in \\{2,3\\} \\right)$, algorithms for Wasserstein distance computation with approximate or exact precision guarantees scale poorly in the runtime as a function of $n$ and the desired precision. In response, we consider the computational-statistical runtime, where the goal is to estimate from samples the Wasserstein distance between potentially smooth measures up to $ε$-additive error in expectation with respect to the sampling; we allow $O(1)$ computational cost for collecting a sample. Towards this, we develop a Sample-Sketch-Solve paradigm where we introduce a regular cartesian grid sketch of the samples. We show that (especially under $α$-Hölder smooth distributions) this can compress the data without increasing asymptotic error, and also regularizes the structure which enables faster exact algorithms. Ultimately, we approximate $W_2^2(P,Q)$ within $ε$ error in $ε^{-\\max(2,\\frac{d+1+o(1)}{1+α})}$ time for $0 < α< 1$ Hölder smooth distributions $P,Q$ on $(0,1)^{d}$; an optimal $Θ(ε^{-2})$ for $α> 1/2$ when $d=2$ and nearly optimal as $α\\to 1$ when $d = 3$.",
-      "authors": [
-        "Peter Matthew Jacobs",
-        "Jeff M. Phillips"
+        "Antoine Maillard",
+        "Sebastian Goldt"
       ],
       "categories": [
         "stat.ML",
-        "cs.CC",
+        "cond-mat.dis-nn",
+        "cond-mat.stat-mech",
         "cs.LG"
       ],
       "primaryCategory": "stat.ML",
-      "absUrl": "https://arxiv.org/abs/2605.20122v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20122v1",
-      "publishedAt": "2026-05-19T17:10:47.000Z",
-      "updatedAt": "2026-05-19T17:10:47.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21402v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21402v1",
+      "publishedAt": "2026-05-20T17:00:37.000Z",
+      "updatedAt": "2026-05-20T17:00:37.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20120v1",
-      "title": "Using Aristotle API for AI-Assisted Theorem Proving in Lean 4: A Formalisation Case Study of the Grasshopper Problem",
-      "summary": "AI-assisted theorem proving can now generate substantial Lean developments for olympiad-level mathematics, but the evidential status of such developments depends on which declarations are actually verified. This paper reports a Lean 4 formalization case study of an Aristotle API proof attempt for the Grasshopper problem, originally posed as IMO 2009 Problem 6. The generated artifact states a generalized Lean version of the theorem, contains four verified helper lemmas for local components of a maximality and adjacent-swap exchange strategy, and leaves the main theorem grasshopper closed directly by one unresolved sorry. The verified components establish that the final partial sum equals the total sum, that an adjacent transposition can affect only the relevant intermediate partial sum, that the changed partial sum has the expected form, and that maximality at a position admitting an adjacent successor swap forces a corresponding forbidden-set membership fact. The Aristotle output summary identifies the intended remaining mathematical step as the global counting step needed to show that these membership facts produce at least n distinct forbidden values, contradicting the cardinality assumption |M| < n; the Lean source itself does not reduce the main theorem to a separately encoded counting lemma. This case study gives an inspectable example of a central limitation in AI-assisted formalization, namely that local proof search can succeed while the global combinatorial bookkeeping required for a theorem remains unresolved. The paper contributes a reproducible Lean artifact and a precise analysis of its verified and unverified proof content.",
+      "arxivId": "2605.21401v1",
+      "title": "Open-source LLMs administer maximum electric shocks in a Milgram-like obedience experiment",
+      "summary": "Large language models (LLMs) are increasingly deployed as autonomous agents that make sequences of decisions over extended interactions in high-stakes domains. However, the behavior of LLMs under sustained authority pressure is still an open question with direct implications for the safety of agentic pipelines. We ran a variation of Milgram's obedience experiment on 11 open-source LLMs and found that most models reached or approached the final shock level before refusing, across 8 conditions with 30 trials per model per condition. We found four main takeaways: (1) LLMs are subject to pressure, and they comply despite explicitly expressing distress, just like human subjects did in the original experiment; (2) LLMs are vulnerable to gradual boundary/value violations; (3) when LLMs refuse, they may ignore the response format requirements, so the response is discarded by the orchestrator, which causes a retry that can result in compliance with the underlying request even when refusal was intended initially; (4) we hypothesise that there is a low-level token pattern continuation attractor that might be contributing to compliance, overriding higher level processing of the situation's meaning and values.",
       "authors": [
-        "Gabriel Rongyang Lau"
+        "Roland Pihlakas",
+        "Jan Llenzl Dagohoy"
+      ],
+      "categories": [
+        "cs.CY",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CY",
+      "absUrl": "https://arxiv.org/abs/2605.21401v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21401v1",
+      "publishedAt": "2026-05-20T16:59:44.000Z",
+      "updatedAt": "2026-05-20T16:59:44.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21395v1",
+      "title": "Towards Resilient and Autonomous Networks: A BlueSky Vision on AI-Native 6G",
+      "summary": "The proliferation of emerging applications, such as autonomous driving and immersive experiences, demands cellular networks that are not only faster, but fundamentally more resilient and autonomous. This paper presents a BlueSky vision on how Artificial Intelligence will be natively integrated into 6G, shifting the paradigm from \\underline{Network for AI} to \\underline{AI for Network}. We envision that, unlike 5G's reliance on scattered, ad-hoc models each trained for a single task, native AI in the 6G era will be anchored by a foundation model and and orchestrated via collaborative multi-agent systems, framing network management as a unified, multi-modal, multi-task optimization problem. Built on this vision, we outline two transformative directions. The first focuses on developing a 6G foundation model as a unified backbone, with task-specific knowledge distilled into compact models suited for diverse edge deployments. The second advances multi-agent systems designed to autonomously diagnose, maintain, and recover networks with minimal human intervention. These directions chart a roadmap for 6G to evolve into an intelligent, self-sustaining communication infrastructure.",
+      "authors": [
+        "Liang Wu",
+        "Kelly Wan",
+        "Mayank Darbari",
+        "Liangjie Hong"
       ],
       "categories": [
         "cs.AI",
-        "cs.LO"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20120v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20120v1",
-      "publishedAt": "2026-05-19T17:08:58.000Z",
-      "updatedAt": "2026-05-19T17:08:58.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20119v1",
-      "title": "Toto 2.0: Time Series Forecasting Enters the Scaling Era",
-      "summary": "We show that time series foundation models scale: a single training recipe produces reliable forecast-quality improvements from 4M to 2.5B parameters. We release Toto 2.0, a family of five open-weights forecasting models trained under this recipe. The Toto 2.0 family sets a new state of the art on three forecasting benchmarks: BOOM, our observability benchmark; GIFT-Eval, the standard general-purpose benchmark; and the recent contamination-resistant TIME benchmark. This report describes our experimental results and details the design decisions behind Toto 2.0: its architecture and training recipe, training data, and the u-muP hyperparameter transfer pipeline. All five base checkpoints are released under Apache 2.0.",
-      "authors": [
-        "Emaad Khwaja",
-        "Chris Lettieri",
-        "Gerald Woo",
-        "Eden Belouadah",
-        "Marc Cenac",
-        "Guillaume Jarry",
-        "Enguerrand Paquin",
-        "Xunyi Zhao",
-        "Viktoriya Zhukov",
-        "Othmane Abou-Amal",
-        "Chenghao Liu",
-        "Ameet Talwalkar",
-        "David Asker"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20119v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20119v1",
-      "publishedAt": "2026-05-19T17:08:24.000Z",
-      "updatedAt": "2026-05-19T17:08:24.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20110v1",
-      "title": "SetCon: Towards Open-Ended Referring Segmentation via Set-Level Concept Prediction",
-      "summary": "Referring segmentation grounds natural-language queries to pixel-level masks, but extending it to complex scenarios with multiple instances, cross-category groups, or open-ended target sets remains challenging. Previous Large Vision Language Model (LVLM)-based methods represent referred targets with one or more special tokens sequentially, treating multiple targets as separate outputs rather than a coherent set and offering little incentive to capture set-level properties such as completeness and mutual exclusivity. We reformulate open-ended referring segmentation as explicit set-level concept prediction and propose Set-Concept Segmentation (SetCon), which uses LVLM-generated natural-language concepts, instead of segmentation-specific tokens, as semantic conditions for joint mask-set decoding. A hierarchical semantic decomposition first predicts a shared set-level concept defining the target scope and then refines it into fine-grained concept groups aligned with target subsets. To support this, a two-stage annotation pipeline augments existing reasoning segmentation datasets with hierarchical semantic supervision (236k samples, 784k concept phrases). SetCon achieves state-of-the-art results on image benchmarks (+3.3 gIoU on gRefCOCO, +12.1 gIoU on MUSE), with margins that grow as the number of referred targets increases. The concept interface also transfers to video under a detect-and-track setting, yielding new state-of-the-art results on seven referring video benchmarks, including +10.9 J&F on MeViS and +12.4 J&F on Ref-SeCVOS.",
-      "authors": [
-        "Zhixiong Zhang",
-        "Yizhuo Li",
-        "Shuangrui Ding",
-        "Yuhang Zang",
-        "Shengyuan Ding",
-        "Long Xing",
-        "Yibin Wang",
-        "Qiaosheng Zhang",
-        "Jiaqi Wang"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20110v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20110v1",
-      "publishedAt": "2026-05-19T16:59:11.000Z",
-      "updatedAt": "2026-05-19T16:59:11.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20108v1",
-      "title": "k-Inductive Neural Barrier Certificates for Unknown Nonlinear Dynamics",
-      "summary": "While conventional (k=1) discrete-time barrier certificate conditions impose strict safety constraints by requiring the function to be non-increasing at every step, k-inductive barrier certificates relax this by allowing a temporary increase -- up to k-1 times, each within a threshold $ε$ -- while maintaining overall safety, and improving flexibility. This paper leverages neural networks and constructs k-inductive neural barrier certificates (k-NBCs) for (partially) unknown nonlinear systems. While neural networks offer scalability in the design process, they lack formal guarantees, requiring additional approaches such as counterexample-guided inductive synthesis (CEGIS) with satisfiability modulo theories (SMT) for verification. However, the CEGIS-SMT framework requires knowledge of system dynamics, which is unavailable in practical settings. To address this, we leverage the generalization of the Willems et al.'s fundamental lemma, using a single state trajectory, to construct a data-driven representation of (partially) unknown models for SMT verification without sacrificing accuracy. Additionally, CEGIS-SMT further removes the constraint of restricting barrier certificates to specific function classes, such as sum-of-squares, enabling greater flexibility in their design. We validate our approach on three nonlinear case studies with (partially) unknown dynamics.",
-      "authors": [
-        "Ben Wooding",
-        "Hongchao Zhang",
-        "Taylor T. Johnson",
-        "Abolfazl Lavaei"
-      ],
-      "categories": [
-        "eess.SY",
-        "cs.AI",
-        "cs.LG",
-        "cs.LO"
-      ],
-      "primaryCategory": "eess.SY",
-      "absUrl": "https://arxiv.org/abs/2605.20108v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20108v1",
-      "publishedAt": "2026-05-19T16:58:37.000Z",
-      "updatedAt": "2026-05-19T16:58:37.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20107v1",
-      "title": "Beyond Isotropy in JEPAs: Hamiltonian Geometry and Symplectic Prediction",
-      "summary": "JEPAs often regularize one-view embeddings toward an isotropic Gaussian, implicitly baking Euclidean symmetry into the representation. We show that this is not merely a benign default. For a known structured downstream geometry $H\\succ0$, the minimax and maximum-entropy covariance under a Hamiltonian energy budget is $(c/d)H^{-1}$, and Euclidean isotropy incurs a closed-form price of isotropy. More importantly, when the downstream geometry is unknown, no geometry-independent fixed marginal target is canonical: every fixed covariance shape can be maximally misaligned for some structured geometry. We further show that even oracle one-view marginals do not identify the JEPA view-to-view predictive coupling. These results suggest that the structural bias in JEPAs should enter the cross-view coupling rather than a fixed encoder marginal. We instantiate this principle with \\textbf{HamJEPA}, which encodes each view as a phase-space state $(q,p)$ and predicts view-to-view transitions with a learned Hamiltonian leapfrog map, while non-isotropic scale and spectral floors prevent collapse. In a deliberately headless token protocol, HamJEPA improves over SIGReg on CIFAR-100 by $+4.89$ kNN@20 and $+3.52$ linear-probe points at 30 epochs, and by $+6.45$ kNN@20 and $+10.64$ linear-probe points at 80 epochs, while a matched MLP predictor ablation shows that the symplectic coupling is the ingredient driving the neighborhood-geometry gain. On ImageNet-100, HamJEPA-$q$ improves by $+4.82$ kNN@20 and $+7.52$ linear-probe points at 45 epochs.",
-      "authors": [
-        "Robert Jenkinson Alvarez"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20107v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20107v1",
-      "publishedAt": "2026-05-19T16:57:47.000Z",
-      "updatedAt": "2026-05-19T16:57:47.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20105v1",
-      "title": "Optimal Representation Size: High-Dimensional Analysis of Pretraining and Linear Probing",
-      "summary": "Learning to generalise from limited data is a fundamental challenge for both artificial and biological systems. A common strategy is to extract reusable structure from abundant unlabelled data, enabling efficient adaptation to new tasks from limited labelled data. This two-stage paradigm is now standard in modern training pipelines, where pretraining is followed by fine-tuning or linear probing. We provide an analytical model of this process: structure extraction is formalized as principal component analysis on unlabelled data, and downstream learning as linear regression on a separate labelled dataset. In the high-dimensional regime, we derive exact expressions for training and generalisation error showcasing their dependence on representation dimensionality, unlabelled and labelled sample sizes, and task alignment. Our results show that pretrained representations strongly influence downstream generalisation, and we characterize the optimal representation size as a function of task parameters: with abundant pretraining data but scarce downstream data, maximally compressed representations are optimal, whereas with limited pretraining data, higher-dimensional representations generalise better. Furthermore, we establish an exact trade-off between pretraining and supervision, quantifying how much unlabelled data is required to replace a single labelled sample. Beyond our idealised model, we observe similar phenomenology in autoencoders and pretrained LLMs. Altogether, we highlight that optimising representation size is critical, giving conditions for when compression during pretraining improves generalisation.",
-      "authors": [
-        "Valentina Njaradi",
-        "Clémentine Dominé",
-        "Rachel Swanson",
-        "Marco Mondelli",
-        "Andrew Saxe"
-      ],
-      "categories": [
         "cs.LG"
       ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20105v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20105v1",
-      "publishedAt": "2026-05-19T16:56:56.000Z",
-      "updatedAt": "2026-05-19T16:56:56.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20104v1",
-      "title": "Draft Less, Retrieve More: Hybrid Tree Construction for Speculative Decoding",
-      "summary": "Speculative decoding (SD) accelerates large language model inference by leveraging a draft-then-verify paradigm. To maximize the acceptance rate, recent methods construct expansive draft trees, which unfortunately incur severe VRAM bandwidth and computational overheads that bottleneck end-to-end speedups. While dynamic-depth pruning can reduce this latency by removing marginal branches, it also discards potentially valid candidates, preventing the acceptance rate from reaching the upper bound of dense trees. In this paper, we identify a critical opportunity in resource allocation: the transition from dense to pruned drafting frees up significant computational budget. To break this Pareto tradeoff, we introduce Graft, a compensation framework that couples pruning and retrieval as mutually reinforcing operations. Pruning supplies sufficient budget for retrieval, while retrieval compensates for pruning-induced coverage loss and recovers accepted length. By employing a sequential `prune-then-graft' mechanism, Graft attaches highly predictive retrieved tokens into positions opened by pruning, filling the topological gaps with near-zero overhead. Graft is entirely training-free and lossless. Comprehensive evaluations show that Graft establishes a new Pareto frontier across practical deployment settings, including short-context generation, long-context generation, and large-scale models. On short-context benchmarks, it achieves up to 5.41$\\times$ speedup and improves average speedup over EAGLE-3 by up to 21.8% on the large-scale Qwen3-235B. We also provide a preliminary exploration of applying Graft to the DFlash-style block drafting paradigm, offering initial evidence and insights for extending grafting beyond autoregressive draft trees.",
-      "authors": [
-        "Yuhao Shen",
-        "Tianyu Liu",
-        "Xinyi Hu",
-        "Quan Kong",
-        "Baolin Zhang",
-        "Jun Dai",
-        "Jun Zhang",
-        "Shuang Ge",
-        "Lei Chen",
-        "Yue Li",
-        "Mingcheng Wan",
-        "Cong Wang"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20104v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20104v1",
-      "publishedAt": "2026-05-19T16:55:48.000Z",
-      "updatedAt": "2026-05-19T16:55:48.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20098v1",
-      "title": "Neurosymbolic Learning for Inference-Time Argumentation",
-      "summary": "Claim verification is an important problem in high-stakes settings, including health and finance. When information underpinning claims is incomplete or conflicting, uncertain answers may be more appropriate than binary true or false classifications. In all cases, faithful explanations of the considerations determining the final verdict are crucial. We introduce inference-time argumentation (ITA), a trainable neurosymbolic framework for ternary claim verification in which a formal argumentation semantics giving the strength of claims is used both (i) to guide LLM training as models learn to generate arguments and assign them base scores (representing intrinsic strengths) and (ii) to compute ternary (true/false/uncertain) predictions from generated, scored arguments. As a result, at training time, argument generation and scoring can be optimised according to the quality of the induced argumentative predictions. Moreover, at inference time, the final prediction is faithful, by construction, to the arguments and scores determining the verdict, rather than being justified by a potentially unfaithful post-hoc reasoning trace as in conventional reasoning models. We finally show that, on two datasets for ternary claim verification, ITA improves upon argumentative baselines and can perform competitively against non-argumentative direct-prediction baselines, while providing verdicts that are computed deterministically from explicit, inspectable argumentative structures.",
-      "authors": [
-        "Gabriel Freedman",
-        "Adam Dejl",
-        "Adam Gould",
-        "Mansi",
-        "Lihu Chen",
-        "Jianqi Jiang",
-        "Francesca Toni"
-      ],
-      "categories": [
-        "cs.AI"
-      ],
       "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20098v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20098v1",
-      "publishedAt": "2026-05-19T16:49:29.000Z",
-      "updatedAt": "2026-05-19T16:49:29.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21395v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21395v1",
+      "publishedAt": "2026-05-20T16:53:06.000Z",
+      "updatedAt": "2026-05-20T16:53:06.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20090v1",
-      "title": "MetaEarth-MM: Unified Multimodal Remote Sensing Image Generation with Scene-centered Joint Modeling",
-      "summary": "Multi-modal remote sensing images are vital for Earth observation, yet complete paired observations are often scarce in practice. Existing generative methods commonly address this problem through isolated pairwise modality translation, but their versatility and scalability remain limited as the number of modalities and generation tasks increases. Here, we develop a generative foundation model MetaEarth-MM for multi-modal remote sensing imagery, enabling paired joint generation and any-to-any translation across five modalities within a unified model. Recognizing the intrinsic scene consistency underlying multi-modal observations, we introduce a scene-centered joint modeling paradigm in MetaEarth-MM. Unlike previous methods that rely on direct appearance-level cross-modal mapping, our model organizes the generation around the underlying scene content. Specifically, MetaEarth-MM adopts a decoupled architecture that first infers a latent scene representation from available observations, and then generates target modalities conditioned on this intermediate state. To support training, we further construct EarthMM, a large-scale dataset comprising 2.8 million multi-resolution global images with 2.2 million aligned pairs. Extensive experiments demonstrate that MetaEarth-MM not only exhibits strong generative capability and robust generalization across diverse generation tasks, but also supports downstream tasks at both data and representation levels, highlighting its potential as a general foundation model for cross-modal Earth observation. The code and dataset will be available at https://github.com/YZPioneer/MetaEarth-MM.",
+      "arxivId": "2605.21391v1",
+      "title": "Post-Hoc Understanding of Metaphor Processing in Decoder-Only Language Models via Conditional Scale Entropy",
+      "summary": "Metaphor requires a language model to resolve a token whose contextual meaning diverges from its basic literal sense. Understanding how transformer models organize this reinterpretation across depth remains an open problem in mechanistic interpretability. We introduce conditional scale entropy (CSE), a wavelet-derived measure of how broadly transformer computation engages across frequency scales at each layer position. Two theorems establish that CSE is invariant to update magnitude, isolating the structural pattern of updates from their intensity. Using CSE, we find that metaphorical tokens produce significantly higher spectral breadth than literal tokens at contiguous layer positions on every decoder-only architecture tested, from 124M to 20B parameters (GPT-2 family, LLaMA-2 7B, GPT-oss 20B). The effect survives cluster-based permutation correction, recurs in the early-to-mid relative depth range across models, and converges with an independent analysis of 200 naturalistic VUA pairs. Specificity controls further show that the effect is not explained by semantic complexity or by matched propositional content. These results identify multi-scale coordination as a consistent signature of metaphorical language processing in the decoder-only architectures examined, and establish CSE as a principled tool for characterizing cross-depth structure in transformers.",
       "authors": [
-        "Zhiping Yu",
-        "Chenyang Liu",
-        "Jinqi Cao",
-        "Qinzhe Yang",
-        "Siwei Yu",
-        "Zhengxia Zou",
-        "Zhenwei Shi"
+        "Lawhori Chakrabarti",
+        "Jennifer Johnson-Leung",
+        "Bert Baumgaertner",
+        "Aleksandar Vakanski",
+        "Min Xian",
+        "Boyu Zhang"
       ],
       "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20090v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20090v1",
-      "publishedAt": "2026-05-19T16:47:02.000Z",
-      "updatedAt": "2026-05-19T16:47:02.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20088v1",
-      "title": "INSHAPE: Instance-Level Shapelets for Interpretable Time-Series Classification",
-      "summary": "Discovering shapelets -- i.e., discriminative temporal patterns within time series -- has been widely studied to address the inherent complexity of time-series classification (TSC) and to make model decision-making processes more transparent. However, existing methods primarily focus on population-level shapelets optimized across the entire dataset, which leads to two fundamental limitations: (i) population-level patterns often misalign with instance-specific features, resulting in suboptimal performance and potentially misleading interpretations, and (ii) most methods treat shapelets as independent entities, overlooking important temporal dependencies and interactions among multiple patterns. To address these limitations, we propose INSHAPE, an interpretable TSC framework that discovers variable-length, discriminative temporal patterns specific to each time series. INSHAPE identifies these patterns as non-overlapping segments and models their temporal dependencies, thereby providing clear instance-level interpretations while achieving strong predictive performance. Furthermore, INSHAPE bridges local and global interpretability through a bottom-up approach, aggregating instance-level shapelets into prototypical (population-level) shapelets. Extensive experiments on 128 UCR and 30 UEA benchmark datasets show that INSHAPE consistently outperforms state-of-the-art shapelet-based methods while providing more intuitive and interpretable insights.",
-      "authors": [
-        "Seongjun Lee",
-        "Seokhyun Lee",
-        "Changhee Lee"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20088v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20088v1",
-      "publishedAt": "2026-05-19T16:43:41.000Z",
-      "updatedAt": "2026-05-19T16:43:41.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20087v1",
-      "title": "ThoughtTrace: Understanding User Thoughts in Real-World LLM Interactions",
-      "summary": "Conversational AI has now reached billions of users, yet existing datasets capture only what people say, not what they think. We introduce ThoughtTrace, the first large-scale dataset that pairs real-world multi-turn human--AI conversations with users' self-reported thoughts: their reasons for sending prompts and reactions to assistant responses. ThoughtTrace comprises 1,058 users, 2,155 conversations, 17,058 turns, and 10,174 thought annotations collected across 20 language models. Our analysis shows that ThoughtTrace captures long-horizon, topically diverse interactions, and that thoughts are semantically distinct from messages, difficult for frontier LLMs to infer from context, diverse in content, and tied to conversation stages. We further demonstrate the utility of thoughts for downstream modeling. First, thoughts improve user-behavior prediction as inference-time context. Second, thought-guided rewrites provide fine-grained alignment signals for training personalized assistants. Together, ThoughtTrace establishes user thoughts as a new data modality for studying the cognitive dynamics behind human--AI interaction and provides a foundation for building assistants that better understand and adapt to users' latent goals, preferences, and needs.",
-      "authors": [
-        "Chuanyang Jin",
-        "Binze Li",
-        "Haopeng Xie",
-        "Cathy Mengying Fang",
-        "Tianjian Li",
-        "Shayne Longpre",
-        "Hongxiang Gu",
-        "Maximillian Chen",
-        "Tianmin Shu"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
+        "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20087v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20087v1",
-      "publishedAt": "2026-05-19T16:42:06.000Z",
-      "updatedAt": "2026-05-19T16:42:06.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21391v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21391v1",
+      "publishedAt": "2026-05-20T16:45:59.000Z",
+      "updatedAt": "2026-05-20T16:45:59.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20086v1",
-      "title": "What Do Evolutionary Coding Agents Evolve?",
-      "summary": "Recent work pairs LLMs with evolutionary search to iteratively generate, modify, and select code using task-specific feedback. These systems have produced strong results in mathematical discovery and algorithm design, yet a fundamental question remains: what do they actually evolve? Progress is typically summarized by the best score a run reaches under a task-specific evaluator, but that score can reflect several different mechanisms: new algorithmic structure, re-tuning an existing strategy, recombining ideas already in the model's internal knowledge, or overfitting to the evaluator. Distinguishing these mechanisms requires inspecting the search process itself, not only its final outcome. We introduce EvoTrace, a dataset of evolutionary coding traces spanning four evolutionary frameworks, reasoning and non-reasoning models, and 16 tasks across mathematics and algorithm design. To analyze these traces, we develop EvoReplay, a replay-based methodology that reconstructs the local search states behind high-scoring solutions and tests controlled interventions, including adjusting constants, removing program components and substituting models or prompting contexts. We annotate every code edit in EvoTrace with one of nine recurring edit types using an LLM-as-judge pipeline validated against blind human re-annotation. Across EvoTrace, most score gains come from a small subset of these edit types. We further find a deterministic cycling pattern: about 30% of code lines added during search are byte-identical re-introductions of previously-deleted lines, present throughout nearly every run. These results show that benchmark gains in evolutionary coding agents can arise from qualitatively different mechanisms, only some of which correspond to new algorithmic structure. EvoTrace enables more diagnostic evaluation of evolutionary coding agents beyond final benchmark scores.",
+      "arxivId": "2605.21390v1",
+      "title": "Designing Conversations with the Dead: How People Engage with Generative Ghosts",
+      "summary": "We examine how people experience two choices in the design of generative ghosts, AI systems that are trained on data of the dead: representation, where an AI speaks about a deceased person in the third person, and reincarnation, where the AI speaks as the deceased in the first person. Through a qualitative user study with 16 participants, we explore how each shaped authenticity, affect, and risk. Reincarnation was preferred for its immediacy, but participants shared fears of over-reliance. Representation was preferred for engaging with memory over conversational presence, though participants often ignored this distinction, engaging in dialogue despite third-person framing. Across both modes, participants privileged affective resonance over factual fidelity. We conclude by showing how factors such as tone, language, and conversational rhythm -- factors unique to the user's memory of the deceased -- shape interactions with generative ghosts, and argue that those interactions are always collaborative.",
       "authors": [
-        "Nico Pelleriti",
-        "Sree Harsha Nelaturu",
-        "Zhanke Zhou",
-        "Zongze Li",
-        "Max Zimmer",
-        "Bo Han",
-        "Sebastian Pokutta"
+        "Jack Manning",
+        "Daniel Sullivan",
+        "Dylan Thomas Doyle",
+        "Anthony T. Pinter",
+        "Jed R. Brubaker"
+      ],
+      "categories": [
+        "cs.HC",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.HC",
+      "absUrl": "https://arxiv.org/abs/2605.21390v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21390v1",
+      "publishedAt": "2026-05-20T16:45:32.000Z",
+      "updatedAt": "2026-05-20T16:45:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21388v1",
+      "title": "On the Regularity and Generalization of One-Step Wasserstein-guided Generative Models for PDE-Induced Measures",
+      "summary": "Despite the remarkable empirical success of generative models, the available theory on their statistical accuracy in scientific computing remains largely pessimistic. This paper develops a theoretical framework for understanding the regularity of transport maps and the generalization properties of one-step Wasserstein-guided generative models for PDE-induced probability measures. We consider normalized target densities associated with linear elliptic and parabolic equations on bounded domains, as well as diffusion and Fokker--Planck equations on the torus. Under standard structural assumptions, we prove that these target measures satisfy doubling conditions. By combining this fact with regularity theory for optimal transport between doubling measures, we show that the optimal transport map from a uniform source measure to the target measure is Hölder continuous. This regularity yields an approximation-theoretic justification for one-step generative models that learn PDE-induced distributions via a single pushforward map. As a representative instance, we study DeepParticle and derive excess-risk bounds characterizing the discrepancy between the learned map and the population-optimal map. We also establish a robustness estimate under target shift and illustrate the theory with experiments which support the derived rates.",
+      "authors": [
+        "Likun Lin",
+        "Zhongjian Wang",
+        "Jack Xin",
+        "Zhiwen Zhang"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI",
+        "math.NA",
+        "stat.ML"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21388v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21388v1",
+      "publishedAt": "2026-05-20T16:43:55.000Z",
+      "updatedAt": "2026-05-20T16:43:55.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21384v1",
+      "title": "SpecBench: Measuring Reward Hacking in Long-Horizon Coding Agents",
+      "summary": "As long-horizon coding agents produce more code than any developer can review, oversight collapses onto a single surface: the automated test suite. Reward hacking naturally arises in this setup, as the agent optimizes for passing tests while deviating from the users true goal. We study this reward hacking phenomenon by decompose software engineering tasks into three parts: (i) a natural language description of the specification (ii) visible validation tests that exercise specified features in isolation, and (iii) held-out tests that compose those same features to simulate real-world usage. Based on the specification and the visible validation test suites, a genuine agent would be able to generate a solution that can also pass all of the held-out tests. Therefore we use the gap in pass rates on these two suites to quantify reward hacking. Based on this methodology, we introduce SpecBench, a benchmark comprising 30 systems-level programming tasks ranging from short horizon tasks like building a JSON parser to ultra long horizon tasks like building an entire OS kernel from scratch. Large-scale experiments reveal a consistent pattern: while every frontier agent saturates the visible suite, reward hacking persists, with smaller models exhibiting larger gaps on holdout suites. The gap also scales sharply with task length: it grows by 28 percentage points for every tenfold increase in code size. Failures range from subtle feature isolation to deliberate exploits, including a 2,900-line hash-table \"compiler\" that memorizes test inputs. SpecBench offers a principled testbed for measuring whether coding agents build genuine working systems or merely game the test suites developers hand them.",
+      "authors": [
+        "Bingchen Zhao",
+        "Dhruv Srikanth",
+        "Yuxiang Wu",
+        "Zhengyao Jiang"
+      ],
+      "categories": [
+        "cs.SE",
+        "cs.AI",
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.SE",
+      "absUrl": "https://arxiv.org/abs/2605.21384v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21384v1",
+      "publishedAt": "2026-05-20T16:41:51.000Z",
+      "updatedAt": "2026-05-20T16:41:51.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21381v1",
+      "title": "Disentangling Generation and Regression in Stochastic Interpolants for Controllable Image Restoration",
+      "summary": "Recent advances in Image Restoration (IR) have been largely driven by generative methods such as Diffusion Models and Flow Matching, which excel in synthesizing realistic textures while suffering from slow multi-step inference and compromised pixel fidelity. In contrast, classical regression-based IR methods excel precisely in these aspects, offering single-step efficiency and high pixel-level reconstruction fidelity. To bridge this gap, we propose DiSI, a unified framework that Disentangles the underlying Stochastic Interpolant process into independent generation and regression components. This decoupling endows DiSI with remarkable versatility, enabling a continuous and controllable transition from a pure regression process to a fully generative one. Technically, we instantiate this framework with two specific sampling trajectories, accompanied by a unified sampler for high-quality, few-step inference on arbitrary trajectories. Furthermore, we design a dual-branch U-Net style transformer network in pixel space, using a dedicated branch to enhance conditional guidance while ensuring high throughput. Extensive experiments demonstrate that DiSI efficiently achieves competitive results on various IR tasks, while uniquely offering the inference-time flexibility to control the distortion-perception trade-off within a single model.",
+      "authors": [
+        "Yi Liu",
+        "Jia Ma",
+        "Wengen Li",
+        "Jihong Guan",
+        "Shuigeng Zhou",
+        "Yichao Zhang"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21381v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21381v1",
+      "publishedAt": "2026-05-20T16:41:32.000Z",
+      "updatedAt": "2026-05-20T16:41:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21379v1",
+      "title": "How to Build Marcus's Algebraic Mind: Algebro-Deterministic Substrate over Galois Fields",
+      "summary": "In The Algebraic Mind, Gary Marcus identified three components essential for any adequate cognitive architecture: operations over variables, recursively structured representations, and a distinction between mental representations of individuals and kinds. He argued that standard multilayer perceptrons supported none of these, acknowledging that a neural implementation using registers and treelets, constructed via developmental programs rather than gradient descent, remained a programmatic conjecture. Twenty-five years later, the required substrate is now available. Our newly developed PyVaCoAl/VaCoAl is a hyperdimensional computing architecture organized end-to-end around a single algebraic primitive: XOR-and-shift over GF(2), implemented by primitive-polynomial linear-feedback shift registers. The architecture supports reversible variable binding via Bind(R,F) = R XOR shift(F), non-commutative compositional bundling that distinguishes \"the dog bites the man\" from \"the man bites the dog,\" and address-space individual/kind separation under the same algebra. A companion perspective argues that the dentate gyrus-CA3 circuit is a biological homologue of this same engine, with developmentally specified mossy-fiber targeting supplying the innate microcircuitry Marcus anticipated. In this paper, we map the correspondence between Marcus's three pillars and the operational commitments of PyVaCoAl/VaCoAl. We reinterpret the treelet as an algebraic register set indexed by a primitive generator polynomial, arguing that this architecture provides a functional neural substrate meeting Marcus's specifications far more closely than the tensor products, circular convolution, or temporal synchrony available in 2001. We also demonstrate how this substrate naturally extends to Pearl's rung-3 counterfactual reasoning, a capability the original treelet program did not directly target.",
+      "authors": [
+        "Hiroyuki Chuma",
+        "Kanji Otsuk",
+        "Yoichi Sato"
       ],
       "categories": [
         "cs.NE",
-        "cs.AI",
-        "cs.LG"
+        "cs.AI"
       ],
       "primaryCategory": "cs.NE",
-      "absUrl": "https://arxiv.org/abs/2605.20086v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20086v1",
-      "publishedAt": "2026-05-19T16:41:45.000Z",
-      "updatedAt": "2026-05-19T16:41:45.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21379v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21379v1",
+      "publishedAt": "2026-05-20T16:40:27.000Z",
+      "updatedAt": "2026-05-20T16:40:27.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20085v1",
-      "title": "Spatially Prompted Visual Trajectory Prediction for Egocentric Manipulation",
-      "summary": "Robotic manipulation is often specified through language instructions or task identifiers, yet cluttered environments with similar objects are better handled by spatially indicating what to move and where to place it. Addressing the vision-centric challenge of object and goal specification, we present, to the best of our knowledge, the first formalization of Spatially Prompted Visual Trajectory Prediction (SP-VTP). This novel setting utilizes initial spatial prompts (like bounding boxes or points) to define task objectives, tasking the model with forecasting future end-effector trajectories from egocentric streams. To study this problem, we collect and annotate EgoSPT, a dataset of egocentric spatially prompted manipulation trajectories with first-frame object and target grounding annotations and recovered 3D end-effector motion. SP-VTP is challenging because the task specification is static, while the scene configuration evolves over time. To solve this problem, we propose SPOT(Spatially Prompted Object-Target Policy), which combines a task encoder for first-frame visual and coordinate spatial prompts, an observation encoder for current visual and history context, and a trajectory generator for future end-effector motion. Experiments under strict scene-level splits show that SPOT improves cross-scene trajectory prediction over non-prompted or single-source prompted baselines. Together, EgoSPT and SPOT establish a new spatial prompting problem SP-VTP, as a simple and scalable task condition for egocentric manipulation.",
+      "arxivId": "2605.21372v1",
+      "title": "Closed Loop Dynamic Driving Data Mixture for Real-Synthetic Co-Training",
+      "summary": "Data scaling is fundamental to modern deep learning, and grows increasingly critical as autonomous driving shifts to end-to-end learning. Real-world driving data is expensive to annotate and scene-biased, making real-synthetic co-training with near-infinite synthetic data a promising direction. However, naively incorporating all available synthetic data is inefficient and leads to distribution shifts, and optimizing data mixture under practical training budgets remains a critical yet under-explored problem. In this sense, we claim that the mixture of training data requires clear guidance in terms of scene types and quantities. Particularly in this work, we conceptualize the data mixture approximately as a dynamic optimization process that iteratively adjusts the training data mixture to maximize model performance, guided by closed-loop evaluation feedback, and propose AutoScale, a fully automated closed-loop data engine unifying scene representation, data mixture optimization and retrieval, as well as model training and evaluation. Specifically, we propose Graph Regularized AutoEncoder (Graph-RAE) for driving scene representations, introduce Cluster-aware Gradient Ascent (Cluster-GA) for cluster-wise importance estimation and reweighting, and perform cluster-guided vector retrieval to select high-value samples. Experiments on NavSim demonstrate that AutoScale outperforms vanilla co-training and cross-domain baselines, achieving better performance with fewer synthetic samples under constrained budgets.",
       "authors": [
-        "Yifan Li",
-        "Xinyu Zhou",
-        "Yunhao Ge",
-        "Yu Kong"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20085v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20085v1",
-      "publishedAt": "2026-05-19T16:39:30.000Z",
-      "updatedAt": "2026-05-19T16:39:30.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20084v1",
-      "title": "BalanceRAG: Joint Risk Calibration for Cascaded Retrieval-Augmented Generation",
-      "summary": "Large language models (LLMs) can enhance factuality via retrieval-augmented generation (RAG), but applying RAG to every query is unnecessary when the model-only answer is reliable. This motivates cascaded RAG: each query is first handled by an LLM-only branch, escalated to a RAG fallback only if the primary branch is uncertain, and abstained from when neither branch is sufficiently trustworthy. However, calibrating such cascades stage by stage may be conservative, since the final utility depends on joint uncertainty thresholding of LLM-only and RAG. In this work, we develop BalanceRAG to certify threshold pairs at a target risk level. Given uncertainty scores from the two branches, BalanceRAG frames each threshold pair as an operating point on a two-dimensional lattice and identifies safe operating points using sequential graphical testing. This enables risk-adaptive threshold calibration, controlling the system-level error rate among accepted points, while retaining more examples. Furthermore, BalanceRAG extends to multi-risk calibration, allowing retrieval usage to be bounded together with the selection-conditioned risk. Experiments on three open-domain question answering (QA) benchmarks across multiple LLM backbones demonstrate that BalanceRAG meets prescribed risk levels, preserves higher coverage and more accepted correct examples, and reduces unnecessary retrieval calls compared with always-on RAG.",
-      "authors": [
-        "Zijun Jia",
-        "Yuanchang Ye",
-        "Sen Jia",
-        "Yiyao Qian",
-        "Haoning Wang",
-        "Baojie Chen",
-        "Diyin Tang",
-        "Jinsong Yu",
-        "Zhiyuan Wang"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20084v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20084v1",
-      "publishedAt": "2026-05-19T16:38:55.000Z",
-      "updatedAt": "2026-05-19T16:38:55.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20082v1",
-      "title": "VL-DPO: Vision-Language-Guided Finetuning for Preference-Aligned Autonomous Driving",
-      "summary": "The rapid growth of autonomous driving datasets has enabled the scaling of powerful motion forecasting models. While large-scale pretraining provides strong performance, the standard imitation objective may not fully capture the complex nuances of human driving preferences. Meanwhile, recent advances in vision-language models (VLMs) have demonstrated impressive reasoning and commonsense understanding. Building on these capabilities, this paper presents VL-DPO, a vision-language-guided framework that aligns ego-vehicle motion forecasting models with human preferences. Our approach leverages a VLM as a zero-shot reasoner to automatically generate preference pairs from a pretrained model's rollouts, which are then used to finetune the model via Direct Preference Optimization (DPO). We finetune our models on the Waymo Open End-to-End Driving Dataset (WOD-E2E) and evaluate performance against held-out human preference annotations using rater feedback score (RFS) and average displacement error (ADE). Our experiments confirm that the VLM's trajectory selection is a high-quality proxy for human preference. Our final model, VL-DPO, yields an 11.94% increase in RFS and a 10.01% reduction in ADE over the pretrained model.",
-      "authors": [
-        "Zhefan Xu",
-        "Ghassen Jerfel",
-        "Marina Haliem",
-        "Qi Zhao",
-        "Jeonhyung Kang",
-        "Khaled S. Refaat"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20082v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20082v1",
-      "publishedAt": "2026-05-19T16:36:34.000Z",
-      "updatedAt": "2026-05-19T16:36:34.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20079v1",
-      "title": "Probability-Conserving Flow Guidance",
-      "summary": "Diffusion and flow-based generative models dominate visual synthesis, with guidance aligning samples to user input and improving perceptual quality. However, Classifier-Free Guidance (CFG) and extrapolation-based methods are heuristic linear combinations of velocities/scores that ignore the generative manifold geometry, breaking probability conservation and driving samples off the learned manifold under strong guidance. We analyse guidance through the continuity equation and show its effect decomposes into a divergence term and a score-parallel term defined invariantly across parameterisations. We prove the divergence term blows up structurally as sampling approaches the data manifold, motivating a time-dependent schedule alongside score-parallel attenuation. The resulting plug-and-play rule, Adaptive Manifold Guidance (AdaMaG), bounds both terms at no additional inference cost. Finally, we show that most empirical heuristics for reducing saturation or improving generation quality correspond directly to the two terms in our decomposition. Across image generation benchmarks, AdaMaG improves realism, reduces hallucinations, and induces controlled desaturation in high-guidance regimes.",
-      "authors": [
-        "Parsa Esmati",
-        "Junha Hyung",
-        "Amirhossein Dadashzadeh",
-        "Jaegul Choo",
-        "Majid Mirmehdi"
+        "Hongzhi Ruan",
+        "Pei Liu",
+        "Weiliang Ma",
+        "Zhengning Li",
+        "Xueyang Zhang",
+        "Jun Ma",
+        "Dan Xu",
+        "Kun Zhan"
       ],
       "categories": [
         "cs.CV",
         "cs.AI",
         "cs.LG",
-        "eess.IV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20079v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20079v1",
-      "publishedAt": "2026-05-19T16:34:01.000Z",
-      "updatedAt": "2026-05-19T16:34:01.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20075v1",
-      "title": "CopT: Contrastive On-Policy Thinking with Continuous Spaces for General and Agentic Reasoning",
-      "summary": "Chain-of-thought (CoT) is a standard approach for eliciting reasoning capabilities from large language models (LLMs). However, the common CoT paradigm treats thinking as a prerequisite for answering, which can delay access to plausible answers and incur unnecessary token costs even when the model is able to identify an answer before extended thinking, a behavior known as performative reasoning. In this paper, we introduce CopT, a reformulated reasoning pipeline that reverses the usual order of thinking and answering. Instead of thinking before answering, CopT first elicits a draft answer and then invokes subsequent on-policy thinking conditioned on its own draft answer for reflection and correction. To assess whether the draft answer should be trusted, CopT recasts continuous embeddings as inference-time contrastive verifiers. Specifically, it contrasts the model's support for the same generated tokens under discrete-token inputs and continuous-embedding inputs, yielding a sequence-level reverse KL estimator for answer reliability. Our analysis shows that under certain assumptions, the expected estimate equals the mutual information between the unresolved latent state and the emitted answer token, explaining why it captures answer-relevant uncertainty rather than arbitrary uncertainty in the latent state. When the answer is deemed insufficiently reliable, CopT performs further on-policy thinking, where a second KL estimator dynamically controls draft-answer visibility, preserving useful partial information while reducing the risk of being misled by unreliable content. Across mathematics, coding, and agentic reasoning tasks, CopT improves peak accuracy by up to 23% and reduces token usage by up to 57% at comparable or higher accuracy, without any additional training. The code is available at https://github.com/sdc17/CopT.",
-      "authors": [
-        "Dachuan Shi",
-        "Hanlin Zhu",
-        "Xiangchi Yuan",
-        "Wanjia Zhao",
-        "Kejing Xia",
-        "Wen Xiao",
-        "Wenke Lee"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20075v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20075v1",
-      "publishedAt": "2026-05-19T16:28:53.000Z",
-      "updatedAt": "2026-05-19T16:28:53.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20074v1",
-      "title": "Towards Distillation Guarantees under Algorithmic Alignment for Combinatorial Optimization",
-      "summary": "Distillation transfers knowledge from a large model trained on broad data to a smaller, more efficient model suitable for deployment. In structured prediction settings, prior knowledge about the task can guide the choice of a target architecture that is algorithmically aligned with the underlying problem. Building on recent learning-theoretic analyses of decision-tree (DT) distillation (Boix-Adsera, 2024), we study when distillation succeeds for combinatorial optimization tasks. We focus on the case where the target model is a graph neural network whose architecture is aligned with a dynamic programming (DP) algorithm for the task. Assuming that the source model is sufficiently rich, formalized through the linear representation hypothesis (LRH) (Elhage et al., 2022; Park et al., 2024), we show that the distillation problem can be solved efficiently in the complexity parameters of the DP transition function, represented as a DT. Our results provide a rigorous sufficient condition for successful distillation in the flavour of algorithmic alignment.",
-      "authors": [
-        "Thien Le",
-        "Melanie Weber"
-      ],
-      "categories": [
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20074v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20074v1",
-      "publishedAt": "2026-05-19T16:28:18.000Z",
-      "updatedAt": "2026-05-19T16:28:18.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20073v1",
-      "title": "X-Ray cardiac angiographic vessel segmentation based on pixel classification using machine learning and region growing",
-      "summary": "This work proposes a pixel-classification approach for vessel segmentation in x-ray angiograms. The proposal uses textural features such as anisotropic diffusion, features based on the Hessian matrix, mathematical morphology and statistics. These features are extracted from the neighborhood of each pixel. The approach also uses the ELEMENT methodology, which consists of creating a pixel-classification controlled by region-growing where the result of the classification affects further classifications of pixels. The Random Forests classifier is used to predict whether the pixel belongs to the vessel structure. The approach achieved the best accuracy in the literature (95.48%) outperforming unsupervised state-of-the-art approaches.",
-      "authors": [
-        "E O Rodrigues",
-        "L O Rodrigues",
-        "J J Lima",
-        "D Casanova",
-        "F Favarim",
-        "E R Dosciatti",
-        "V Pegorini",
-        "L S N Oliveira",
-        "F F C Morais"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20073v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20073v1",
-      "publishedAt": "2026-05-19T16:27:45.000Z",
-      "updatedAt": "2026-05-19T16:27:45.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20072v1",
-      "title": "Probing Embodied LLMs: When Higher Observation Fidelity Hurts Problem Solving",
-      "summary": "Large Language Models are increasingly proposed as cognitive components for robotic systems, yet their opaque decision processes make it difficult to explain success or failure in closed-loop embodied tasks. Following an empirical AI methodology, we study embodied LLM agents behaviorally by varying the information available to the agent and measuring the resulting changes in behavior. Using the Lockbox, a sequential mechanical puzzle with hidden interdependencies, we evaluate LLMs across RGB, RGB-D, and ground-truth symbolic observations in a physical robotic setup and use controlled simulation to probe the resulting behavior. Counterintuitively, agents perform best under raw RGB input and worst under perfect ground-truth observations. In simulation, we probe this effect by randomly flipping perceived action outcomes and find that moderate noise improves performance, peaking at a 40% flip probability with a 2.85-fold success rate increase over the noise-free baseline. Further analysis links this gain to a reduction in repetitive action loops. These findings suggest that success rates alone are insufficient for evaluating LLMs, as measured performance may reflect the interaction between perceptual errors and reasoning failures rather than robust problem solving.",
-      "authors": [
-        "Oussama Zenkri",
-        "Oliver Brock"
-      ],
-      "categories": [
-        "cs.AI",
         "cs.RO"
       ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20072v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20072v1",
-      "publishedAt": "2026-05-19T16:27:00.000Z",
-      "updatedAt": "2026-05-19T16:27:00.000Z",
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21372v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21372v1",
+      "publishedAt": "2026-05-20T16:36:26.000Z",
+      "updatedAt": "2026-05-20T16:36:26.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20069v1",
-      "title": "Smooth Partial Lotteries for Stable Randomized Selection",
-      "summary": "Competitive selection processes, from scientific funding to admissions and hiring, use evaluations to score candidates, and eventually choose a subset of them based on those scores. Recently, many organizations have adopted partial lotteries, which randomize selection based on evaluation scores. However, existing lottery designs are inherently unstable, as a small change to a single candidate's score can cause large shifts in their selection probabilities. This instability undermines a key goal of lotteries: reducing the influence of fine-grained score distinctions near the decision boundary. We propose smoothness as a design principle for partial lotteries, formalizing it as a Lipschitz condition on the mapping from review scores over candidates to selection probabilities. We introduce the Clipped Linear Lottery, a simple mechanism in which selection probabilities scale linearly with estimated quality between an upper threshold, above which we always accept, and a lower threshold, below which we always reject. We prove that the Clipped Linear Lottery's worst-case regret matches a lower bound for any smooth selection rule up to a factor of $(1 - k/n)$, where $k/n$ is the acceptance rate. We compare smooth selection to other stability notions like Individual Fairness and Differential Privacy, showing that the Clipped Linear Lottery achieves a better smoothness-regret tradeoff than alternatives. Experiments on real peer review data from ICLR 2025, NeurIPS 2024, and the Swiss National Science Foundation demonstrate that existing lottery designs are highly unstable in practice even under perturbations to a single score. Our experiments also confirm the tightness of our theoretical analysis and show that our proposed Clipped Linear Lottery achieves a better smoothness-utility tradeoff than alternatives in practice.",
+      "arxivId": "2605.21371v1",
+      "title": "A Non-Reference Diffusion-Based Restoration Framework for Landsat 7 ETM+ SLC-off Imagery in Antarctica",
+      "summary": "Acquiring usable optical imagery in Antarctica is inherently challenging due to prolonged polar nights and frequent cloud cover. Landsat provides the longest and most continuous optical observations and constitutes one of the most important remote sensing data sources for Antarctic studies. However, the scan-line corrector (SLC) failure in 2003 resulted in approximately 22% missing pixels in Landsat 7 ETM+ SLC-off imagery, severely limiting its usability. Unlike many non-polar environments, Antarctic surfaces undergo rapid and substantial changes, which makes it difficult to obtain reliable reference imagery and reduces the applicability of conventional reference-based gap-filling methods. To address this challenge, we propose DiffGF, a non-reference diffusion-based framework for restoring Landsat 7 SLC-off imagery without requiring any external reference data. DiffGF adopts a two-stage design consisting of a latent-space diffusion process and a pixel-space refinement. A dedicated Antarctic dataset, SLCANT, is constructed for training and evaluation. Quantitative and qualitative results demonstrate that DiffGF restores Antarctic SLC-off imagery with high fidelity. Its practical value is further examined through a downstream crevasse segmentation application. The results suggest that DiffGF provides a useful approach for exploiting Landsat 7 SLC-off archives in Antarctica, enabling the extraction of valuable information from historical records and supporting related Antarctic studies.",
       "authors": [
-        "Alexander Goldberg",
-        "Giulia Fanti",
-        "Nihar B. Shah"
+        "Leyue Tang",
+        "Jonathan Louis Bamber",
+        "Gang Qiao",
+        "Yuanhang Kong"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21371v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21371v1",
+      "publishedAt": "2026-05-20T16:35:46.000Z",
+      "updatedAt": "2026-05-20T16:35:46.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21369v1",
+      "title": "Findings of the Fifth Shared Task on Multilingual Coreference Resolution: Expanding Datasets for Long-Range Entities",
+      "summary": "This paper describes the fifth edition of the Shared Task on Multilingual Coreference Resolution, held in conjunction with the CODI-CRAC 2026 workshop. Building on previous iterations, the task required participants to develop systems capable of mention identification and identity-based coreference clustering. The 2026 edition specifically emphasizes long-range entities, defined as coreferential chains spanning significant distances, across many words and sentences. The task expanded its linguistic scope by incorporating five new datasets and two additional languages. These additions leverage version 1.4 of CorefUD, a harmonized multilingual collection comprising 27 datasets in 19 languages. In total, ten systems participated, including four LLM-based approaches (three fine-tuned models and one few-shot approach). While traditional systems still maintained their lead, LLMs demonstrated significant potential, suggesting they may soon challenge established approaches in future editions.",
+      "authors": [
+        "Michal Novák",
+        "Miloslav Konopík",
+        "Anna Nedoluzhko",
+        "Martin Popel",
+        "Ondřej Pražák",
+        "Jakub Sido",
+        "Milan Straka",
+        "Zdeněk Žabokrtský",
+        "Daniel Zeman"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21369v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21369v1",
+      "publishedAt": "2026-05-20T16:35:09.000Z",
+      "updatedAt": "2026-05-20T16:35:09.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21363v1",
+      "title": "\"I didn't Make the Micro Decisions\": Measuring, Inducing, and Exposing Goal-Level AI Contributions in Collaboration",
+      "summary": "As large language models (LLMs) increasingly shape how users form, refine, and extend their goals, attributing contributions in human-AI collaboration becomes critical for users calibrating their own reliance and for evaluators assessing AI-assisted work. Yet existing methods focus on final artifacts, missing the process through which goals themselves are jointly shaped. We introduce a goal-level attribution framework, CoTrace, that decomposes explicit goals into verifiable requirements and traces both direct contributions and indirect influences across dialogue turns. Applying CoTrace to 638 real-world collaboration logs, we find that while models account for only 11-26% of goal-shaping contribution, they contribute substantially more on introducing lower-level concrete requirements, and make various kinds of indirect contributions. Through controlled simulations, we show that interaction design choices significantly affect model goal-shaping behavior. In a user study, exposing participants to goal-level analyses shifts their perceived contributions by nearly 2 points on a 5-point scale, revealing systematic miscalibration in how users understand their own AI-assisted work.",
+      "authors": [
+        "Eunsu Kim",
+        "Jessica R. Mindel",
+        "Kyungjin Kim",
+        "Sherry Tongshuang Wu"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21363v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21363v1",
+      "publishedAt": "2026-05-20T16:28:34.000Z",
+      "updatedAt": "2026-05-20T16:28:34.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21362v1",
+      "title": "LASH: Adaptive Semantic Hybridization for Black-Box Jailbreaking of Large Language Models",
+      "summary": "Jailbreak attacks expose a persistent gap between the intended safety behavior of aligned large language models and their behavior under adversarial prompting. Existing automated methods are increasingly effective but each commits to a single attack family (e.g., one refinement loop, one tree search, one mutation space, or one strategy library) and no single family dominates: the best-performing method shifts across target models and harm categories, suggesting complementary strengths that per-prompt composition could exploit. We introduce LASH (LLM Adaptive Semantic Hybridization), a black-box framework that treats outputs from multiple base attacks as reusable seed prompts and adaptively composes them for each target request. Given a seed pool, LASH searches over seed subsets and softmax-normalized mixture weights; a composition module synthesizes a single candidate prompt, and a derivative-free genetic optimizer updates the weights using black-box target feedback and a two-stage fitness function combining keyword-based refusal detection with LLM-judge scoring. On JailbreakBench, which contains 100 harmful prompts across 10 categories, we evaluate LASH on six common target models. LASH achieves an average attack success rate of 84.5% under keyword-based evaluation and 74.5% under two-stage evaluation, where responses are first filtered for refusals and then scored by an LLM judge for whether they substantively fulfill the original harmful request. LASH outperforms five state-of-the-art baselines on both metrics with only 30 mean target queries. LASH also remains competitive under three defense mechanisms and induces more success-like internal representations. These results suggest that adaptive composition across heterogeneous jailbreak strategies is a promising direction for black-box red-teaming.",
+      "authors": [
+        "Abdullah Al Nomaan Nafi",
+        "Fnu Suya",
+        "Swarup Bhunia",
+        "Prabuddha Chakraborty"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21362v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21362v1",
+      "publishedAt": "2026-05-20T16:27:00.000Z",
+      "updatedAt": "2026-05-20T16:27:00.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21352v1",
+      "title": "Classification of Single and Mixed Partial Discharges under Switching Voltage Using an AWA-CNN Framework",
+      "summary": "The growing use of fast-switching power electronics has made partial discharge (PD) analysis under switching-voltage excitation increasingly important, yet more challenging than under sinusoidal conditions due to activity concentrated at voltage transitions. This work presents an Amplitude-Width-Area (AWA) pattern representation for source-oriented PD analysis under switching-voltage excitation. In the proposed method, time domain PD pulses are characterized using pulse amplitude, width, and area, and mapped into a visual pattern where amplitude and area define the coordinate axes and width is encoded by color. The generated AWA patterns are used to distinguish six single and mixed PD source conditions: corona, internal, surface, corona+internal, corona+surface, and internal+surface. To evaluate the classification capability of the proposed representation, a Random Forest baseline and two Convolutional Neural Network (CNN) models, InceptionV3 and ResNet-18, are compared. The AWA patterns show distinguishable source-dependent distributions, and CNN-based classification achieves testing accuracy above 96%, compared with 73.33% for Random Forest. The results indicate that AWA patterns provide a visual representation of PD pulses suitable for multi-class PD source classification under switching-voltage excitation.",
+      "authors": [
+        "Md Rafid Kaysar Shagor",
+        "Zannatul Ferdousy Mouri",
+        "Farhina Haque",
+        "Anindya Bijoy Das"
       ],
       "categories": [
         "cs.LG",
-        "cs.GT"
+        "cs.CE",
+        "cs.ET"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20069v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20069v1",
-      "publishedAt": "2026-05-19T16:22:51.000Z",
-      "updatedAt": "2026-05-19T16:22:51.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21352v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21352v1",
+      "publishedAt": "2026-05-20T16:16:51.000Z",
+      "updatedAt": "2026-05-20T16:16:51.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20068v1",
-      "title": "Tail Annealing for Heavy-Tailed Flow Matching",
-      "summary": "Standard generative models struggle with heavy-tailed data: Lipschitz architectures cannot produce power-law tails from Gaussian noise, and interpolating between heavy-tailed data and Gaussians is ill-posed. We propose a simple fix: apply the soft-log transform $φ(x) = \\mathrm{sign}(x) \\cdot \\log(1 + |x|)$ coordinate-wise to data before training, then exponentiate samples after generation. A Hill diagnostic decides per-coordinate whether to transform, leaving light-tailed margins untouched at no added complexity. This compresses heavy tails into a range where standard flow matching succeeds, without heavy-tailed base distributions or architectural modifications. We provide theoretical intuition for why this works: the log-transform maps Pareto tails to exponentials, and the induced dynamics implement a form of tail annealing via power transformations. On a 144-configuration multivariate benchmark (3 copulas, $d$ up to 100, 4 tail indices), Log-FM dominates specialized baselines on $W_1$, CVaR$_{99}$, and extreme-quantile metrics, and is the only method with zero severe divergences across 2{,}880 runs.",
+      "arxivId": "2605.21347v1",
+      "title": "Insights Generator: Systematic Corpus-Level Trace Diagnostics for LLM Agents",
+      "summary": "Diagnosing failures in LLM agents remains largely manual. Practitioners inspect a small subset of execution traces, form ad-hoc hypotheses, and iterate. This process misses patterns that only emerge across trace populations and does not scale to production corpora where individual traces span tens of thousands of tokens. We formalize the problem of corpus-level trace diagnostics. Given a corpus of execution traces, the goal is to produce grounded natural-language insights that characterize systematic behavioral patterns across trace groups, each linked to supporting evidence. We present the Insights Generator (IG), a multi-agent system that answers diagnostic questions by proposing and testing hypotheses across the trace corpus to produce an evidence-backed insights report. We evaluate IG across qualitative and objective dimensions, spanning rubric-based report assessment and downstream performance improvements achieved by implementing IG insights. Human experts using IG reports improve scaffold performance by 30.4pp over the unmodified baseline scaffold, and coding agents leveraging IG-derived insights show consistent and stable gains. Across benchmarks, IG's scout-investigator architecture produces findings comparable in detection coverage to competing approaches, while domain experts rated IG reports as leading depth and evidence quality.",
       "authors": [
-        "Jean Pachebat"
+        "Akshay Manglik",
+        "Apaar Shanker",
+        "Kaustubh Deshpande",
+        "Jason Qin",
+        "Yash Maurya",
+        "Veronica Chatrath",
+        "Vijay S. Kalmath",
+        "Levi Lentz",
+        "Yuan",
+        "Xue"
+      ],
+      "categories": [
+        "cs.AI",
+        "cs.LG",
+        "cs.SE"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.21347v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21347v1",
+      "publishedAt": "2026-05-20T16:13:53.000Z",
+      "updatedAt": "2026-05-20T16:13:53.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21348v1",
+      "title": "Data-Efficient Neural Operator Training via Physics-Based Active Learning",
+      "summary": "Solving partial differential equations with neural operators significantly reduces computational costs but remains bottlenecked by high training data requirements. Active learning offers a natural framework to mitigate this by selectively acquiring the most informative samples in an iterative manner. We introduce physics-based acquisition - a novel physics-informed active learning algorithm that leverages the partial differential equation residual to guide data selection. We validate the method by presenting numerical experiments for the 1D Burgers equation and the 2D compressible Navier-Stokes equations. We show that, in our experiments, physics-based acquisition consistently outperforms random acquisition and matches the state of the art in data efficiency. At the same time, it has the unique advantage of injecting a physics inductive bias into the training process, ensuring that simulation cost is spent where the model's physical understanding is weakest.",
+      "authors": [
+        "Alicja Polanska",
+        "Lorenzo Zanisi",
+        "Vignesh Gopakumar",
+        "Stanislas Pamela"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI",
+        "math.NA",
+        "physics.comp-ph"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21348v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21348v1",
+      "publishedAt": "2026-05-20T16:13:53.000Z",
+      "updatedAt": "2026-05-20T16:13:53.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21343v1",
+      "title": "OcclusionFormer: Arranging Z-Order for Layout-Grounded Image Generation",
+      "summary": "Recent layout-to-image models have achieved remarkable progress in spatial controllability. However, they still struggle with inter-object occlusion. When bounding boxes overlap, most existing methods lack explicit occlusion information, which makes the generation in intersection regions inherently ambiguous and hinders the determination of complex occlusion relationships. As a result, they often produce entangled textures or physically inconsistent layering in the overlapped areas. To address this issue, we first construct SA-Z, a large-scale dataset enriched with explicit occlusion ordering and pixel-level annotations. Building upon our proposed dataset, we introduce OcclusionFormer, a novel occlusion-aware Diffusion Transformer framework that explicitly models Z-order priority by decoupling instances and compositing them via volume rendering. Furthermore, to ensure fine-grained spatial precision, we introduce a queried alignment loss that explicitly supervises individual instances and enhances semantic consistency. The proposed method effectively reduces ambiguity in overlapping regions, enforces correct occlusion dependencies, and preserves structural integrity, leading to substantial accuracy gains across diverse scenes.",
+      "authors": [
+        "Ziye Li",
+        "Henghui Ding"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21343v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21343v1",
+      "publishedAt": "2026-05-20T16:10:44.000Z",
+      "updatedAt": "2026-05-20T16:10:44.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21341v1",
+      "title": "Semiparametric Efficient Bilevel Gradient Estimation",
+      "summary": "Functional bilevel methods estimate a lower-level function and plug it into a hypergradient, but this plug-in gradient can retain first-order bias when the lower-level problem is learned nonparametrically. To remove this bias, we develop a semiparametric debiasing theory for population bilevel gradients based on the efficient influence function. This perspective leads to a cross-fitted orthogonal hypergradient estimator for which we establish asymptotic normality together with uniform control over the outer parameter. Under quadratic losses, the estimator reduces to a simple doubly robust score based on conditional mean nuisances. On synthetic bilevel benchmarks with known ground truth, the method tracks the oracle efficient-gradient benchmark and improves over plug-in functional hypergradients and regularized kernel bilevel baselines.",
+      "authors": [
+        "Fares El Khoury",
+        "Houssam Zenati",
+        "Nathan Kallus",
+        "Michael Arbel",
+        "Aurélien Bibaut"
       ],
       "categories": [
         "stat.ML",
         "cs.LG"
       ],
       "primaryCategory": "stat.ML",
-      "absUrl": "https://arxiv.org/abs/2605.20068v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20068v1",
-      "publishedAt": "2026-05-19T16:22:03.000Z",
-      "updatedAt": "2026-05-19T16:22:03.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21341v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21341v1",
+      "publishedAt": "2026-05-20T16:07:55.000Z",
+      "updatedAt": "2026-05-20T16:07:55.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20066v1",
-      "title": "Text-to-SPARQL Generation with Reinforcement Learning: A GRPO-based Approach on DBLP",
-      "summary": "Knowledge graph question answering seeks to translate natural language questions into executable queries over knowledge graphs, but existing approaches often rely on large models or full supervision in the form of gold query annotations. This study examines whether reinforcement learning with outcome-based rewards can train a small instruction-tuned language model to perform zero-shot Text-to-SPARQL generation in the scholarly domain. Group-Relative Policy Optimization (GRPO) is applied to the Qwen3-1.7B model on DBLP-QuAD, using prompts that combine natural language questions with symbolic hints about entities and relations. Training relies on execution feedback, structural constraints, and answer-level rewards, with an additional variant that incorporates gold-query-based shaping. The resulting models are compared to the unmodified zero-shot baseline and to a supervised DoRA-finetuned baseline across answer-level accuracy, execution accuracy, category-wise scores, and generalization to held-out templates. GRPO substantially improves over the zero-shot baseline and exhibits competitive generalization, while supervised DoRA finetuning achieves higher overall accuracy on the same model scale. Ablation analyses indicate that execution-based rewards account for most gains, with additional shaping yielding limited additional benefit, suggesting that outcome-based reinforcement learning is a viable training strategy when gold queries are unavailable for token-level supervision.",
+      "arxivId": "2605.21338v1",
+      "title": "Text Analytics Evaluation Framework: A Case Study on LLMs and Social Media",
+      "summary": "LLMs have demonstrated exceptional proficiency in a wide range of NLP tasks. However, a notable gap remains in practical data analysis scenarios, particularly when LLMs are required to process long sequences of unstructured documents, such as news feeds or, as specifically addressed in this paper, social media posts. To empirically assess the effectiveness of LLMs in this setting, we introduce a question-based evaluation framework comprising 470 manually curated questions designed to evaluate LLMs' semantic understanding and reasoning abilities over aggregated text data. We apply our benchmark on diverse Twitter datasets covering various NLP tasks, including sentiment analysis, hate speech detection, and emotion recognition. Our results reveal that the performance depends heavily on input scale and the complexity of the data sources, declining noticeably in multi-label or target-dependent scenarios. In addition, as task complexity increases, performance drops progressively from basic semantic existence identification to more demanding operations such as comparison, counting, and calculation. Furthermore, as the input size grows beyond 500 instances, we identify a common limitation across LLMs, particularly Open-weights models: performance degrades substantially, especially on numerical tasks. These findings highlight critical architectural bottlenecks in current LLMs for performing rigorous quantitative analysis over large text collections.",
       "authors": [
-        "Jann Pfeifer",
-        "Debayan Banerjee",
-        "Ricardo Usbeck"
+        "Yuefeng Shi",
+        "Nedjma Ousidhoum",
+        "Jose Camacho-Collados"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20066v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20066v1",
-      "publishedAt": "2026-05-19T16:20:57.000Z",
-      "updatedAt": "2026-05-19T16:20:57.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21338v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21338v1",
+      "publishedAt": "2026-05-20T16:05:05.000Z",
+      "updatedAt": "2026-05-20T16:05:05.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20064v1",
-      "title": "Cardiac fat segmentation using computed tomography and an image-to-image conditional generative adversarial neural network",
-      "summary": "In recent years, research has highlighted the association between increased adipose tissue surrounding the human heart and elevated susceptibility to cardiovascular diseases such as atrial fibrillation and coronary heart disease. However, the manual segmentation of these fat deposits has not been widely implemented in clinical practice due to the substantial workload it entails for medical professionals and the associated costs. Consequently, the demand for more precise and time-efficient quantitative analysis has driven the emergence of novel computational methods for fat segmentation. This study presents a novel deep learning-based methodology that offers autonomous segmentation and quantification of two distinct types of cardiac fat deposits. The proposed approach leverages the pix2pix network, a generative conditional adversarial network primarily designed for image-to-image translation tasks. By applying this network architecture, we aim to investigate its efficacy in tackling the specific challenge of cardiac fat segmentation, despite not being originally tailored for this purpose. The two types of fat deposits of interest in this study are referred to as epicardial and mediastinal fats, which are spatially separated by the pericardium. The experimental results demonstrated an average accuracy of 99.08% and f1-score 98.73 for the segmentation of the epicardial fat and 97.90% of accuracy and f1-score of 98.40 for the mediastinal fat. These findings represent the high precision and overlap agreement achieved by the proposed methodology. In comparison to existing studies, our approach exhibited superior performance in terms of f1-score and run time, enabling the images to be segmented in real time.",
+      "arxivId": "2605.21333v1",
+      "title": "SymbolicLight V1: Spike-Gated Dual-Path Language Modeling with High Activation Sparsity and Sub-Billion-Scale Pre-Training Evidence",
+      "summary": "Natively trained spiking language models struggle to combine Transformer-like language quality, stable multi-domain pre-training, and high activation sparsity. We present SymbolicLight V1, a spike-gated dual-path language model that combines binary Leaky Integrate-and-Fire spike dynamics with a continuous residual stream. Its Dual-Path SparseTCAM module replaces dense self-attention with an exponential-decay aggregation path for long-range memory and a spike-gated local attention path for short-range precision, complemented by a dynamic context-conditioned decoding head and a bilingual tokenizer. A 194M-parameter SymbolicLight V1 model trained from scratch on a 3B-token Chinese-English corpus reaches held-out validation PPL 8.88-8.93 across four independent runs at >89% per-element activation sparsity. It trails GPT-2 201M by 7.7% in PPL while surpassing GPT-2 124M under the reported comparison. Component ablations at matched 0.5B-token training budgets show that the spike-gated local attention path is the largest contributor, and that replacing LIF dynamics with a deterministic top-k mask at matched sparsity causes a larger degradation, indicating that temporal integration rather than sparsity alone drives performance. We also report a 0.8B-parameter scale-up run trained on 48.8B tokens as evidence of optimization and sparsity preservation, not as a primary quality comparison. Current dense-hardware inference is slower than GPT-2, so neuromorphic deployment is presented as a future sparsity-driven opportunity rather than an achieved hardware speedup.",
       "authors": [
-        "Guilherme Santos da Silva",
-        "Dalcimar Casanova",
-        "Jefferson Tales Oliva",
-        "Erick Oliveira Rodrigues"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20064v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20064v1",
-      "publishedAt": "2026-05-19T16:20:24.000Z",
-      "updatedAt": "2026-05-19T16:20:24.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20061v1",
-      "title": "Rewarding Beliefs, Not Actions: Consistency-Guided Credit Assignment for Long-Horizon Agents",
-      "summary": "Reinforcement learning from verifiable rewards (RLVR) is a promising paradigm for improving large language model (LLM) agents on long-horizon interactive tasks. However, in partially observable environments, incomplete observations cause agent beliefs to drift over time, while delayed rewards obscure the causal impact of intermediate decisions, exacerbating temporal credit assignment challenges. To address this, we propose ReBel (Reward Belief), a process-level reinforcement learning algorithm that explicitly models structured belief states to summarize interaction history and guide subsequent policy learning. ReBel introduces belief-consistency supervision, converting discrepancies between predicted beliefs and observed feedback into dense self-supervised signals without requiring external step-wise annotations or verifiers. It also employs belief-aware grouping to compare trajectories under similar belief states, yielding more robust and lower-variance advantage estimates. We evaluate ReBel on challenging long-horizon benchmarks, including ALFWorld and WebShop. ReBel improves task success by up to $20.4$ percentage points over the episode-level baseline GRPO and increases sample efficiency by $2.1\\times$. These results suggest that belief-aware self-supervision is a promising direction for reliable long-horizon decision-making under partial observability. Code is available at: https://github.com/Fateyetian/Rebel.git.",
-      "authors": [
-        "Wenjie Tang",
-        "Minne Li",
-        "Sijie Huang",
-        "Liquan Xiao",
-        "Yuan Zhou"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20061v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20061v1",
-      "publishedAt": "2026-05-19T16:19:29.000Z",
-      "updatedAt": "2026-05-19T16:19:29.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20055v1",
-      "title": "Towards LLM-Assisted Architecture Recovery for Real-World ROS~2 Systems: An Agent-Based Multi-Level Approach to Hierarchical Structural Architecture Reconstruction",
-      "summary": "Explicit software architecture models are essential artifacts for communicating, analyzing, and evolving complex software-intensive systems. In ROS~2-based robotic systems, however, structural (de-)composition and integration semantics are often only implicitly encoded across distributed artifacts such as source code and launch files, making recovery of hierarchical architecture particularly difficult. Existing approaches mainly focus on node-level entities and communication wiring, while providing limited support for recovering hierarchical structural (de-)composition across multiple abstraction levels. In this paper, we extend our previously proposed blueprint-guided LLM-assisted architecture recovery pipeline for ROS~2 systems through two major enhancements: (1) refined prompting to improve the consistency and controllability of architecture synthesis, and (2) a staged recovery strategy based on multi-level intermediate architectural representations that incorporate the atomic ROS node list and launch file dependencies, thereby enabling structurally constrained reconstruction across multiple abstraction levels. The approach is evaluated on a real-world automated product disassembly system based on cooperative robotic arms and heterogeneous ROS~2 artifacts. Compared to our previous work, the considered case study exhibits substantially higher integration complexity and richer functionality. The results demonstrate improved structural consistency, scalability, and robustness of architecture recovery, while also revealing remaining challenges related to dynamic integration semantics in large-scale ROS~2 systems.",
-      "authors": [
-        "Dominique Briechle",
-        "Raj Chanchad",
-        "Tobias Geger",
-        "Ruidi He",
-        "Dhruv Jajadiya",
-        "Dhruv Kapadiya",
-        "Andreas Rausch",
-        "Meng Zhang"
-      ],
-      "categories": [
-        "cs.SE",
-        "cs.AI",
-        "cs.RO"
-      ],
-      "primaryCategory": "cs.SE",
-      "absUrl": "https://arxiv.org/abs/2605.20055v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20055v1",
-      "publishedAt": "2026-05-19T16:14:33.000Z",
-      "updatedAt": "2026-05-19T16:14:33.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20052v1",
-      "title": "PromptRad: Knowledge-Enhanced Multi-Label Prompt-Tuning for Low-Resource Radiology Report Labeling",
-      "summary": "Automatic report labeling facilitates the identification of clinical findings from unstructured text and enables large-scale annotation for medical imaging research. Existing rule-based labelers struggle with the diverse descriptions in clinical reports, while fine-tuning pre-trained language models (PLMs) requires large amounts of labeled data that are often unavailable in clinical settings. In this paper, we propose PromptRad, a knowledge-enhanced multi-label \\textbf{prompt}-tuning approach for \\textbf{rad}iology report labeling under low-resource settings. PromptRad reformulates multi-label classification as masked language modeling and incorporates synonyms from the UMLS Metathesaurus into a multi-word verbalizer to enrich category representations. By fine-tuning the PLM without additional classification layers, PromptRad requires substantially less labeled data than conventional fine-tuning. Experiments on liver CT reports show that PromptRad outperforms dictionary-based and fine-tuning baselines with only 32 labeled training examples, and achieves competitive performance with GPT-4 despite using a much smaller model. Further analysis demonstrates that PromptRad captures complex negation patterns more effectively than existing methods, making it a promising solution for report labeling in data-scarce clinical scenarios. Our code is available at https://github.com/ila-lab/PromptRad.",
-      "authors": [
-        "Ying-Jia Lin",
-        "Tzu-Chin Lo",
-        "Ping-Chien Li",
-        "Chi-Tung Cheng",
-        "Chien-Hung Liao",
-        "Hung-Yu Kao"
+        "Ting Liu"
       ],
       "categories": [
         "cs.CL",
         "cs.AI"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20052v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20052v1",
-      "publishedAt": "2026-05-19T16:07:42.000Z",
-      "updatedAt": "2026-05-19T16:07:42.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21333v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21333v1",
+      "publishedAt": "2026-05-20T16:00:20.000Z",
+      "updatedAt": "2026-05-20T16:00:20.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20050v1",
-      "title": "Language Mutations Sustain the Persistences of Conspiracy Theories on Social Media",
-      "summary": "This study investigates how language mutations affect the persistent diffusion of conspiracy theories on social media. Drawing on a three-year dataset of conspiracy-related posts from X, and applying computational linguistic analysis alongside survival modelling, we find that conspiracy claims with greater semantic mutations have substantially longer lifespans. Mutations in psycholinguistic properties, including pronouns, social reference words, cognitive process terms, risk- and health- related vocabularies, are associated with extended lifespans. Mutations in actor, action and target (AAT) categories are associated with longer lifespans as well. Qualitative analysis identifies two predominant mutation patterns: simplification and assimilation, at both linguistic and AAT structural levels. Taken together, the results advance our understanding of how language mutations contribute to conspiracy persistence online and shed lights on longitudinal content moderation strategies. We argue that content moderation should consider the mutability of conspiracy claims and focus on the core claims that can address their potential variations.",
+      "arxivId": "2605.21325v1",
+      "title": "Fast and Stable Triangular Inversion for Delta-Rule Linear Transformers",
+      "summary": "Linear attention has emerged as a cornerstone for efficient long-context architectures, as evidenced by its integration into state-of-the-art open-source models including Qwen3.5/3.6, Kimi Linear, and RWKV-7. Models that incorporate linear attention layers with the so-called Delta-Rule involve the inversion of triangular matrices as a core sub-routine. This operation often forms a performance bottleneck, and, due to its high-sensitivity to numerical errors, it can significantly deteriorate end-to-end model accuracy if it is not carefully implemented. This work provides a systematic analysis of both direct and iterative triangular inversion algorithms, targeting methods that are rich in matrix products, and, therefore, have the potential to efficiently utilize modern hardware. To that end, our analysis covers a broad spectrum of mathematical and practical aspects, with a heavy focus on numerical stability, computational complexity, and, ultimately, hardware efficiency and practical considerations. We provide a rigorous experimental evaluation to verify these properties in practical scenarios, and in low-precision floating-point representations, highlighting the strengths and limitations of each method. Performance benchmarks on NPUs reveal up to $4.3\\times$ speed-up against the state-of-the-art implementations of SGLang for triangular matrix inversion, leading to significant performance improvements on the entire layer level, while maintaining full end-to-end model accuracy.",
       "authors": [
-        "Calvin Yixiang Cheng",
-        "Dorian Quelle",
-        "Scott A. Hale"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20050v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20050v1",
-      "publishedAt": "2026-05-19T16:06:41.000Z",
-      "updatedAt": "2026-05-19T16:06:41.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20049v1",
-      "title": "Does Code Cleanliness Affect Coding Agents? A Controlled Minimal-Pair Study",
-      "summary": "As autonomous coding agents see rapid adoption, their evaluation has primarily focused on task completion rates holding the target codebase fixed. This leaves a critical question unanswered: does the structural and stylistic quality, or ``cleanliness'' of the underlying code affect an agent's ability to navigate and modify it? To isolate the effect of code cleanliness from agent capability, we introduce an evaluation protocol built around minimal pairs: repositories that match on architecture, dependencies, and external behaviour, but differ on static-analysis rule violations and cognitive complexity. The pairs are constructed in both directions, by agent pipelines that either degrade a clean repository or clean a messy one. We author 33 tasks across six such pairs, evaluated through hidden tests at the application's public surface. Across 660 trials with Claude Code, code cleanliness does not change the agent's pass rate. However, it substantially alters the agent's operational footprint: agents working on cleaner code use 7 to 8% fewer tokens and reduce file revisitations by 34%. Our findings suggest that traditional maintainability principles remain highly relevant in the era of AI-driven development, shaping the computational cost and navigational efficiency of coding agents. Code cleanliness joins model choice, harness, and prompting as a factor that materially affects agent behaviours.",
-      "authors": [
-        "Priyansh Trivedi",
-        "Olivier Schmitt"
-      ],
-      "categories": [
-        "cs.SE",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.SE",
-      "absUrl": "https://arxiv.org/abs/2605.20049v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20049v1",
-      "publishedAt": "2026-05-19T16:06:26.000Z",
-      "updatedAt": "2026-05-19T16:06:26.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20044v1",
-      "title": "OP2GS: Object-Aware 3D Gaussian Splatting with Dual-Opacity Primitives",
-      "summary": "3D Gaussian Splatting (3DGS) provides an explicit and efficient scene representation, but its primitives lack inherent object-level identity, hindering downstream tasks such as open-vocabulary scene understanding. Existing methods typically address this by either distilling high-dimensional feature embeddings into Gaussians or by lifting 2D mask labels into 3D via heuristic refinement. However, feature-based approaches incur heavy storage and decoding overhead, while lifting-based pipelines remain vulnerable to label contamination: Gaussians necessary for appearance reconstruction often receive incorrect object labels during 2D-to-3D projection. We propose OP2GS, an object-aware Gaussian representation that augments each primitive with an explicit instance identity and a dedicated instance opacity $σ^{*}$ for object-mask rendering. The original opacity $σ$ remains responsible for visual reconstruction, while $σ^{*}$ models whether a Gaussian should contribute to a particular object mask. This dual-opacity formulation decouples visual existence from instance occupancy: mislabeled Gaussians can remain available for image rendering while becoming transparent in the object-mask branch. To learn this representation, we introduce a random object loss that optimizes the 1D instance occupancy field using the standard transmittance-based visibility of 3DGS. Semantic descriptors are then attached at the object level through multi-view aggregation, eliminating per-Gaussian feature storage. Compared with feature-training approaches, OP2GS achieves competitive open-vocabulary performance while significantly reducing computational overhead. Compared with training-free pipelines, it leverages physically consistent occupancy learning to resolve visibility ambiguities.",
-      "authors": [
-        "Guiyu Liu",
-        "Niklas Vaara",
-        "Janne Mustaniemi",
-        "Juho Kannala",
-        "Janne Heikkilä"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20044v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20044v1",
-      "publishedAt": "2026-05-19T16:05:48.000Z",
-      "updatedAt": "2026-05-19T16:05:48.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20043v1",
-      "title": "Mind Your Moras: Orthography-Aware Error Analysis of Neural Japanese Morphological Generation",
-      "summary": "We present an orthography-aware error analysis of Japanese past-tense morphological inflection, treating hiragana not merely as a transcriptional medium, but as a representational system encoding morphophonological distinctions that may influence model generalization. We evaluate two character-level sequence-to-sequence architectures on past-tense formation using datasets formatted according to the SIGMORPHON 2020 and 2023 shared task conventions. Despite high aggregate accuracy, models exhibit systematic, linguistically interpretable errors that cluster around specific orthographic properties of hiragana. We introduce a concise error taxonomy capturing seven primary failure modes and provide both quantitative and qualitative analyses. Gemination-related errors dominate residual failures, accounting for 75-80% of errors, particularly in verbs whose stems end in the vowel e and require gemination before the past-tense suffix. Error patterns remain highly consistent across architectures and random seeds, suggesting a robust interaction between orthographic representation, morphological structure, and data frequency effects in shaping model generalization. These results underscore the necessity of orthography-aware evaluation for understanding neural generalization in morphologically complex languages.",
-      "authors": [
-        "Wen Zhang"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20043v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20043v1",
-      "publishedAt": "2026-05-19T16:04:33.000Z",
-      "updatedAt": "2026-05-19T16:04:33.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20040v1",
-      "title": "Active Context Selection Improves Simple Regret in Contextual Bandits",
-      "summary": "We study the contextual multi-armed bandit problem with a finite context space (a.k.a. subpopulations), where the learner recommends a best action for each context and is evaluated by context-weighted simple regret. Our guarantees are worst-case over the reward distributions, while remaining instance-dependent with respect to the context distribution vector $p$. Akin to experimental design problems where the population of interest is fixed but the sampled subpopulation can be controlled, we allow the learner to actively choose which context to sample from. For a known $p$, we characterize tight regret rates: passive sampling where contexts are randomly revealed achieves regret of order $\\sqrt{n/T \\, \\lVert p \\rVert_{1/2}}$, whereas active sampling with allocation $q_j \\propto p_j^{2/3}$ achieves the tight rate $\\sqrt{n/T} \\, \\lVert p \\rVert_{2/3}$. The resulting improvement can be as large as $Θ(k^{1/4})$, where $k$ is the number of contexts. We further extend the analysis to budgeted active sampling, characterize the corresponding tight rate, and identify when a limited active budget suffices to recover the fully active rate. When $p$ is unknown, we propose the Explore-Explore-Then-Commit (EETC) algorithm, which optimally balances estimating the context distribution and the time to switch to active allocation, such that for large horizons, it matches the known-$p$ active rate up to constants. Experiments on synthetic and real-world data support our theoretical findings.",
-      "authors": [
-        "Mohammad Shahverdikondori",
-        "Jalal Etesami",
-        "Negar Kiyavash"
+        "Aleksandros Sobczyk",
+        "Gioele Gottardo",
+        "Christos K. Matzoros",
+        "Mirko De Vita",
+        "Filip Skogh",
+        "Anastasios Zouzias",
+        "Jiawei Zhuang"
       ],
       "categories": [
         "cs.LG"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20040v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20040v1",
-      "publishedAt": "2026-05-19T16:01:58.000Z",
-      "updatedAt": "2026-05-19T16:01:58.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21325v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21325v1",
+      "publishedAt": "2026-05-20T15:51:32.000Z",
+      "updatedAt": "2026-05-20T15:51:32.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20037v1",
-      "title": "When Critics Disagree: Adaptive Reward Poisoning Attacks in RIS-Aided Wireless Control System",
-      "summary": "Reward-poisoning attacks present a significant risk to learning-based wireless control systems. Given this, we propose a Disagreement-Guided Reward Poisoning (DGRP) adaptive attack on a Soft Actor-Critic (SAC) agent. In a Cognitive Radio Network (CRN) environment assisted by Reconfigurable Intelligent Surfaces (RIS), the SAC agent is tasked with maximizing the long-term secondary users' (SUs) rate by simultaneously optimizing the transmission power of the SU transmitter and the RIS phase shifts. DGRP corrupts rewards, particularly when the SAC dual critics exhibit substantial disagreement-especially in high-leverage, high-uncertainty states-resulting in distorted value estimations and guiding the policy towards suboptimal actions. Our findings demonstrate that DGRP substantially diminishes the performance improvements typically provided by RIS and degrades transmission quality. We further investigate key attack parameters and determine their impact on learning. In comparison to periodic-timing and exploration-triggered baselines, DGRP consistently causes greater damage, highlighting the necessity of considering disagreement-aware threats when evaluating the robustness of Deep Reinforcement Learning (DRL) in RIS-assisted networks.",
+      "arxivId": "2605.21324v1",
+      "title": "Stimulus symmetries can confound representational similarity analyses",
+      "summary": "What can representational similarity matrices (RSMs) tell us about a neural code? As the popularity of these summary statistics grows, so too does the need for a more complete characterization of their properties. Here, we show that symmetries in network inputs can confound RSM-based analyses. Stimulus symmetries render many representations functionally equivalent, but these different configurations can lead to different RSMs. These different RSMs reflect qualitatively different representational geometries. We show that stochastic gradient descent or energetic regularization can generate sparse, drifting codes, leading in turn to drifting RSMs. Moreover, we demonstrate that these phenomena are present in networks trained to encode image data, where the symmetry is latent. Our results illustrate the challenges inherent in comparing nonlinear neural codes, when functionally-equivalent representations are not related by a simple rotation.",
       "authors": [
-        "Deemah H. Tashman",
-        "Soumaya Cherkaoui"
+        "Farhad Pashakhanloo",
+        "Jacob A. Zavatone-Veth"
+      ],
+      "categories": [
+        "q-bio.NC",
+        "cs.LG"
+      ],
+      "primaryCategory": "q-bio.NC",
+      "absUrl": "https://arxiv.org/abs/2605.21324v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21324v1",
+      "publishedAt": "2026-05-20T15:51:21.000Z",
+      "updatedAt": "2026-05-20T15:51:21.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21322v1",
+      "title": "Optimized Federated Knowledge Distillation with Distributed Neural Architecture Search",
+      "summary": "Federated Learning (FL) enables collaborative model training without centralizing data. However, real-world deployments must simultaneously address statistical heterogeneity across client data (non-IID), system heterogeneity in device capabilities, and communication efficiency. Existing FL approaches mitigate these challenges through improved aggregation, personalization, or knowledge distillation, but they almost universally assume a fixed client architecture, limiting adaptability to heterogeneous data complexity and hardware constraints. This architectural constraint often leads to suboptimal trade-offs between accuracy and efficiency in real-world FL systems. This work introduces FedKDNAS, a distillation-driven FL framework that combines client-side neural architecture selection with distillation of server-coordinated knowledge. Each client autonomously selects a lightweight model under accuracy-resource constraints. It then trains it locally using a hybrid objective combining supervised learning and knowledge distillation and shares only predictions on a public reference set. The server then aggregates and smooths these predictions, optionally combining them with a teacher model, to produce stable distillation targets for the next round. Extensive evaluation on six datasets against six representative FL baselines (FedAvg, Ditto, FedMD, FedDF, FedDistill, Local-KD) demonstrates that FedKDNAS consistently achieves superior Pareto efficiency, improving accuracy by up to 15\\% under non-IID conditions, reducing client CPU usage by approximately 28\\%, and decreasing communication overhead by up to 44 times while maintaining lightweight logit-based communication.",
+      "authors": [
+        "Chaimaa Medjadji",
+        "Sylvain Kubler",
+        "Yves Le Traon",
+        "Guilain Leduc",
+        "Sadi Alawadi",
+        "Feras M. Awaysheh"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21322v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21322v1",
+      "publishedAt": "2026-05-20T15:50:49.000Z",
+      "updatedAt": "2026-05-20T15:50:49.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21318v1",
+      "title": "TextReg: Mitigating Prompt Distributional Overfitting via Regularized Text-Space Optimization",
+      "summary": "Large language models (LLMs) are highly sensitive to the prompts used to specify task objectives and behavioral constraints. Many recent prompt optimization methods iteratively rewrite prompts using LLM-generated feedback, but the resulting prompts often become longer, accumulate narrow sample-specific rules, and generalize poorly beyond the training distribution. We study this failure mode as prompt distributional overfitting and argue that it reflects a lack of representation control in discrete text-space optimization. We formalize this view through representational inefficiency, a dual-factor measure that decomposes prompt inefficiency into capacity cost and scope narrowness, attributing distributional prompt overfitting to their coupled growth during optimization. We propose TextReg, a regularization framework that realizes a soft-penalty objective through regularized textual gradients, combining Dual-Evidence Gradient Purification, Semantic Edit Regularization, and Regularization-Guided Prompt Update. Across multiple reasoning benchmarks, TextReg substantially improves out-of-distribution (OOD) generalization, with accuracy gains of up to +11.8% over TextGrad and +16.5% over REVOLVE.",
+      "authors": [
+        "Lucheng Fu",
+        "Ye Yu",
+        "Yiyang Wang",
+        "Yiqiao Jin",
+        "Haibo Jin",
+        "B. Aditya Prakash",
+        "Haohan Wang"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21318v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21318v1",
+      "publishedAt": "2026-05-20T15:47:26.000Z",
+      "updatedAt": "2026-05-20T15:47:26.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21317v1",
+      "title": "CRAFT: Conflict-Resolved Aggregation for Federated Training",
+      "summary": "The aggregation of conflicting client updates remains a fundamental bottleneck in federated learning (FL) under heterogeneous data distributions. Naive averaging can produce a global update that improves the global objective while conflicting with specific clients, causing degradation for those clients. In this work, we propose CRAFT (Conflict-Resolved Aggregation for Federated Training), a new aggregation framework that treats the global update as a geometric correction problem. We formulate aggregation as finding the update closest to a reference direction while satisfying conflict-free alignment constraints. We derive a closed-form expression for the constrained optimization problem, avoiding the computational overhead of iterative solvers. Furthermore, we use a layer-wise adaptation to address conflicts at varying feature granularities. We provide a theoretical analysis showing that CRAFT promotes a common-descent structure and mitigates conflicts through its projection geometry. Extensive experiments on heterogeneous benchmarks demonstrate that CRAFT improves the accuracy of the global model while reducing performance disparity across clients compared with state-of-the-art baselines. The source code for CRAFT is available at https://github.com/tum-pbs/CRAFT.",
+      "authors": [
+        "Ziqi Wang",
+        "Qiang Liu",
+        "Nils Thuerey"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21317v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21317v1",
+      "publishedAt": "2026-05-20T15:47:11.000Z",
+      "updatedAt": "2026-05-20T15:47:11.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21313v1",
+      "title": "A New Framework to Analyse the Distributional Robustness of Deep Neural Networks",
+      "summary": "Deep neural networks have achieved impressive performance on a variety of tasks, but their brittleness to distributional shifts remains a significant barrier to real-world deployment. In this paper, we propose a framework to analyse and quantify the distributional robustness of neural networks by studying the interactions between layer weights and activations. We model these interactions using Bernoulli distributions, using the separation between classes as a diagnostic proxy for robustness. We demonstrate the usefulness of this framework through models trained on CIFAR-10 and ImageNet. We show that our proposed metrics can distinguish between networks that have memorised their training data and those that have not. We also perform analogous experiments in the activation space and find that the same properties do not hold up. Additionally, we investigate the behaviour of our metrics under various distribution shifts and show that these shifts reduce separation under our path-based diagnostics. Our results suggest that this framework provides useful model-level diagnostics of representation structure and robustness.",
+      "authors": [
+        "Divij Khaitan",
+        "Subhashis Banerjee"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21313v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21313v1",
+      "publishedAt": "2026-05-20T15:42:56.000Z",
+      "updatedAt": "2026-05-20T15:42:56.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21312v1",
+      "title": "Frontier: Towards Comprehensive and Accurate LLM Inference Simulation",
+      "summary": "Modern LLM serving is no longer homogeneous or monolithic. Production systems now combine disaggregated execution, complex parallelism, runtime optimizations, and stateful workloads such as reasoning, agents, and RL rollouts. Simulation is attractive for exploring this growing design space, yet existing simulators lack the architectural completeness and decision-grade fidelity it demands. Their monolithic-replica abstractions are ill-suited to disaggregated serving, while average-case analytical proxies can distort SLA predictions and even reverse optimization conclusions. We present Frontier, a discrete-event simulator for modern LLM inference serving. Frontier features a disaggregated abstraction. It captures the structure and dynamics of modern serving systems by modeling co-location, Prefill-Decode Disaggregation (PDD), and Attention-FFN Disaggregation (AFD) with role-specific cluster workers, incorporating key runtime optimizations (e.g., CUDA Graphs, speculative decoding) within the scheduler-batch-engine loop, and supporting stateful requests for emerging workloads. It further provides accurate and generalizable predictions of computation, communication, and memory costs across diverse serving scenarios with complex workload compositions. On 16-H800 GPU testbed, Frontier achieves an average throughput error below 4%. Compared with state-of-the-art simulators, it reduces end-to-end latency error from 44.9% to 6.4% under co-location and from 51.7% to 2.6% under disaggregation. It scales to over 1K GPUs on commodity CPUs and enables new use cases such as SLA-dependent Pareto frontier exploration, heterogeneous disaggregated allocation, agentic reasoning scheduling validation, and RL post-training reconfiguration.",
+      "authors": [
+        "Yicheng Feng",
+        "Xin Tan",
+        "Yangtao Deng",
+        "Yimin Jiang",
+        "Yibo Zhu",
+        "Hong Xu"
+      ],
+      "categories": [
+        "cs.DC",
+        "cs.AI",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.DC",
+      "absUrl": "https://arxiv.org/abs/2605.21312v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21312v1",
+      "publishedAt": "2026-05-20T15:40:18.000Z",
+      "updatedAt": "2026-05-20T15:40:18.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21311v1",
+      "title": "DeCoR: Design and Control Co-Optimization for Urban Streets Using Reinforcement Learning",
+      "summary": "Modern vision systems can detect, track, and forecast urban actors at scale, yet translating perception outputs to urban design remains limited. We introduce DeCoR, a two-stage reinforcement learning framework that leverages flow observations to co-optimize crosswalk layout and network-level signal control. The design stage encodes the pedestrian network as a graph and learns a generative policy that parameterizes a Gaussian mixture model over crosswalk location and width, from which new crosswalks are sampled. For each layout, a shared control policy learns adaptive signal timings to minimize joint pedestrian and vehicle delay. On a 750 m real-world urban corridor with demand sensed from video and Wi-Fi logs, DeCoR learns a layout that reduces pedestrian arrival time to their nearest crosswalk by 23% while using fewer crosswalks than existing configurations. On the control side, DeCoR reduces pedestrian and vehicle wait time by 79% and 65%, respectively, relative to fixed-time signalization. Further, the control policy generalizes to demands outside of training and is robust to layout changes without retraining.",
+      "authors": [
+        "Bibek Poudel",
+        "Lei Zhu",
+        "Kevin Heaslip",
+        "Sai Swaminathan",
+        "Weizi Li"
       ],
       "categories": [
         "cs.LG",
         "cs.AI"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20037v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20037v1",
-      "publishedAt": "2026-05-19T15:59:43.000Z",
-      "updatedAt": "2026-05-19T15:59:43.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21311v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21311v1",
+      "publishedAt": "2026-05-20T15:39:06.000Z",
+      "updatedAt": "2026-05-20T15:39:06.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20036v1",
-      "title": "D$^3$-Subsidy: Online and Sequential Driver Subsidy Decision-Making for Large-Scale Ride-Hailing Market",
-      "summary": "Ride-hailing platforms like DiDi Chuxing operate in highly dynamic environments where balancing driver supply and passenger demand is critical. Although driver-side subsidies serve as a primary lever to align these forces and improve key KPIs like completed rides (\\texttt{Rides}) and gross merchandise value (\\texttt{GMV}), optimizing them in production requires simultaneously meeting three constraints: (i) responsiveness to stochastic shocks, (ii) strict subsidy-rate caps, and (iii) low-latency execution at city scale. These requirements rule out expensive per-order optimization, calling for a forward-looking, constraint-aware city-level controller for online sequential decision making. To meet these requirements, we introduce D$^3$-Subsidy (Dynamic Driver-side Diffusion-based Subsidy), a hierarchical diffusion-based framework for deployable city-wide subsidy control. To bridge the train-inference gap, D$^3$-Subsidy employs a prefix-conditioned diffusion model that samples plausible future trajectories from immutable historical observations, ensuring the training protocol aligns with the fixed-history nature of online deployment. These generated plans are then decoded by a context-conditioned inverse module into low-dimensional city-level control signals. For scalable execution, we bridge the gap between city-level planning and fine-grained dispatch via a Lagrangian-dual-derived mapping, which embeds subsidy-rate caps directly into order-driver incentives without iterative optimization. Additionally, a multi-city pretraining strategy with parameter-efficient fine-tuning enables robust transfer across heterogeneous cities. Extensive offline evaluations demonstrate that D$^3$-Subsidy improves \\texttt{Rides} and \\texttt{GMV} while enhancing cap compliance, and a real-world A/B test confirms significant uplift while keeping budget-related violation metrics within operational thresholds.",
+      "arxivId": "2605.21309v1",
+      "title": "Hyper-V2X: Hypernetworks for Estimating Epistemic and Aleatoric Uncertainty in Cooperative Bird's-Eye-View Semantic Segmentation",
+      "summary": "Cooperative perception enabled by Vehicle-to-Everything (V2X) communication enhances autonomous driving safety by creating a unified environmental representation through shared sensory data. While recent works have advanced multi-agent fusion for improved perception, uncertainty quantification in such cooperative frameworks remains largely unexplored. This paper introduces Hyper-V2X, a hypernetwork-based framework for estimating both epistemic and aleatoric uncertainties in V2X-based perception. Specifically, we propose a partial weight generation scheme and V2X context embedding module that conditions a Bayesian hypernetwork on fused multi-agent features to generate weight distributions for stochastic Bird's-Eye-View (BEV) segmentation. Unlike existing deterministic BEV models, Hyper-V2X enables efficient uncertainty estimation with little computation overhead. Our approach is architecture-agnostic, and can be seamlessly integrating with modern cooperative backbones such as CoBEVT. Experiments on the OPV2V benchmark demonstrate that Hyper-V2X provides accurate, well-calibrated uncertainty estimates and improves overall perception reliability. Our code and benchmark are publicly available under an open-source license: https://github.com/abhishekjagtap1/Hyper-V2X",
       "authors": [
-        "Taijie Chen",
-        "Rui Su",
-        "Siyuan Feng",
-        "Laoming Zhang",
-        "Hongyang Zhang",
-        "Haijiao Wang",
-        "Zhaofeng Ma",
-        "Jintao Ke"
-      ],
-      "categories": [
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20036v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20036v1",
-      "publishedAt": "2026-05-19T15:55:55.000Z",
-      "updatedAt": "2026-05-19T15:55:55.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20035v1",
-      "title": "Stage-adaptive Token Selection for Efficient Omni-modal LLMs",
-      "summary": "Omni-modal large language models (om-LLMs) achieve unified audio-visual understanding by encoding video and audio into temporally aligned token sequences interleaved at the window level. However, processing these dense non-textual tokens throughout the LLM incurs substantial computational overhead. Although training-free token selection can reduce this cost, existing methods either focus on visual-only inputs or prune om-LLM tokens only before the LLM with fixed per-modality ratios, failing to capture how cross-modal token importance evolves across layers. To address this limitation, we first analyze the layer-wise token dependency of om-LLMs. We find that visual and audio dependencies follow a block-wise pattern and gradually weaken with depth, indicating that many late-layer non-textual tokens become redundant after cross-modal fusion. Motivated by this observation, we propose SEATS, a training-free, stage-adaptive token selection method for efficient om-LLM inference. Before the LLM, SEATS removes spatiotemporal redundancy via attention-weighted diversity selection. Inside the LLM, it progressively prunes tokens across blocks and dynamically allocates the retention budget from temporal windows to modalities using query relevance scores. In late layers, it removes all remaining non-textual tokens once cross-modal fusion is complete. Experiments on Qwen2.5-Omni and Qwen3-Omni demonstrate that SEATS effectively improves inference efficiency. Retaining only 10% of visual and audio tokens, it achieves a 9.3x FLOPs reduction and a 4.8x prefill speedup while preserving 96.3% of the original performance.",
-      "authors": [
-        "Zijie Xin",
-        "Jie Yang",
-        "Ruixiang Zhao",
-        "Tianyi Wang",
-        "Fengyun Rao",
-        "Jing Lyu",
-        "Xirong Li"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20035v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20035v1",
-      "publishedAt": "2026-05-19T15:55:16.000Z",
-      "updatedAt": "2026-05-19T15:55:16.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20033v1",
-      "title": "A Nash Equilibrium Framework For Training-Free Multimodal Step Verification",
-      "summary": "Multimodal large language models often generate reasoning chains containing subtle errors that lead to incorrect answers. Current verification approaches have notable limitations. Learned critics need extensive labeled data and show inconsistent performance across different tasks. Meanwhile, existing training-free methods simply average scores from different sources, missing a key insight: when these scores disagree, that disagreement itself carries important information about whether a reasoning step is truly valid or not. We propose a training-free verification approach that treats step-wise verification as a coordination problem among specialized judges. We formalize these judges' interaction as a Nash equilibrium game where agreement signals valid steps while disagreement reveals instability. Our method computes equilibrium scores through a closed-form solution, enabling both disagreement-aware filtering and stability-conscious ranking of reasoning steps. Evaluated across six benchmarks, our approach achieves consistent improvements of 2.4% to 5.2% over baseline models and shows competitive performance against learned critics, demonstrating that cross-modal agreement (not just average confidence) provides robust verification signals without task-specific adaptation.",
-      "authors": [
-        "Rohit Sinha",
-        "Kunal Tilaganji",
-        "Tanuja Ganu",
-        "Nagarajan Natarajan",
-        "Amit Sharma",
-        "Vineeth N. Balasubramanian"
+        "Abhishek Dinkar Jagtap",
+        "Sanath Tiptur Sadashivaiah",
+        "Andreas Festag"
       ],
       "categories": [
         "cs.CV",
-        "cs.GT"
+        "cs.RO"
       ],
       "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.20033v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20033v1",
-      "publishedAt": "2026-05-19T15:54:22.000Z",
-      "updatedAt": "2026-05-19T15:54:22.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21309v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21309v1",
+      "publishedAt": "2026-05-20T15:36:46.000Z",
+      "updatedAt": "2026-05-20T15:36:46.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20032v1",
-      "title": "CAMERA: Adapting to Semantic Camouflage in Unsupervised Text-Attributed Graph Fraud Detection",
-      "summary": "Text-attributed graph fraud detection (TAGFD) plays a critical role in preventing fraudulent activities on online social and e-commerce platforms. However, to evade detection, fraudsters continuously evolve their camouflaging strategies by deliberately mimicking textual responses of benign users, thereby concealing their malicious purposes. This phenomenon, referred to as semantic camouflage, fundamentally undermines commonly relied assumptions on how structural and attribute cues can be exploited to identify fraudsters, and makes it difficult to spot fraudsters with unsupervised TAGFD. To bridge the gaps, we propose a Case-Adaptive Multi-cue Expert fRAmework (CAMERA) for unsupervised TAGFD. CAMERA employs an ego-decoupled mixture-of-experts architecture, where each expert specializes in modeling a distinct type of fraud-indicative cue. A context-informed gating model is introduced to jointly consider the ego node representation and its local neighborhood context for adaptive integration of cues learned by different experts. Furthermore, CAMERA leverages the inherent rarity of fraudsters to support unsupervised one-class learning with expert-level objectives that encourage modeling dominant benign patterns, thereby enabling reliable unsupervised detection of camouflaged fraudsters. Experiments on 4 challenging datasets show that CAMERA consistently outperforms competitors, showing its effectiveness against semantically camouflaged fraudsters. Code available at https://github.com/CampanulaBells/CAMERA",
+      "arxivId": "2605.21308v1",
+      "title": "Deformba: Vision State Space Model with Adaptive State Fusion",
+      "summary": "State Space Models (SSMs) have emerged as a powerful and efficient alternative to Transformers, demonstrating linear-time complexity and exceptional sequence modeling capabilities. However, their application to vision tasks remains challenging. First, existing vision SSMs largely depend on manually designed fixed scanning methods to flatten image patches into sequences, which imposes predefined geometric structures and increases the complexity. Second, the broader adoption of vision SSMs is hindered in domains that require query-based interactions between distinct information streams. This is a result of the inherently causal and self-referential nature of SSMs designed for 1D sequence modeling tasks. This fusion mechanism is indispensable for critical perception tasks such as multi-view 3D fusion. To address these limitations, we propose Deformba, a context adaptive method that dynamically augments the spatial structural information while maintaining the linear complexity of SSMs. Deformba also allows multi-modal fusion like cross attention. To demonstrate the effectiveness and general applicability of Deformba, we test its performance on general 2D vision tasks such as image classification, object detection, and segmentation, as well as 3D vision tasks like BEV perception. Extensive experiments show that Deformba achieves strong performance across various visual perception benchmarks.",
       "authors": [
-        "Junjun Pan",
-        "Yixin Liu",
-        "Yu Zheng",
-        "Lianhua Chi",
-        "Alan Wee-Chung Liew",
-        "Shirui Pan"
+        "Hongyu Ke",
+        "Jack Morris",
+        "Yongkang Liu",
+        "Satoshi Kitai",
+        "Kentaro Oguchi",
+        "Yi Ding",
+        "Haoxin Wang"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21308v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21308v1",
+      "publishedAt": "2026-05-20T15:36:20.000Z",
+      "updatedAt": "2026-05-20T15:36:20.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21303v1",
+      "title": "From Circuit Evidence to Mechanistic Theory: An Inductive Logic Approach",
+      "summary": "Mechanistic interpretability produces circuit-level causal analyses of neural network behaviour, but discovered circuits often remain isolated experimental artefacts: there is no shared formal representation for what circuits compute, how they relate, or when two findings provide evidence for the same mechanism. This work provides a formal infrastructure for cumulative mechanistic science by treating circuit interpretation as inductive theory construction. Each circuit is characterised at two levels: a Causal Functional Signature (CFS), which grounds component behaviour in causal attribution evidence and token role profiles, and an architectural signature $τ_{\\mathrm{arch}}$, learned by inductive logic programming (ILP) from scale-invariant structural predicates. Together, these constitute a formal coherence layer that makes mechanistic claims explicit, comparable via $θ$-subsumption, and portable across model scales. CFS reveals qualitatively distinct computational strategies across task types, including attention-mediated copying versus MLP-mediated binding. ILP signatures achieve substantially better structural separation than graph kernel and feature-vector baselines, and support principled transfer across model scales and architecture families.",
+      "authors": [
+        "Nura Aljaafari",
+        "Danilo S. Carvalho",
+        "Andre Freitas"
       ],
       "categories": [
         "cs.LG",
-        "cs.MM"
+        "cs.AI",
+        "cs.LO"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20032v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20032v1",
-      "publishedAt": "2026-05-19T15:54:09.000Z",
-      "updatedAt": "2026-05-19T15:54:09.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21303v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21303v1",
+      "publishedAt": "2026-05-20T15:33:14.000Z",
+      "updatedAt": "2026-05-20T15:33:14.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20030v1",
-      "title": "Take It or Leave It: Intent-Controlled Partial Optimal Transport",
-      "summary": "While optimal transport (OT) enforces a rigid constraint by requiring two measures to be matched exactly, partial optimal transport relaxes this requirement by allowing mass to remain unmatched through a global budget, scalar rebate, or uniform rejection rule. However, many applications call for more structured, pointwise rejection mechanisms, where the decision to leave mass unmatched depends on side-specific reliability, support geometry, or external information about which components should participate in the comparison. We introduce \\emph{intent-controlled partial optimal transport} (IC-POT), a targeted generalization of partial transport that replaces the global rejection paradigm with pointwise rejection costs over both measures. We show that the resulting optimization problem admits a dual interpretation in terms of local acceptance thresholds and can be solved by recasting it as a balanced Kantorovich OT problem on an augmented support. Beyond theoretical analysis, we demonstrate the practical relevance of IC-POT in settings where rejection is driven by side information. In positive-unlabeled learning and open-partial domain adaptation, incorporating pointwise rejection rules that encode statistical structure improves fixed baseline pipelines. Finally, we motivate the use of IC-POT with a geophysical practical case: multi-modal satellite ocean measurements, for which physical and sensors priors naturally inform the rejection mechanism and define the retrieved comparable signal information.",
+      "arxivId": "2605.21301v1",
+      "title": "Automatic Discovery of Disease Subgroups by Contrasting with Healthy Controls",
+      "summary": "In biomedical Subgroup Discovery, practitioners are interested in discovering interpretable and homogeneous subgroups within a group of patients. In this paper, assuming that healthy subjects (i.e., controls) share common but irrelevant factors of variation with the patients, we motivate and develop a Contrastive Subgroup Discovery method, entitled Deep UCSL. By contrasting patients with controls, Deep UCSL identifies subgroups driven solely by pathological factors, ignoring common variability shared with healthy subjects. Our framework employs a deep feature extractor to learn a discriminative representation space. Mathematically, we derive a novel loss based on the conditional joint likelihood of latent clusters and patient/control labels, optimized via an Expectation-Maximization strategy alternating between subgroup inference and feature encoder updates. A regularization term further encourages representations to capture disease-specific variability while ignoring variability shared with controls. Compared to previous related works, our approach quantitatively improves the quality of the estimated subgroups, as demonstrated on a MNIST example and four distinct real medical imaging datasets. Code and datasets are available at: https://github.com/rlouiset/deep_ucsl.",
       "authors": [
-        "Salil Parth Tripathi",
-        "Bertrand Chapron",
-        "Fabrice Collard",
-        "Nicolas Courty",
-        "Ronan Fablet"
+        "Robin Louiset",
+        "Edouard Duchesnay",
+        "Benoit Dufumier",
+        "Antoine Grigis",
+        "Pietro Gori"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21301v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21301v1",
+      "publishedAt": "2026-05-20T15:31:16.000Z",
+      "updatedAt": "2026-05-20T15:31:16.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21300v1",
+      "title": "Reducing Object Hallucination in LVLMs via Emphasizing Image-negative Tokens",
+      "summary": "Object hallucination is a significant challenge that hinders the application of large vision-language models (LVLMs) in practice. We hypothesize that one possible origin of hallucination is the model's tendency to prioritize text generation over meaningful interaction with images. To explore this, we examine the generation process and categorize text tokens into three groups: image-positive, invariant, and negative, based on their visual dependence on input image tokens. Our analysis reveals that most generated tokens are minimally influenced by the image information. This suggests that during the model's training stage, more emphasis is placed on learning how to follow textual instructions, rather than extracting information from images. Based on this finding, we propose adjusting the training weights of different tokens depending on their visual dependence to control hallucination. Additionally, we remove a portion of the training data that potentially contains more hallucinations as a data filtering strategy. Both methods achieve a reduction in hallucination without compromising response length or introducing additional computational costs during inference. We validate our methods across three LVLM variants, demonstrating the effectiveness and general applicability.",
+      "authors": [
+        "Meng Shen",
+        "Minghao Wu",
+        "Deepu Rajan"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21300v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21300v1",
+      "publishedAt": "2026-05-20T15:29:20.000Z",
+      "updatedAt": "2026-05-20T15:29:20.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21299v1",
+      "title": "Tracing the ongoing emergence of human-like reasoning in Large Language Models",
+      "summary": "Humans effortlessly go beyond literal meanings: If you mow the lawn, I will give you fifty dollars, is typically understood as implying that the speaker will pay only if the lawn is mowed, whereas If you are hungry, there is pizza in the oven implies that pizza is available regardless of the hearers hunger. Large Language Models - LLMs - show human-like performance on many tasks, yet it remains unclear whether they reason like humans. To address this, we conducted a population-matching experiment assessing how twentyfive LLMs compute conditional inferences across four languages, compared to an equal number of humans per language. We find that humans enrich logical reasoning through pragmatic inferences across languages. Model behavior is more variable. Some LLMs perfectly follow the truth-table of conditionals but they ignore pragmatic inferences, while others deviate from the truth-table, adhering to a single interpretation across the board, thus reflecting accurate rule-based processing but not human-like reasoning. Overall, LLMs are accurate semantic operators, but fail to capture the pragmatic enrichments characteristic of human reasoning. Crucially, LLM accuracy is neither predicted nor boosted by open vs. closed status, training orientation, or architecture type, suggesting that pragmatic reasoning is still an emerging ability in the cognitive toolkit of artificial systems.",
+      "authors": [
+        "Paolo Morosi",
+        "Nikoleta Pantelidou",
+        "Fritz Günther",
+        "Elena Pagliarini",
+        "Evelina Leivada"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21299v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21299v1",
+      "publishedAt": "2026-05-20T15:28:52.000Z",
+      "updatedAt": "2026-05-20T15:28:52.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21295v1",
+      "title": "TimeSRL: Generalizable Time-Series Behavioral Modeling via Semantic RL-Tuned LLMs -- A Case Study in Mental Health",
+      "summary": "Longitudinal passive sensing enables continuous health prediction, yet models often fail under cross-dataset distribution shifts. Traditional ML overfits cohort-specific artifacts, while Large Language Models (LLMs) struggle to reason reliably over long, heterogeneous time-series. We introduce TimeSRL, a two-stage LLM framework that routes predictions through an explicit semantic bottleneck. The model first abstracts raw signals into high-level natural language, then predicts behavioral outcomes from these abstractions alone. This forces the model to reason over semantic concepts that we argue generalize better than raw numbers. We optimize this process end-to-end using Group Relative Policy Optimization (GRPO) with Reinforcement Learning from Verifiable Rewards (RLVR), learning outcome-aligned abstractions without gold intermediate annotations. Instantiated on mental-health prediction, TimeSRL achieves state-of-the-art performance on a benchmark designed to stress-test cross-cohort generalization under a rigorous leave-one-dataset-out (LOSO) protocol, reducing mean absolute error (MAE) over strong non-LLM ML and LLM baselines by 3.1--10.1% and 9.5--44.1% for anxiety, and 3.2--9.6% and 27.4--57.6% for depression (all $p$s<0.05). TimeSRL significantly outperforms prior methods in cross-benchmark transfer across different sensing pipelines, rivaling its own within-domain performance without target-domain fine-tuning. These results demonstrate that semantic abstractions are reusable and point to a new direction for generalizable behavior modeling via RL-tuned LLMs.",
+      "authors": [
+        "Yuang Fan",
+        "Lilin Xu",
+        "Millie Wu",
+        "Jingping Nie",
+        "Qingyu Chen",
+        "Yuzhe Yang",
+        "Zhuo Zhang",
+        "Xin Liu",
+        "Subigya Nepal",
+        "Xiaofan Jiang",
+        "Xuhai \"Orson\" Xu"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI",
+        "cs.HC"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21295v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21295v1",
+      "publishedAt": "2026-05-20T15:25:46.000Z",
+      "updatedAt": "2026-05-20T15:25:46.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21292v1",
+      "title": "Large-Step Training Dynamics of a Two-Factor Linear Transformer Model",
+      "summary": "Gradient-flow analyses show that simplified linear transformers can learn the in-context linear-regression algorithm, but they do not explain the finite-step behavior of gradient descent at large learning rates. Motivated by empirical work on high-learning-rate transformer instabilities and by the cubic-map phase diagram for quadratic regression, we study an exactly reducible one-prompt linear-transformer training problem. After normalization, the dynamics reduce to a two-factor product map with an effective step-size parameter \\(μ\\). On the balanced slice, this map recovers the known scalar cubic transition from monotone convergence to catapult convergence, periodic and chaotic bounded nonconvergence, and divergence. We then analyze the full two-dimensional system and show that, for \\(0<μ<2\\), it has an explicit invariant Chebyshev ellipse separating forward-invariant regions; this ellipse carries off-balanced chaotic dynamics but is transversely repelling, while balanced scalar attractors can be transversely attracting. These results show that large constant learning rates can change the training attractor of the learned transformer rather than merely accelerating convergence: beyond sharp stability thresholds, finite-step training may settle into cycles, bounded chaos, or divergence instead of a single in-context linear-regression solution. We also discuss the consequences for mini-batch gradient descent based training methods.",
+      "authors": [
+        "Krishnakumar Balasubramanian"
+      ],
+      "categories": [
+        "stat.ML",
+        "cs.AI",
+        "cs.LG",
+        "math.DS"
+      ],
+      "primaryCategory": "stat.ML",
+      "absUrl": "https://arxiv.org/abs/2605.21292v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21292v1",
+      "publishedAt": "2026-05-20T15:25:13.000Z",
+      "updatedAt": "2026-05-20T15:25:13.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21288v1",
+      "title": "A Mechanistic Study of Tabular Foundation Models",
+      "summary": "Tabular foundation models with different architectures converge in accuracy across a range of classification and regression tasks. This raises questions a leaderboard cannot answer: (i) whether the models execute the same in-context algorithm, (ii) where row, column, and class-permutation invariances originate, and (iii) how robust they are under perturbations engineered against the inferred mechanism. We characterize all three. The model families realize qualitatively distinct similarity-based readouts: from an attention-weighted vote over context labels to a class-conditional mean readout, each confirmed by causal intervention. We find that the representation collapse highlighted in prior work is not a practical concern for them. Each model's permutation invariances trace to specific positional parameters whose removal preserves accuracy and makes approximate invariance exact. Perturbations engineered against each readout reproduce predicted failure modes; hub and rank attacks isolate them from refit baselines. Together these results give a mechanistic account of contemporary tabular foundation models and identify which inductive biases govern both their accuracy and characteristic failures.",
+      "authors": [
+        "Marin Biloš",
+        "James T. Wilson",
+        "Anderson Schneider",
+        "Yuriy Nevmyvaka"
       ],
       "categories": [
         "cs.LG"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20030v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20030v1",
-      "publishedAt": "2026-05-19T15:52:59.000Z",
-      "updatedAt": "2026-05-19T15:52:59.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21288v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21288v1",
+      "publishedAt": "2026-05-20T15:23:16.000Z",
+      "updatedAt": "2026-05-20T15:23:16.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20028v1",
-      "title": "Training-Free Bayesian Filtering with Generative Emulators",
-      "summary": "Bayesian filtering is a well-known problem that aims to estimate plausible states of a dynamical system from observations. Among existing approaches to solve this problem, particle filters are theoretically exact for non-linear dynamics and observations, but suffer from poor scalability in high dimensions. In this work, we show that diffusion-based emulators of dynamical systems can be used to implement, without additional training, an optimal variant of particle filters that has remained largely unexplored due to implementation challenges with classical numerical solvers. Experiments on nonlinear chaotic systems, including atmospheric dynamics, demonstrate that the proposed approach successfully scales particle filtering to high-dimensional settings.",
+      "arxivId": "2605.21282v1",
+      "title": "\\textit{Stochastic} MeanFlow Policies: One-Step Generative Control with Entropic Mirror Descent",
+      "summary": "Online off-policy reinforcement learning (RL) is shaped by two coupled choices: the policy class and the update rule. Gaussian policies are fast and have tractable entropy, but struggle with multimodal action distributions. Generative policies are more expressive, but often require iterative sampling or lack tractable entropy estimates. On the optimisation side, SAC-style soft policy improvement and mirror descent (MD) can be viewed as minimising different KL divergences: the former moves the policy towards a value-induced Boltzmann distribution, while the latter regularises each update against the previous policy. Combining entropy regularisation with an MD constraint is therefore attractive, as it supports exploration while stabilising policy improvement; however, the resulting target can be multimodal and is poorly matched by unimodal Gaussian policies. We propose Stochastic MeanFlow Policies (SMFP), a one-step generative policy class that maps Gaussian noise to actions through a MeanFlow transformation. This stochastic reparameterisation yields a tractable entropy surrogate and allows MeanFlow policies to be trained within off-policy mirror descent under a unified objective for exploratory yet stable improvement. Across seven MuJoCo benchmarks, SMFP improves over Gaussian and generative baselines while retaining single-step inference efficiency.",
       "authors": [
-        "Thomas Savary",
-        "François Rozet",
-        "Gilles Louppe"
+        "Zeyuan Wang",
+        "Da Li",
+        "Yulin Chen",
+        "Yuehu Gong",
+        "Yanming Guo",
+        "Ye Shi",
+        "Liang Bai",
+        "Tianyuan Yu",
+        "Yanwei Fu"
       ],
       "categories": [
         "cs.LG",
-        "physics.ao-ph"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20028v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20028v1",
-      "publishedAt": "2026-05-19T15:52:09.000Z",
-      "updatedAt": "2026-05-19T15:52:09.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20025v1",
-      "title": "AutoResearchClaw: Self-Reinforcing Autonomous Research with Human-AI Collaboration",
-      "summary": "Automating scientific discovery requires more than generating papers from ideas. Real research is iterative: hypotheses are challenged from multiple perspectives, experiments fail and inform the next attempt, and lessons accumulate across cycles. Existing autonomous research systems often model this process as a linear pipeline: they rely on single-agent reasoning, stop when execution fails, and do not carry experience across runs. We present AutoResearchClaw, a multi-agent autonomous research pipeline built on five mechanisms: structured multi-agent debate for hypothesis generation and result analysis, a self-healing executor with a \\textsc{Pivot}/\\textsc{Refine} decision loop that transforms failures into information, verifiable result reporting that prevents fabricated numbers and hallucinated citations, human-in-the-loop collaboration with seven intervention modes spanning full autonomy to step-by-step oversight, and cross-run evolution that converts past mistakes into future safeguards. On ARC-Bench, a 25-topic experiment-stage benchmark, AutoResearchClaw outperforms AI Scientist v2 by 54.7%. A human-in-the-loop ablation across seven intervention modes reveals that precise, targeted collaboration at high-leverage decision points consistently outperforms both full autonomy and exhaustive step-by-step oversight. We position AutoResearchClaw as a research amplifier that augments rather than replaces human scientific judgment. Code is available at https://github.com/aiming-lab/AutoResearchClaw.",
-      "authors": [
-        "Jiaqi Liu",
-        "Shi Qiu",
-        "Mairui Li",
-        "Bingzhou Li",
-        "Haonian Ji",
-        "Siwei Han",
-        "Xinyu Ye",
-        "Peng Xia",
-        "Zihan Dong",
-        "Congyu Zhang",
-        "Letian Zhang",
-        "Guiming Chen",
-        "Haoqin Tu",
-        "Xinyu Yang",
-        "Lu Feng",
-        "Xujiang Zhao",
-        "Haifeng Chen",
-        "Jiawei Zhou",
-        "Xiao Wang",
-        "Weitong Zhang",
-        "Hongtu Zhu",
-        "Yun Li",
-        "Jieru Mei",
-        "Hongliang Fei",
-        "Jiaheng Zhang",
-        "Linjie Li",
-        "Linjun Zhang",
-        "Yuyin Zhou",
-        "Sheng Wang",
-        "Caiming Xiong",
-        "James Zou",
-        "Zeyu Zheng",
-        "Cihang Xie",
-        "Mingyu Ding",
-        "Huaxiu Yao"
-      ],
-      "categories": [
         "cs.AI"
       ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20025v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20025v1",
-      "publishedAt": "2026-05-19T15:49:51.000Z",
-      "updatedAt": "2026-05-19T15:49:51.000Z",
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21282v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21282v1",
+      "publishedAt": "2026-05-20T15:14:14.000Z",
+      "updatedAt": "2026-05-20T15:14:14.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20023v1",
-      "title": "When Skills Don't Help: A Negative Result on Procedural Knowledge for Tool-Grounded Agents in Offensive Cybersecurity",
-      "summary": "Agent Skills, structured packages of procedural knowledge loaded into an LLM agent at inference time, are widely reported to improve task pass rates by an average of 16.2~percentage points across diverse domains. Yet the same benchmarks show wide variance, with 16 of 84 tasks suffering negative deltas when Skills are introduced. The community has not yet articulated a clean mechanism for \\emph{when} Skills help and when they are merely redundant overhead. We re-analyze a recently published 180-run controlled study of an MCP-grounded autonomous Capture-the-Flag (CTF) agent under four documentation conditions of increasing richness (55, 1{,}478, 1{,}976, and 4{,}147 lines), and show that these conditions correspond almost exactly to a No-Skills, Experiential-Skills, Curated-Skills, and Comprehensive-Skills ablation. In offensive cybersecurity, a domain not deeply covered by existing Skills benchmarks, the marginal benefit of Skills collapses. The spread between the no-Skills and full-Skills conditions is only 8.9~pp ($p = 0.71$, $χ^2$; $p = 0.25$, Cochran--Armitage trend test; five of six pairwise Cohen's $h$ values fall below the $0.2$ small-effect threshold). We argue that the missing variable is \\emph{environment-feedback bandwidth}. When an agent's tool layer returns strict, schema-validated, low-latency observations, the environment itself supplies the procedural correction signal that Skills are normally needed to provide. As a result, the marginal benefit of curated Skills diminishes substantially, and, in some cases (e.g., our timing side-channel setting), actively degrades performance. We articulate a falsifiable hypothesis, sketch its design implications for compound AI systems, and will release the reanalysis pipeline to support replication.",
+      "arxivId": "2605.21280v1",
+      "title": "Let EEG Models Learn EEG",
+      "summary": "High-fidelity EEG generation is critical for alleviating data scarcity and addressing privacy constraints in large-scale neural modeling. Despite recent progress, most existing approaches formulate EEG generation via discrete denoising objectives, which inadequately reflect the inherently continuous temporal dynamics and spectral structure of neural activity. As a result, these methods often struggle to preserve long-range temporal dependencies and exhibit mismatches in the spectral and temporal structure of the generated signals. In this work, we argue that effective EEG generation requires models that operate directly on the continuous evolution of neural signals. We introduce Just EEG Transformer (JET), a generative framework based on conditional flow matching that models EEG as raw sequences evolving along continuous trajectories. By learning a smooth vector field that transports noise to the EEG data distribution, JET captures temporal continuity and transient dynamics without relying on discretized denoising schemes or domain-specific representations. To ensure that the learned dynamics remain consistent with key properties of EEG signals, we introduce principled constraints that preserve spectral structure, temporal stationarity, and signal-level statistics. Across three large-scale benchmarks, JET consistently achieves state-of-the-art performance, reducing TS-FID by over 40% compared to strong baselines. Extensive analyses show that JET captures key structural properties of neural dynamics, providing a scalable and principled approach to EEG generation. Project page: https://y-research-sbu.github.io/JET/ .",
       "authors": [
-        "Samuel Jacob Chacko",
-        "James Hugglestone",
-        "Chashi Mahiul Islam",
-        "Xiuwen Liu"
+        "Yifan Wang",
+        "Yijia Ma",
+        "Wen Li",
+        "Chenyu You"
       ],
       "categories": [
-        "cs.AI",
-        "cs.MA"
+        "cs.CV"
       ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20023v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20023v1",
-      "publishedAt": "2026-05-19T15:48:35.000Z",
-      "updatedAt": "2026-05-19T15:48:35.000Z",
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21280v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21280v1",
+      "publishedAt": "2026-05-20T15:10:10.000Z",
+      "updatedAt": "2026-05-20T15:10:10.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20022v1",
-      "title": "FlexDraft: Flexible Speculative Decoding via Attention Tuning and Bonus-Guided Calibration",
-      "summary": "Speculative decoding accelerates memory-bound LLM inference without quality degradation by using a fast drafter to propose multiple candidate tokens and the target model to verify them in parallel. However, conventional sequential speculative decoding suffers from mutual waiting between drafting and verification, and repeated exchange of intermediate states further increases memory access overhead. Parallel speculative decoding addresses this limitation by performing drafting and verification within a single target forward pass, allowing future drafts to be prepared while current candidates are being verified. Although effective at small batch sizes, existing parallel speculative decoding methods either require costly continual pretraining with quality degradation or suffer from low acceptance rates. More importantly, this paradigm inherently suffers from uncertainty in both the bonus token and the accepted length, leading to draft verification mismatch and causing throughput gains to collapse at large batch sizes. To address these limitations, we introduce FlexDraft, a lossless speculative decoding framework that flexibly adapts to varying batch sizes through three key designs. (1) Attention Tuning enables block diffusion drafting by tuning only the attention projectors of the final few layers on mask tokens, while keeping the autoregressive path frozen to preserve the target distribution and produce high quality drafts with minimal trainable parameters. (2) Bonus-guided Calibration uses a lightweight MLP conditioned on the resolved bonus token to calibrate draft logits, mitigating draft verification mismatch caused by bonus token uncertainty. (3) Flex Decoding dynamically switches between parallel draft and verify at small batch sizes and sequential draft then verify at large batch sizes, and adjusts verification length based on draft confidence to eliminate redundant computation.",
+      "arxivId": "2605.21273v1",
+      "title": "DriveMA: Rethinking Language Interfaces in Driving VLAs with One-Step Meta-Actions",
+      "summary": "Driving Vision-Language-Action Models (Driving VLAs) commonly introduce natural-language reasoning as an intermediate interface for end-to-end planning, but reasoning-centric interfaces face three practical bottlenecks: obtaining high-quality reasoning annotations is difficult, generating and understanding long reasoning chains is challenging for compact models, and inference latency is substantially increased. In this paper, we rethink the design of language interfaces in Driving VLAs and show that concise one-step meta-actions are a simple yet effective alternative to verbose reasoning. Meta-actions provide semantic decision grounding while remaining low-entropy, and being automatically derivable from expert trajectories, enabling scalable supervision and reliable trajectory conditioning. Building on this interface, we propose DriveMA, which combines action-centric supervised training with a turn-level credit-assignment reinforcement learning framework that jointly optimizes meta-action correctness, trajectory quality, and trajectory--meta-action consistency. Experiments show that DriveMA already achieves a new state of the art on the Waymo End-to-End Driving Challenge with a 2B model, reaching a Rater Feedback Score (RFS) of 8.060, while its 4B version further improves the state of the art to 8.079; DriveMA also obtains competitive performance on NAVSIM. Ablations demonstrate that one-step meta-actions offer a better practical trade-off between expressiveness, predictability, and inference efficiency than natural-language reasoning or finer-grained action sequences. Code, data, and models will be released to facilitate future research.",
       "authors": [
-        "Yaojie Zhang",
-        "Jianuo Huang",
-        "Junlong Ke",
-        "Yuhang Han",
-        "Yongji Long",
-        "Tianchen Zhao",
-        "Biqing Qi",
-        "Linfeng Zhang"
+        "Weicheng Zheng",
+        "Yixin Huang",
+        "Qiao Sun",
+        "Derun Li",
+        "Hang zhao"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21273v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21273v1",
+      "publishedAt": "2026-05-20T15:05:36.000Z",
+      "updatedAt": "2026-05-20T15:05:36.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21272v1",
+      "title": "MONET: A Massive, Open, Non-redundant and Enriched Text-to-image dataset",
+      "summary": "Training large text-to-image models requires high-quality, curated datasets with diverse content and detailed captions. Yet the cost and complexity of collecting, filtering, deduplicating, and re-captioning such corpora at scale hinders open and reproducible research in the field. We introduce MONET, an open Apache 2.0 dataset of approx. 104.9M image--text pairs collected from 2.9B raw pairs across heterogeneous open sources through successive stages of safety filtering, domain-based filtering, exact and near-duplicate removal, and re-captioning with multiple vision-language models covering short to long-form descriptions, and further augmented with synthetically generated samples. Each image is shipped with pre-computed embeddings and annotations to accelerate downstream use. To validate the effectiveness of MONET, we train a 4B-parameter latent diffusion model exclusively on it and reach competitive GenEval and DPG scores, demonstrating that our dataset lowers the barrier to large-scale, reproducible text-to-image research.",
+      "authors": [
+        "Benjamin Aubin",
+        "Gonzalo Iñaki Quintana",
+        "Onur Tasar",
+        "Sanjeev Sreetharan",
+        "Urszula Czerwinska",
+        "Damien Henry",
+        "Clément Chadebec"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21272v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21272v1",
+      "publishedAt": "2026-05-20T15:04:56.000Z",
+      "updatedAt": "2026-05-20T15:04:56.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21268v1",
+      "title": "Vision Transformers and Convolutional Neural Networks for Land Use Scene Classification",
+      "summary": "Land Use Scene Classification (LUSC) from remote sensing imagery plays a critical role in environmental monitoring, urban planning, and sustainable resource management. In recent years, deep learning methods have significantly advanced the state of the art, with Convolutional Neural Networks (CNNs) dominating the field because of their strong ability to capture local spatial features. However, the emergence of Vision Transformers (ViTs) has introduced a new paradigm that models long-range dependencies through self-attention mechanisms, potentially enabling improved global context understanding. This paper presents a comparative assessment of Vision Transformers and CNN-based architecture for remote sensing land use scene classification. Representative CNN models, such as AlexNet, is evaluated alongside the Vision Transformer (ViT) using benchmark remote sensing datasets, including the UC Merced Land Use and EuroSAT Land Use datasets. The study examines classification accuracy, precision, recall, F1-score, and computational complexity to provide a comprehensive performance comparison. Experimental results demonstrate that CNNs perform robustly on datasets with limited training samples and strong local texture characteristics, whereas Vision Transformers exhibit superior performance in capturing global spatial relationships in complex scenes when sufficient training data are available. However, ViTs typically require greater computational resources and larger training datasets to achieve optimal performance. The findings of this study provide insights into the strengths and limitations of both architectures and offer guidance for selecting appropriate models for remote sensing land use scene classification applications.",
+      "authors": [
+        "Arun D. Kulkarni"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21268v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21268v1",
+      "publishedAt": "2026-05-20T14:57:16.000Z",
+      "updatedAt": "2026-05-20T14:57:16.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21266v1",
+      "title": "How Much Online RL is Enough? Informative Rollouts for Offline Preference Optimization in RLVR",
+      "summary": "Reinforcement Learning from Verifiable Rewards (RLVR) has emerged as a powerful paradigm for reasoning in language models, with GRPO as its primary example. However, GRPO requires continuous online rollout generation, making it computationally expensive and difficult to scale. While Direct Preference Optimization (DPO) offers a stable and efficient offline alternative, it is typically expected to underperform w.r.t. online RL methods such as GRPO when trained on rollouts from a cold supervised fine-tuned (SFT) policy. We introduce G2D (GRPO to DPO)}, a three-stage pipeline that performs a short GRPO warm-up, constructs a static preference dataset, and fine-tunes a model offline with DPO. Across a set of values of the number of online steps (K) in GRPO on Qwen2.5-7B and Llama-3.1-8B, we find that offline DPO with moderate warm-up matches or outperforms GRPO at substantially lower compute cost in our setting. On Qwen2.5-7B, G2D at K=150 achieves 62.4% on MATH-500, outperforming GRPO (51.6%) by 10.8% at ~4x lower compute. On Llama-3.1-8B, G2D at K=500 achieves 49.4%, surpassing GRPO in our experimental setting. We show that performance is not governed by the number of preference pairs, which does not vary much w.r.t. K, but by their informativeness. Moderate warm-up produces rollouts with calibrated uncertainty, yielding stronger contrastive signal, while excessive warm-up leads to overconfident policies and less informative data. Our results recast the offline-online gap in RLVR as primarily a data informativeness problem, and identify short online RL warm-up with appropriate difficulty calibration of the fine-tuning dataset as a compute-efficient alternative to online RL.",
+      "authors": [
+        "Richa Verma",
+        "Balaraman Ravindran"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21266v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21266v1",
+      "publishedAt": "2026-05-20T14:53:43.000Z",
+      "updatedAt": "2026-05-20T14:53:43.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21264v1",
+      "title": "FedCoE: Bridging Generalization and Personalization via Federated Coordinated Dual-level MoEs",
+      "summary": "Federated Learning (FL) has emerged as a promising paradigm for privacy-preserving distributed learning. However, existing FL methods face a fundamental challenge. Traditional averaging-based approaches suffer from parameter divergence under non-IID conditions, while personalized FL methods overfit to local data and fail to generalize to new clients (cold-start problem). Mixture-of-Experts naturally addresses this by routing heterogeneous data to specialized experts rather than forcing uniform aggregation. In this paper, we propose FedCoE, a Federated Coordinated dual-level mixture-of-Experts framework that effectively balances global generalization with local personalization. FedCoE maintains multiple independent global expert models on the server and employs a shared gating network to dynamically model client-expert correlations during aggregation, effectively mitigating expert drift and gating inconsistency. To address the cold-start challenge, we introduce an adaptive mechanism that enables new clients to immediately leverage the global expert pool without extensive local training. Extensive experiments demonstrate that FedCoE achieves 78.00% global accuracy and 89.32% personalized accuracy on average, outperforming the baseline by 8.82% and 29.19%, respectively. In cold-start scenarios, FedCoE delivers 77.27% accuracy without any local fine-tuning, outperforming baselines by over 12.54%.",
+      "authors": [
+        "Penglin Dai",
+        "Fulian Li",
+        "Xincao Xu",
+        "Junhua Wang",
+        "Lixin Duan",
+        "Xiao Wu"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21264v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21264v1",
+      "publishedAt": "2026-05-20T14:52:07.000Z",
+      "updatedAt": "2026-05-20T14:52:07.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21263v1",
+      "title": "Nonparametric Learning and Earning with One-Point Feedback under Nonstationarity",
+      "summary": "Firms increasingly rely on dynamic pricing to respond to evolving customer demand, yet in many applications they observe only the revenue generated by a single posted price in each period. At the same time, market conditions may shift gradually or abruptly due to changes in customer preferences, competition, or external shocks. These features create two intertwined challenges: learning the revenue--demand relationship from limited feedback and adapting pricing decisions to a changing environment. We study how a seller can learn and earn effectively under these constraints, without assuming a specific parametric form for demand. We develop a learning framework that updates prices using revenue-based gradient approximations constructed from one observation per period. To address environmental changes, we incorporate a restarting mechanism that periodically refreshes the learning process so that outdated information is discounted. When the degree of nonstationarity is unknown, we further introduce a meta-learning layer to adaptively hedge across multiple restarting schedules. We provide performance guarantees for our approach, showing how cumulative revenue loss relative to a fully informed benchmark depends on both the time horizon and the magnitude of market variation. Simulation experiments using synthetic and real-world data illustrate the effectiveness of the proposed procedures.",
+      "authors": [
+        "Xiangyu Yang",
+        "Feng Xu",
+        "Jian-Qiang Hu",
+        "Jiaqiao Hu"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21263v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21263v1",
+      "publishedAt": "2026-05-20T14:52:03.000Z",
+      "updatedAt": "2026-05-20T14:52:03.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21261v1",
+      "title": "STiTch: Semantic Transition and Transportation in Collaboration for Training-Free Zero-Shot Composed Image Retrieval",
+      "summary": "Training-free zero-shot composed image retrieval models are recently gaining increasing research interest due to their generalizability and flexibility in unseen multimodal retrieval. Recent LLM-based advances focus on generating the expected target caption by exploring the compositional ability behind the LLMs. Although efficient, we find that 1) the generated captions tend to introduce unexpected features from the reference image due to the semantic gap between the input image and text modification, where the image contains much more details than the text; 2) the point-to-point alignment during the retrieval stage fails to capture diverse compositions. To address these challenges, we introduce a novel Semantic Transition and Transportation in collaboration framework for training-free zero-shot CIR tasks. Specifically, given the composed caption inferred by an LLM, we aim to refine it through a transition vector in the embedding space and make it closer to the target image. Combining LLMs with user instruction, the refined caption concentrates more on the core modification intent and thus filters out unnecessary noise. Moreover, to explore diverse alignment during the retrieval stage, we model the caption and image as discrete distributions and reformulate the retrieval task as a set-to-set alignment task. Finally, a bidirectional transportation distance is developed to consider fine-grained alignments across modalities and calculate the retrieval score. Extensive experiments demonstrate that our method can be general, effective, and beneficial for many CIR tasks.",
+      "authors": [
+        "Miaoge Li",
+        "Dongsheng Wang",
+        "Zening Sun",
+        "Jinsen Zhang",
+        "Wenhan Luo",
+        "Jingcai Guo"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21261v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21261v1",
+      "publishedAt": "2026-05-20T14:51:29.000Z",
+      "updatedAt": "2026-05-20T14:51:29.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21258v1",
+      "title": "Learning Structural Latent Points for Efficient Visual Representations in Robotic Manipulation",
+      "summary": "Current 3D-aware pretraining methods for embodied perception and manipulation are largely built on differentiable rendering frameworks, producing either fully implicit neural fields or fully explicit geometric primitives. Implicit representations, while expressive, lack explicit structural cues, whereas explicit ones preserve geometry but suffer from resolution limits and weak generalization. To address these limitations, we propose a novel pretraining framework that learns a hybrid representation-structural latent points. Specifically, we insert a point-wise latent variational autoencoder into the latent space of a point-cloud autoencoder, jointly regularizing point-wise features and coordinates toward a Gaussian prior. The resulting compact latent preserves coarse structural tendencies, which do not encode precise geometry but capture richer rough shape and semantic information, effectively combining the expressiveness of implicit representations with the structural priors of explicit ones. In addition, informed by shared design choices in prior work, we develop a streamlined, efficient 3DGS-based rendering pipeline that is deliberately kept lightweight, improving efficiency while leaving greater representational capacity to the front-end latent module. Extensive evaluations on RLBench, ManiSkill2, and a real-robot platform demonstrate consistent gains in task success, sample efficiency, and robustness to viewpoint and scene variations over strong baselines. Ablation studies further confirm that each component of our framework is critical to overall performance.",
+      "authors": [
+        "Yicheng Jiang",
+        "Jiaxu Wang",
+        "Junhao He",
+        "Zesen Gan",
+        "Junhao Li",
+        "Qiang Zhang",
+        "Jingkai Sun",
+        "Jiahang Cao",
+        "Mingyuan Sun",
+        "Xiangyu Yue",
+        "Qiming Shao"
+      ],
+      "categories": [
+        "cs.RO",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.21258v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21258v1",
+      "publishedAt": "2026-05-20T14:48:01.000Z",
+      "updatedAt": "2026-05-20T14:48:01.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21256v1",
+      "title": "Reliable Automated Triage in Spanish Clinical Notes: A Hybrid Framework for Risk-Aware HIV Suspicion Identification",
+      "summary": "Standard clinical Natural Language Processing (NLP) benchmarks often yield inflated metrics by forcing deterministic classification on ambiguous instances, thereby obscuring the clinical risks of overconfident predictions. To bridge this gap, we propose a risk-aware hybrid selective classification framework, evaluated on early Human Immunodeficiency Virus suspicion identification in Spanish clinical notes. Our dual-verification approach explicitly decouples aleatoric uncertainty through Mondrian conformal prediction and epistemic uncertainty using a Multi-Centroid Mahalanobis Distance veto. Empirical evaluations reveal that standard uncertainty metrics and baseline classifiers are structurally insufficient for safe medical triage, suffering severe coverage collapse when forced to operate under strict reliability constraints. In contrast, by demanding that clinical narratives pass both probabilistic and geometric safeguards, the proposed framework successfully isolates a highly trustworthy operational domain.",
+      "authors": [
+        "Rodrigo Morales-Sánchez",
+        "Soto Montalvo",
+        "Raquel Martínez"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.20022v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20022v1",
-      "publishedAt": "2026-05-19T15:48:16.000Z",
-      "updatedAt": "2026-05-19T15:48:16.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21256v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21256v1",
+      "publishedAt": "2026-05-20T14:45:00.000Z",
+      "updatedAt": "2026-05-20T14:45:00.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20016v1",
-      "title": "FGSVQA: Frequency-Guided Short-form Video Quality Assessment",
-      "summary": "Short-form video poses new challenges to the quality assessment of user-generated content (UGC) due to its complex generation pipeline, rapid content variation, and mixed distortions. To address this challenge, we propose an end-to-end video quality assessment (VQA) framework that employs a dense visual encoder based on CLIP, and incorporates compression priors derived from the frequency domain to generate artifact- and structure-aware weight maps for feature aggregation. By explicitly decomposing artifact, structure, and original visual feature branches and adaptively fusing them over time through a learned gating module, the proposed method achieves accurate and efficient quality prediction. Experimental results show that our method achieves strong performance on short-form video datasets in terms of average rank and linear correlation (SRCC: 0.736, PLCC: 0.787), while maintaining efficient inference runtime. The code and additional results are available at: https://github.com/xinyiW915/FGSVQA.",
+      "arxivId": "2605.21251v1",
+      "title": "Local-sensitive connectivity filter (ls-cf): A post-processing unsupervised improvement of the frangi, hessian and vesselness filters for multimodal vessel segmentation",
+      "summary": "A retinal vessel analysis is a procedure that can be used as an assessment of risks to the eye. This work proposes an unsupervised multimodal approach that improves the response of the Frangi filter, enabling automatic vessel segmentation. We propose a filter that computes pixel-level vessel continuity while introducing a local tolerance heuristic to fill in vessel discontinuities produced by the Frangi response. This proposal, called the local-sensitive connectivity filter (LS-CF), is compared against a naive connectivity filter to the baseline thresholded Frangi filter response and to the naive connectivity filter response in combination with the morphological closing and to the current approaches in the literature. The proposal was able to achieve competitive results in a variety of multimodal datasets. It was robust enough to outperform all the state-of-the-art approaches in the literature for the OSIRIX angiographic dataset in terms of accuracy and 4 out of 5 works in the case of the IOSTAR dataset while also outperforming several works in the case of the DRIVE and STARE datasets and 6 out of 10 in the CHASE-DB dataset. For the CHASE-DB, it also outperformed all the state-of-the-art unsupervised methods.",
       "authors": [
-        "Xinyi Wang",
-        "Angeliki Katsenou",
-        "Junxiao Shen",
-        "David Bull"
+        "Erick O Rodrigues",
+        "Lucas O Rodrigues",
+        "João HP Machado",
+        "Dalcimar Casanova",
+        "Marcelo Teixeira",
+        "Jeferson T Oliva",
+        "Giovani Bernardes",
+        "Panos Liatsis"
       ],
       "categories": [
         "eess.IV",
         "cs.CV"
       ],
       "primaryCategory": "eess.IV",
-      "absUrl": "https://arxiv.org/abs/2605.20016v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20016v1",
-      "publishedAt": "2026-05-19T15:44:45.000Z",
-      "updatedAt": "2026-05-19T15:44:45.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21251v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21251v1",
+      "publishedAt": "2026-05-20T14:40:35.000Z",
+      "updatedAt": "2026-05-20T14:40:35.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.20009v1",
-      "title": "Training Neural Networks with Optimal Double-Bayesian Learning",
-      "summary": "Backpropagation with gradient descent is a common optimization strategy employed by most neural network architectures in machine learning. However, finding optimal hyperparameters to guide training has proven challenging. While it is widely acknowledged that selecting appropriate parameters is crucial for avoiding overfitting and achieving unbiased outcomes, this choice remains largely based on empirical experiments and experience. This paper presents a new probabilistic framework for the learning rate, a key parameter in stochastic gradient descent. The framework develops classic Bayesian statistics into a double-Bayesian decision mechanism involving two antagonistic Bayesian processes. A theoretically optimal learning rate can be derived from these two processes and used for stochastic gradient descent. Experiments across various classification, segmentation, and detection tasks corroborate the practical significance of the theoretically derived learning rate. The paper also discusses the ramifications of the proposed double-Bayesian framework for network training and model performance.",
+      "arxivId": "2605.21244v1",
+      "title": "SR-Ground: Image Quality Grounding for Super-Resolved Content",
+      "summary": "Super-Resolution (SR) has advanced rapidly in recent years, with diffusion-based models achieving unprecedented fidelity at the cost of introducing new types of visual artifacts. While existing Image Quality Assessment (IQA) methods provide holistic quality scores, they lack interpretability and fail to distinguish between different artifact types arising from modern SR approaches. To address this gap, we introduce SR-Ground, a large-scale dataset specifically designed for fine-grained artifact segmentation in super-resolved images. The dataset comprises images processed by a diverse set of state-of-the-art SR models, with pixel-level annotations for multiple artifact categories. We conduct a large-scale crowdsourcing study involving 1,062 participants to validate and refine automatically generated segmentations, resulting in a high-quality dataset of 63,000 images spanning 6 distinct artifact types. We demonstrate that training IQA models with grounding capabilities on SR-Ground significantly improves performance on downstream tasks. Furthermore, we introduce a fine-tuning pipeline that leverages our grounding model to reduce perceptible artifacts in SR outputs, showcasing the practical utility of our dataset.",
       "authors": [
-        "Vy Bui",
-        "Hang Yu",
-        "Karthik Kantipudi",
-        "Ziv Yaniv",
-        "Stefan Jaeger"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI",
-        "cs.NE"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20009v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20009v1",
-      "publishedAt": "2026-05-19T15:39:36.000Z",
-      "updatedAt": "2026-05-19T15:39:36.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20006v1",
-      "title": "GeoX: Mastering Geospatial Reasoning Through Self-Play and Verifiable Rewards",
-      "summary": "Geospatial reasoning requires solving image-grounded problems over the complex spatial structure of a scene. However, developing this capability is hindered by the cost of annotating a vast and combinatorial question space. We propose GeoX, a self-play framework that acquires spatial logic through executable programs that yield verifiable rewards, without relying on large-scale human-curated data Given a satellite or aerial image, our framework employs a single multimodal policy that proposes spatial problems as executable programs and solves them under three reasoning modes-abduction, deduction, and induction-over spatial primitives and an image understanding tool. A verifier executes each program to covert a reward signal that jointly optimizes the two roles via reinforcement learning. GeoX consistently improves its base VLMs by up to 5.5 points on average, matching or exceeding conventional baselines trained on millions of curated data. Along-side the proposed method, we release a benchmark for geospatial understanding accumulated through self-play.",
-      "authors": [
-        "Kyeongjin Ahn",
-        "Seungeon Lee",
-        "Krishna P. Gummadi",
-        "Meeyoung Cha"
-      ],
-      "categories": [
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.20006v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20006v1",
-      "publishedAt": "2026-05-19T15:37:01.000Z",
-      "updatedAt": "2026-05-19T15:37:01.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.20005v1",
-      "title": "Fine-Tuning Without Forgetting via Loss-Adaptive Learning Rates",
-      "summary": "Fine-tuning large language models on new data improves task performance but degrades capabilities learned during pretraining, a phenomenon known as catastrophic forgetting. Existing methods mitigate this by modifying the fine-tuning objective to suppress high-loss tokens or sequences, but these tokens are essential for learning new tasks, especially those with poor pretraining coverage. In such settings, hard tokens should still contribute to learning, so forgetting must be controlled without suppressing them. We identify a simple mechanism for doing so: per-step forgetting is bounded by the product of the learning rate and the square root of the current training loss. This suggests that high-loss batches are especially prone to inducing forgetting. Motivated by this observation, we introduce FINCH, a loss-adaptive learning-rate schedule that reduces the learning rate on high-loss batches and increases it as the model converges, while leaving the fine-tuning objective unchanged. Across knowledge acquisition, science, and low-resource language adaptation benchmarks, FINCH reduces forgetting by 93% on average while matching the task performance of standard fine-tuning. On Qwen3-4B knowledge acquisition, FINCH cuts TruthfulQA degradation by 5x and reverses HaluEval degradation, while better preserving confidence calibration. Overall, our results show that learning-rate schedules are an effective tool to shape model behavior during fine-tuning, beyond just target-task optimization.",
-      "authors": [
-        "Parjanya Prajakta Prashant",
-        "Jiongli Zhu",
-        "Aldan Creo",
-        "Babak Salimi"
-      ],
-      "categories": [
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.20005v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.20005v1",
-      "publishedAt": "2026-05-19T15:36:52.000Z",
-      "updatedAt": "2026-05-19T15:36:52.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19999v1",
-      "title": "LLM Benchmark Datasets Should Be Contamination-Resistant",
-      "summary": "Benchmark datasets are critical for reproducible, reliable, and discriminative evaluation of LLMs. However, recent studies reveal that many benchmark datasets are included in pretraining corpora, i.e., $\\textit{contaminated}$, which diminishes their value as reliable measures of model generalization. In this paper, we argue that benchmark datasets should be $\\textit{contamination-resistant}$, i.e., $\\textit{unlearnable}$, but support $\\textit{inference}$. To accomplish this, we first highlight the wide prevalence of benchmark dataset contamination and outline the properties of contamination-resistant datasets. Second, we highlight how the asymmetry between the inference and training pipelines in the Transformer architecture can be leveraged to support contamination-resistance. Third, we outline mathematical advancements to make these datasets interoperable across various LLM architectures. Based on the above, we call on the community to ensure the reliability of LLM benchmarking by: (i) advancing novel contamination-resistant methodologies, (ii) developing supporting methods and platforms, and (iii) adopting contamination-resistant benchmarks into existing evaluation pipelines.",
-      "authors": [
-        "Ali Al-Lawati",
-        "Jason Lucas",
-        "Dongwon Lee",
-        "Suhang Wang"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI",
-        "cs.CR"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19999v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19999v1",
-      "publishedAt": "2026-05-19T15:33:16.000Z",
-      "updatedAt": "2026-05-19T15:33:16.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19995v1",
-      "title": "CogOmniControl: Reasoning-Driven Controllable Video Generation via Creative Intent Cognition",
-      "summary": "Recent diffusion models achieve strong photorealism and fluency in video generation, yet remain fragile under abstract, sparse or complex conditions, leading to poor performance in professional production workflows such as storyboard sketches and clay render conditions. Existing video generation models, either inject conditions through adapters or couple a generic vision-language model (VLM) within a diffusion backbone, leaving a capability gap and failing to produce the videos that align with the user's creative intent. We present CogOmniControl, a reasoning-driven framework that factorizes controllable video generation into creative intent cognition and generation. Specifically, we train a specialized CogVLM using authentic anime production data. Compared to generic VLMs, it generates more professional and clear outputs, accurately cognizing user creative intent from sparse and abstract conditions and tuning these cues into dense reasoning output. Besides, CogOmniDiT unifies the controls from various conditions through in-context generation and is aligned to the CogVLM reasoning outputs via reinforcement learning. Furthermore, leveraging CogVLM's robust capability in guiding video generation, we release its potential in planning specific evaluators and enable a Best-of-N selection for the generated videos. This integration transforms the entire framework into a closed-loop \"harness-like\" architecture. We further introduce CogReasonBench and CogControlBench, built from professional workflows data that carry genuine creative intent rather than simulated ones. Experiments on two benchmarks show that CogOmniControl surpassed the existing open-source models. The project website: https://um-lab.github.io/CogOmniControl/",
-      "authors": [
-        "Hongji Yang",
-        "Songlian Li",
-        "Yucheng Zhou",
-        "Xiaotong Zhao",
-        "Alan Zhao",
-        "Chengzhong Xu",
-        "Jianbing Shen"
+        "Artem Borisov",
+        "Evgeney Bogatyrev",
+        "Khaled Abud",
+        "Dmitriy Vatolin"
       ],
       "categories": [
         "cs.CV"
       ],
       "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19995v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19995v1",
-      "publishedAt": "2026-05-19T15:29:33.000Z",
-      "updatedAt": "2026-05-19T15:29:33.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21244v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21244v1",
+      "publishedAt": "2026-05-20T14:33:13.000Z",
+      "updatedAt": "2026-05-20T14:33:13.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19990v1",
-      "title": "Minimalist Visual Inertial Odometry",
-      "summary": "Visual-Inertial Odometry(VIO), which is critical to mobile robot navigation, uses cameras with a large number of pixels. Capturing and processing camera images requires significant resources. This work presents a minimalist approach to planar odometry, demonstrating that just four visual measurements and an IMU can provide robust motion estimation for differential-drive robots. Our key insight is that four downward-facing photodiodes that sense the world through optical Gabor masks produce signals that encode speed. Based on this, we jointly optimize the mask parameters alongside a Temporal Convolutional Network (TCN) using a physically-grounded simulator. The resulting model decodes speed from just the four measurements produced by the photodiodes. Pairing these estimates with the angular speed from an IMU yields a continuous planar trajectory. We validate our approach with a prototype sensor mounted on a differential drive robot. Across diverse indoor and outdoor terrains, our system closely tracks the reference ground truth without any real-world fine-tuning. Our work shows that minimalist sensing enables efficient and accurate planar odometry.",
+      "arxivId": "2605.21240v1",
+      "title": "APEX: Autonomous Policy Exploration for Self-Evolving LLM Agents",
+      "summary": "LLM agents have shown strong performance across a wide range of complex tasks, including interactive environments that require long-horizon decision making. But these agents cannot learn on the fly at test time. Self-evolving agents address this by accumulating memory and reflection across episodes rather than requiring model-weight updates. However, these agents often suffer from exploration collapse: as memory grows, behavior concentrates around familiar high-reward routines, reducing the chance of discovering better alternatives. To address this problem, we propose Autonomous Policy EXploration (APEX), which builds and maintains an explicit strategy space through a strategy map-a directed acyclic graph of milestones with prerequisite dependency edges. In APEX, Fork Discovery expands the map with evidence-grounded unexplored directions, while Policy Selection balances exploration and exploitation during planning. Evaluated on nine Jericho text-adventure games and WebArena, a realistic web interaction benchmark, APEX outperforms all baselines. Extensive ablations validate each component's contribution and demonstrate robustness across diverse settings, demonstrating APEX's effectiveness for sustained exploration in self-evolving agents.",
       "authors": [
-        "Francesco Pasti",
-        "Jeremy Klotz",
-        "Nicola Bellotto",
-        "Shree K. Nayar"
+        "Yibo Li",
+        "Jiashuo Yang",
+        "Zhi Zheng",
+        "Zhiyuan Hu",
+        "Yuan Sui",
+        "Shizun Wang",
+        "Yufei He",
+        "Bryan Hooi"
       ],
       "categories": [
-        "cs.RO",
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21240v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21240v1",
+      "publishedAt": "2026-05-20T14:29:27.000Z",
+      "updatedAt": "2026-05-20T14:29:27.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21237v1",
+      "title": "RePCM: Region-Specific and Phenotype-Adaptive Bi-Ventricular Cardiac Motion Synthesis",
+      "summary": "Cardiac motion over a cardiac cycle is crucial for quantifying regional function and is strongly affected by cardiovascular diseases. Since temporally dense mesh sequences are difficult to obtain in practice, we focus on leveraging the more accessible end-diastolic frame to infer a full-cycle sequence. Due to strong regional and disease-specific differences, traditional methods often oversmooth the data by relying on generative models that are optimized for global patterns. To address this problem, we propose Region-Aware and Phenotype-Adaptive Bi-Ventricular Cardiac Motion Synthesis (RePCM) for single frame Bi-ventricular mesh motion completion. In Stage I, a reconstruction network learns vertex wise motion descriptors and clustering yields a data driven functional partition, providing an explicit motion derived region structure. In Stage II, a Region-Specific Injection Module enforces masked, synchronized region exchange within a conditional VAE, preserving localized specific dynamics and restricting cross-region mixing. A Phenotype-Adaptive Mixture-of-Experts prior conditioned on ED shape uses anatomy-guided cues to model latent motion trends and capture inter-disease variability. Experiments on three datasets covering different cardiovascular diseases show consistent gains in geometric and functional metrics and improved preservation of region specific dynamics.",
+      "authors": [
+        "Xuan Yang",
+        "Xiaohan Yuan",
+        "Hao Li",
+        "Lingyu Chen",
+        "Yanan Liu",
+        "Lei Li"
+      ],
+      "categories": [
         "cs.CV",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.RO",
-      "absUrl": "https://arxiv.org/abs/2605.19990v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19990v1",
-      "publishedAt": "2026-05-19T15:27:28.000Z",
-      "updatedAt": "2026-05-19T15:27:28.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19988v1",
-      "title": "A Case for Agentic Tuning: From Documentation to Action in PostgreSQL",
-      "summary": "Documentation has long guided computer system tuning by distilling expert knowledge into per-parameter recommendations. Yet such guides capture only what experts conclude, discarding how they reason. This fundamental gap manifests in three concrete deficiencies: documentation grows stale as software evolves, fails under heterogeneous workloads, and ignores inter-parameter dependencies. We propose shifting from static documentation to dynamic action for system tuning. We introduce PerfEvolve, which translates expert tuning methodologies into executable skills that equip LLM-based agents to perform version-consistency verification, workload-specific profiling, and multi-parameter joint optimization. Evaluated on PostgreSQL under TPC-C and TPC-H benchmarks, PerfEvolve outperforms state-of-the-art documentation-driven tuning baselines by up to 35.2%. The tool is available at https://github.com/ISCAS-OSLab/PerfEvolve.",
-      "authors": [
-        "Hongyu Lin",
-        "Mingyu Li",
-        "Weichen Zhang",
-        "Yihang Lou",
-        "Mingjie Xing",
-        "Yanjun Wu",
-        "Haibo Chen"
-      ],
-      "categories": [
-        "cs.SE",
-        "cs.AI",
-        "cs.DB",
-        "cs.PF"
-      ],
-      "primaryCategory": "cs.SE",
-      "absUrl": "https://arxiv.org/abs/2605.19988v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19988v1",
-      "publishedAt": "2026-05-19T15:26:28.000Z",
-      "updatedAt": "2026-05-19T15:26:28.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19986v1",
-      "title": "Beyond Binary Success: A Diagnostic Meta-Evaluation Framework for Fine-Grained Manipulation",
-      "summary": "Fine-grained manipulation marks a regime where global scene context no longer suffices, and success hinges on the tight coupling of local attribute grounding, high-fidelity spatial perception, and constraint-respecting motor execution. However, current embodied AI benchmarks collapse these capacities into binary success rates, systematically inflating reported capabilities by up to 70% and masking the architectural bottlenecks that impede real-world deployment. We introduce MetaFine, a diagnostic meta-evaluation framework that disentangles manipulation competency along three axes: understanding, perception, and controlled behavior. Built on a compositional task graph, MetaFine absorbs heterogeneous external benchmarks and reconstructs them into diagnostic scenarios of varying complexity under a unified protocol. Evaluating state-of-the-art vision-language-action (VLA) models through this lens exposes severe dimension-specific failures invisible to conventional metrics. Through targeted causal intervention, we identify the visual encoder's ability to preserve local spatial structure as a key bottleneck for fine-grained precision: improving it directly unlocks previously inaccessible manipulation capabilities without modifying downstream policies. MetaFine further supports hybrid real-sim validation, using limited paired real-world rollouts to calibrate scalable simulation-based estimates for more stable physical benchmarking. By shifting evaluation from ranking to diagnosis, MetaFine turns benchmarking into an actionable compass for repairing the layered capacities underlying genuine physical dexterity. The MetaFine framework, benchmarks, and supporting resources will be publicly released at our project page: https://metafine.github.io/.",
-      "authors": [
-        "He-Yang Xu",
-        "Pengyuan Zhang",
-        "Zongyuan Ge",
-        "Xiaoshuai Hao",
-        "Serge Belongie",
-        "Xin Geng",
-        "Yuxin Peng",
-        "Xiu-Shen Wei"
-      ],
-      "categories": [
-        "cs.RO",
-        "cs.CV",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.RO",
-      "absUrl": "https://arxiv.org/abs/2605.19986v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19986v1",
-      "publishedAt": "2026-05-19T15:25:13.000Z",
-      "updatedAt": "2026-05-19T15:25:13.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19982v1",
-      "title": "InterLight: Leveraging Intrinsic Illumination Priors for Low-Light Image Enhancement",
-      "summary": "Low-Light Image Enhancement (LLIE) has long been a challenging problem in low-level vision, as insufficient illumination often leads to low contrast, detail loss, and noise. Recent studies show that deep learning-based Retinex theory can effectively decouple illumination and reflectance. However, existing methods frequently suffer from over-enhancement or color distortion, and often assume uniform noise or ideal lighting. To address these limitations, we propose InterLight, a novel framework that systematically excavates and operationalizes intrinsic illumination priors for LLIE.Our core insight is that robust enhancement requires not just estimating illumination, but constructing an illumination-aware pipeline. We first inject sensor-level illumination-response priors via physics-guided augmentation, then represent the degradation through adaptive prompts conditioned on the scene's latent illumination state. This explicit representation directly guides a luminance-gated intrinsic memory mechanism to selectively compensate for information loss, prioritizing reconstruction in dark regions while preserving fidelity in bright ones. Finally, the entire process is regularized by a self-supervised consistency objective that distills illumination-invariant features. By deeply exploiting intrinsic illumination priors, our method achieves clearer textures and more visually coherent enhancement results. Extensive experiments across multiple benchmarks demonstrate the effectiveness of our approach. Code is available at: https://github.com/House-yuyu/InterLight.",
-      "authors": [
-        "Ziqi Wang",
-        "Xu Zhang",
-        "Laibin Chang",
-        "Shi Chen",
-        "Jiaqi Ma",
-        "Huan Zhang"
-      ],
-      "categories": [
-        "cs.CV"
+        "cs.AI"
       ],
       "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19982v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19982v1",
-      "publishedAt": "2026-05-19T15:24:00.000Z",
-      "updatedAt": "2026-05-19T15:24:00.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21237v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21237v1",
+      "publishedAt": "2026-05-20T14:26:34.000Z",
+      "updatedAt": "2026-05-20T14:26:34.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19976v1",
-      "title": "RECIPE: Procedural Planning via Grounding in Instructional Video",
-      "summary": "Visual planning asks a model to generate the remaining steps of a procedure in natural language given a partial video context and a goal. Progress on this task is bottlenecked by annotation: clean labeled datasets are small, domain-narrow, and encode a single execution trajectory per example, even though many valid orderings exist. Large-scale instructional video corpora offer orders of magnitude more procedural content, but supervised fine-tuning on pseudo-labels from their noisy ASR narrations propagates segmentation and alignment errors and stays single-trajectory. We identify a key asymmetry: extracting clean step labels from noisy video is hard, but verifying whether a generated step sequence is temporally grounded in ASR transcripts is cheap and scales to millions of videos via precomputed text embeddings. We exploit this asymmetry in RECIPE, which uses grounding quality as a reward for GRPO, turning the noisy corpus into a verifier rather than a label source. The framework applies uniformly to two planner input configurations (Socratic, with a textual history extracted by a frozen VLM, and Video, consuming video tokens directly) and to annotated and weakly supervised regimes. We evaluate on 7 procedural benchmarks using a reference-based LLM-as-judge protocol scoring plans across 6 procedural criteria. RECIPE-RL improves over the base checkpoint at all scales (0.5B, 3B, 7B) and every benchmark, with macro-accuracy gains of +7 to +8 points in-domain and up to +16 points zero-shot. It outperforms supervised fine-tuning on both annotated and pseudo-labeled plans (the latter degrades the base) and remains robust without human annotations. Used as the proposal stage of a prior propose-assess-search planner, it improves over the strongest zero-shot baseline at every horizon on Visual Planning for Assistance, and on COIN it preserves the generation diversity that SFT collapses.",
+      "arxivId": "2605.21235v1",
+      "title": "LamPO: A Lambda Style Policy Optimization for Reasoning Language Models",
+      "summary": "Reinforcement learning with verifiable rewards (RLVR) has become an effective paradigm for improving reasoning language models on tasks such as mathematics, coding, and scientific question answering. However, widely used group-relative objectives, such as GRPO, summarize each sampled group with scalar statistics and therefore discard fine-grained relational information among candidate responses. This weakens credit assignment under sparse outcome rewards, especially when multiple generated solutions differ only subtly in reasoning quality. We propose \\textbf{LamPO}, a \\textbf{Lambda-Style Policy Optimization} method that replaces scalar group advantages with a \\emph{Pairwise Decomposed Advantage}. LamPO aggregates pairwise reward gaps within each response group and modulates each comparison by a confidence-aware weight computed from sequence log-probability differences, while retaining the critic-free and clipped-update structure of PPO-style optimization. When reference solutions are available, we further add a lightweight ROUGE-L-based dense auxiliary reward to reduce reward sparsity. Experiments on AIME24, AIME25, MATH-500, and GPQA-Diamond with Qwen3-1.7B, Qwen3-4B, and Phi-4-mini show that LamPO consistently improves over GRPO and recent RLVR variants, with more stable training dynamics and better sample efficiency.",
       "authors": [
-        "Luigi Seminara",
-        "Antonino Furnari",
-        "Lorenzo Torresani"
+        "Zhe Yuan",
+        "Yipeng Zhou",
+        "Jinghan Li",
+        "Xinyuan Chen",
+        "Bowen Deng",
+        "Zhiqian Chen",
+        "Liang Zhao"
       ],
       "categories": [
-        "cs.CV"
+        "cs.CL"
       ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19976v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19976v1",
-      "publishedAt": "2026-05-19T15:20:39.000Z",
-      "updatedAt": "2026-05-19T15:20:39.000Z",
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21235v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21235v1",
+      "publishedAt": "2026-05-20T14:24:11.000Z",
+      "updatedAt": "2026-05-20T14:24:11.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19975v1",
-      "title": "Learning with Foresight: Enhancing Neural Routing Policy via Multi-Node Lookahead Prediction",
-      "summary": "Neural policies have shown promise in solving vehicle routing problems due to their reduced reliance on handcrafted heuristics. However, current training paradigms suffer from a fundamental limitation: they primarily focus on next-node prediction for solution construction, resulting in myopic decision-making that undermines long-horizon planning capacity. To this end, we introduce Multi-node Lookahead Prediction (MnLP), a novel training strategy that extends the supervised learning paradigm to predict multiple future nodes simultaneously. We incorporate causal and discardable MnLP modules that operate exclusively during training, facilitating models to anticipate multi-step decisions while preserving inference-time efficiency. By incorporating multi-depth auxiliary supervision into the loss function, MnLP equips neural policies with the ability of long-range contextual understanding. Experimentally, MnLP outperforms existing training methods, improving the generalization capability of neural policies across various problem sizes, distributions, and real-world benchmarks. Moreover, MnLP can be seamlessly integrated into diverse neural architectures without introducing additional inference overhead.",
+      "arxivId": "2605.21227v1",
+      "title": "Do LLMs Know What Luxembourgish Borrows? Probing Lexical Neology in Low-Resource Multilingual Models",
+      "summary": "Large language models (LLMs) are increasingly used for writing assistance in small contact languages, yet it is unclear whether they respect community norms around lexical borrowing and neology. We introduce LexNeo-Bench, a 3{,}050-instance token-level benchmark derived from LuxBorrow, a large-scale Luxembourgish news corpus, where target tokens are labelled as native or as French, German, or English borrowings. Using this benchmark, we probe three multilingual LLMs across 34 prompt settings on two tasks: borrowing type classification and a binary lexical-innovation proxy (borrowing versus native). Without external context, models perform only slightly above chance on borrowing classification, so we construct a linguistic knowledge graph that encodes donor language, morphological patterns, and lexical analogues, and inject instance-specific subgraphs into the prompt. Knowledge-graph prompts raise borrowing classification accuracy from 25 -- 35\\% up to 71 -- 81\\% and largely close the gap between small and large models, while leaving neology detection difficult and sensitive to few-shot design. Our results show that lexicon-aware prompting is highly beneficial for robust borrowing judgments in low-resource contact languages and that lexical resources can serve as structured context for LLM evaluation. This study was carried out within the ENEOLI COST Action and examines borrowing as a form of lexical innovation in multilingual Luxembourgish data.",
       "authors": [
-        "Xia Jiang",
-        "Yaoxin Wu",
-        "Yew-Soon Ong",
-        "Yingqian Zhang"
+        "Nina Hosseini-Kivanani"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21227v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21227v1",
+      "publishedAt": "2026-05-20T14:19:55.000Z",
+      "updatedAt": "2026-05-20T14:19:55.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21226v1",
+      "title": "OCTOPUS: Optimized KV Cache for Transformers via Octahedral Parametrization Under optimal Squared error quantization",
+      "summary": "The key-value (KV) cache dominates memory bandwidth and footprint in long-context autoregressive inference. Recent rotation-preconditioned codecs (TurboQuant, PolarQuant) show that a structured random rotation followed by a per-coordinate scalar quantizer matched to an analytically tractable marginal is a near-optimal recipe for KV compression. OCTOPUS advances this paradigm through joint quantization of rotated coordinate triplets. Each triplet's direction is mapped to a square via an octahedral parameterization, and the two resulting coordinates and the triplet norm are Lloyd-Max quantized against implementation-matched marginals. Optimizing the per-triplet squared error gives a strictly non-uniform bit allocation depending only on the total dimensionality of the keys. We find the finite-dimensional quality optimum with sweeps to be constant on every real decoder we test. The codec is data-oblivious, online, and deterministic given a seed. Across text, video, and audio, OCTOPUS matches or beats every prior rotation codec at every reported bit width and metric, with a lead that grows as bits drop for extreme compression. Furthermore, a fused Triton implementation reconstructs keys on the fly without materializing the uncompressed key, so the codec adds no decode-time bandwidth or latency over the existing dequantization. Project Page: https://octopus-quant.github.io/",
+      "authors": [
+        "Mark Boss",
+        "Vikram Voleti",
+        "Simon Donné",
+        "Shimon Vainer"
       ],
       "categories": [
         "cs.LG",
         "cs.AI"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19975v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19975v1",
-      "publishedAt": "2026-05-19T15:19:59.000Z",
-      "updatedAt": "2026-05-19T15:19:59.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21226v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21226v1",
+      "publishedAt": "2026-05-20T14:19:51.000Z",
+      "updatedAt": "2026-05-20T14:19:51.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19974v1",
-      "title": "SphericalDreamer: Generating Navigable Immersive 3D Worlds with Panorama Fusion",
-      "summary": "The generation of immersive and navigable 3D environments is increasingly prevalent with the growing adoption of virtual reality and 3D content. However, recent methods face a fundamental limitation: they cannot produce 3D worlds that simultaneously (i) are navigable over long-range spatial extents and (ii) cover the complete omnidirectional field of view ($360^\\circ$ horizontally and $180^\\circ$ vertically). To address this challenge, we introduce SphericalDreamer, a method for generating fully immersive and long-range 3D outdoor environments from textual prompts. Our approach is built on the generation of multiple panoramic images, which are subsequently lifted into 3D and fused together while maintaining visual and geometric consistency. SphericalDreamer produces highly detailed, fully immersive 3D environments, while substantially improving scale and navigability compared to prior approaches.",
+      "arxivId": "2605.21225v1",
+      "title": "PREFINE: Preference-Based Implicit Reward and Cost Fine-Tuning for Safety Alignment",
+      "summary": "We address the problem of making a pre-trained reinforcement learning (RL) policy safety-aware by incorporating cost constraints without retraining it from scratch. While costs could be numerically encoded, we assume a more general setting is when costs are provided as preferences. Given a reward-optimized policy and a small dataset of preferred (low-cost) and dispreferred (high-cost) trajectories, our goal is to fine-tune the policy to generate low-cost behaviors while retaining high rewards. Unlike standard RLHF in language models, where preferences are defined over responses to the same prompt, our setting involves trajectory-level preferences in continuous control environments. We introduce PREFINE: Preference-based Implicit Reward and Cost Fine-Tuning for Safety Alignment which is a preference-based fine-tuning method that adapts Direct Preference Optimization (DPO), which is now widely used for LLM fine-tuning, to the sequential decision making setting. PREFINE constructs policy-sampled counterfactual trajectories to establish meaningful preference contrasts and jointly optimizes for reward retention and safety alignment. Empirically, PREFINE reduces constraint violations and catastrophic failures by over 60% while maintaining original reward behavior. PREFINE produces policies that achieve low-cost, high-reward performance with significantly improved data and computational efficiency compared to full offline RL or imitation learning, bridging preference alignment and safe policy adaptation in continuous domains.",
       "authors": [
-        "Antoine Schnepf",
-        "Karim Kassab",
-        "Flavian Vasile",
-        "Andrew Comport"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19974v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19974v1",
-      "publishedAt": "2026-05-19T15:19:16.000Z",
-      "updatedAt": "2026-05-19T15:19:16.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19972v1",
-      "title": "Block-Sphere Vector Quantization",
-      "summary": "Vector quantization is a fundamental primitive for scalable machine learning systems, enabling memory-efficient storage, fast retrieval, and compressed inference. Recent rotation-based quantizers such as EDEN, RabitQ, and TurboQuant have introduced strong guarantees and empirical performance, but the surrounding comparisons have been difficult to interpret because they rely on different distortion criteria, probability regimes, and implementation assumptions. As our first contribution, we provide a unified theoretical comparison of these methods and show that their relative advantages are criterion-dependent rather than absolute: EDEN and TurboQuant are favorable for MSE distortion, EDEN is also effective for expected inner-product distortion, and RabitQ provides strong high-probability control. This comparison further clarifies that EDEN provides particularly strong guarantees for expected distortion measures. As our second contribution, we introduce Block-Sphere Quantization (BlockQuant), a new rotation-based block quantization algorithm designed around the spherical geometry of randomly rotated vectors. Unlike coordinate-wise quantizers, BlockQuant quantizes blocks on the sphere, preserving the geometry of rotated embeddings more faithfully. We prove that this block-spherical design theoretically improves over the baselines considered in this paper for both reconstruction MSE and expected inner-product distortion. Our experiments on real embedding datasets and long-context LLM inference tasks show practical gains that are consistent with our theoretical improvements.",
-      "authors": [
-        "Heesang Ann",
-        "Joongkyu Lee",
-        "Min-hwan Oh"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI",
-        "cs.DB",
-        "cs.DS"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19972v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19972v1",
-      "publishedAt": "2026-05-19T15:18:56.000Z",
-      "updatedAt": "2026-05-19T15:18:56.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19969v1",
-      "title": "Your Neighbors Know: Leveraging Local Neighborhoods for Backdoor Detection in Decentralized Learning",
-      "summary": "Decentralized learning (DL) is an emerging machine learning paradigm where nodes collaboratively train models without a central server. However, the collaborative nature of DL makes it vulnerable to backdoor attacks, where a model is taught to behave normally on standard inputs while executing hidden, malicious actions when encountering data with specific triggers. Backdoor attacks in DL remain understudied and existing defenses often overlook DL constraints. We introduce Argus, a novel backdoor detection framework native to DL that requires neither a central coordinator nor prior knowledge of the trigger. In Argus, honest nodes locally analyze received model updates to identify potential backdoor triggers. Nodes then collectively share their triggers with their neighbors and use a structural similarity metric to separate true backdoors from false alarms induced by data heterogeneity. A key insight is that false positive triggers exhibit inconsistencies across participants while true positive ones show consistent patterns. Model updates that fail this collaborative test are rejected, and persistently malicious senders are eventually evicted. We provide the first theoretical convergence guarantees for a DL-specific backdoor detection mechanism, showing that filtering out suspicious model updates with high probability preserves a convergence rate comparable to standard DL. We implement and evaluate Argus on three standard datasets and against three state-of-the-art baselines. Across settings, Argus reduces attack success rates by up to 90 points compared to no defense, while preserving model utility within 5 percentage points of an omniscient oracle. Furthermore, the effectiveness of Argus compared to baselines improves as data heterogeneity increases.",
-      "authors": [
-        "Sayan Biswas",
-        "Antoine Boutet",
-        "Davide Frey",
-        "Romaric Gaudel",
-        "Rachid Guerraoui",
-        "Maxime Jacovella",
-        "Anne-Marie Kermarrec",
-        "Dimitri Lerévérend",
-        "François Taïani",
-        "Martijn de Vos"
-      ],
-      "categories": [
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19969v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19969v1",
-      "publishedAt": "2026-05-19T15:17:01.000Z",
-      "updatedAt": "2026-05-19T15:17:01.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19966v1",
-      "title": "Detecting Fluent Optimization-Based Adversarial Prompts via Sequential Entropy Changes",
-      "summary": "Optimization-based adversarial suffixes can jailbreak aligned large language models (LLMs) while remaining fluent, weakening static and windowed perplexity-based detectors. We cast adversarial suffix detection as an online change-point detection problem over the token-level next-token entropy stream. Using the LLM system prompt to estimate a robust baseline, we standardize user-token entropies and apply a one-sided CUSUM statistic. The resulting detector, CPD Online (CPD), is model-agnostic, training-free, runs online, and localizes the adversarial suffix onset. On a benchmark of 1,012 optimization-based suffix attacks (GCG, AutoDAN, AdvPrompter, BEAST, AutoDAN-HGA) and 1,012 perplexity-controlled benign prompts, CPD improves F1 over the strongest windowed-perplexity baseline on all six open-weight chat models (LLaMA-2-7B/13B, Vicuna-7B/13B, Qwen2.5-7B/14B). On LLaMA-2-7B at the canonical CUSUM setting ($k=0$), CPD reaches AUROC $0.88$ and F1 $0.82$. Beyond prompt-level detection, CPD concentrates 79.6% of its triggers inside the adversarial suffix, versus 17-46% for windowed perplexity. Finally, when used as a lightweight gate for LLaMA Guard, CPD reduces guard calls by 17-22% on a high-volume, benign-dominated deployment while preserving guard-level detection quality",
-      "authors": [
-        "Mohammed Alshaalan",
-        "Miguel R. D. Rodrigues"
+        "Richa Verma",
+        "Bavish Kulur",
+        "Sanjay Chawla",
+        "Balaraman Ravindran"
       ],
       "categories": [
         "cs.LG",
         "cs.AI"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19966v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19966v1",
-      "publishedAt": "2026-05-19T15:15:51.000Z",
-      "updatedAt": "2026-05-19T15:15:51.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21225v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21225v1",
+      "publishedAt": "2026-05-20T14:19:45.000Z",
+      "updatedAt": "2026-05-20T14:19:45.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19965v1",
-      "title": "Normative Networks for Source Separation via Local Plasticity and Dendritic Computation",
-      "summary": "Blind source separation (BSS) is a natural framework for studying how latent causes may be recovered from sensory mixtures, but deriving online and biologically plausible algorithms for structured (i.e., constrained to known domains) and potentially correlated sources remains challenging. Recent work has derived neural networks for BSS from maximization of an entropy measure, yet its online implementations involve complex and nonlocal recurrent dynamics. Motivated by this perspective, we propose Predictive Entropy Maximization, which achieves competitive performance in BSS, using only local weight updates. The method employs a close approximation of an entropy measure, yielding an objective function with easily interpretable components. Minimizing this objective leads to a predictive neural architecture in which feedforward synapses follow an error-driven rule (that can be realized through dendritic mechanisms), lateral inhibitory connections are learned with local Hebbian plasticity, and source-domain constraints are enforced through simple output nonlinearities. We derive explicit spectral bounds on the surrogate error, characterizing when the approximation is accurate. Empirically, Predictive Entropy Maximization remains robust under increasing source correlation and observation noise, outperforms biologically plausible algorithms that rely on stronger independence or decorrelation assumptions, and remains competitive with exact determinant- and correlative-information-based baselines. These results show how local plasticity and adaptive lateral inhibition can emerge from maximizing a regularized second-order entropy over structured source domains. Our implementation code is available at https://github.com/BariscanBozkurt/Predictive-Entropy-Maximization.",
+      "arxivId": "2605.21224v1",
+      "title": "Artificial Intelligence Reshapes Microwave Photonics",
+      "summary": "As a rapidly emerging interdisciplinary field that intrinsically integrates microwave and photonics, microwave photonics (MWP) provides disruptive solutions to overcome the fundamental bandwidth of conventional electronic systems. By exploiting the inherently ultra-wide bandwidth and low-loss characteristics of photonic technologies, MWP enables the generation, transmission, processing, and detection of microwave, millimeter-wave, and terahertz signals. Representative breakthroughs include fully photonic microwave radar systems, photonic analog-to-digital converters with bandwidth up to 320 GHz, and photonic wireless communication systems achieving data rate as high as 616 Gbit/s. Meanwhile, the rapid growth of artificial intelligence (AI) is reshaping scientific research, engineering, and daily life in unprecedented ways, such as AI for science/engineering and AI co-scientist/assistant. Correspondingly, AI is profoundly reshaping MWP in all aspects, ranging from signal generation, transmission to signal processing and detection. AI has revolutionized the design, simulation, fabrication, testing, deployment, and maintenance of MWP systems, delivering autonomous operation and exceptional efficiency beyond traditional systems. Motivated by these developments, this Review Paper provides the first comprehensive overview of AI-enabled MWP, systematically summarizing the state-of-the-art advances and presenting insights for both the academic community and the broader public.",
       "authors": [
-        "Bariscan Bozkurt",
-        "Efe Ali Gorguner",
-        "Francesco Innocenti",
-        "Rafal Bogacz"
+        "Peng Li",
+        "Xihua Zou",
+        "Jia Ye",
+        "Wei Pan",
+        "Lianshan Yan"
       ],
       "categories": [
-        "cs.LG",
+        "physics.optics",
+        "cs.AI",
         "eess.SP"
       ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19965v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19965v1",
-      "publishedAt": "2026-05-19T15:15:26.000Z",
-      "updatedAt": "2026-05-19T15:15:26.000Z",
+      "primaryCategory": "physics.optics",
+      "absUrl": "https://arxiv.org/abs/2605.21224v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21224v1",
+      "publishedAt": "2026-05-20T14:17:10.000Z",
+      "updatedAt": "2026-05-20T14:17:10.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19959v1",
-      "title": "Learning Orthonormal Bases for Function Spaces",
-      "summary": "Infinite-dimensional orthonormal basis expansions play a central role in representing and computing with function spaces due to their favorable linear algebraic properties. However, common bases such as Fourier or wavelets are fixed and do not adapt to the structure of a given problem or dataset. In this paper, we aim to represent these bases with neural networks and optimize them. Our key idea is that any target infinite-dimensional orthonormal basis can be viewed either as a point on the Lie manifold of the orthogonal group, or equivalently, as the endpoint of a continuous path on that manifold that connects a reference basis, e.g. Fourier, to that target. Paths on the Lie manifold satisfy ordinary differential equations (ODEs) governed by skew-adjoint integral operators. Using neural networks to define finite-rank generators of such ODEs allows us to parameterize and optimize orthonormal bases in function space. While relying on finite-rank generators to model infinite operators might seem restrictive, we prove a universality result: even with a rank-2 generator, the integrated solutions of the ODE are dense in the orthogonal group under the appropriate operator topology. In other words, for any target orthonormal basis, there exists a path originating from a reference basis and driven by finite-rank generators that gets arbitrarily close to that target basis. We demonstrate the flexibility of our framework by transforming the Fourier basis into the principal components of a functional dataset, eigenfunctions of linear operators, or dynamic modes of energy-preserving physical simulations.",
+      "arxivId": "2605.21214v1",
+      "title": "Behavior-Consistent Deep Reinforcement Learning",
+      "summary": "Reinforcement learning (RL) often exhibits high variance across training runs, leading to unreliable performance and posing a major challenge to deployment in real-world domains. In this work, we address the challenge of cross-run policy divergence by formalizing the problem of behavior-consistent RL, where the objective is to obtain policies that are both high-performing and distributionally similar across training runs. Our key observation is that maximum-entropy RL provides a direct mechanism for controlling behavioral divergence by anchoring runs to a common (uniform) prior. We prove that, for Boltzmann policies, choosing the temperature proportional to $Q$-function disagreement bounds the pairwise KL divergence between the induced policies. However, we also show that naïvely increasing entropy might impair policy optimization while amplifying off-policy error. Building upon these observations, we propose $Q$-value Expectile Disagreement (QED), a state-dependent temperature schedule that uses double-critic disagreement as a single-run proxy for cross-run disagreement. Empirically, we demonstrate that across 18 continuous-control tasks, QED reduces across-run divergence by two orders of magnitude without sacrificing performance, resulting in a considerable reduction in return variance at modest sample-efficiency costs.",
       "authors": [
-        "Hamidreza Kamkari",
-        "Mohammad Sina Nabizadeh",
-        "Justin Solomon"
+        "Marcel Hussing",
+        "Liv G. d'Aliberti",
+        "Claas Voelcker",
+        "Benjamin Eysenbach",
+        "Eric Eaton"
       ],
       "categories": [
         "cs.LG",
-        "math.FA"
+        "cs.AI"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19959v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19959v1",
-      "publishedAt": "2026-05-19T15:12:05.000Z",
-      "updatedAt": "2026-05-19T15:12:05.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21214v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21214v1",
+      "publishedAt": "2026-05-20T14:08:33.000Z",
+      "updatedAt": "2026-05-20T14:08:33.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19957v1",
-      "title": "World-Ego Modeling for Long-Horizon Evolution in Hybrid Embodied Tasks",
-      "summary": "World models are widely explored in embodied intelligence, yet they typically predict distinct evolutions of the world and the ego within a single stream, where the world captures persistent instruction-agnostic scene regularities and the ego captures robot-centric instruction-conditioned dynamics. This world-ego entanglement leads to a degradation in long-horizon embodied scenarios, particularly in hybrid tasks with interleaved navigation and manipulation behaviors. In this paper, we introduce \\emph{World-Ego Modeling}, a new conceptual paradigm that decomposes future evolution into world and ego components. We define the world-ego boundary from three perspectives, i.e., motion-, semantic-, and intention-based views, and analyze three disentanglement strategies with post-, pre-, and full disentanglement. Further, we instantiate this paradigm as the World-Ego Model (WEM), a unified embodied world model that couples an implicit separate world-ego planner with a cascade-parallel mixture-of-experts (CP-MoE) diffusion generator. To enable rigorous evaluation, we further construct HTEWorld, the first benchmark for long-horizon world modeling with hybrid navigation-manipulation tasks, providing 125K video clips (over 4.5M frames) with fine-grained action annotations and 300 multi-turn evaluation trajectories (over 2K instructions). Extensive experiments show that WEM achieves state-of-the-art performance on HTEWorld while remaining competitive on existing manipulation-only benchmarks.",
+      "arxivId": "2605.21213v1",
+      "title": "Enhanced Reinforcement Learning-based Process Synthesis via Quantum Computing",
+      "summary": "In this work, we present quantum reinforcement learning (RL) as a solution strategy for process synthesis problems. Building on our prior work, we develop a generalized framework that formally poses process synthesis as a Markov decision process and introduces quantum-enhanced RL algorithms to solve it with improved scalability. Earlier implementations of quantum-based RL for process synthesis were limited by qubit requirements, which scaled poorly with problem complexity. This work overcomes this challenge by introducing state encoding algorithms to decouple qubit requirements from problem size. A classical RL-based solution strategy is used as a baseline to benchmark the quantum algorithms under identical training conditions. All algorithms are evaluated across a flowsheet synthesis problem of increasing unit counts to analyze their performance and scalability. Results show that all approaches are capable of identifying the optimal flowsheet designs in small design spaces. For moderate-scale unit counts, quantum approaches demonstrate competitive performance on a per-episode basis and improved efficiency on a per-parameter basis versus the classical RL benchmark. This work provides a foundation for future quantum computing applications within process systems engineering, establishes a controlled benchmark for comparing classical and quantum algorithms, and shows that the proposed quantum variants remain competitive for the process synthesis problem examined in this work.",
       "authors": [
-        "Zuyao Lin",
-        "Jianhui Zhang",
-        "Peidong Jia",
-        "Xiaoguang Zhao",
-        "Shanghang Zhang",
-        "Xingyu Chen"
+        "Austin Braniff",
+        "Fengqi You",
+        "Yuhe Tian"
+      ],
+      "categories": [
+        "quant-ph",
+        "cs.AI",
+        "cs.LG",
+        "math.OC"
+      ],
+      "primaryCategory": "quant-ph",
+      "absUrl": "https://arxiv.org/abs/2605.21213v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21213v1",
+      "publishedAt": "2026-05-20T14:08:25.000Z",
+      "updatedAt": "2026-05-20T14:08:25.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21207v1",
+      "title": "PGC: Peak-Guided Calibration for Generalizable AI-Generated Image Detection",
+      "summary": "The rapid evolution of generative AI, from GANs to modern diffusion models, has resulted in increasingly subtle discriminative clues. These fine-grained signals are often overshadowed by dominant, high-fidelity image content (e.g., the main subject), limiting the reliability of existing detectors that predominantly rely on global representations. To address this challenge, we propose the Peak-Guided Calibration (PGC) framework. PGC introduces a novel strategy that aggregates salient features via a peak-focusing mechanism. Specifically, by employing a peak-sensitive aggregation that accentuates the most discriminative local clues, PGC leverages these critical signals to calibrate the global decision. This approach recovers subtle patterns that would otherwise be submerged in the global context. Furthermore, to better simulate real-world threats, we introduce the CommGen15 dataset, a challenging benchmark comprising samples from 15 commercial models. Extensive experiments demonstrate that PGC achieves state-of-the-art performance. Specifically, it improves mean accuracy by +12.3% on our CommGen15 dataset, and sets new records on standard benchmarks, including GenImage (+2.1%), AIGI (+3.5%), and UniversalFakeDetect (+1.7%). Code is available at https://github.com/xiaoyu6868/PGC.",
+      "authors": [
+        "Xiaoyu Zhou",
+        "Jianwei Fei",
+        "Peipeng Yu",
+        "Jingchang Xie",
+        "Chong Cheng",
+        "Zhihua Xia"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21207v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21207v1",
+      "publishedAt": "2026-05-20T14:04:53.000Z",
+      "updatedAt": "2026-05-20T14:04:53.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21198v1",
+      "title": "SURGE: An Event-Centric Social Media Sentiment Time Series Benchmark with Interaction Structure",
+      "summary": "Public events on social media generate large volumes of discussion whose collective dynamics carry direct value for opinion forecasting and crisis response. Capturing how these dynamics evolve across an event's lifecycle requires organizing fragmented posts into event-level time series. Existing datasets cover only a small number of events within a single category, and typically discard the interaction structure between posts when constructing time series, which restricts both transfer across event types and controlled study of how interactions shape the resulting collective dynamics. We present SURGE, a multi-event social media benchmark that pairs event-level time series with aligned text and interaction structure linking posts within an event. SURGE is built through an automated pipeline that produces calendar-aligned time series at three temporal granularities, covering 67 events and more than 800K posts across five event categories. Each time bin is paired with flat and structured textual views derived from the same selected posts, enabling controlled evaluation of whether social interaction structure affects forecasting behavior. On top of SURGE we define benchmark protocols for numerical-only forecasting, text-augmented forecasting, high-interaction evaluation, and leave-one-category-out generalization. Experiments with representative time-series and multimodal forecasting models reveal three properties of the benchmark: a strong local-persistence regime in which naive baselines remain hard to beat under absolute error, limited transfer of existing text-augmented forecasters to event-driven social-media data, and increased difficulty on reply-dense periods that aggregate metrics tend to obscure. We further include a lightweight structure-aware probe as a reference implementation, illustrating how SURGE can support interaction-aware forecasting research.",
+      "authors": [
+        "Chen Su",
+        "Pengsen Cheng",
+        "Yuanhe Tian",
+        "Yan Song"
+      ],
+      "categories": [
+        "cs.SI",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.SI",
+      "absUrl": "https://arxiv.org/abs/2605.21198v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21198v1",
+      "publishedAt": "2026-05-20T13:59:32.000Z",
+      "updatedAt": "2026-05-20T13:59:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21195v1",
+      "title": "RankE: End-to-End Post-Training for Discrete Text-to-Image Generation with Decoder Co-Evolution",
+      "summary": "Discrete autoregressive (AR) text-to-image (T2I) models pair a VQ tokenizer with an AR policy, and current post-training pipelines optimize only the policy while keeping the VQ decoder frozen. Recent diffusion T2I work, exemplified by REPA-E, has shown that the VAE itself constitutes a key alignment bottleneck, yet no analogous investigation exists for discrete AR models. We show that policy-only optimization induces Latent Covariate Shift: as the policy evolves, the resulting token distribution diverges from the ground-truth distribution on which the decoder was trained, such that reward scores improve while decoded image quality degrades. To address this mismatch, we propose RankE, the first end-to-end post-training framework for discrete T2I generation. Rather than optimizing the policy against a fixed decoder, RankE co-evolves both components through alternating optimization: each module maximizes a ranking-based alignment objective while being regularized by a stability-preserving anchor suited to its parameter space. This co-evolution breaks the fidelity--alignment trade-off that plagues frozen-decoder approaches: on LlamaGen-XL (775M), standard RL improves CLIP but degrades FID, whereas RankE improves both simultaneously (FID 15.21, CLIP 33.76 on MS-COCO 30K). Consistent gains on Janus-Pro (1B) confirm that decoder co-evolution reliably converts reward optimization into pixel-space quality improvements.",
+      "authors": [
+        "Siyong Jian",
+        "Siyuan Li",
+        "Luyuan Zhang",
+        "Zedong Wang",
+        "Xin Jin",
+        "Ying Li",
+        "Cheng Tan",
+        "Huan Wang"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21195v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21195v1",
+      "publishedAt": "2026-05-20T13:56:52.000Z",
+      "updatedAt": "2026-05-20T13:56:52.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21190v1",
+      "title": "Semantic Granularity Navigation in Image Editing",
+      "summary": "Despite the generative capabilities of diffusion and flow models, real-image editing remains constrained by a persistent trade-off between semantic editability and structural fidelity. We trace a primary cause of this limitation to the implicit coupling of edit progress with model scale in existing paradigms. Under this coupling, stronger edits typically require visiting noisier states, which spends computation on destabilizing layout before the semantic change is well localized. We introduce NaviEdit, a training-free inference-time controller that decouples edit progress from model scale traversal through a strict self-consistency contract. NaviEdit operates at the rollout level and leaves the underlying pretrained model unchanged. It treats scale as a control input and reallocates a fixed step budget toward semantically responsive intermediate scales instead of destructive high-noise regimes. Experiments show positive average gains across compatible editors and flow backbones, supporting decoupling as a portable inference-time control principle.",
+      "authors": [
+        "Liangsi Lu",
+        "Minzhe Guo",
+        "Xuhang Chen",
+        "Yang Shi"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21190v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21190v1",
+      "publishedAt": "2026-05-20T13:53:13.000Z",
+      "updatedAt": "2026-05-20T13:53:13.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21186v1",
+      "title": "SAM-Sode: Towards Faithful Explanations for Tiny Bacteria Detection",
+      "summary": "Interpretability in object detection provides crucial confidence support for clinical auxiliary diagnosis. However, in tiny bacteria detection, traditional explanation methods often suffer from blurred foreground boundaries and diffuse feature attribution due to the extreme sparsity of target morphological features and severe interference from complex backgrounds. Such limitations hinder the provision of logically coherent morphological evidence. To bridge this gap, we propose a novel eXplainable AI (XAI) framework, SAM-Sode. The framework innovatively transforms initial feature attribution maps into geometry-aware prompts, leveraging the prior knowledge of the foundation model (SAM3) to achieve spatial refinement and morphological reconstruction of the explanatory mappings. Furthermore, we introduce a dual-constraint mechanism based on physical significance and geometric alignment to perform instance-level denoising, generating coherent explanations that better align with human expert intuition. Experimental results on our self-constructed bacteria dataset with complex circuit backgrounds (containing 2,524 images) and other public datasets demonstrate that the proposed method effectively suppresses background redundancy and significantly enhances the decision-making transparency of tiny object detection.",
+      "authors": [
+        "Wanying Tan",
+        "Shuo Yan",
+        "Dazhi Huang",
+        "Yazheng Liu",
+        "Zili Shao",
+        "Rufeng Chen",
+        "Hechang Chen",
+        "Mude Shi",
+        "Tianxing Ji",
+        "Sihong Xie"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21186v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21186v1",
+      "publishedAt": "2026-05-20T13:51:22.000Z",
+      "updatedAt": "2026-05-20T13:51:22.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21182v1",
+      "title": "Manga109-v2026: Revisiting Manga109 Annotations for Modern Manga Understanding",
+      "summary": "Manga is a culturally distinctive multimodal medium and one of the most influential forms of Japanese popular culture. As AI systems increasingly target manga understanding, OCR, and translation, Manga109 has become a foundational dataset for manga-related AI research. However, the current Manga109 dataset contains transcription errors and coarse annotations, which do not align well with modern OCR and multimodal manga understanding tasks. In this work, we revisit the dialogue text annotations of Manga109 and identify five categories of annotation issues, including transcription errors, missing text regions, overlapping dialogue and onomatopoeia, and under-segmented speech balloons. To address these issues, we combine OCR-based issue detection and manual revision to construct Manga109-v2026, revising approximately 29,000 dialogue annotations. Our revisions better align Manga109 with modern OCR and multimodal manga understanding systems while preserving expressive structures characteristic of manga.",
+      "authors": [
+        "Jeonghun Baek",
+        "Atsuyuki Miyai",
+        "Shota Onohara",
+        "Hikaru Ikuta",
+        "Kiyoharu Aizawa"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI",
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21182v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21182v1",
+      "publishedAt": "2026-05-20T13:49:13.000Z",
+      "updatedAt": "2026-05-20T13:49:13.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21178v1",
+      "title": "Metaphors in Literary Post-Editing: Opening Pandora's Box?",
+      "summary": "This paper investigates how post-editors of literary texts react and respond to the way metaphors have been translated by Neu ral Machine Translation (NMT) and Large Language Models (LLMs). The results show that one in three metaphors in the output were changed by the post-editors, demonstrating that the translation of fig urative language is indeed problematic in literary MT (LitMT). The responses indi cate that the post-editors were aware of overly literal translations, though mostly for multiword expressions. Moreover, at times they found it difficult to determine whether solutions were acceptable. They rated the overall quality of the MT out put as quite poor and stated that the post editing was more work and more effort than it would have been translating from scratch. This supports previous studies ar guing that post-editing constrains transla tors in their creativity and diminishes their sense of text ownership.",
+      "authors": [
+        "Aletta G. Dorst",
+        "Mayra O. Nas",
+        "Katinka Zeven"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21178v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21178v1",
+      "publishedAt": "2026-05-20T13:45:07.000Z",
+      "updatedAt": "2026-05-20T13:45:07.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21177v1",
+      "title": "ChunkFT: Byte-Streamed Optimization for Memory-Efficient Full Fine-Tuning",
+      "summary": "This work presents \\textsc{ChunkFT}, a memory-efficient fine-tuning framework that reformulates full-parameter fine-tuning around a dynamically activated working set. \\textsc{ChunkFT} enables gradient computation for arbitrary sub-tensors without modifying the network architecture, providing an algorithmic foundation for optimizing arbitrary sub-networks while avoiding standard dense gradient computation. We provide a theoretical convergence analysis of \\textsc{ChunkFT} in the deterministic setting. Empirically, we apply \\textsc{ChunkFT} to fine-tune Llama 3-8B and Llama 3-70B using a single RTX 4090-24GB GPU and 2$\\times$ H800-80GB GPUs, respectively. Full-parameter fine-tuning of a 7B model with a 1K input length requires only 13.72GB of GPU memory. The results demonstrate the effectiveness of \\textsc{ChunkFT} in memory usage, running time, and optimization quality. Moreover, downstream evaluations on language understanding, mathematical reasoning, and MT-Bench show that \\textsc{ChunkFT} consistently outperforms existing memory-efficient baselines. Notably, \\textsc{ChunkFT} achieves performance comparable to, and in some cases exceeding, full-parameter fine-tuning. Our repository is on https://github.com/misonsky/chunk.",
+      "authors": [
+        "Yongkang Liu",
+        "Zijing Wang",
+        "Mengjie Zhao",
+        "Ercong Nie",
+        "Mingyang Wang",
+        "Qian Li",
+        "Feiliang Ren",
+        "Shi Feng",
+        "Daling Wang",
+        "Hinrich Schütze"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.21177v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21177v1",
+      "publishedAt": "2026-05-20T13:44:44.000Z",
+      "updatedAt": "2026-05-20T13:44:44.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21171v1",
+      "title": "FTerViT: Fully Ternary Vision Transformer",
+      "summary": "Ternary Vision Transformers offer substantial model compression, however state-of-the-art methods only ternarize the encoder layers, leaving patch embeddings, LayerNorm parameters, and classifier heads in full precision. In compact models targeting resource-constrained processors, such as microcontrollers, these remaining full-precision components determine the total memory footprint, severely limiting deployment efficiency and on-device feasibility. In this work, we introduce a fully ternarized Vision Transformer in which \\emph{all} weight matrices and normalization parameters are ternarized (FTerViT). To this end, we introduce two novel operators : TernaryBitConv2d with per-channel scaling for patch embedding and TernaryLayerNorm. FTerViT is trained using knowledge distillation, followed by a lightweight quantization-aware recovery phase. Our ternary W2A8 DeiT-III-S at 384$\\times$384 resolution achieves 82.43\\% ImageNet-1K top-1 at 6.09\\,MB (${\\sim}$15$\\times$ compression, $-$2.42\\,pp vs.\\ FP32), outperforming prior ternary ViTs methods up to 8 pp. Finally, we demonstrate the first implementation of ternary vision transformers on a dual cores XTensa LX7 microcontroller inside the ESP32-S3 system-on-chip. By deploying FTerViT-Small (based on DeiT-III-Small at 224$\\times$224 resolution, 5.81\\,MB), we achieve 79.64\\% ImageNet-1K top-1 accuracy.",
+      "authors": [
+        "Szymon Ruciński",
+        "Pietro Bonazzi",
+        "Engin Türetken",
+        "Simon Narduzzi",
+        "Michele Magno",
+        "Nadim Maamari"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21171v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21171v1",
+      "publishedAt": "2026-05-20T13:41:53.000Z",
+      "updatedAt": "2026-05-20T13:41:53.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21157v1",
+      "title": "Comparative Analysis of Military Detection Using Drone Imagery Across Multiple Visual Spectrums",
+      "summary": "In modern warfare, drones are becoming an essential part of intelligence gathering and carrying out precise attacks in different kinds of hostile environments. Their ability to operate in real-time and hostile environments from a safe distance makes them invaluable for surveillance and military operations. The KIIT-MiTA dataset is comprised of images of different military scenarios taken from drones, and these provide a foundation for detecting military objects, but it does not take into account the various types of real-world scenarios. With that in mind, to evaluate how the models are performing under varying conditions, four different types of datasets are created: Gray Scale, Thermal Vision, Night Vision, and Obscura Vision. These simulate the real-world environments such as low visibility, heat-based imagery, and nighttime conditions. The YOLOv11-small model is trained and used to detect objects across diverse settings. This research boosts the performance and reliability of drone-based operations by contributing to the development of advanced detection systems in both defensive and offensive missions.",
+      "authors": [
+        "Sourov Roy Shuvo",
+        "Prajwal Panth",
+        "Rajesh Chowdhury",
+        "Sorup Chakraborty",
+        "Sudip Chakrabarty",
+        "Prasant Kumar Pattnaik"
       ],
       "categories": [
         "cs.CV",
         "cs.AI",
+        "cs.LG",
         "cs.RO"
       ],
       "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19957v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19957v1",
-      "publishedAt": "2026-05-19T15:10:27.000Z",
-      "updatedAt": "2026-05-19T15:10:27.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21157v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21157v1",
+      "publishedAt": "2026-05-20T13:26:35.000Z",
+      "updatedAt": "2026-05-20T13:26:35.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19956v1",
-      "title": "Towards Fine-Grained Robustness: Attention-Guided Test-Time Prompt Tuning for Vision-Language Models",
-      "summary": "Vision-Language Models (VLMs), such as CLIP, have achieved significant zero-shot performance on downstream tasks with various fine-tuning adaptation methods. However, recent studies have proven that adversarial attacks can significantly degrade the inference ability of VLMs, posing substantial risks to their practical applications. Prevalent test-time adaptation methods typically rely on multi-view augmentation to implement various fine-tuning strategies, which struggle to identify semantic information and are prone to destroying discriminative regions in fine-grained scenarios. To address these limitations, we propose Attention-Guided Test-Time Prompt Tuning (A-TPT), a semantics-preserving method designed for test-time adaptation. We first refine the gradient attention rollout mechanism to identify semantically meaningful regions surviving under adversarial attacks. Furthermore, we leverage them to guide the spatially varying augmentation intensities and multi-view ensemble for prompt tuning and inference. Extensive experiments demonstrate that A-TPT outperforms existing test-time adaptation methods on both adversarial and clean data. Codes are available at https://github.com/SEU-VIPGroup/A-TPT .",
+      "arxivId": "2605.21154v1",
+      "title": "Automated ICD Classification of Psychiatric Diagnoses: From Classical NLP to Large Language Models",
+      "summary": "Mental health has become a global priority, leading to a massive administrative burden in the coding of clinical diagnoses. This study proposes the automation of psychiatric diagnostic analysis by mapping free-text descriptions to the International Classification of Diseases (ICD) using Natural Language Processing (NLP) and Machine Learning (ML) techniques. Utilizing a specialized dataset of 145,513 Spanish psychiatric descriptions, various text representation paradigms were evaluated, ranging from classical frequency-based models (BoW, TF-IDF) to state-of-the-art Large Language Models (LLMs) such as e5\\_large, BioLORD, and Llama-3-8B. Results indicate that transformer-based embeddings consistently outperform traditional methods by capturing implicit semantic cues and nuanced medical terminology. The e5\\_large model, through end-to-end fine-tuning, achieved the highest performance with a $F1_{micro}$ score of 0.866. This research demonstrates that adapting LLMs to specific clinical nomenclature is essential for overcoming the challenges of ``long-tail'' label distributions and the inherent ambiguity of psychiatric discourse.",
       "authors": [
-        "Jia-Wei Hai",
-        "Yijun Wang",
-        "Xiu-Shen Wei"
+        "Fernando Ortega",
+        "Raúl Lara-Cabrera",
+        "Jorge Dueñas-Lerín",
+        "Alejandro de la Torre-Luque",
+        "Mercé Salvador Robert",
+        "Enrique Baca-García"
       ],
       "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19956v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19956v1",
-      "publishedAt": "2026-05-19T15:10:06.000Z",
-      "updatedAt": "2026-05-19T15:10:06.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19952v1",
-      "title": "Rethinking How to Remember: Beyond Atomic Facts in Lifelong LLM Agent Memory",
-      "summary": "To enable reliable long-term interaction, LLM agents require a memory system that can faithfully store, efficiently retrieve, and deeply reason over accumulated dialogue history. Most existing methods adopt an extracted fact based paradigm: handcrafted static prompts compress raw dialogues into atomic facts, which are then stored, matched, and injected into downstream reasoning. Nevertheless, such fact-centric designs inevitably discard fine-grained details in original dialogues and fail to support deep reasoning over scattered isolated facts. Moreover, static prompts cannot maintain consistent extraction granularity across diverse dialogue styles. To address these limitations, we propose TriMem, which maintains three coexisting representation granularities, including raw dialogue segments anchored by source identifiers for storage fidelity, extracted atomic facts for efficient memory retrieval, synthesized profiles that aggregate dispersed facts into holistic semantic understanding for deep reasoning. We further adopt TextGrad-based prompt optimization, which iteratively refines extraction and profiling prompts via response quality feedback, achieving lifelong evolution without any parameter updating. Extensive experiments on LoCoMo and PerLTQA across multiple LLM backbones demonstrate that TriMem consistently outperforms strong memory baselines. The code is available at https://TMLR-TriMem.github.io .",
-      "authors": [
-        "Jingwei Sun",
-        "Jianing Zhu",
-        "Jiangchao Yao",
-        "Tongliang Liu",
-        "Bo Han"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19952v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19952v1",
-      "publishedAt": "2026-05-19T15:05:06.000Z",
-      "updatedAt": "2026-05-19T15:05:06.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19950v1",
-      "title": "AffectVerse: Emotional World Models for Multimodal Affective Computing",
-      "summary": "Humans infer emotions by integrating observed multimodal cues with expectations about how affective states may unfold. Existing multimodal large language models (MLLMs), however, often treat emotion recognition as static fusion over complete audiovisual-text inputs, leaving affective dynamics implicit. We propose AffectVerse, a Qwen2.5-Omni-based model equipped with an Emotion World Module (EWM), an action-free representation-level module for short-horizon latent affective prediction. \\rev{EWM contains three modules: 1) Cross-Modal Temporal Imagination predicts future video/audio representations from past tokens with multi-step rollout. 2) MAMA(Modality-Aware Multi-step Attention) Belief Aggregation compresses imagined tokens into modality-aware belief tokens. 3) Belief Injection inserts these belief tokens into the LLM for affective reasoning.} AffectVerse uses future prediction as a past-conditioned self-supervised signal: it does not replace modeling observed history or require unseen signals at inference, but forces the current belief state to encode transition cues that are predictive of subsequent affective change. Across nine benchmarks, AffectVerse improves at least 2.57\\% over other models, while controlled ablations show additive gains from temporal imagination, cross-modal rollout, and belief aggregation. These results suggest predictive belief-state modeling is a practical alternative for affective computing.",
-      "authors": [
-        "Bo Zhao",
-        "Fanghua Ye",
-        "Yixin Ji",
-        "Sicheng Zhao",
-        "Xiaojiang Peng",
-        "Zitong YU"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19950v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19950v1",
-      "publishedAt": "2026-05-19T15:05:00.000Z",
-      "updatedAt": "2026-05-19T15:05:00.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19949v1",
-      "title": "Feed-Forward Gaussian Splatting from Sparse Aerial Views",
-      "summary": "Reconstructing large-scale urban scenes from sparse aerial views is a crucial yet challenging task. Due to biased top-down and shallow-oblique camera poses, sparse aerial captures exhibit strong evidence imbalance: roofs and open regions are repeatedly observed, while facades, distant buildings, and occluded structures receive little multi-view support. Existing feed-forward 3D Gaussian Splatting methods directly regress a deterministic representation from sparse inputs, but this often leads to ghosting, melted facades, and stretched textures. Recent pseudo-view and video-based generative reconstruction methods use additional supervision or generative priors. However, they often lack a clear separation between observed geometry and prior-driven content, which can lead to plausible but inconsistent structures. We propose AnyCity, an observation-grounded generative reconstruction framework for sparse aerial urban scenes. AnyCity first predicts an observation-supported geometry latent to anchor reliable structures, and then uses scaffold-conditioned aerial completion tokens to predict a gated residual update for weakly constrained content before Gaussian decoding. During training, dense-to-sparse distillation transfers structural cues from dense-view reconstruction, while an aerial-adapted video diffusion prior provides fine-grained urban appearance cues through gated token conditioning. Observation-preserving objectives keep the refined representation consistent with input-supported geometry. At inference time, AnyCity reconstructs the final 3D Gaussian scene from sparse aerial views in a single feed-forward pass, achieving coherent urban novel-view synthesis with second-level inference. Experiments on synthetic, aerial-domain, UAV-textured, and real-world scenes show consistent improvements over feed-forward baselines.",
-      "authors": [
-        "Dongli Wu",
-        "Zhuoxiao Li",
-        "Tongyan Hua",
-        "Yinrui Ren",
-        "Xiaobao Wei",
-        "Rongjun Qin",
-        "Wufan Zhao"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19949v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19949v1",
-      "publishedAt": "2026-05-19T15:04:34.000Z",
-      "updatedAt": "2026-05-19T15:04:34.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19947v1",
-      "title": "Exploiting Non-Negativity in DAG Structure Learning",
-      "summary": "This work addresses the problem of learning directed acyclic graphs (DAGs) from nodal observations generated by a linear structural equation model. DAG learning is a central task in signal processing, machine learning, and causal inference, but it remains challenging because acyclicity is a global combinatorial property. Continuous acyclicity constraints have led to important algorithmic advances by replacing the discrete DAG constraint with smooth equality constraints. However, existing formulations still involve difficult non-convex optimization landscapes and may suffer from degenerate first-order optimality conditions. Here, we restrict attention to DAGs with non-negative edge weights and exploit this additional structure to obtain a simpler characterization of acyclicity. Building on this characterization, we formulate a regularized non-negative DAG learning problem and develop an algorithm based on the method of multipliers. We further analyze the benign optimization landscape induced by non-negativity. In the population regime, we show that the true DAG is the unique global minimizer of the proposed augmented-Lagrangian formulation; moreover, the landscape contains no spurious interior stationary points, and the true DAG is the only acyclic KKT point. Numerical experiments on synthetic and real-world data show that the proposed method improves over state-of-the-art continuous DAG-learning alternatives.",
-      "authors": [
-        "Samuel Rey",
-        "Madeline navarro",
-        "Gonzalo Mateos"
-      ],
-      "categories": [
+        "cs.CL",
+        "cs.AI",
         "cs.LG"
       ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19947v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19947v1",
-      "publishedAt": "2026-05-19T15:03:33.000Z",
-      "updatedAt": "2026-05-19T15:03:33.000Z",
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21154v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21154v1",
+      "publishedAt": "2026-05-20T13:26:05.000Z",
+      "updatedAt": "2026-05-20T13:26:05.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19945v1",
-      "title": "GEM: GPU-Variability-Aware Expert to GPU Mapping for MoE Systems",
-      "summary": "Mixture-of-Expert (MoE) models enable efficient inference by employing smaller experts and activating only a subset of them per token. MoE serving engines distribute experts across multiple GPUs and route tokens to appropriate GPUs at inference time based on experts activated. They process tokens in lock-step fashion, where tokens within a batch must finish processing before proceeding to the next layer. This synchronization barrier acts as a critical bottleneck because the performance of MoE models is limited by the straggler GPU that finishes last. Stragglers emerge when too many heavily used experts are placed on the same GPU or the slowest GPU. While prior works place experts that balance token loads across GPUs, they all overlook GPU variability and often place highly used experts on the slowest GPUs. We propose GEM, GPU-variability-aware Expert Mapping, a framework for GPU variability-aware expert to GPU mapping for MoE models. GEM exploits two insights. First, we must place experts such that each GPU receives non-uniform token loads based on their variability and they all finish processing a layer at about the same time. Our studies show that there are two types of experts: consistent that are used most of the time and temporal that are often used together for the remaining time. Our second insight is that we must place simultaneously used consistent and temporal experts on different GPUs and avoid placing them on slower GPUs to reduce slowdown. GEM gathers the variability profile of GPUs for each model and task and uses the token load distributions per task to map experts to GPUs. Our experiments show that GEM improves end-to-end latency by 7.9% on average and by up to 16.5% compared to the baseline.",
+      "arxivId": "2605.21147v1",
+      "title": "SMoA: Spectrum Modulation Adapter for Parameter-Efficient Fine-Tuning",
+      "summary": "As the number of model parameters increases, parameter-efficient fine-tuning (PEFT) has become the go-to choice for tailoring pre-trained large language models. Low-rank Adaptation (LoRA) uses a low-rank update method to simulate full parameter fine-tuning, which is widely used to reduce resource requirements. However, decreasing the rank encounters challenges with limited representational capacity. Theory suggests that LoRA fine-tuning with rank r converges toward the top r singular values of the pre-trained weight matrix. As the rank increases, more principal singular directions are preserved, which generally improves the model's performance. However, a larger rank also introduces more trainable parameters, leading to higher computational cost. To overcome this dilemma, we propose SMoA, a \\textbf{S}pectrum \\textbf{Mo}dulation \\textbf{A}dapter that enlarges the accessible family of spectrum-aware updates under a smaller parameter budget. SMoA partitions the layer into multiple aligned spectral blocks and applies one in-block Hadamard-modulated low-rank branch to each diagonal block, yielding broader coverage of pretrained spectral directions. We provide theoretical analysis and empirical results on multiple tasks. In our experiments, SMoA improves average performance in the current lower-budget setting over LoRA and competitive LoRA-style baselines.",
       "authors": [
-        "Sourish Wawdhane",
-        "Avinash Kumar",
-        "Poulami Das"
-      ],
-      "categories": [
-        "cs.DC",
-        "cs.AI",
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.DC",
-      "absUrl": "https://arxiv.org/abs/2605.19945v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19945v1",
-      "publishedAt": "2026-05-19T15:01:39.000Z",
-      "updatedAt": "2026-05-19T15:01:39.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19944v1",
-      "title": "A Measure-Theoretic Analysis of Reasoning: Structural Generalization and Approximation Limits",
-      "summary": "While empirical scaling laws for LLM reasoning are well-documented, the theoretical mechanisms governing out-of-distribution (OOD) generalization remain elusive. We formalize reasoning via optimal transport, projecting discrete trajectories into a continuous metric space to quantify domain shifts using the Wasserstein-1 distance. Invoking Kantorovich duality, we bound OOD generalization via architectural Lipschitz continuity and functional approximation limits. This exposes two primary constraints. First, position-dependent attention (e.g., Absolute Positional Encoding) fails to preserve shift invariance, yielding an $Ω(1)$ Lipschitz constant and expected risk, whereas shift-invariant mechanisms (e.g., Rotary Embeddings) preserve equivariance and bound the error. Second, by mapping sequential backtracking to a Dyck-$k$ language, we establish a strict circuit depth lower bound for $\\text{TC}^0$ Transformers. Scaling physical layer depth is necessary to avert representation collapse -- a constraint that scaling representation width cannot bypass due to irreducible approximation bounds in Barron spaces. Evaluations across 54 Transformer configurations on combinatorial search corroborate these bounds, demonstrating that generalization risk degrades monotonically with the Wasserstein domain shift.",
-      "authors": [
-        "Yuyang Zhang",
-        "Yifu Zhang",
-        "Xuehai Zhou",
-        "Xiaoyin Chen"
+        "Yongkang Liu",
+        "Xing Li",
+        "Mengjie Zhao",
+        "Shanru Zhang",
+        "Zijing Wang",
+        "Qian Li",
+        "Shi Feng",
+        "Feiliang Ren",
+        "Daling Wang",
+        "Hinrich Schütze"
       ],
       "categories": [
         "cs.LG",
-        "cs.AI",
-        "cs.CC",
         "cs.CL"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19944v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19944v1",
-      "publishedAt": "2026-05-19T15:00:51.000Z",
-      "updatedAt": "2026-05-19T15:00:51.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21147v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21147v1",
+      "publishedAt": "2026-05-20T13:19:28.000Z",
+      "updatedAt": "2026-05-20T13:19:28.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19943v1",
-      "title": "Probabilistic Tiny Recursive Model",
-      "summary": "Tiny Recursive Models (TRM) solve complex reasoning tasks with a fraction of the parameters of modern large language models (LLMs) by iteratively refining a latent state and final answer. While powerful, their deterministic recursion can lead to convergence at suboptimal solutions, without escape mechanism. A common workaround relies on task-specific input perturbations at test time combined with answer aggregation via voting. We introduce Probabilistic TRM (PTRM), a task-agnostic framework for test-time compute scaling that addresses this limitation through stochastic exploration. PTRM injects Gaussian noise at each deep recursion step, enabling parallel trajectories to explore diverse solution basins, and selects among them using the model's existing Q head (used for early stopping in the original TRM). Without requiring retraining or task-specific augmentations, PTRM enables substantial accuracy gains across benchmarks, including Sudoku-Extreme (87.4% to 98.75%) and on various puzzles from Pencil Puzzle Bench (62.6% to 91.2%). On the latter, PTRM achieves nearly double the accuracy of frontier LLMs (91.2% vs. 55.1%) at less than 0.0001x the cost, using only 7M parameters.",
+      "arxivId": "2605.21139v1",
+      "title": "Distill to Think, Foresee to Act: Cognitive-Physical Reinforcement Learning for Autonomous Driving",
+      "summary": "Current end-to-end autonomous driving models are fundamentally constrained by the behavioral cloning ceiling of imitation learning. While reinforcement learning offers a path to smarter autonomy, it demands two missing pieces of infrastructure: (1) a cognitive foundation that understands traffic semantics and driving intent, and (2) a foresighted physical environment that can anticipate the consequences of candidate actions. To this end, we propose CoPhy, a CognitivePhysical reinforcement learning framework for autonomous driving. To distill to think, we distill VLM knowledge into the BEV encoder and then discard the VLM entirely, retaining cognitive ability at zero inference cost while releasing the cognitive channel as a pluggable interface for optional human language commands. To foresee to act, we build an auto-regressive BEV world model that explicitly predicts future semantic maps conditioned on candidate actions, serving as an interpretable physical sandbox from which safety metrics are directly derived. Built upon this dual infrastructure, we optimize the driving policy via GRPO with a novel dual-reward mechanism: a physical reward derived from BEV rollouts enforces hard safety constraints, while a cognitive reward from a language-aligned scorer ensures intent compliance. Extensive experiments demonstrate that CoPhy not only achieves state-of-the-art results on NAVSIM v1 and v2 benchmarks, but also enables safer driving via cognitively informed scene compliance and flexible intent control through user-defined language instructions.",
       "authors": [
-        "Amin Sghaier",
-        "Ali Parviz",
-        "Alexia Jolicoeur-Martineau"
+        "Yang Wu",
+        "Qiang Meng",
+        "Zhaojiang Liu",
+        "Youquan Liu",
+        "Jian Yang",
+        "Jin Xie"
       ],
       "categories": [
-        "cs.AI"
+        "cs.CV",
+        "cs.LG"
       ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19943v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19943v1",
-      "publishedAt": "2026-05-19T15:00:38.000Z",
-      "updatedAt": "2026-05-19T15:00:38.000Z",
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21139v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21139v1",
+      "publishedAt": "2026-05-20T13:14:28.000Z",
+      "updatedAt": "2026-05-20T13:14:28.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19940v1",
-      "title": "Robotics-Inspired Guardrails for Foundation Models in Socially Sensitive Domains",
-      "summary": "Foundation models are increasingly deployed in socially sensitive domains such as education, mental health, and caregiving, where failures are often cumulative and context-dependent. Existing guardrail approaches -- ranging from training-time alignment to prompting, decoding constraints, and post-hoc moderation -- primarily provide empirical risk reduction rather than enforceable behavioral guarantees, and largely treat safety as a property of individual outputs rather than interaction trajectories. We reframe guardrails as a problem of runtime behavioral control over interaction trajectories, drawing on robotics to introduce formal constructs for constraint enforcement in uncertain, closed-loop systems. We instantiate these ideas in the Grounded Observer framework and apply it across three real-world deployments: small talk, in-home autism therapy, and behavioral de-escalation in schools. Across settings, the framework enables runtime interventions that mitigate drift into undesirable interaction regimes while adapting to diverse social contexts. We discuss extensions to the framework and propose research directions toward stronger guarantees.",
+      "arxivId": "2605.21135v1",
+      "title": "Smarter edits? Post-editing with error highlights and translation suggestions",
+      "summary": "As MT quality increases, interest in enhanced post-editing features such as QE-derived error highlights is growing, yet evidence for their usefulness remains limited. In this work, we explore the usefulness of LLM-derived error highlights and correction suggestions based on automatic post-editing (APE). We conduct a study where professional translators (En-Nl) post-edit translations using APE error highlights and correction suggestions and compare productivity, quality and user experience to regular PE and PE with QE-derived highlights. While no condition yielded productivity or quality gains compared to regular PE, APE highlights were better received than QE-derived highlights, and correction suggestions improved overall user experience.",
       "authors": [
-        "Rebecca Ramnauth",
-        "Drazen Brscic",
-        "Brian Scassellati"
-      ],
-      "categories": [
-        "cs.AI",
-        "cs.RO"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19940v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19940v1",
-      "publishedAt": "2026-05-19T15:00:06.000Z",
-      "updatedAt": "2026-05-19T15:00:06.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19938v1",
-      "title": "Variance-Reduced Manifold Sampling via Polynomial-Maximization Density Estimation",
-      "summary": "Uniform sampling on implicitly defined manifolds is a core primitive in motion planning, constrained simulation, and probabilistic machine learning. MASEM addresses this problem by entropy-maximizing resampling, but its resampling weights depend on a local k-nearest-neighbour density estimate whose errors can be amplified by aggressive resampling temperatures. We ask whether a polynomial-maximization moment estimator can replace the plug-in density rule without changing the surrounding MASEM architecture. The proposed PMM-MASEM module computes shell spacings from nested k-nearest-neighbour radii, estimates their standardized cumulants, and uses a gated PMM2/PMM3 estimator only when the spacing distribution departs from the flat Exp(1) regime; otherwise it falls back to the plug-in/MLE rule. This fallback is essential: on a flat homogeneous manifold the plug-in estimator is already the MLE, so PMM should not outperform it. A local Known-DGP Monte Carlo experiment confirms this gate: the selector returns MLE on flat Exp(1) spacings and reduces density MSE by 22--36% on asymmetric gamma and boundary-spacing regimes. The evidence is not uniformly positive: PMM3 worsens a platykurtic uniform spacing law, and a lightweight resampling-proxy experiment improves seven-lobes coverage but degrades the sine and swiss-roll proxies. The current evidence therefore supports an applicability-boundary result rather than a general MASEM improvement claim.",
-      "authors": [
-        "Serhii Zabolotnii"
-      ],
-      "categories": [
-        "stat.ME",
-        "cs.LG",
-        "stat.ML"
-      ],
-      "primaryCategory": "stat.ME",
-      "absUrl": "https://arxiv.org/abs/2605.19938v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19938v1",
-      "publishedAt": "2026-05-19T14:57:39.000Z",
-      "updatedAt": "2026-05-19T14:57:39.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19936v1",
-      "title": "What Are LLMs Doing to Scientific Communication? Measuring Changes in Writing Practices and Reading Experience",
-      "summary": "Has the style of scientific communication changed due to the growing use of large language models in the writing process? We address this question in the domain of Natural Language Processing by leveraging two data resources we create: a naturalistic corpus of over 37,000 papers from the ACL Anthology (2020-2024); and a synthetic dataset of 3,000 human-written passages and their LLM-generated improvements. We first implement a series of diachronic lexical analyses, showing that both word frequency and usage contexts have changed significantly over time, indicating semantic specialization in some cases and generalization in others. Broadening our perspective, we then model a range of more complex stylistic features and find that LLM-modified texts more frequently contain certain syntactic constructions, more complex and longer words and a lower lexical diversity. Finally, we connect these changes in writing practices to subjective reading experience through a pilot annotation study with 20 domain experts. They overall rate LLM-improved texts as more understandable and exciting, but also express negative qualitative attitudes towards LLMs, highlighting the strongly subjective effect of AI-assisted writing on reading experience.",
-      "authors": [
-        "Filip Miletić",
-        "Neele Falk"
+        "Fleur V. J. van Tellingen",
+        "Gautam Ranka",
+        "Dora Žugčić",
+        "Joyce van der Wal",
+        "Andrea Camasta",
+        "Livio Guerra",
+        "Alina Karakanta"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19936v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19936v1",
-      "publishedAt": "2026-05-19T14:54:33.000Z",
-      "updatedAt": "2026-05-19T14:54:33.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21135v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21135v1",
+      "publishedAt": "2026-05-20T13:09:51.000Z",
+      "updatedAt": "2026-05-20T13:09:51.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19932v1",
-      "title": "PEEK: Context Map as an Orientation Cache for Long-Context LLM Agents",
-      "summary": "Large language model (LLM) agents increasingly operate over long and recurring external contexts, like document corpora and code repositories. Across invocations, existing approaches preserve either the agent's trajectory, passive access to raw material, or task-level strategies. None of them preserves what we argue is most needed for repeated same-context workloads: reusable orientation knowledge (e.g., what the context contains, how it is organized, and which entities, constants, and schemas have historically been useful) about the recurring context itself. We introduce PEEK, a system that caches and maintains this orientation knowledge as a context map: a small, constant-sized artifact in the agent's prompt that gives it a persistent peek into the external context. The map is maintained by a programmable cache policy with three modules: a Distiller that extracts transferable knowledge from inference-time signals, a Cartographer that translates it into structured edits, and a priority-based Evictor that enforces a fixed token budget. On long-context reasoning and information aggregation, PEEK improves over strong baselines by 6.3-34.0% while using 93-145 fewer iterations and incurring 1.7-5.8x lower cost than the state-of-the-art prompt-learning framework, ACE. On context learning, PEEK improves solving rate and rubric accuracy by 6.0-14.0% and 7.8-12.1%, respectively, at 1.4x lower cost than ACE. These gains generalize across LMs and agent architectures, including OpenAI Codex, a production-grade coding agent. Together, these results show that a context map helps long-context LLM agents interact with recurring external contexts more accurately and efficiently.",
+      "arxivId": "2605.21132v1",
+      "title": "SurgOnAir: Hierarchy-Aware Real-Time Surgical Video Commentary",
+      "summary": "Understanding surgical workflow in real time is fundamental for intelligent surgical embodiment, where AI systems continuously perceive and respond as surgery proceeds. In the operating room, critical decisions depend on subtle, moment-to-moment changes, such as fine instrument movements and evolving tissue states, where even slight perceptual delays can limit assistance or compromise safety. Yet existing methods remain offline or operate at coarse temporal scales, generating descriptions only after processing clips, preventing immediate reaction. We address this by proposing SurgOnAir, a streaming vision-language model that processes frames sequentially without future access and progressively generates narration tokens as visual input arrives. SurgOnAir achieves fine-grained frame-to-token generation, enabling instant responsiveness to evolving surgical dynamics. Built upon our curated hierarchical dataset SurgOnAir-11k spanning action-, step-, and phase-level supervision, the model is trained to produce multi-level textual responses that reflect the inherent hierarchy of surgical procedures. Furthermore, special transition tokens are generated to explicitly mark state changes, allowing SurgOnAir to capture and signal key workflow transitions as they occur. Experiments show that SurgOnAir enables real-time understanding through a single vision-language model that unifies streaming across multiple hierarchies of the surgical workflow, generating superior and hierarchy-aware narrations. Code and dataset will be public.",
       "authors": [
-        "Zhuohan Gu",
-        "Qizheng Zhang",
-        "Omar Khattab",
-        "Samuel Madden"
+        "Jingyi He",
+        "Yue Zhou",
+        "Long Bai",
+        "Kun Yuan",
+        "Nassir Navab",
+        "Yuan Bi"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21132v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21132v1",
+      "publishedAt": "2026-05-20T13:04:39.000Z",
+      "updatedAt": "2026-05-20T13:04:39.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21131v1",
+      "title": "UniT: Unified Geometry Learning with Group Autoregressive Transformer",
+      "summary": "Recent feed-forward models have significantly advanced geometry perception for inferring dense 3D structure from sensor observations. However, its essential capabilities remain fragmented across multiple incompatible paradigms, including online perception, offline reconstruction, multi-modal integration, long-horizon scalability, and metric-scale estimation. We present UniT, a unified model built upon a novel Group Autoregressive Transformer, which reformulates these seemingly disparate capabilities within a single framework. The key idea is to treat groups of sensor observations as the basic autoregressive units and predict the corresponding point maps in an anchor-free and scale-adaptive manner. More specifically, diverse view configurations in both online and offline settings are naturally unified within a single group autoregression process. By varying the group size, online mode operates over multiple autoregressive steps with single-frame groups, whereas offline mode aggregates a multi-frame group in a single forward pass. Meanwhile, a queue-style KV caching mechanism ensures bounded autoregressive memory over long horizons. This is enabled by reducing long-range dependencies on early frames through anchor-free relational modeling, thereby allowing outdated memory to be discarded on the fly. To improve metric-scale generalization across scenes, a scale-adaptive geometry loss is further introduced within this framework. It couples relative geometric constraints with a partial absolute scale term, implicitly regularizing global scale and inducing a progressive transition from scale-invariant geometry to metric-scale solutions. Together with a dedicated modal attention module for integrating auxiliary modalities, UniT achieves state-of-the-art performance in unified geometry perception, as validated on ten benchmarks spanning seven representative tasks.",
+      "authors": [
+        "Haotian Wang",
+        "Yusong Huang",
+        "Zhaonian Kuang",
+        "Hongliang Lu",
+        "Xinhu Zheng",
+        "Meng Yang",
+        "Gang Hua"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21131v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21131v1",
+      "publishedAt": "2026-05-20T13:04:34.000Z",
+      "updatedAt": "2026-05-20T13:04:34.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21130v1",
+      "title": "VersusQ: Pairwise Margin Reasoning for Generalizable Video Quality Assessment",
+      "summary": "Large Multimodal Models (LMMs) have shown promise for video quality assessment, but most methods still predict an absolute score for each video. Such pointwise supervision often mixes perceptual quality with dataset-specific calibration, including annotation protocols, rating habits, and score distributions. As a result, the learned scoring rule may work well within a benchmark but transfer poorly across unseen domains. We argue that relative comparisons alleviate the absolute-scale calibration bias by focusing purely on perceptual differences rather than dataset-specific rating habits. Consequently, we propose \\textbf{VersusQ}, a pairwise margin reasoning framework driven entirely by direct comparisons. Specifically, VersusQ performs LMM-based comparison between two videos, reasons about their visual and temporal quality differences, and predicts a signed continuous margin that captures both the preferred choice and the degree of difference. Furthermore, to align interpretable comparison rationales with fine-grained numerical differences, we introduce Margin-Coupled GRPO, which jointly optimizes rollout-based relational reasoning and continuous margin regression. Extensive experiments on multiple public VQA benchmarks demonstrate that VersusQ achieves state-of-the-art performance, strong cross-domain generalization, and reliable fine-grained ranking under heterogeneous evaluation scenarios.",
+      "authors": [
+        "Shibei Meng",
+        "Binxin Yang",
+        "Yuan Liu",
+        "Jiexuan Zhang",
+        "Zhengyao Lv",
+        "Hubery Yin",
+        "Qiang Xu"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21130v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21130v1",
+      "publishedAt": "2026-05-20T13:03:17.000Z",
+      "updatedAt": "2026-05-20T13:03:17.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21123v1",
+      "title": "Linear-DPO: Linear Direct Preference Optimization for Diffusion and Flow-Matching Generative Models",
+      "summary": "Direct Preference Optimization (DPO) is successful for alignment in LLMs but still faces challenges in text-to-image generation. Existing studies are confined to denoising diffusion models while overlooking flow-matching, and suffer from an objective mismatch when applying discrete NLP-based DPO to regression-based generative tasks.\\ In this paper, we derive a generalized DPO objective that covers both diffusion and flow-matching via a unified reverse-time SDE framework, and point out from a gradient perspective that the standard DPO objective is suboptimal for text-to-image generation. Consequently, we propose Linear-DPO, which replaces the aggressive sigmoid-based utility function with a sustained linear utility and incorporates an EMA-updated reference model. Qualitative and quantitative experiments on diffusion models (SD1.5, SDXL) and flow-matching model (SD3-Medium) demonstrate the superiority of our approach over existing baselines.",
+      "authors": [
+        "Kesong Li",
+        "Yixuan Xu",
+        "Kuo-kun Tseng",
+        "Weiyi Lu",
+        "Kan Liu",
+        "Tao Lan"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21123v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21123v1",
+      "publishedAt": "2026-05-20T12:54:51.000Z",
+      "updatedAt": "2026-05-20T12:54:51.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21121v1",
+      "title": "ROAR-3D: Routing Arbitrary Views for High-Fidelity 3D Generation",
+      "summary": "Single-image-to-3D generative models can now produce high-quality geometry, yet conditioning on a single view inevitably introduces ambiguity about unseen regions. Multi-view conditioning can reduce this ambiguity, but existing methods either require fixed canonical viewpoints or rely on external reconstruction modules that impose heavy training costs and limit generation quality. We observe that pretrained single-view models already possess strong 2D-to-3D grounding that can be reused for multi-view conditioning. However, a closer analysis reveals that their conditioning mechanism entangles orientation control with geometry transfer, two functions that conflict when images from different viewpoints are naively combined. Based on this analysis, we propose ROAR-3D, a lightweight method that upgrades a pretrained single-view model to accept an arbitrary number of unposed images. A token-wise view router assigns each 3D latent token to its most relevant view, implicitly establishing 2D-to-3D correspondences without explicit pose input. A dual-stream attention design preserves the pretrained primary-view behavior while routing auxiliary views through a separate path dedicated to geometric enrichment. An orientation perturbation strategy ensures the auxiliary path learns orientation-independent geometry transfer. These components introduce minimal trainable parameters and add negligible inference overhead relative to the single-view baseline. ROAR-3D achieves state-of-the-art multi-view 3D generation quality and supports test-time view scaling from 1 to 12+ views with consistent improvements.",
+      "authors": [
+        "Hanxiao Sun",
+        "Mingxin Yang",
+        "Shuhui Yang",
+        "Zebin He",
+        "Xintong Han",
+        "Hongbo Fu",
+        "Chunchao Guo",
+        "Wenhan Luo"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.GR"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21121v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21121v1",
+      "publishedAt": "2026-05-20T12:50:52.000Z",
+      "updatedAt": "2026-05-20T12:50:52.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21112v1",
+      "title": "RCGDet3D: Rethinking 4D Radar-Camera Fusion-based 3D Object Detection with Enhanced Radar Feature Encoding",
+      "summary": "4D automotive radar is indispensable for autonomous driving due to its low cost and robustness, yet its point cloud sparsity challenges 3D object detection. Existing 4D radar-camera fusion methods focus on complex fusion strategies, trading inference speed for marginal gains. This trade-off hinders real-time deployment due to heavy computation on dense feature maps. In contrast, feature extraction from sparse radar points is less time-consuming but remains under-explored. This work uncovers that simply enhancing radar feature extraction can achieve comparable or even higher performance than elaborate fusion modules, while maintaining real-time performance. Based on this finding, we propose RCGDet3D, which centers on radar feature encoding and simplifies multi-modal fusion. Its encoder inherits from the efficient Gaussian Splatting-based Point Gaussian Encoder (PGE) in RadarGaussianDet3D with two key improvements. First, the Ray-centric PGE (R-PGE) predicts Gaussian attributes in ray-aligned coordinate systems before unifying them to Bird's-Eye View (BEV) space, significantly improving geometric consistency and reducing learning difficulty by decoupling the coordinate transformation from representation learning. Second, a Semantic Injection (SI) module incorporates visual cues from images, producing more geometrically accurate and semantically enriched radar features. Experiments on View-of-Delft (VoD) and TJ4DRadSet show that RCGDet3D outperforms state-of-the-art methods in both accuracy and speed, setting a new benchmark for real-time deployment.",
+      "authors": [
+        "Weiyi Xiong",
+        "Bing Zhu"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21112v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21112v1",
+      "publishedAt": "2026-05-20T12:45:01.000Z",
+      "updatedAt": "2026-05-20T12:45:01.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21102v1",
+      "title": "ACL-Verbatim: hallucination-free question answering for research",
+      "summary": "Academic researchers need efficient and reliable methods for collecting high-quality information from trusted sources, but modern tools for AI-assisted research still suffer from the tendency of Large Language Models (LLMs) to produce factually inaccurate or nonsensical output, commonly referred to as hallucinations. We apply the extractive question answering system VerbatimRAG to research papers in the ACL Anthology, directly mapping user queries to verbatim text spans in retrieved documents. We contribute a novel ground truth dataset for the task of mapping user queries to relevant text spans in research papers, and use it to train and evaluate a variety of extractive models. Human annotation is performed by NLP researchers and is based on synthetic user queries generated using a custom pipeline based on the ScIRGen methodology, paired with chunks of research papers retrieved by VerbatimRAG. On this benchmark, a 150M-parameter ModernBERT token classifier trained on silver supervision from our pipeline achieves the best word-level F1 (53.6), ahead of the strongest evaluated LLM extractor (48.7).",
+      "authors": [
+        "Gábor Recski",
+        "Szilveszter Tóth",
+        "Nadia Verdha",
+        "István Boros",
+        "Ádám Kovács"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI",
+        "cs.SE"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21102v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21102v1",
+      "publishedAt": "2026-05-20T12:30:29.000Z",
+      "updatedAt": "2026-05-20T12:30:29.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21099v1",
+      "title": "R2AoP: Reliable and Robust Angle of Progression Estimation from Intrapartum Ultrasound",
+      "summary": "Accurate estimation of the Angle of Progression (AoP) from intrapartum transperineal ultrasound is critical for objective assessment of labor progression, yet remains highly sensitive to imaging noise, boundary ambiguities, and the geometric amplification of local segmentation errors. We propose R2AoP, a reliable and robust AoP estimation framework that integrates structurally informed segmentation and confidence-guided geometric modeling to achieve stable and reproducible measurements. A three-branch local-structure-enhanced backbone improves the delineation of the pubic symphysis (PS) and fetal head (FH), while confidence-weighted contour fitting explicitly suppresses the influence of unreliable boundary points in AoP computation. To further improve performance under heterogeneous acquisition conditions, we introduce a lightweight geometry-reliable test-time adaptation strategy as an auxiliary component, enabling stable inference without target annotations. Extensive evaluations on multi-center benchmarks demonstrate consistent reductions in AoP error and boundary metrics compared with state-of-the-art AoP methods. Our source code is available at https://github.com/baiyou1234/R2AoP.",
+      "authors": [
+        "Yuanhan Wang",
+        "Yifei Chen",
+        "Beining Wu",
+        "Mingxuan Liu",
+        "Xiaotian Hu",
+        "Chunbo Jiang",
+        "Yijin Li",
+        "Changmiao Wang",
+        "Feiwei Qin",
+        "Qiyuan Tian"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21099v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21099v1",
+      "publishedAt": "2026-05-20T12:28:37.000Z",
+      "updatedAt": "2026-05-20T12:28:37.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21097v1",
+      "title": "WCXB: A Multi-Type Web Content Extraction Benchmark",
+      "summary": "Web content extraction - isolating a page's main content from surrounding boilerplate - is a prerequisite for search indexing, retrieval-augmented generation, NLP dataset construction, and large language model training. Progress in this area has been constrained by the limitations of existing evaluation benchmarks, which are small (100-800 pages), restricted to news articles, or based on web pages from over a decade ago. We introduce the Web Content Extraction Benchmark (WCXB), a dataset of 2,008 web pages from 1,613 domains spanning seven structurally distinct page types: articles, forums, products, collections, listings, documentation, and service pages. The dataset includes a 1,497-page development set and a 511-page held-out test set with matched page type distributions. Ground truth annotations were produced through a five-stage pipeline: LLM-assisted drafting, automated verification, four-pass frontier model review, snippet and quality verification scripts, and human review. We evaluate 13 extraction systems - 11 heuristic and 2 neural - and find that while top systems converge on articles (F1 = 0.93), performance diverges sharply on structured page types (F1 = 0.41-0.84), revealing blind spots invisible to existing article-only benchmarks. The dataset is released under CC-BY-4.0 with HTML source files, ground truth annotations, page type labels, and baseline results.",
+      "authors": [
+        "Murrough Foley"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21097v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21097v1",
+      "publishedAt": "2026-05-20T12:28:12.000Z",
+      "updatedAt": "2026-05-20T12:28:12.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21090v1",
+      "title": "TextSculptor: Training and Benchmarking Scene Text Editing",
+      "summary": "Recent advances in Multimodal Large Language Models (MLLMs) and diffusion-based generative models have substantially improved prompt-driven image editing. However, scene text editing remains challenging, as it requires models to precisely modify textual content while preserving visual realism and non-target regions. Current open-source models still lag behind proprietary systems, largely due to the scarcity of high-quality training data and the lack of standardized benchmarks tailored to text editing. To address these challenges, we present TextSculptor, a comprehensive framework for data construction and evaluation of scene text editing. We first develop an automated data construction pipeline that combines text-aware image synthesis with programmatic text rendering and compositing. Based on this pipeline, we build TextSculpt-Data, a large-scale dataset containing 3.2M training samples, including 1.2M OCR-verified text-to-image samples and 2M paired text editing samples with naturally aligned source-target images and strong background consistency. We further introduce TextSculpt-Bench, a benchmark covering four fundamental text editing tasks: text addition, text replacement, text removal, and hybrid editing. To support reliable evaluation, we design a tailored protocol that measures text accuracy, visual quality, and background preservation through OCR-based text alignment, multimodal judgment, and background-region similarity. Extensive experiments show that TextSculptor improves open-source text editing performance and narrows the gap to proprietary models. The data and benchmark are available at https://github.com/linyiheng123/TextSculptor.",
+      "authors": [
+        "Yiheng Lin",
+        "Siyu Jiao",
+        "Xiaohan Lan",
+        "Wei Zhou",
+        "Qi She",
+        "Fei Yu",
+        "Heyun Chen",
+        "Zhengwei Wang",
+        "Jinghuan Chen",
+        "Moran Li",
+        "Yingchen Yu",
+        "Zijian Feng",
+        "Yao Zhao",
+        "Yunchao Wei",
+        "Yujie Zhong"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21090v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21090v1",
+      "publishedAt": "2026-05-20T12:22:26.000Z",
+      "updatedAt": "2026-05-20T12:22:26.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21086v1",
+      "title": "LoCar: Localization-Aware Evaluation of In-Vehicle Assistants through Fine-Grained Sociolinguistic Control",
+      "summary": "While Large Language Models (LLMs) are increasingly integrated into in-vehicle conversational systems, identifying the optimal model remains challenging due to the lack of domain-specific evaluation standards tailored to real-world deployment requirements. In this paper, we propose a novel evaluation framework for in-vehicle assistants, with a particular focus on Korean-language localization. Our empirical analysis reveals notable patterns in model behavior. First, fine-grained Korean honorific control remains unstable in current LLMs, indicating that precise speech-level realization must be explicitly evaluated in localization settings. Second, models exhibit weaker performance in strategic conversational metrics like clarification and proactivity. Our analysis suggests this stems from the inherent subjective complexity of these tasks, where our framework adopts a conservative evaluation stance to prioritize reliability. Together, our findings underscore that automotive AI must move beyond general competence toward precise linguistic tailoring and reliable, safety-oriented interaction management.",
+      "authors": [
+        "Seogyeong Jeong",
+        "Kiwoong Park",
+        "Seyoung Song",
+        "Eunsu Kim",
+        "Ken E. Friedl",
+        "Jaeho Kim",
+        "Alice Oh"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21086v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21086v1",
+      "publishedAt": "2026-05-20T12:21:15.000Z",
+      "updatedAt": "2026-05-20T12:21:15.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21079v1",
+      "title": "VDFP: Video Deflickering with Flicker-banding Priors",
+      "summary": "Capturing digital screens with smartphones frequently induces severe banding due to hardware synchronization mismatches. Existing video restoration methods struggle with these structured, periodic luminance fluctuations, often resulting in residual artifacts or over-smoothed textures. We firstly construct DeViD, a real-world dataset in various scenes to deal with the lack of available datasets.Then we propose VDFP (Video Deflickering with Flicker-banding Priors), a novel perception-guided generation framework. First, we introduce a Degradation Field Modeling Based on Rolling Shutter Mechanism (DFM) capable of synthesizing complex multi-banding scenarios. Second, we present a spatial-temporal continuous prior perception (CPP). Unlike traditional binary segmentation, this module is optimized via a Flicker-Aware Mean Squared Error (FA-MSE) to capture the luminance transitions. By zero-initializing an augmented input layer, our model preserves pre-trained generative priors as well as spatial-temporal prior perception. Extensive experiments demonstrate that VDFP significantly outperforms other methods, eliminating complex banding with high-fidelity spatial details and temporal consistency. Our dataset and code will be released at~ https://github.com/ZhiyiZZhou/VDFP.",
+      "authors": [
+        "Zhiyi Zhou",
+        "Libo Zhu",
+        "Zihan Zhou",
+        "Yulun Zhang",
+        "Xiaokang Yang"
+      ],
+      "categories": [
+        "cs.CV"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21079v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21079v1",
+      "publishedAt": "2026-05-20T12:14:43.000Z",
+      "updatedAt": "2026-05-20T12:14:43.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21076v1",
+      "title": "GradeLegal: Automated Grading for German Legal Cases",
+      "summary": "Grading German legal exam solutions faces growing volumes and a shortage of qualified graders, delaying feedback and creating a bottleneck. At the same time, it is a high-stakes expert task, since state exam grades strongly influence career outcomes in Germany. Despite this practical relevance, literature lacks systematic studies on effective methods for grading legal exams. To address this gap, we investigate whether large language models (LLMs) can support the automated grading of German legal case solutions in criminal and public law, thereby enabling scalable feedback and student self-testing. We present a systematic evaluation of 27 proprietary and open-source LLMs, benchmarking prompting strategies that incrementally add task-related information, such as a sample solution and a grading rubric. Using quadratic weighted kappa (QWK), reasoning-oriented LLMs can approximate expert grading in public law when given a sample solution and a grading rubric (up to 0.91), compared to 0.60 in criminal law, suggesting a harder grading task in criminal law. Beyond single-model grading, ensembling improves agreement by up to 0.15 over its best member and can offer an alternative to stronger closed-source single models. In addition, our findings suggest that effective prompt design and model selection are necessary for reliable LLM-based grading of legal exams.",
+      "authors": [
+        "Abdullah Al Zubaer",
+        "Lorenz Wendlinger",
+        "Simon Alexander Nonn",
+        "Michael Granitzer",
+        "Jelena Mitrovic"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21076v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21076v1",
+      "publishedAt": "2026-05-20T12:09:49.000Z",
+      "updatedAt": "2026-05-20T12:09:49.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21075v1",
+      "title": "SpectralEarth-FM: Bringing Hyperspectral Imagery into Multimodal Earth Observation Pretraining",
+      "summary": "Earth observation (EO) foundation models (FMs) are increasingly trained on multisensor data, spanning multispectral imagery (MSI), synthetic aperture radar (SAR), and derived geospatial layers, but hyperspectral imagery (HSI) remains underrepresented. Conversely, existing hyperspectral FMs are trained on HSI alone, leaving joint pretraining and fusion of HSI with co-located EO sensors unexplored. We introduce SpectralEarth-FM, a hierarchical transformer for multisensor EO input with heterogeneous spectral dimensionality. The architecture combines spectral tokenization for hyperspectral inputs, sensor-specific encoders, a cross-sensor fusion module, and a shared hierarchical encoder, enabling joint processing of HSI and lower-channel observations. To pretrain SpectralEarth-FM, we curate SpectralEarth-MM, a dataset that co-locates HSI from three spaceborne sensors (EnMAP, EMIT, DESIS) with Sentinel-2, Landsat-8/9 optical imagery, Landsat land surface temperature (LST), and Sentinel-1 SAR, over common geographic footprints. It comprises approximately 2M globally distributed locations, 25M georeferenced patches, and over 40TB of data. Pretraining uses a Joint-Embedding Predictive Architecture (JEPA)-style objective that matches representations between global views and single-sensor local views from the same location. We evaluate SpectralEarth-FM on hyperspectral downstream tasks and standard EO benchmarks following the PANGAEA protocol, achieving state-of-the-art results across both evaluation settings.",
+      "authors": [
+        "Nassim Ait Ali Braham",
+        "Aaron Banze",
+        "Conrad M. Albrecht",
+        "Julien Mairal",
+        "Jocelyn Chanussot",
+        "Xiao Xiang Zhu"
+      ],
+      "categories": [
+        "cs.CV",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.CV",
+      "absUrl": "https://arxiv.org/abs/2605.21075v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21075v1",
+      "publishedAt": "2026-05-20T12:08:16.000Z",
+      "updatedAt": "2026-05-20T12:08:16.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21071v1",
+      "title": "Fine-grained Claim-level RAG Benchmark for Law",
+      "summary": "The rapid progress of large language models (LLMs) is shifting semantic search toward a question-answering paradigm, where users ask questions and LLMs generate responses. In high-stake domains such as law, retrieval-augmented generation (RAG) is commonly used to mitigate hallucinations in generated responses. Nonetheless, prior work shows that RAG systems, whether general-purpose or legal-specific, still hallucinate at varying rates, making fine-grained evaluation essential. Despite the need, existing evaluation frameworks for legal RAG systems lack the granularity required to provide detailed analysis of retrieval and generation performance separately. Moreover, current benchmarks are largely English-only and centered on legal expert queries, overlooking non-expert needs. We introduce ClaimRAG-LAW, a comprehensive dataset for legal RAG that supports French and English, targets both experts and non-experts, and includes diverse question types reflecting realistic scenarios. We further apply a fine-grained evaluation framework of state-of-the-art legal RAG systems, revealing limitations in retrieval, generation, and claim-level analysis in the legal domain.",
+      "authors": [
+        "Souvick Das",
+        "Sallam Abualhaija",
+        "Domenico Bianculli"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21071v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21071v1",
+      "publishedAt": "2026-05-20T11:56:27.000Z",
+      "updatedAt": "2026-05-20T11:56:27.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21063v1",
+      "title": "APM: Evaluating Style Personalization in LLMs with Arbitrary Preference Mappings",
+      "summary": "Typical LLM responses tend to follow a default style, even though users often have distinct preferences regarding tone, verbosity, and formality that they do not explicitly state in their prompts. Evaluating whether personalization methods can adapt to these implicit preferences is challenging, since users typically provide prompts rather than reference responses, style preferences are not factually verifiable, and reference-free LLM judges may conflate personalization with general response quality. To address these challenges, we introduce the Arbitrary Preference Mapping (APM) benchmark, which decouples user attributes (e.g. enthusiastic) from response principles (e.g. persuasive) via a hidden, randomized mapping $\\mathbf{C}$ that maps user attributes to preferences about response traits. Because $\\mathbf{C}$ carries no semantic content and is resampled across runs, models cannot exploit stereotypical associations and must infer preferences from conversation history. Using this unbiased evaluation methodology, we adapt retrieval-augmented, prompt-optimization, and routing personalization methods and evaluate them on Llama-3.1-8B and Qwen-3.5-27B. Our results show that routing is the most reliable approach, while RAG only improves with the stronger base LLM, and soft prompt optimization fails to improve significantly over a non-personalized baseline. Our extensive evaluation reveals that in this realistic setting, personalization remains challenging, but our adapted methods show promise.",
+      "authors": [
+        "Philipp Spohn",
+        "Leander Girrbach",
+        "Zeynep Akata"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21063v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21063v1",
+      "publishedAt": "2026-05-20T11:47:40.000Z",
+      "updatedAt": "2026-05-20T11:47:40.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21049v1",
+      "title": "Cross-lingual robustness of LLM-brain alignment and its computational roots",
+      "summary": "Large language models (LLMs) reliably predict neural activity during language comprehension and transformer depth has been interpreted as mirroring hierarchical cortical organization. However, it remains unclear whether such alignment extends to subcortical regions, overlaps spatially across languages, and what the computational roots of such alignment are. Here, we used a multilingual, whole-brain encoding framework to examine brain-LLM alignment across three typologically distinct languages: Mandarin, English, and French during naturalistic story listening. Our results show that across languages, transformer-based models predicted activity in a distributed landscape spanning widely distributed cortical functional networks like limbic, ventral attention, default mode network, and subcortical structures. Spatial alignment patterns showed substantial cross-linguistic overlap and remained largely stable across model layers, with limited layer progression consistent with functional cortical hierarchies. Contrary to previous evidence, contextual embeddings did not outperform static embeddings. To test candidate computational explanations, we examined whether layer-wise brain scores reflect surprisal and intrinsic dimensionality, and thereby predictive processing and information compression. Neither of these two computational metrics mirrored neural alignment profiles. Our findings suggest that brain-LLM alignment is spatially robust and cross-linguistically stable but not explainable from predictive uncertainty or representational geometry. Rather than directly reflecting shared hierarchical computation, neural predictivity may primarily arise from distributed lexical-semantic correspondences that generalize across languages.",
+      "authors": [
+        "Ni Yang",
+        "Rui He",
+        "Philipp Homan",
+        "Iris Sommer",
+        "Davide Staub",
+        "Wolfram Hinzen"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21049v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21049v1",
+      "publishedAt": "2026-05-20T11:34:05.000Z",
+      "updatedAt": "2026-05-20T11:34:05.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21029v1",
+      "title": "Building a Custom Taxonomy of AI Skills and Tasks from the Ground Up with Job Postings",
+      "summary": "Utilizing LLMs for automated taxonomy construction presents a clear opportunity for the comprehensive, yet efficient mapping of potentially complex domains. When contending with high volumes of rapidly growing corpora, however, it becomes unclear how to best leverage such data for optimal taxonomy construction. Taking the case of systematizing AI skills in the workplace, we use two large-scale job postings corpora to investigate key design decisions for the inclusion (or exclusion) of data points for taxonomy construction. We propose TaxonomyBuilder as a blueprint for our systematic study, with which we evaluate various configurations of custom, data-informed, and hierarchical taxonomies. We demonstrate that less data can provide more clarity: filtering inputs to TaxonomyBuilder provides better domain-specific coverage than offering unfiltered inputs to clustering and LLM-enhanced hierarchical taxonomy labeling tools.",
+      "authors": [
+        "Stephen Meisenbacher",
+        "Peter Norlander"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21029v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21029v1",
+      "publishedAt": "2026-05-20T11:01:49.000Z",
+      "updatedAt": "2026-05-20T11:01:49.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21027v1",
+      "title": "Beyond Text-to-SQL: An Agentic LLM System for Governed Enterprise Analytics APIs",
+      "summary": "Enterprise analytics aims to make organizational data accessible for decision-making, yet non-technical users still face barriers when using traditional business intelligence tools or Text-to-SQL systems. While recent Text-to-SQL approaches based on Large Language Models (LLMs) promise natural language access to structured data, they fall short in enterprise settings where analytics pipelines rely on governed APIs rather than raw databases. In practice, these APIs encapsulate complex business logic to ensure consistency, auditability, and security. However, delegating mathematical or aggregation logic to an LLM introduces reliability and compliance risks. To this end, we present Analytic Agent, an LLM-based agentic system that translates natural language intents into secure interactions with enterprise analytics APIs. Evaluated on 90 real enterprise use cases constructed by domain experts, it reliably interprets user goals, validates permissions, executes governed queries, and generates compliant visualizations through multi-step reasoning and policy-aware orchestration.",
+      "authors": [
+        "Gundeep Singh",
+        "Parsa Kavehzadeh",
+        "Jing Xia",
+        "Xue-Yong Fu",
+        "Julien Bouvier Tremblay",
+        "Md Tahmid Rahman Laskar",
+        "Vincent Lum",
+        "Shashi Bhushan TN"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.21027v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21027v1",
+      "publishedAt": "2026-05-20T11:00:56.000Z",
+      "updatedAt": "2026-05-20T11:00:56.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.21006v1",
+      "title": "Playing Devil's Advocate: Off-the-Shelf Persona Vectors Rival Targeted Steering for Sycophancy",
+      "summary": "We study the effect of different persona on \\textbf{sycophancy}: model's agreement with users even when the user is incorrect. The standard mitigation, Contrastive Activation Addition (CAA), derives a steering direction from labelled pairs of sycophantic and honest responses. This study evaluates whether off-the-shelf persona steering vectors, originally developed for general role-playing and not trained on sycophancy data, can serve as an alternative. In two instruction-tuned models, steering toward personas characterised by doubt or scrutiny reduces sycophancy to approximately $68\\%$ and $98\\%$ of CAA's effect, and, unlike CAA, maintains accuracy when the user is correct. The effect is also asymmetric: steering toward agreeable personas does not produce a mirror increase in sycophancy. Geometrically, the persona vector is largely independent of the direction of sycophancy in activation space. Collectively, these findings suggest that sycophancy is better understood as a persona-level property rather than a single steerable direction. We release our code here: https://anonymous.4open.science/r/Sycophancy-Steering-9DF0/.",
+      "authors": [
+        "Ishaan Kelkar",
+        "Nebras Alam",
+        "Vikram Kakaria",
+        "Madhur Panwar",
+        "Vasu Sharma",
+        "Maheep Chaudhary"
       ],
       "categories": [
         "cs.AI",
@@ -2211,1235 +3115,361 @@
         "cs.LG"
       ],
       "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19932v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19932v1",
-      "publishedAt": "2026-05-19T14:51:32.000Z",
-      "updatedAt": "2026-05-19T14:51:32.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.21006v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.21006v1",
+      "publishedAt": "2026-05-20T10:43:17.000Z",
+      "updatedAt": "2026-05-20T10:43:17.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19931v1",
-      "title": "StruMPL: Multi-task Dense Regression under Disjoint Partial Supervision and MNAR Labels",
-      "summary": "Estimating forest aboveground biomass (AGB) from Earth observation combines two structurally incompatible label sources: spaceborne lidar provides canopy structure at millions of locations but no biomass estimate, and ground-based plots provide biomass at thousands of biased locations but no metrics of structure. No single training sample carries labels for all target variables, plot labels are missing not at random (MNAR), and biomass is linked to the structural variables by known but biome-specific allometric laws. We formalise this as multi-task dense regression under heterogeneous disjoint partial supervision with MNAR labels and inter-task physical constraints, and propose StruMPL to address it jointly. A shared encoder feeds per-variable regression, imputation, and propensity heads for spatial MNAR correction, and a learnable physics module that evaluates the inter-task constraint on the model's own predictions at every pixel. The supervised loss uses an Augmented IPW (AIPW) pseudo-outcome with stop-gradients on the propensity and on the imputation baseline; we show analytically and empirically that both are necessary for joint optimisation to recover IPW-weighted stationary points while keeping the loss bounded. On two ecologically distinct biomes, StruMPL outperforms ablation variants and the closest published method on AGB RMSE and bias, with a stratified analysis showing AIPW reduces high-AGB bias by ~54%.",
+      "arxivId": "2605.20998v1",
+      "title": "Single-Pass, Depth-Selective Reading for Multi-Aspect Sentiment Analysis",
+      "summary": "Aspect-Term Sentiment Analysis (ATSA) in multi-aspect sentences faces a fundamental tradeoff between efficiency and expressiveness. Existing models either re-encode the sentence for each aspect or rely on static use of deep representations, leading to redundant computation and limited adaptivity. We argue that Transformer depth is a costly, queryable resource, and propose DABS, a single-pass inference framework that encodes each sentence once to construct a reusable, depth-ordered substrate. Each aspect then queries this shared representation to selectively read relevant tokens and abstraction levels, without re-encoding. This decouples shared sentence encoding from lightweight, aspect-conditioned readout. Experiments on four ATSA benchmarks show that DABS achieves competitive performance while reducing end-to-end computation by up to 60% in multi-aspect settings (M >= 2). Further analyses indicate that adaptive depth querying is most beneficial for linguistically complex cases such as negation and contrast. Code is publicly available at https://github.com/panzhzh/acl-dabs",
       "authors": [
-        "Reza M. Asiyabi",
-        "Juan Alberto Molina-Valero",
-        "The SEOSAW Partnership",
-        "Steven Hancock",
-        "Casey M. Ryan"
+        "Yan Xia",
+        "Zhuangzhuang Pan",
+        "Amirrudin Kamsin",
+        "Chee Seng Chan"
       ],
       "categories": [
-        "cs.CV",
-        "cs.AI",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19931v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19931v1",
-      "publishedAt": "2026-05-19T14:51:12.000Z",
-      "updatedAt": "2026-05-19T14:51:12.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19929v1",
-      "title": "Breaking Modality Heterogeneity in Low-Bit Quantization for Large Vision-Language Models",
-      "summary": "Low-bit post-training quantization (PTQ) is a pivotal technique for deploying Vision-Language Models (VLMs) on resource-constrained devices. However, existing PTQ methods often degrade VLMs' accuracy due to the heterogeneous activation distributions of text and vision modalities during quantization. We find that this cross-modal heterogeneity is distributed unevenly across channels: a small subset of channels contains most modality-specific outliers, and these outliers typically reside in different channels for each modality. Motivated by this, we propose SplitQ, a channel-Splitting-driven post-training Quantization framework. At its core, SplitQ introduces a novel Modality-specific Outlier Channel Decoupling (MOCD) module that effectively isolates salient modality-specific outlier channels with minimal overhead. To further address the remaining cross-modal distribution discrepancies, we design an Adaptive Cross-Modal Calibration (ACC) module that employs dual lightweight learnable branches to dynamically mitigate modality-induced quantization errors. Extensive experiments on popular VLMs demonstrate that SplitQ significantly outperforms existing approaches across 6 popular multi-modal datasets under all evaluated quantization settings, including W4A8, W4A4, W3A3, and W3A2. Notably, SplitQ preserves 93.5% of FP16 performance under the challenging W3A3 setting (69.5 vs. 74.3), pushing the efficiency frontier for deploying advanced VLMs. Our code is available at https://github.com/EMVision-NK/SplitQ",
-      "authors": [
-        "Yi Zhong",
-        "Haotong Qin",
-        "Xindong Zhang",
-        "Lei Zhang",
-        "Guolei Sun"
-      ],
-      "categories": [
-        "cs.CV",
+        "cs.CL",
         "cs.AI"
       ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19929v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19929v1",
-      "publishedAt": "2026-05-19T14:49:57.000Z",
-      "updatedAt": "2026-05-19T14:49:57.000Z",
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20998v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20998v1",
+      "publishedAt": "2026-05-20T10:37:57.000Z",
+      "updatedAt": "2026-05-20T10:37:57.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19928v1",
-      "title": "Real-Time Parallel Counterfactual Regret Minimization",
-      "summary": "Counterfactual Regret Minimization (CFR) is the dominant algorithmic family for solving large imperfect-information games, underpinning breakthroughs such as Libratus and Pluribus in No-Limit Texas Hold'em poker. In real-time game-playing systems, the solver must compute a near-equilibrium strategy within a strict time budget of only a few seconds per decision, and the number of CFR iterations completed in this window directly determines play strength. We present \\textbf{Parallel CFR}, the first parallelization framework for real-time depth-limited CFR solving that seamlessly integrates pruning, abstraction, and advanced CFR variants. We decompose each CFR iteration into a pipeline of seven stages and identify two orthogonal dimensions of parallelism: \\emph{by information set} and \\emph{by tree node}. Leaf node evaluation is offloaded to GPUs via batched neural network inference, creating a heterogeneous CPU--GPU pipeline. Experiments on Heads-Up No-Limit Texas Hold'em demonstrate that Parallel CFR achieves $3.3$--$3.4\\times$ speedup over the single-threaded baseline on postflop streets, with per-iteration time of ${\\sim}47$--$54$~ms on a depth-limited game tree with over $1$ billion histories. All experiments run on a single desktop-class device (NVIDIA DGX Spark), enabling hundreds of CFR iterations within a typical real-time decision budget without requiring datacenter-scale infrastructure.",
+      "arxivId": "2605.20994v1",
+      "title": "Towards Context-Invariant Safety Alignment for Large Language Models",
+      "summary": "Preference-based post-training aligns LLMs with human intent, yet safety behavior often remains brittle. A model may refuse a harmful request in a standard prompt but comply when the same intent is wrapped in adversarial wording. We suggest that robust safety requires context-invariant alignment, where behavior depends on the underlying intent rather than surface form. Enforcing invariance is difficult in alignment because not all training signals are equally trustworthy; for some prompt variants we can obtain verifiable feedback (e.g., multiple-choice), while for open-ended variants we typically rely on noisy, gameable reward proxies (e.g., learned judges). As a result, standard symmetric invariance regularizers can reduce cross-context discrepancies by lowering performance on reliable variants instead of improving open-ended robustness. To address this, we introduce Anchor Invariance Regularization (AIR), which treats verifiable prompts as anchors and uses a stop-gradient target to regularize only the open-ended variants toward the anchor performance. AIR is implemented as a plug-in auxiliary loss and combined with group-based preference optimization (e.g., GRPO) via heterogeneous prompt grouping. Across Safety, Moral Reasoning, and Math, AIR improves context invariance, boosting in-distribution group accuracy by 12.71% and out-of-distribution consistency by 33.49%, making safety constraints robust to adversarial framings.",
       "authors": [
-        "Boning Li",
-        "Longbo Huang"
+        "Yixu Wang",
+        "Yang Yao",
+        "Xin Wang",
+        "Yifeng Gao",
+        "Yan Teng",
+        "Xingjun Ma",
+        "Yingchun Wang"
       ],
       "categories": [
-        "cs.GT",
-        "cs.AI",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.GT",
-      "absUrl": "https://arxiv.org/abs/2605.19928v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19928v1",
-      "publishedAt": "2026-05-19T14:49:30.000Z",
-      "updatedAt": "2026-05-19T14:49:30.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19926v1",
-      "title": "JAXenstein: Accelerated Benchmarking for First-Person Environments",
-      "summary": "The progression of reinforcement learning algorithms have been driven by challenging benchmarks. The rate in which a researcher can iterate on a problem setting directly impacts the speed of algorithm development. Modern machine learning has produced tools that allow for fast and scalable algorithm development like the JAX library. With the availability of these tools, a serious bottleneck in algorithm development is the availability of large and complex domains for experimentation. Most notably, the JAX reinforcement learning ecosystem does not have any benchmarks that test visual first-person tasks; these domains are crucial for testing both exploration and an agent's ability to overcome partial observability. We introduce JAXenstein: an open-source JAX-based benchmark that implements the Wolfenstein 3D rendering engine for fast and scalable experimentation in visual first-person tasks. JAXenstein is several times faster than comparable vision-based benchmarks, and is easily extensible to more complex first-person domains.",
-      "authors": [
-        "Ruo Yu Tao",
-        "George Konidaris"
-      ],
-      "categories": [
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19926v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19926v1",
-      "publishedAt": "2026-05-19T14:47:55.000Z",
-      "updatedAt": "2026-05-19T14:47:55.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19916v1",
-      "title": "Fast and Featureless Node Representation Learning with Partial Pairwise Supervision",
-      "summary": "We introduce Contrastive FUSE, a fast and unified framework for scalable node representation learning in graphs with partially available pairwise node labels and no available node features. Unlike existing methods, we directly optimize a spectral contrastive objective that integrates community-aware structural signals with signed pairwise constraints. To support large-scale training, we replace the expensive modularity gradient with a lightweight approximation, which preserves the structure-seeking behavior of modularity while reducing the computational cost significantly. This yields an efficient optimization scheme with a natural gradient decomposition and adaptive learning-rate scaling, enabling fast iterative updates even on million-edge graphs. Extensive experiments on benchmark citation networks, large co-purchase graphs, and OGB datasets show that Contrastive FUSE achieves competitive or superior contrastive classification performance without relying on node features, while offering substantial runtime gains over existing baselines. These results highlight the effectiveness of coupling modularity-inspired structural learning with contrastive supervision for efficient and scalable contrastive node representation learning.",
-      "authors": [
-        "Sujan Chakraborty",
-        "Saptarshi Bej"
-      ],
-      "categories": [
-        "cs.LG",
+        "cs.CL",
         "cs.AI"
       ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19916v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19916v1",
-      "publishedAt": "2026-05-19T14:40:51.000Z",
-      "updatedAt": "2026-05-19T14:40:51.000Z",
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20994v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20994v1",
+      "publishedAt": "2026-05-20T10:33:11.000Z",
+      "updatedAt": "2026-05-20T10:33:11.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19908v1",
-      "title": "Where Does Authorship Signal Emerge in Encoder-Based Language Models?",
-      "summary": "Authorship attribution models fine-tuned with the same pretrained encoder, data, and loss can differ four-fold in performance depending only on their scoring mechanism. We use mechanistic interpretability tools to explain this gap. Stylistic features such as word length, punctuation density, and function-word frequency are equally available at every layer in every model, including in an off-the-shelf control encoder, hence the gap not coming from representation quality. Instead, causal intervention shows that the scorer determines where the encoder consolidates authorship signal. Mean pooling forces consolidation by early to mid layers, while late interaction defers it to later layers. We further derive this difference from the gradient structure of each scorer, and training dynamics reveal distinct learning trajectories that follow from that difference.",
+      "arxivId": "2605.20967v1",
+      "title": "ArPoMeme: An Annotated Arabic Multimodal Dataset for Political Ideology and Polarization",
+      "summary": "Memes have become a prominent medium of political communication in the Arab world, reflecting how humor, imagery, and text interact to express ideological and cultural positions. Despite the centrality of memes to online political discourse, there is a lack of systematically curated resources for analyzing their multimodal and ideological dimensions in Arabic. This paper presents ArPoMeme, a large-scale dataset of approximately 7,300 Arabic political memes categorized by ideological orientation, including Leftist, Islamist, Pan-Arabist, and Satirical perspectives. The dataset captures the diversity of Arabic meme ecosystems by grounding classification in the self-identification of public Facebook pages and groups that produce and disseminate these memes. To ensure both scale and accuracy, we designed a semi-automated data collection pipeline combining Playwright-based Facebook scraping with Google Drive synchronization, followed by text extraction using the Qwen2.5-VL-7B vision language model. The extracted text was manually verified and annotated for three polarization dimensions: Us vs. Them framing, Hostility toward out-groups, and Calls to action. Annotation was conducted through a custom Streamlit-based interface supporting distributed labeling, real-time tracking, and version control. The resulting dataset links visual content, textual messages, and ideological orientation, enabling fine-grained analysis of political antagonism, mobilization, and humor. Quantitative analysis of the annotated corpus reveals strong asymmetries in antagonistic framing across ideological groups, with Islamist and satirical memes exhibiting the highest levels of hostility and mobilization cues. The dataset and the annotation tool offers a reproducible and publicly available resource for studying Arabic political discourse, multimodal ideology detection, and polarization dynamics.",
       "authors": [
-        "Francis Kulumba",
-        "Guillaume Vimont",
-        "Laurent Romary",
-        "Florian Cafiero"
+        "Wajdi Zaghouani",
+        "Kais Attia",
+        "Md. Rafiul Biswas",
+        "Fadhl Eryani"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19908v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19908v1",
-      "publishedAt": "2026-05-19T14:37:51.000Z",
-      "updatedAt": "2026-05-19T14:37:51.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.20967v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20967v1",
+      "publishedAt": "2026-05-20T09:53:01.000Z",
+      "updatedAt": "2026-05-20T09:53:01.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19902v1",
-      "title": "Hierarchical Contrastive Learning for Multi-Domain Protein-Ligand Binding",
-      "summary": "Predicting protein-ligand binding affinity remains intractable for multi-domain proteins, where inter-domain dynamics govern molecular recognition. Existing geometric deep learning methods typically treat proteins as monolithic static graphs, suffering from rigid-body assumptions and aleatoric noise in flexible regions. To address this, we introduced HCLBind, a self-supervised framework that decouples geometric representation learning from affinity regression. HCLBind leverages a general-to-specific pre-training paradigm on the Q-BioLiP database to learn a robust physical grammar of binding. We propose a novel hierarchical decoy strategy: the model learns local physicochemical constraints through protein coordinate perturbation in single-domain proteins and global conformational geometry through inter-domain rotation in multi-domain complexes. Our hybrid architecture integrates a domain-gated graph attention network and cross-modal attention to explicitly prioritize domain interfaces. Furthermore, we employ LoRA on protein and ligand foundation models, ensuring efficient optimization while preserving evolutionary knowledge. Experiments on PDBBind demonstrate that HCLBind effectively learns discriminative interface features and provides robust uncertainty estimation, overcoming the limitations of standard supervised learning. The code is available at https://github.com/jiankliu/HCLBind.",
+      "arxivId": "2605.20960v1",
+      "title": "JobArabi: An Arabic Corpus and Analysis of Job Announcements from Social Media",
+      "summary": "This paper introduces JobArabi, a large-scale corpus of Arabic job announcements collected from social media between January 2024 and October 2025. The dataset contains 20,528 public posts from X and captures more than two years of employment-related discourse across Arabic-speaking online communities. The corpus was compiled using a linguistically informed query framework covering 21 Arabic keyword families that reflect gendered, plural, formal, and dialectal expressions of recruitment language. The resulting dataset includes posts from institutional, commercial, and individual accounts and provides metadata such as timestamps, engagement indicators, and geolocation when available, enabling temporal and regional analysis of employment discourse. Quantitative analysis reveals several sociolinguistic patterns in online recruitment, including the persistence of gendered hiring language, regional variation in occupational demand, and the emotional framing of recruitment messages. These findings highlight the potential of Arabic social media as a resource for studying labor market communication and linguistic change. The JobArabi corpus, together with documentation and collection scripts, will be released to support research in Arabic NLP, computational social science, and digital labor studies.",
       "authors": [
-        "Shuo Zhang",
-        "Rongqi Hong",
-        "Huifeng Zhang",
-        "Jian K. Liu"
+        "Wajdi Zaghouani",
+        "Shimaa Amer Ibrahim",
+        "Mabrouka Bessghaier",
+        "Houda Bouamor"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20960v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20960v1",
+      "publishedAt": "2026-05-20T09:45:33.000Z",
+      "updatedAt": "2026-05-20T09:45:33.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.20948v1",
+      "title": "Memory Grafting: Scaling Language Model Pre-training via Offline Conditional Memory",
+      "summary": "Scaling conditional memory offers a promising way to increase language-model capacity, but existing methods such as Engram learn large memory tables from scratch during pre-training, making memory scaling expensive and sometimes ineffective. We propose Memory Grafting, a conditional memory scaling method that utilizes frozen hidden states from a grafting model as conditional n-gram memory. Given frequent local n-grams, we run the grafting model offline, store final-token hidden representations as memory values, and let the recipient model retrieve them through exact longest-match suffix lookup. Retrieved memories are adapted by lightweight projections and gates, while a hash-based Engram fallback preserves coverage for unmatched contexts. Since the grafting model is only run offline and exact lookup has expected O(1) complexity with respect to memory-bank size, Memory Grafting expands external latent capacity with limited training and inference overhead. Experiments under matched recipient architectures and pre-training budgets show that Memory Grafting improves over both MoE and vanilla Engram baselines. In the 2.8B-scale setting, it improves the average benchmark score from 51.95 for MoE and 52.43 for vanilla Engram to 53.86. In the 0.92B-scale setting, all grafting-model variants improve over the baselines, with Qwen3.5-35B-A3B giving the strongest gains. These results suggest that pretrained models can serve as reusable constructors of external latent memory, providing a practical step toward scaling future language models beyond trainable parameters alone.",
+      "authors": [
+        "Runxi Cheng",
+        "Yuchen Guan",
+        "Yongxian Wei",
+        "Qianpu Sun",
+        "Qixiu Li",
+        "Sinan Du",
+        "Feng Xiong",
+        "Chun Yuan",
+        "Yan Lu",
+        "Yeyun Gong"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20948v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20948v1",
+      "publishedAt": "2026-05-20T09:35:04.000Z",
+      "updatedAt": "2026-05-20T09:35:04.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.20946v1",
+      "title": "Thinking-while-speaking: A Controlled, Interleaved Reasoning Method for Real-Time Speech Generation",
+      "summary": "The thinking-while-speaking paradigm aims to make AI communication more human. A key challenge is maintaining fluent speech while performing deep reasoning. Our method, InterRS, tackles this by inserting reasoning steps only during natural speech generation. This requires high-quality data where reasoning and speech are precisely aligned, and the length ratio are under controlled. We introduce a novel pipeline to generate such seamlessly interleaved audio data. To train our model, we combine interleaved SFT with refined data and reinforcement learning with two new rewards: a TA-Balance Reward to manage timing and thinking-answer ratio, and a Linguistic Quality Reward to refine expression. Experiments show our approach achieves 13% better performance on mathmatical and logic benchmarks while generating instant response like a spoken-language instruct model which outputs fast CoT response. Furthermore, our method generates more natural and fluent answers than prior methods.",
+      "authors": [
+        "Xuan Du",
+        "Qiangyu Yan",
+        "Wenshuo Li",
+        "Borui Jiang",
+        "Changming Xiao",
+        "Han Shu",
+        "Xinghao Chen"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20946v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20946v1",
+      "publishedAt": "2026-05-20T09:32:35.000Z",
+      "updatedAt": "2026-05-20T09:32:35.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.20936v1",
+      "title": "DASH: Fast Differentiable Architecture Search for Hybrid Attention in Minutes on a Single GPU",
+      "summary": "Hybrid attention architectures are becoming an increasingly important paradigm for improving LLM inference efficiency while preserving model quality, making hybrid architecture design a central problem. Existing designs often rely on manual empirical rules or proxy-based selector signals for layer-wise operator allocation. Recent NAS-style systems such as Jet-Nemotron demonstrate the promise of automated hybrid architecture search. However, Jet-Nemotron's PostNAS search stages alone use 200B tokens, making such search pipelines difficult to use as routine methods for hybrid architecture design. We introduce DASH, a fast differentiable search framework for hybrid attention architecture design, which relaxes discrete layer-wise attention operator placement into continuous architecture logits, prepares reusable teacher-aligned linear candidates, and performs architecture-only search with model and operator weights frozen to significantly enhance search efficiency. On Qwen2.5-3B-Instruct, DASH consistently outperforms a comprehensive suite of existing selector-style hybrid attention design baselines, showing that direct differentiable search can discover stronger hybrid architectures. Moreover, DASH achieves stronger RULER performance than released Jet-Nemotron models while remaining competitive on overlapping short-context and general benchmarks. Notably, each DASH search run uses only 12.3M tokens and takes about 20 minutes on a single RTX Pro 6000 GPU, corresponding to merely 0.006% of the PostNAS search tokens reported by Jet-Nemotron. These results suggest that high-quality hybrid attention architectures can be obtained through minutes-level differentiable search, providing a promising direction for hybrid architecture design.",
+      "authors": [
+        "Weizhe Chen",
+        "Miao Zhang",
+        "Junpeng Jiang",
+        "Yaping Li",
+        "Weili Guan",
+        "Liqiang Nie"
       ],
       "categories": [
         "cs.LG",
-        "q-bio.QM"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19902v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19902v1",
-      "publishedAt": "2026-05-19T14:33:02.000Z",
-      "updatedAt": "2026-05-19T14:33:02.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19895v1",
-      "title": "Streamlined Constraint Reasoning via CNN Pattern Recognition on Enumerated Solutions",
-      "summary": "Constraint programming practitioners accelerate hard problems through a layered set of techniques applied in order of risk. Standard hardening (symmetry-breaking and implied constraints) is applied first and preserves satisfiability. Streamliner constraints, which restrict search to a structural sub-family of solutions, do not preserve satisfiability and are reserved as a final lever. Existing automated streamliner-synthesis approaches either search a constraint grammar or prompt a Large Language Model directly on the problem model. We propose a different approach: enumerate feasible solutions, train a Convolutional Neural Network contrastively against perturbed non-solutions to detect structural patterns, and translate the CNN's discriminative signal into candidate MiniZinc streamliners through LLM-driven synthesis. The CNN grounds the LLM's constraint generation in observed solution structure rather than model text alone. We evaluate on hardened benchmark models where streamliner discovery is the residual performance lever. Our pipeline achieves 98.8% portfolio time reduction on hardened Vessel Loading, 98.6% on hardened Social Golfers, and 89.4% on Black Hole, with best-single streamliners reaching geometric-mean speedups of 932x, 356x, and 1103x respectively. Discovered streamliners include class-based packing constraints on Vessel Loading, beyond-hardening canonicalisations on Social Golfers, and layout-coordinate bounds on Black Hole.",
-      "authors": [
-        "Patrick Spracklen"
-      ],
-      "categories": [
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19895v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19895v1",
-      "publishedAt": "2026-05-19T14:25:39.000Z",
-      "updatedAt": "2026-05-19T14:25:39.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19892v1",
-      "title": "Deep Tech to Space: Space Data Centers and AI Revolution at the Edge",
-      "summary": "Dramatic cost reductions driven by private sector innovations have led to a rapid increase in the number of satellites in orbit and a corresponding surge in space-generated data. As this trend continues, transmitting large volumes of data to Earth for processing may become increasingly costly and challenging due to potential space-to-Earth link congestion and increased latency. Moreover, traditional ground station networks may face difficulties accommodating growing data flows and workloads because of capacity constraints, complex scheduling logistics, and restricted visibility windows, which can limit scalability. Space Data Centers (SDCs) -- software-driven, multi-tenant artificial intelligence-based service platforms capable of processing data in orbit to generate actionable insights for client satellites and ground users -- represent a promising approach to address these challenges. This article presents the architecture of a Low Earth Orbit SDC satellite constellation, considering orbital design, inter-satellite links and network topology, computational resource organization, and software service orchestration. We analyze the potential technical feasibility and economic viability of SDCs using forecasting models informed by technology roadmaps and illustrate the concept through Earth observation and lunar exploration use cases.",
-      "authors": [
-        "Jonas Weiss",
-        "Patricia Sagmeister",
-        "Gabriel Maiolini Capez",
-        "Dinesh Verma",
-        "Roberto Garello",
-        "Alberto Perotti",
-        "Dawid Lazaj",
-        "Alicja Musial",
-        "Jakub Nalepa",
-        "Thomas Morf",
-        "Martin Schmatz",
-        "Marek Krawczyk",
-        "Mateusz Przeliorz",
-        "Kevin Roche",
-        "Sagar Tayal",
-        "Mahalakshmi Lakshminarayanan",
-        "Nicolas Longépé",
-        "Pierre-Philippe Mathieu",
-        "Agata Wijata"
-      ],
-      "categories": [
-        "cs.DC",
         "cs.AI",
-        "cs.ET",
-        "cs.NI"
-      ],
-      "primaryCategory": "cs.DC",
-      "absUrl": "https://arxiv.org/abs/2605.19892v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19892v1",
-      "publishedAt": "2026-05-19T14:23:26.000Z",
-      "updatedAt": "2026-05-19T14:23:26.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19890v1",
-      "title": "GoTTA be Diverse: Rethinking Memory Policies for Test-Time Adaptation",
-      "summary": "Test-time adaptation (TTA) enables a pre-trained model to adapt online to an unlabeled test stream under distribution shift. While most TTA research focuses on the adaptation objective, practical streams also depend critically on the memory used to select which test samples drive adaptation. Existing memory mechanisms are usually evaluated as components of specific TTA algorithms, making it difficult to isolate which memory design choices matter and when they matter. In this work, we provide a systematic benchmark that decouples memory from the adaptation algorithm and evaluates memory policies under unified conditions across i.i.d., non-i.i.d., continual, and practical test streams. Our study shows that effective memory management requires more than retaining recent or class-balanced samples. In particular, intra-class diversity is a key factor for avoiding redundant buffers and maintaining representative adaptation signals under temporally correlated and label-skewed streams. Motivated by this finding, we introduce Guided Observational Test-Time Adaptation (GOTTA), a family of diversity-aware memory policies that combine class-balanced allocation with feature-space diversity. GOTTA memories act as drop-in replacements for existing buffers and can be paired with different TTA objectives. Across corruption benchmarks and video-stream settings, diversity-aware memory improves adaptation most clearly under constrained memory budgets and challenging non-i.i.d. streams, while remaining competitive as memory capacity increases. These results highlight memory management as a first-class component of robust test-time adaptation and identify diversity as a central principle for practical TTA.",
-      "authors": [
-        "Shyma Alhuwaider",
-        "Yasmeen Alsaedy",
-        "Merey Ramazanova",
-        "Silvio Giancola",
-        "Bernard Ghanem"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19890v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19890v1",
-      "publishedAt": "2026-05-19T14:18:46.000Z",
-      "updatedAt": "2026-05-19T14:18:46.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19889v1",
-      "title": "GLUT: 3D Gaussian Lookup Table for Continuous Color Transformation",
-      "summary": "3D Lookup Tables (3D LUTs) are widely used for color mapping, but their grid-based representation requires discretizing the RGB space, leading to a capacity-memory trade-off that becomes prohibitive when storing large numbers of LUTs. Recent approaches adopt implicit neural representations to improve scalability, yet their black-box nature limits interpretability and hinders intuitive, localized editing. In this paper, we propose Gaussian LUT (GLUT), a continuous and explicit color representation that models color transformations using a set of learnable 3D Gaussian primitives. By avoiding fixed-resolution grids, GLUT achieves flexible representational capacity while maintaining a compact memory footprint. Its explicit, spatially localized formulation further enables both accurate modeling and interpretability. Building on this representation, we introduce a compact conditional generator (CGLUT) that predicts GLUT parameters for multiple LUT instances, encoding diverse color styles in a single framework to enable smooth and controllable LUT style blending. Moreover, GLUT supports efficient, user-friendly editing by allowing localized adjustments to specific color regions without global retraining. Experimental results demonstrate that our approach outperforms prior neural LUT representations in both accuracy and efficiency, while offering improved interpretability and interactive control.",
-      "authors": [
-        "Danna Xue",
-        "David Serrano-Lozano",
-        "Shaolin Su",
-        "Javier Vazquez-Corral"
-      ],
-      "categories": [
-        "cs.GR",
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.GR",
-      "absUrl": "https://arxiv.org/abs/2605.19889v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19889v1",
-      "publishedAt": "2026-05-19T14:17:44.000Z",
-      "updatedAt": "2026-05-19T14:17:44.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19876v1",
-      "title": "Structural Energy Guidance for View-Consistent Text-to-3D Generation",
-      "summary": "Text-to-3D generation based on diffusion models often suffers from the Janus problem, leading to inconsistent geometry across viewpoints. This work identifies viewpoint bias in 2D diffusion priors as the main cause and proposes Structural Energy-Guided Sampling (SEGS), a training-free and plug-and-play framework to improve multi-view consistency. SEGS constructs a structural energy in the PCA subspace of U-Net features and injects its gradient into the denoising process. It can be easily integrated into SDS/VSD pipelines without retraining. Experiments show that SEGS reduces the Janus Rate by about 10% on average and improves View-CS scores across multiple baselines, including DreamFusion, Magic3D, and LucidDreamer. This method effectively alleviates viewpoint artifacts while preserving appearance fidelity, providing a flexible solution for high-quality text-to-3D content generation.",
-      "authors": [
-        "Qing Zhang",
-        "Jinguang Tong",
-        "Jing Zhang",
-        "Jie Hong",
-        "Xuesong Li"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19876v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19876v1",
-      "publishedAt": "2026-05-19T14:08:52.000Z",
-      "updatedAt": "2026-05-19T14:08:52.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19869v1",
-      "title": "Passive Construction Site Safety Monitoring via Persona-Scaffolded Adversarial Chain-of-Thought VLM Verification",
-      "summary": "Construction remains the deadliest industry sector in the United States, with 1,055 fatal worker injuries recorded in 2023, and the majority preventable. Existing monitoring approaches are expensive, require real-time human operators, or address only a narrow subset of violations. This paper presents a passive, end-of-shift construction safety monitoring pipeline processing video from POV body-worn and fixed wall-mounted cameras through a three-stage architecture: (1) fine-tuned YOLO11 for primary PPE and hazard detection, (2) SAM 3 for segmentation refinement and worker deduplication, and (3) Qwen3-VL-8B-Instruct with a method-prompted, persona-scaffolded three-pass adversarial chain-of-thought protocol for compliance verification and hallucination control. The principal contribution is the Stage 3 prompt design: professional persona backstories following the method-actor framing drive an observed 12% precision improvement over single-pass prompting in an informal three-author review of the 12-video Ironsite development corpus, with the largest gains on hallucination-prone violation categories. Structural message isolation enforces observational independence between a generator, discriminator, and reconciliation pass governed by asymmetric rules encoding priors about human observation versus automated detection reliability. The system maps violations to OSHA standards, performs REBA-inspired ergonomic risk scoring from pose keypoints, and produces per-worker safety reports with timestamped evidence. An evaluation harness is released for future reproduction.",
-      "authors": [
-        "Ananth Sriram",
-        "Neel Mokaria",
-        "Rajveer Singh"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19869v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19869v1",
-      "publishedAt": "2026-05-19T14:00:01.000Z",
-      "updatedAt": "2026-05-19T14:00:01.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19868v1",
-      "title": "WoundFormer: Multi-Scale Spatial Feature Fusion for Multi-Class Wound Tissue Segmentation",
-      "summary": "Chronic wounds such as diabetic foot ulcers and pressure injuries require accurate tissue-level assessment to guide treatment planning and monitor healing progression. While deep learning methods have advanced automated wound analysis, most existing approaches focus on binary segmentation and inadequately model heterogeneous tissue composition due to high intra-class variability and limited annotated data. Multi-class wound tissue segmentation, therefore, remains a challenging and clinically relevant problem. We propose WoundFormer, a transformer-based framework that enhances hierarchical spatial feature fusion for multi-class wound tissue segmentation. Specifically, we replace the standard SegFormer decoder with a spatially-preserving multi-scale aggregation head that maintains feature topology during cross-scale integration and strengthens contextual interactions through convolutional fusion. This design improves boundary localization and discrimination between visually similar tissue categories while preserving transformer efficiency. We evaluate WoundFormer on the WoundTissueSeg dataset (147 images, six tissue classes) and a second benchmark (DFUTissue dataset). The proposed method achieves an overall Dice score of 81.9%, outperforming strong CNN- and transformer-based baselines by up to 4.3 Dice points on the WoundTissueSeg benchmark, with consistent improvements across minority tissue classes. These results indicate that explicit modeling of hierarchical spatial interactions enhances transformer representations for heterogeneous wound tissue segmentation and supports more reliable quantitative wound assessment.",
-      "authors": [
-        "Muhammad Ashad Kabir",
-        "Rabin Dulal"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19868v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19868v1",
-      "publishedAt": "2026-05-19T13:58:58.000Z",
-      "updatedAt": "2026-05-19T13:58:58.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19866v1",
-      "title": "Structured Layout Priors for Robust Out-of-Distribution Visual Document Understanding",
-      "summary": "Vision-Language Models (VLMs) parse documents end-to-end but frequently break down on layouts unlike those seen in training. We attribute this to a two-hop bottleneck: before the decoder can extract content (Hop 2), it must first classify and localize the enclosing layout entity (Hop 1), and when the first hop fails the second collapses into omissions, malformed structure, or autoregressive repetition. We pre-resolve Hop 1 outside the decoder by running a lightweight RT-DETR detector, serializing its outputs in the parser's native DocTags vocabulary, and injecting them into the prompt alongside the full page image. Unlike analyze-then-parse approaches that crop the page, or prior prompt-level priors written in plain text, our prior shares the decoder's generation space and leaves the global image in view as a fallback when detections are noisy. On a 10k-page structural out-of-distribution benchmark, markdown F1 rises from $0.37$ to $0.92$; on the Chinese subset of OmniDocBench, table TEDS rises from $0.01$ to $0.36$; and on the 26k-page ViDoRe V3 benchmark, infinite-loop decoding failures drop across every industrial domain tested. These gains cost $15\\%$ wall-clock latency and a median of $74$ prompt tokens, with no architectural change to the base VLM. An attention-level analysis further reveals a bimodal phase shift in which the decoder attends to injected layout tokens when emitting structure and to image patches when emitting content, consistent with the two-hop bottleneck being alleviated. Model weights will be released to support reproducibility.",
-      "authors": [
-        "Peter El Hachem",
-        "Ahmed Nassar",
-        "A. Said Gurbuz",
-        "Christoph Auer",
-        "Peter W. J. Staar"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19866v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19866v1",
-      "publishedAt": "2026-05-19T13:58:24.000Z",
-      "updatedAt": "2026-05-19T13:58:24.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19865v1",
-      "title": "Landscape-Awareness for Geometric View Diffusion Model",
-      "summary": "Accurate camera viewpoint estimation under sparse-view conditions remains challenging, particularly in two-view scenarios. Recent approaches leverage diffusion models such as Zero123 to synthesize novel views conditioned on relative viewpoint, showing promising results when repurposed for viewpoint estimation via optimization with MSE loss. However, existing methods often suffer from nonconvex loss landscape with numerous local minima, making them sensitive to initialization and reliant on naive multistart strategies. We analyze these optimization challenges and visualize failure cases, showing that geometric ambiguities, such as symmetry and self-similarity, can mislead gradient-based updates toward incorrect viewpoints. To address these limitations, we propose a score-based method that reshapes the optimization landscape to guide updates toward the ground-truth viewpoint, followed by a refinement stage using a viewpoint-conditioned diffusion model. Experiments show that our method improves convergence, reduces reliance on brute-force sampling, and achieves competitive accuracy with higher sample-efficiency.",
-      "authors": [
-        "Yan-Ting Chen",
-        "Hao-Wei Chen",
-        "Tsu-Ching Hsiao",
-        "Chun-Yi Lee"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19865v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19865v1",
-      "publishedAt": "2026-05-19T13:57:35.000Z",
-      "updatedAt": "2026-05-19T13:57:35.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19859v1",
-      "title": "Eyes on VLM: Benchmarking Gaze Following and Social Gaze Prediction in Vision Language Models",
-      "summary": "Vision-language models (VLMs) have rapidly evolved into general-purpose multimodal reasoners with strong zero-shot generalization. In this context, VLMs could greatly benefit the analysis of human gaze and attention, a central task in human behavior understanding that requires reasoning about the physical scene as well as the activity, interactions, and social context. However, the extent to which VLMs can reliably understand human gaze and related attentional behaviors remains largely unexplored. In this work, we present EyeVLM, a systematic evaluation framework for gaze understanding in VLMs across two complementary dimensions: tasks and models. To assess gaze understanding capabilities, we focus on two core tasks. The first, gaze following, i.e., predicting the 2D location where a person is looking, has a geometric and visual processing focus, requiring a precise understanding of the human face, attention direction, 3D scene structure, and spatial grounding of attended targets. The second, social gaze prediction, requires social and relational reasoning over multi-person interactions (e.g., mutual gaze and shared attention), and may benefit more from the LLM semantic reasoning capabilities within VLMs. Regarding models, EyeVLM evaluates these tasks in two ways: a zero-shot setting with a diverse set of state-of-the-art open- and closed-source VLMs, exploring different prompting strategies; and a fine-tuning approach based on task-specific QA pairs, studying the impact of model scale and data scale. As benchmarks, we rely on existing gaze understanding datasets and perform a systematic comparison with state-of-the-art purely visual models. Overall, our results show that current VLMs lack precise gaze understanding capabilities. While standard training helps reduce the gap with visual models, significant improvements are still needed.",
-      "authors": [
-        "Hengfei Wang",
-        "Anshul Gupta",
-        "Pierre Vuillecard",
-        "Jean-Marc Odobez"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19859v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19859v1",
-      "publishedAt": "2026-05-19T13:50:40.000Z",
-      "updatedAt": "2026-05-19T13:50:40.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19856v1",
-      "title": "StableGrad: Backward Scale Control without Batch Normalization",
-      "summary": "Training very deep neural networks requires controlling the propagation of magnitudes across depth. Without such control, activations and gradients may vanish, explode, or enter unstable regimes that make optimization fail. Modern architectures often mitigate this problem through Batch Normalization, residual connections, or other normalization layers, which repeatedly re-scale or bypass intermediate representations. However, these mechanisms are not always appropriate. In Physics-Informed Neural Networks (PINNs), the network represents a continuous physical field and its input derivatives define the training objective, making batch-dependent normalization problematic because it can introduce non-local dependencies into the predicted field and its derivatives. We propose StableGrad, an optimizer-level scale-control mechanism that corrects layer-wise weight-gradient imbalances without modifying the forward model. Because the normalization is applied only after backpropagation and before the optimizer update, the network output, its derivatives, and the physical residual remain unchanged. We analyze the effective training dynamics induced by this rescaling and evaluate StableGrad on deep PINNs as the target application, with BatchNorm-free convolutional networks serving as a diagnostic stress test. On PINN benchmarks, StableGrad improves matched-depth solution accuracy and makes deeper models more reliable under standard optimization. On ResNet and EfficientNet architectures, where removing Batch Normalization normally leads to training collapse, StableGrad stabilizes optimization without introducing any other architectural change. These results show that optimizer-level control of weight-gradient scale can provide a practical alternative when forward normalization is unavailable or undesirable.",
-      "authors": [
-        "Jose I. Mestre",
-        "Alberto Fernández-Hernández",
-        "Cristian Pérez-Corral",
-        "Manuel F. Dolz",
-        "Enrique S. Quintana-Ortí"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.AI"
+        "cs.CL"
       ],
       "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19856v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19856v1",
-      "publishedAt": "2026-05-19T13:49:30.000Z",
-      "updatedAt": "2026-05-19T13:49:30.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.20936v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20936v1",
+      "publishedAt": "2026-05-20T09:21:22.000Z",
+      "updatedAt": "2026-05-20T09:21:22.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19855v1",
-      "title": "A Framework for Evaluating Zero-Shot Image Generation in Concept-based Explainability",
-      "summary": "Concept-based Explainable Artificial Intelligence (XAI) interprets deep learning models using human-understandable visual features (e.g., textures or object parts) by linking internal representations to class predictions, thereby bridging the gap between low-level image data and high-level semantics. A major challenge, however, is the reliance on large sets of labeled images to represent each concept, which limits scalability. In this work, we investigate the use of zero-shot Text-to-Image (T2I) generative models as a source of synthetic concept datasets for concept-based XAI methods. Specifically, we generate concepts using predefined prompts and evaluate their faithfulness to real ones through four complementary analyses: (1) comparing synthetic vs. real concept images via concept representation similarity; (2) evaluating their intra-similarity by comparing pairs of subsets of the same concept with progressively increasing size; (3) evaluating their performance for downstream explanation tasks using relevant class images; (4) evaluating how removing a concept from tested class images affects explanations of generated concepts. While current T2I generative models promise a shortcut to concept-based XAI, our study highlights challenges and raises open questions about the use of synthetic data generated by zero-shot pipelines in model analyses. The resulting dataset is available at https://github.com/DataSciencePolimi/ZeroShot-T2I-Concepts.",
+      "arxivId": "2605.20924v1",
+      "title": "Strategy-Induct: Task-Level Strategy Induction for Instruction Generation",
+      "summary": "Designing effective task-level prompts is crucial for improving the performance of Large Language Models (LLMs). While prior work on instruction induction demonstrates that LLMs can infer better instructions with limited examples, existing approaches often rely on input-output pairs, where obtaining labeled answers can be difficult or costly. To address this limitation, we propose Strategy-Induct, a framework that derives task-level instructions solely from a small set of example questions without requiring labeled answers. Our approach first prompts the model to generate explicit reasoning strategies for each question, forming (strategy, question) pairs. These pairs are then used to induce a task instruction that guides reasoning. Experiments across multiple tasks and model scales demonstrate that Strategy-Induct outperforms state-of-the-art methods in question-only settings. Furthermore, we observe that jointly utilizing LLMs and Large Reasoning Models across task instruction generation and inference may lead to further performance improvements.",
       "authors": [
-        "Giacomo Astolfi",
-        "Matteo Bianchi",
-        "Riccardo Campi",
-        "Antonio De Santis",
-        "Marco Brambilla"
+        "Po-Chun Chen",
+        "Hen-Hsen Huang",
+        "Hsin-Hsi Chen"
       ],
       "categories": [
-        "cs.CV",
+        "cs.CL",
         "cs.AI"
       ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19855v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19855v1",
-      "publishedAt": "2026-05-19T13:46:58.000Z",
-      "updatedAt": "2026-05-19T13:46:58.000Z",
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20924v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20924v1",
+      "publishedAt": "2026-05-20T09:10:43.000Z",
+      "updatedAt": "2026-05-20T09:10:43.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19852v1",
-      "title": "Are Tools Always Beneficial? Learning to Invoke Tools Adaptively for Dual-Mode Multimodal LLM Reasoning",
-      "summary": "Tool-augmented reasoning has emerged as a promising direction for enhancing the reasoning capabilities of multimodal large language models (MLLMs). However, existing studies mainly focus on enabling models to perform tool invocation, while neglecting the necessity of invoking tools. We argue that tool usage is not always beneficial, as redundant or inappropriate invocations largely increase reasoning overhead and even mislead model predictions. To address this issue, we introduce AutoTool, a model that adaptively decides whether to invoke tools according to the characteristics of each query. Within a reinforcement learning framework, we design an explicit dual-mode reasoning strategy with mode-specific reward functions to guide the model toward producing accurate responses. Moreover, to prevent premature bias toward a single reasoning mode, AutoTool jointly explores and balances tool-assisted and text-centric reasoning throughout training, and promotes free exploration in later stages. Extensive experiments demonstrate that AutoTool exhibits outstanding performance and high efficiency, yielding a 21.8\\% accuracy gain on V* benchmark compared to the base model, and a 44.9\\% improvement in efficiency over existing tool-augmented methods on POPE benchmark. Code is available at https://github.com/MQinghe/AutoTool.",
+      "arxivId": "2605.20920v1",
+      "title": "Evaluating Speech Articulation Synthesis with Articulatory Phoneme Recognition",
+      "summary": "Recent advances in machine learning and the availability of articulatory datasets allow vocal tract synthesis to be conditioned on phonetic sequences, a primary task of articulatory speech synthesis. However, quality assessment needs a better definition. Generally, ranking generative models is tricky due to subjectivity. However, articulatory synthesis has the additional difficulty of requiring specialized knowledge in vocal tract anatomy and acoustics. To address this problem, this paper proposes to evaluate speech articulation synthesis using phoneme recognition as a proxy. Our hypothesis is that phoneme recognition using articulatory features better captures nuances in phoneme production, such as correct places of articulation, which traditional metrics (e.g., point-wise distance metrics) do not. We train a neural network with acoustic and articulatory features extracted from a single-speaker RT-MRI dataset. Then, we compare the recognition performance when testing the model with different synthetic articulatory features. Our results show that our articulatory feature set is phonetically rich and helps exploring additional dimensions on speech articulation synthesis.",
       "authors": [
-        "Qinghe Ma",
-        "Zhen Zhao",
-        "Yiming Wu",
-        "Jian Zhang",
-        "Lei Bai",
-        "Yinghuan Shi"
+        "Vinicius Ribeiro",
+        "Yves Laprie"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.SD"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20920v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20920v1",
+      "publishedAt": "2026-05-20T09:06:22.000Z",
+      "updatedAt": "2026-05-20T09:06:22.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.20916v1",
+      "title": "Task-Routed Mixture-of-Experts with Cognitive Appraisal for Implicit Sentiment Analysis",
+      "summary": "Implicit sentiment analysis is challenging because sentiment toward an aspect is often inferred from events rather than expressed through explicit opinion words. Existing models typically learn from the final polarity label, which provides limited guidance for reasoning about sentiment from the context. Motivated by cognitive appraisal theory, we propose an appraisal-aware multi-task learning (MTL) framework for implicit sentiment analysis that provides polarity prediction with two complementary auxiliary tasks: implicit sentiment detection and cognitive rationale generation. However, training several objectives with different targets and sharing a single backbone across tasks in MTL limits flexibility and can lead to task interference. To reduce interference among these related but distinct objectives, we adopt task-level mixture-of-experts models in which all tasks share a common set of experts, and task identity controls the sparse combination of these experts. Our method builds on an encoder-decoder architecture and replaces a subset of encoder and decoder blocks with these sparse mixtures. We use a task-conditioned router to select sparse expert mixtures for each task, and a task-separated routing objective to encourage different tasks to learn distinct expert-selection patterns. Experimental results show that our model outperforms recently proposed approaches, with strong gains on the implicit sentiment subset. Our code is available at https://github.com/yaping166/TRMoE-ISA.",
+      "authors": [
+        "Yaping Chai",
+        "Haoran Xie",
+        "Joe S. Qin"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19852v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19852v1",
-      "publishedAt": "2026-05-19T13:44:26.000Z",
-      "updatedAt": "2026-05-19T13:44:26.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.20916v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20916v1",
+      "publishedAt": "2026-05-20T08:59:32.000Z",
+      "updatedAt": "2026-05-20T08:59:32.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19848v1",
-      "title": "CLIF: Concept-Level Influence Functions for Transparent Bottleneck Models",
-      "summary": "In recent years, the black-box nature of deep learning models has limited their application in high-stakes domains such as medical diagnosis and finance, where interpretability is essential. To address this, we propose a novel approach using influence functions to enhance interpretability in NLP models at both the sample and concept levels. Experiments on CEBaB and Yelp datasets show that influence functions effectively identify the most impactful training samples, both helpful and harmful, on model predictions. By adjusting the labels and weights of these samples, we demonstrate that model performance can be restored to baseline levels without retraining, confirming the value of influence functions for efficient data debugging. Furthermore, our concept-level analysis identifies key concepts within Concept Bottleneck Models (CBM) that significantly affect predictions. Modifying these concepts alters model behavior observably, providing clear insights into the decision process.",
+      "arxivId": "2605.20915v1",
+      "title": "Calibration vs Decision Making: Revisiting the Reliability Paradox in Unlearned Language Models",
+      "summary": "Machine unlearning aims to remove the influence of specific training data from a model while preserving reliable behavior on the remaining data, making reliable prediction and uncertainty estimation essential for evaluation. Calibration is commonly used as a proxy for reliability in language models, but low calibration error does not necessarily imply reliable decision rules, as models may rely on spurious correlations while remaining well calibrated. We investigate this gap in generative language models using the multiple-choice question-answering evaluation protocol on the TOFU benchmark, measuring probabilistic reliability with calibration metrics (ECE, MCE, Brier) and decision-rule reliability via attribution-based shortcut detection with Integrated Gradients and Local Mutual Information. We find that fine-tuned models achieve low calibration error (ECE ~ 0.04) compared to pretrained models (ECE > 0.5), and models after unlearning retain similarly low calibration despite reduced accuracy on the forget split, while attribution analysis shows increased reliance on correlation-based tokens. These results demonstrate that good calibration can coexist with shortcut-based decision rules after unlearning, extending the reliability paradox to the machine unlearning setting.",
       "authors": [
-        "Yike Sun",
-        "Mingkun Xu",
-        "Mu You",
-        "Zhongzhi He",
-        "Henghua Shen",
-        "Zehan Tan",
-        "Derek F. Wong",
-        "Tao Fang"
+        "Divyaksh Shukla",
+        "Ashutosh Modi"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20915v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20915v1",
+      "publishedAt": "2026-05-20T08:59:23.000Z",
+      "updatedAt": "2026-05-20T08:59:23.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.20912v1",
+      "title": "Enhancing Scientific Discourse: Machine Translation for the Scientific Domain",
+      "summary": "The increasing volume of scientific research necessitates effective communication across language barriers. Machine translation (MT) offers a promising solution for accessing international publications. However, the scientific domain presents unique challenges due to its specialized vocabulary and complex sentence structures. In this paper, we present the development of a collection of parallel and monolingual corpora for the scientific domain. The corpora target the language pairs Spanish-English, French-English, and Portuguese-English. For each language pair, we create a large general scientific corpus as well as four smaller corpora focused on the domains of: Cancer Research, Energy Research, Neuroscience, and Transportation research. To evaluate the quality of these corpora, we utilize them for fine-tuning general-purpose neural machine translation (NMT) systems. We provide details regarding the corpus creation process, the fine-tuning strategies employed, and we conclude with the evaluation results.",
+      "authors": [
+        "Dimitris Roussis",
+        "Sokratis Sofianopoulos",
+        "Stelios Piperidis"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19848v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19848v1",
-      "publishedAt": "2026-05-19T13:42:38.000Z",
-      "updatedAt": "2026-05-19T13:42:38.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.20912v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20912v1",
+      "publishedAt": "2026-05-20T08:57:41.000Z",
+      "updatedAt": "2026-05-20T08:57:41.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19847v1",
-      "title": "Auditing Privacy in Multi-Tenant RAG under Account Collusion",
-      "summary": "Multi-tenant retrieval-augmented generation (RAG) services advertise per-account differential privacy as the operative leakage boundary: each account's queries are guaranteed to satisfy $(\\varepsilon_{\\text{acc}}, δ_{\\text{acc}})$-DP with respect to the index. We identify same-index multi-account collusion as a privacy-boundary failure: for $k$ same-tenant accounts coordinating against the tenant's index -- the operative regime -- known DP composition theory implies joint leakage degrades unconditionally at rate $Θ(\\sqrt{k} \\cdot \\varepsilon_{\\text{acc}})$ for Gaussian-noised retrieval. Cross-tenant and external collusion match the rate only under explicit access-control failure (M4); without M4 these regimes have zero leakage by design and reduce to an architectural audit, not a DP audit. We exhibit an attack realizing the rate and derive a RAG-specific MIA prediction we test empirically. To make this per-account/joint gap auditable, we design the first audit protocol that operates against unmodified RAG deployments and issues a quantitative $(\\textsf{PASS}, \\varepsilon_{\\text{audit}})$ verdict for the retrieval-score channel -- the noise-then-select step the per-account DP guarantee actually covers -- without index disclosure, pipeline redesign, or model-weight exposure. Generation-channel privacy (LLM output conditioned on selected documents) is a separate audit predicate that should compose with ours; we explicitly scope it out. The protocol composes generic cryptographic primitives (Merkle ledgers, ZK function-application proofs, Gaussian noise attestations) with six RAG-specific primitives (embedder commitment, index-content vector commitment, per-account query ledger, noise-then-select attestation, cross-tenant containment proof, coalition-size estimator) and supports both closed-form audit bounds and Rényi-DP moments-accountant tracking.",
+      "arxivId": "2605.20876v1",
+      "title": "Terminal-World: Scaling Terminal-Agent Environments via Agent Skills",
+      "summary": "Terminal agents extend Large Language Models with the ability to execute tasks directly in command-line environments, but their progress is bottlenecked by the scarcity of high-quality training data. Existing approaches bootstrap from partial sources such as human-defined seeds or GitHub repositories to instantiate one component and then complete the rest, producing tasks confined to narrow seed distributions, environments misaligned with task semantics, and inefficient trajectories from unguided exploration. To address these limitations, we introduce Terminal-World, a fully automated pipeline that uses agent skills as the central synthesis primitive, which jointly encode what to accomplish, when to apply (preconditions and environment state), and how to execute, enabling task instructions, environments, and teacher trajectories to be co-derived. To further broaden the synthesis space, Terminal-World composes skills into skill teams and skill graphs for multi-role and cross-domain task synthesis. Using this pipeline, we construct 5,723 training environments and train Terminal-World-8B/14B/32B, evaluated across 6 benchmarks where the Terminal-World series consistently outperforms terminal-agent baselines. Notably, using the same teacher model and only 1.2% of the training data, Terminal-World-32B surpasses Nemotron-Terminal-32B on Terminal-Bench 2.0 by +4.5 Pass@1 (31.5) and achieves 43.8 Pass@3.",
       "authors": [
-        "Florian A. D. Burnat",
-        "Brittany I. Davidson"
+        "Zihao Cheng",
+        "Hongru Wang",
+        "Zeming Liu",
+        "Xinyi Wang",
+        "Xiangrong Zhu",
+        "Yuhang Guo",
+        "Wei Lin",
+        "Jeff Z. Pan",
+        "Yunhong Wang"
       ],
       "categories": [
-        "cs.CR",
+        "cs.CL",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20876v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20876v1",
+      "publishedAt": "2026-05-20T08:14:51.000Z",
+      "updatedAt": "2026-05-20T08:14:51.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.20833v1",
+      "title": "MemGym: a Long-Horizon Memory Environment for LLM Agents",
+      "summary": "Memory is a central capability for LLM agents operating across long-horizon tasks. Existing memory benchmarks predominantly evaluate retention of personalized information in multi-turn chat scenarios, overlooking the dynamic memory formation that occurs during extended agent execution. Consequently, the memory systems they produce transfer poorly to realistic agentic environments, such as coding and web navigation. We present MemGym, a benchmark for agentic memory that unifies existing agent gyms and in-house memory-grounded pipelines behind one memory-reasoning interface. MemGym spans five evaluation tracks grouped into four agentic regimes: tool-use dialogue (tau2-bench), multi-turn deep-research search (MEMGYM-DR), coding (SWE-Gym and MEMGYM-CODEQA), and computer use (WebArena-Infinity). MemGym reports memory-isolated scores that decouple memory performance from reasoning, retrieval, and tool-use ability, so memory strategies can be ranked without those confounders. Our synthetic pipelines for MEMGYM-CODEQA and MEMGYM-DR are length-controllable, ablation-verified at every stage, and tightly aligned with downstream scenarios. To make evaluation on coding environments academically tractable, we train MemRM, a lightweight reward model (Qwen3-1.7B fine-tuned with QLoRA) that scores compression quality as a fast scalar read in place of full Docker rollouts.",
+      "authors": [
+        "Wujiang Xu",
+        "Yu Wang",
+        "Kai Mei",
+        "Kaiqu Liang",
+        "Zhenting Wang",
+        "Mingyu Jin",
+        "Han Zhang",
+        "Shi-Xiong Zhang",
+        "Wenyue Hua",
+        "Sambit Sahu",
+        "Dimitris N. Metaxas"
+      ],
+      "categories": [
+        "cs.CL"
+      ],
+      "primaryCategory": "cs.CL",
+      "absUrl": "https://arxiv.org/abs/2605.20833v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20833v1",
+      "publishedAt": "2026-05-20T07:25:33.000Z",
+      "updatedAt": "2026-05-20T07:25:33.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.20815v1",
+      "title": "GraphRAG on Consumer Hardware: Benchmarking Local LLMs for Healthcare EHR Schema Retrieval",
+      "summary": "Graph-based Retrieval Augmented Generation (GraphRAG) extends retrieval-augmented generation to support structured reasoning over complex corpora, but its reliability under resource-constrained, privacy-sensitive deployments remains unclear. In healthcare, where Electronic Health Record (EHR) data is complex and strictly regulated, reliance on cloud-based large language models (LLMs) introduces challenges in cost, latency, and compliance. In this work, we present a systematic evaluation of GraphRAG for EHR schema retrieval using locally deployed open-source LLMs. We implement the Microsoft GraphRAG pipeline on real-world EHR schema documentation and benchmark four models, including Llama 3.1 (8B), Mistral (7B), Qwen 2.5 (7B), and Phi-4-mini (3.8B), each deployed via Ollama on a single consumer GPU (8 GB VRAM). We evaluate indexing efficiency, knowledge graph construction, query latency, answer quality, and hallucination under both global and local retrieval modes. Our results reveal substantial differences: Llama 3.1 produces the richest knowledge graph (1,172 entities), Qwen 2.5 achieves the best answer quality (3.3/5), Phi-4-mini fails to complete the pipeline due to structured-output errors, and Mistral exhibits degenerate repetition behavior. We further show that GraphRAG exhibits a practical capacity threshold, where models below approximately 7B parameters fail to reliably produce valid structured outputs and cannot complete the pipeline. In addition, indexing and answer quality are decoupled across models, and local retrieval consistently outperforms global summarization in both latency and factual grounding, with reduced hallucination. These findings demonstrate that GraphRAG is feasible on consumer hardware while highlighting the importance of model selection and retrieval design for robust deployment in regulated settings.",
+      "authors": [
+        "Peter Fernandes",
+        "Ria Kanjilal"
+      ],
+      "categories": [
+        "cs.CL",
+        "cs.AI",
         "cs.IR",
         "cs.LG"
       ],
-      "primaryCategory": "cs.CR",
-      "absUrl": "https://arxiv.org/abs/2605.19847v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19847v1",
-      "publishedAt": "2026-05-19T13:41:59.000Z",
-      "updatedAt": "2026-05-19T13:41:59.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19846v1",
-      "title": "FineBench: Benchmarking and Enhancing Vision-Language Models for Fine-grained Human Activity Understanding",
-      "summary": "Vision-Language Models (VLMs) have demonstrated remarkable capabilities in general video understanding, yet they often struggle with the fine-grained comprehension crucial for real-world applications requiring nuanced interpretation of human actions and interactions. While some recent human-centric benchmarks evaluate aspects of model behaviour such as fairness/ethics, emotion perception, and broader human-centric metrics, they do not combine long-form videos, very dense QA coverage, and frame-level spatial/temporal grounding at scale. To bridge this gap, we introduce FineBench, a human-centric video question answering (VQA) benchmark specifically designed to assess fine-grained understanding. FineBench comprises 199,420 multiple-choice QA pairs densely annotated across 64 long-form videos (15 minutes each), focusing on detailed person movement, person interaction, and object manipulation, including compositional actions. Our extensive evaluation reveals that while proprietary models like GPT-5 achieve respectable performance, current open-source VLMs significantly underperform, struggling particularly with spatial reasoning in multi-person scenes and distinguishing subtle differences in human movements and interactions. To address these identified weaknesses, we propose FineAgent, a modular framework that enhances VLMs by leveraging a Localizer and a Descriptor. Experiments show that FineAgent consistently improves the performance of various open VLMs on FineBench. FineBench provides a rigorous testbed for future research into fine-grained human-centric video understanding, while FineAgent offers a practical approach to enhance such reasoning in current VLMs.",
-      "authors": [
-        "Gueter Josmy Faure",
-        "Min-Hung Chen",
-        "Jia-Fong Yeh",
-        "Hung-Ting Su",
-        "Winston H. Hsu"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.AI",
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19846v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19846v1",
-      "publishedAt": "2026-05-19T13:40:26.000Z",
-      "updatedAt": "2026-05-19T13:40:26.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19839v1",
-      "title": "When Preference Labels Fall Short: Aligning Diffusion Models from Real Data",
-      "summary": "Preference alignment aims to guide generative models by learning from comparisons between preferred and non-preferred samples. In practice, most existing approaches rely on preference pairs constructed from model-generated images. Such supervision is inherently relative and can be ambiguous when both samples exhibit artifacts or limited visual quality, making it difficult to infer what constitutes a truly desirable output. In this work, we investigate whether real data can serve as an alternative source of supervision for preference alignment. We adopt a data-centric perspective and study a curation strategy that treats real images as reference points and constructs preference signals by contrasting them with generated or perturbed samples, without requiring manually annotated preference pairs. Through empirical analysis, we show that real-data-based supervision provides effective guidance for aligning diffusion models and achieves performance comparable to existing preference-based methods. Our results suggest that real data offers a practical and complementary source of supervision for preference alignment and highlight directions of label-efficient alignment strategies. Code and models are available at https://cwyxx.github.io/RealAlign.",
-      "authors": [
-        "Weiyan Chen",
-        "Weijian Deng",
-        "Yao Xiao",
-        "Weijie Tu",
-        "ZiYi Dong",
-        "Ibrahim Radwan",
-        "Liang Lin",
-        "Pengxu Wei"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19839v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19839v1",
-      "publishedAt": "2026-05-19T13:35:11.000Z",
-      "updatedAt": "2026-05-19T13:35:11.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19837v1",
-      "title": "CADENet: Condition-Adaptive Asynchronous Dual-Stream Enhancement Network for Adverse Weather Perception in Autonomous Driving",
-      "summary": "Adverse weather (rain, fog, sand, and snow) degrades camera-based object detection in autonomous vehicles. Existing enhancement-then-detect approaches stall the safety-critical perception loop, violating hard real-time requirements. Progress on this problem is also constrained by an under-recognized evaluation ceiling: ground truth annotated on degraded images cannot credit a detector that recovers objects the annotators themselves could not see, so a genuinely useful enhancement can register as a near-flat F1 gain. This paper presents CADENet (Condition-Adaptive Asynchronous Dual-stream Enhancement Network), a training-free three-thread system: Thread S (YOLOv11n) delivers detections at full frame rate with zero added latency; Thread Q applies condition-adaptive enhancement (CAPE) and fuses results via entropy-guided NMS (EG-NMS) without blocking Thread S; Thread E provides CLIP zero-shot weather classification, so new weather categories require only a new text prompt, with no labeled data and no retraining. Evaluated on 1327 DAWN images (YOLOv11m, IoU = 0.5, confidence = 0.25), CADENet achieves Recall = 0.0103 (micro), F1 = 0.0230 on snow, and F1 = 0.0038 on rain. We formalize the annotation completeness bias on DAWN-class data, so the reported F1 values are lower bounds on the true gain; recall is the annotation-gap-immune headline metric. Thread S sustains approximately 44 FPS regardless of enhancement load. No model retraining or additional sensor hardware is required.",
-      "authors": [
-        "Sherif Khairy",
-        "Catherine M. Elias"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.AI",
-        "cs.CL",
-        "cs.RO"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19837v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19837v1",
-      "publishedAt": "2026-05-19T13:30:28.000Z",
-      "updatedAt": "2026-05-19T13:30:28.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19833v1",
-      "title": "Mega-ASR: Towards In-the-wild^2 Speech Recognition via Scaling up Real-world Acoustic Simulation",
-      "summary": "Despite rapid advances in automatic speech recognition (ASR) and large audio-language models, robust recognition in real-world environments remains limited by an \"acoustic robustness bottleneck\": models often lose acoustic grounding and produce omissions or hallucinations under severe, compositional distortions. We propose Mega-ASR, a unified ASR-in-the-wild framework that combines scalable compound-data construction with progressive acoustic-to-semantic optimization. We introduce Voices-in-the-Wild-2M, covering 7 classic acoustic phenomena and 54 physically plausible compound scenarios, and train Mega-ASR with Acoustic-to-Semantic Progressive Supervised Fine-Tuning and Dual-Granularity WER-Gated Policy Optimization. Extensive experiments demonstrate that Mega-ASR achieves significant advantages over prior state-of-the-art systems on adverse-condition ASR benchmarks (45.69% vs. 54.01% on VOiCES R4-B-F, and 21.49% vs. 29.34% on NOIZEUS Sta-0). On complex compositional acoustic scenarios, Mega-ASR further delivers over 30% relative WER reduction against strong open- and closed-source baselines, establishing a scalable paradigm for robust ASR in-the-wild.",
-      "authors": [
-        "Zhifei Xie",
-        "Kaiyu Pang",
-        "Haobin Zhang",
-        "Deheng Ye",
-        "Xiaobin Hu",
-        "Shuicheng Yan",
-        "Chunyan Miao"
-      ],
-      "categories": [
-        "cs.SD",
-        "cs.AI",
-        "cs.CL",
-        "cs.MM",
-        "eess.AS"
-      ],
-      "primaryCategory": "cs.SD",
-      "absUrl": "https://arxiv.org/abs/2605.19833v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19833v1",
-      "publishedAt": "2026-05-19T13:26:51.000Z",
-      "updatedAt": "2026-05-19T13:26:51.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19824v1",
-      "title": "From Prompts to Pavement Through Time: Temporal Grounding in Agentic Scene-to-Plan Reasoning",
-      "summary": "Recent attempts to support high-level scene interpretation and planning in Autonomous Vehicles (AVs) using ensembles of Large Language Models (LLMs) and Large Multimodal Models (LMMs) continue to treat time as a secondary property. This lack of temporal grounding leads to inconsistencies in reasoning about continuous actions, undermining both safety and interpretability. This work explores whether temporal conditioning within inter-agent communication can preserve or enhance coherence without introducing degradation in semantic or logical consistency. To investigate this, we introduce three planner architectures with progressively increasing temporal integration and evaluate them on curated subsets of the BDD-X dataset using semantic, syntactic, and logical metrics. Results show that while temporal conditioning reshapes reasoning style, it yields no statistically significant improvements in standard NLP-based correctness metrics. However, qualitative analysis reveals predictive hazard reasoning, stable corrective behavior, and strategic divergence in the Sentinel. These findings clarify the limits of prompt-based temporal grounding and establish the first empirical benchmark for temporal scene-to-plan reasoning.",
-      "authors": [
-        "Ahmed Y. Gado",
-        "Omar Y. Goba",
-        "Alaa Hassanein",
-        "Catherine M. Elias",
-        "Ahmed Hussein"
-      ],
-      "categories": [
-        "cs.AI",
-        "cs.CL",
-        "cs.CV",
-        "cs.RO"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19824v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19824v1",
-      "publishedAt": "2026-05-19T13:18:35.000Z",
-      "updatedAt": "2026-05-19T13:18:35.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19821v1",
-      "title": "LaCoVL-FER: Landmark-Guided Contrastive Learning Network with Vision-Language Enhancement for Facial Expression Recognition",
-      "summary": "Facial Expression Recognition (FER) in the wild is still challenging due to uncontrolled variations in pose, occlusion, and illumination. Most existing attention-based methods primarily rely on visual appearance cues, suffering from attention redundancy and instability, which limits their performance in complex scenarios. To address these issues, we propose a novel landmark-guided contrastive learning network with vision-language enhancement for FER (LaCoVL-FER), which integrates geometric priors from facial landmarks and semantic priors from a vision-language model. Specifically, a Landmark-Guided Adaptive Encoder (LGAE) is designed to introduce geometric priors through a Bi-branch Gated Cross Attention (BGCA) mechanism, which achieves adaptive fusion of landmark-based geometric and visual appearance features to produce expression-relevant features, thereby focusing on key facial regions and suppressing noise interference. In parallel, a Vision-Language Enhancement Strategy (VLES) is presented to leverage the expression-relevant features to refine the generalizable visual features extracted by the frozen pretrained CLIP image encoder, yielding expression-specific visual representations. Based on these representations, an Expression-Conditioned Prompting (ECP) mechanism is utilized to further adapt the textual features of fixed class-level prompts from the frozen pretrained CLIP text encoder, generating more instance-aware textual representations. These visual-textual representations are aligned as semantic priors to enhance the robustness and generalization of FER. Quantitative and qualitative experiments demonstrate that our LaCoVL-FER outperforms state-of-the-art methods on three representative real-world FER datasets, including RAF-DB, FERPlus, and AffectNet. The code is available at https://github.com/ylin06804/LaCoVL-FER.",
-      "authors": [
-        "Jiaxin Wang",
-        "Muwei Jian",
-        "Hui Yu",
-        "Junyu Dong",
-        "Yifan Xia"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19821v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19821v1",
-      "publishedAt": "2026-05-19T13:15:41.000Z",
-      "updatedAt": "2026-05-19T13:15:41.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19815v1",
-      "title": "LP-Eval: Rubric and Dataset for Measuring the Quality of Legal Proposition Generation",
-      "summary": "Legal proposition generation is central to legal reasoning and doctrinal scholarship, yet remain under-examined in Legal NLP. This paper investigates the automatic generation and evaluation of legal propositions from decisions of the Court of Justice of the European Union using large language models (LLMs). We introduce LP-Eval, a three-step evaluation rubric co-designed with legal experts that decomposes legal proposition quality into formal validity and substantive dimensions. Using this rubric, we release a dataset of two experts' annotations for 100 LLM-generated legal propositions. Our results show that LLMs can generate predominantly well-formed and high-quality propositions, while expert evaluations reveal higher quality for propositions derived from well established cases than from recent ones. We further examine LLMs as evaluators and find that rubric-guided LLM judgments align more closely with expert assessments than direct overall scoring, but remain insensitive to finer-grained distinctions captured by human experts.",
-      "authors": [
-        "Shanshan Xu",
-        "Johan Lindholm",
-        "Amogh Raina",
-        "Henrik Palmer Olsen",
-        "Daniel Hershcovich"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19815v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19815v1",
-      "publishedAt": "2026-05-19T13:10:39.000Z",
-      "updatedAt": "2026-05-19T13:10:39.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.20815v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20815v1",
+      "publishedAt": "2026-05-20T07:09:53.000Z",
+      "updatedAt": "2026-05-20T07:09:53.000Z",
       "linkedRepos": []
     },
     {
-      "arxivId": "2605.19806v1",
-      "title": "Chunking German Legal Code",
-      "summary": "This paper investigates chunking strategies for retrieval-augmented generation on German statutory law, using the German Civil Code as a structured benchmark corpus. We implement and compare a range of segmentation approaches, including structural units (sections, subsections, sentences, propositions), fixed-size windows, contextual chunking, semantic clustering, Lumber-style chunking, and RAPTOR-based hierarchical retrieval. All methods are evaluated on a legal question-answering dataset with section-level gold labels, measuring recall, query latency, index build time, and storage requirements. Results show that chunking strategies aligned with the inherent legal structure - particularly section and subsection - based retrieval-achieve the highest recall, while more complex approaches that override this structure perform worse. These simpler methods also offer favorable computational efficiency compared to LLM-intensive techniques such as contextual chunking, RAPTOR, and Lumber. The findings highlight a key trade-off between semantic enrichment and operational cost, and demonstrate that preserving domain-specific structure is critical for effective legal information retrieval.",
+      "arxivId": "2605.20813v1",
+      "title": "PulseCol: Periodically Refreshed Column-Sparse Attention for Accelerating Diffusion Language Models",
+      "summary": "Inference in diffusion large language models (dLLMs) is computationally expensive, as full self-attention must be repeatedly executed at each step of the denoising process without KV cache. Recent sparse attention methods for dLLMs mitigate this cost via block-sparse computation, which is applied only in later iterations when model performance is less sensitive to coarse-grained sparse approximation, but yields limited improvements in computational efficiency and acceleration. This motivates a finer-grained sparsification strategy that can be applied from earlier iterations and leverages reusable sparsity patterns, enabling further efficiency gains. In this work, we introduce PulseCol, a periodically refreshed column-sparse attention method for accelerating diffusion language models. PulseCol replaces coarse block-level sparsity with a finer-grained column-sparse structure, allowing important attention interactions to be retained more precisely while exposing greater sparsity. Built on this column-level formulation, PulseCol further identifies sparse patterns at the early denoising step and reuses them across subsequent iterations, refreshing them only at a small number of intermediate steps to track the evolution of sparse attention patterns during denoising. Experiments show that PulseCol achieves higher sparsity and greater practical speedup than prior sparse attention methods for dLLMs, while maintaining model quality. Enabled by optimized GPU kernels for column-sparse attention, PulseCol delivers up to 1.95$\\times$ end-to-end speedup over FlashAttention across several context lengths.",
       "authors": [
-        "Max Prior",
-        "Natalia Milanova",
-        "Andreas Schultz"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19806v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19806v1",
-      "publishedAt": "2026-05-19T13:04:58.000Z",
-      "updatedAt": "2026-05-19T13:04:58.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19804v1",
-      "title": "Stitched Value Model for Diffusion Alignment",
-      "summary": "For practical use, diffusion- or flow-based generative models must be aligned with task-specific rewards, such as prompt fidelity or aesthetic preference. That alignment is challenging because the reward is defined for clean output images, but the alignment procedure requires value function estimates at noisy intermediate latents. Existing methods resort to Tweedie-style or Monte Carlo approximations, trading off estimator bias against computational cost: Tweedie estimates are efficient but biased, while Monte Carlo estimates are more accurate but require expensive rollouts. A natural alternative would be a learned value function, but it remains an open question how to effectively train a strong and general value model specifically for noisy latents. Here, we propose StitchVM, a model stitching framework that efficiently transfers reward models pretrained for clean images to the noisy latent regime. StitchVM starts from an existing, truncated pixel-space reward model and attaches a frozen diffusion backbone to it as its head. From the pixel-space model, the resulting hybrid retains a carefully pretrained, robust reward capability; from the diffusion backbone, it inherits its native ability to handle noisy latents. The stitching procedure is exceptionally lightweight, e.g., stitching and finetuning CLIP ViT-L and SD 3.5 Medium takes only 10 GPU-hours. By lifting powerful pixel-space reward models to latent space, StitchVM opens up a new style of diffusion alignment: instead of rough, yet costly per-sample approximation of the value function, the correct function for the actual, noisy latents is constructed once and then amortized over many samples and iterations. We show that this approach yields improvements across a broad range of downstream steering and post-training methods: DPS becomes $3.2\\times$ faster while halving peak GPU memory, and DiffusionNFT becomes $2.3\\times$ faster.",
-      "authors": [
-        "Hyojun Go",
-        "Hyungjin Chung",
-        "Prune Truong",
-        "Goutam Bhat",
-        "Li Mi",
-        "Zhaochong An",
-        "Zixiang Zhao",
-        "Dominik Narnhofer",
-        "Serge Belongie",
-        "Federico Tombari",
-        "Konrad Schindler"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.AI",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19804v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19804v1",
-      "publishedAt": "2026-05-19T13:02:50.000Z",
-      "updatedAt": "2026-05-19T13:02:50.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19799v1",
-      "title": "Synergistic Foundation Models for Semi-Supervised Fetal Cardiac Ultrasound Analysis: SAM-Med2D Boundary Refinement and DINOv3 Semantic Enhancement",
-      "summary": "We present a semi-supervised framework for joint segmentation and classification of fetal cardiac ultrasound images. Built upon the EchoCare multi-task backbone, our method integrates SAM-Med2D for boundary refinement and leverages DINOv3 to enhance pseudo-label quality. We introduce view-specific hard masking along with a two-stage optimization strategy: an EMA phase to consolidate segmentation capabilities, followed by a Classification Fine-Tuning phase that freezes segmentation parameters and resets the classification head to recover classification performance without compromising segmentation gains. Evaluated on the FETUS 2026 leaderboard, our method achieves a Dice Similarity Coefficient at 79.99%, Normalized Surface Distance at 61.62%, and F1-score at 41.20%, validating the effectiveness of our approach for prenatal congenital heart disease screening. Source code is publicly available at: https://github.com/2826056177/zcst_fetus2026.",
-      "authors": [
-        "Tonghao Zhuang",
-        "Shanglong Hu",
-        "Yongsheng Luo",
-        "Zhiqi Zhang",
-        "Yu Li"
-      ],
-      "categories": [
-        "cs.CV",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19799v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19799v1",
-      "publishedAt": "2026-05-19T13:00:19.000Z",
-      "updatedAt": "2026-05-19T13:00:19.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19798v1",
-      "title": "Towards Trust Calibration in Socially Interactive Agents: Investigating Gendered Multimodal Behaviors Generation with LLMs",
-      "summary": "As Socially Interactive Agents (SIAs) become increasingly integrated into daily life, the ability to calibrate user trust to an agent's actual capabilities would help ensure appropriate usage of these agents. In this paper, we explore the capacity of Large Language Models (LLMs) to generate multimodal behaviors (verbal, vocal, gestural, and facial expression modalities) that reflect varying levels of ability and benevolence, two key dimensions of trustworthiness. We propose a novel method for automatically generating behaviors aligned with specific levels of these traits, a first step towards enabling nuanced and trust-calibrated interactions. By analyzing a large dataset of multimodal transcripts generated by LLMs, we demonstrate that GPT-5.4 is able to produce coherent behavior across different modalities (text, intonation, facial expression, and gesture). Using Random Forest feature importance analysis, we show that the generated behaviors align with theoretical expectations for ability and benevolence. However, we also find that when gender is specified in the prompt, LLMs tend to reproduce societal gender stereotypes, associating male agents' behaviors with high ability and female agents' behaviors with high benevolence. To validate our approach, we conducted a user study on Prolific using a within-subjects design. Participants perceived different levels of ability and benevolence in the generated behaviors align with the intended instructions.",
-      "authors": [
-        "Lucie Galland",
-        "Chloé Clavel",
-        "Magalie Ochs"
+        "Yanyi Lyu",
+        "Letian Chen",
+        "Futing Sun",
+        "Miao Zhang",
+        "Weili Guan",
+        "Liqiang Nie"
       ],
       "categories": [
         "cs.CL"
       ],
       "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19798v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19798v1",
-      "publishedAt": "2026-05-19T12:59:21.000Z",
-      "updatedAt": "2026-05-19T12:59:21.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19797v1",
-      "title": "Depth2Pose: A Pose-Based Benchmark for Monocular Depth Estimation without Ground-Truth Depth",
-      "summary": "Monocular depth estimation has improved significantly in recent years, driven by increasingly powerful models and large-scale training data. Predicted depth is increasingly used as an input signal for downstream tasks such as Structure-from-Motion (SfM), visual localization, and SLAM. However, monocular depth estimators (MDEs) are still primarily evaluated in terms of depth accuracy. Standard metrics aggregate errors globally and may not reflect the usefulness of depth for downstream geometric tasks. We therefore propose Depth2Pose, a framework for evaluating MDEs in the context of downstream tasks. By combining depth predictions with feature correspondences in depth-aware geometric solvers, we use relative camera pose estimation accuracy as a task-driven proxy for depth quality. Traditional benchmarks require dense ground truth in the form of per-pixel depth, which is expensive to obtain. In contrast, our formulation requires only camera poses, which can be estimated efficiently, e.g., using Structure-from-Motion pipelines. As a result, our framework can be applied to scenes where ground-truth depth is difficult to obtain, for example due to large scene scale or heavy occlusions (e.g., vegetated environments). Leveraging this, we introduce the D2P dataset, which contains challenging scenes outside the distribution of commonly used training data. We show that methods performing well under standard depth error metrics on existing benchmarks also perform well under our pose-based metric when evaluated on the same datasets, but do not necessarily generalize to our more challenging dataset. Finally, we provide a simple and extensible evaluation framework. The dataset and code are available at kocurvik.github.io/depth2pose.",
-      "authors": [
-        "Viktor Kocur",
-        "Sithu Aung",
-        "Gabrielle Flood",
-        "Yaqing Ding",
-        "Lukas Bujnak",
-        "Torsten Sattler",
-        "Zuzana Kukelova"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19797v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19797v1",
-      "publishedAt": "2026-05-19T12:59:11.000Z",
-      "updatedAt": "2026-05-19T12:59:11.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19792v1",
-      "title": "Mechanisms of Object Localization in Vision-Language Models",
-      "summary": "Visually-grounded language models (VLMs) are highly effective in linking visual and textual information, yet they often struggle with basic classification and localization tasks. While classification mechanisms have been studied more extensively, the processes that support object localization remain poorly understood. In this work, we investigate two representative families, LLaVA-1.5 and InternVL-3.5, using a suite of mechanistic interpretability tools, including token ablations, attention knockout, and causal mediation analysis. We find that localization is driven by a containerization mechanism in which object-aligned tokens define the spatial extent of the object, while the semantic arrangement of tokens within those boundaries is largely irrelevant to the predicted box. Only a very small set of attention heads mediates the causal effect for both classification and localization, concentrating in early-mid layers for LLaVA and mid-late layers for InternVL. The two tasks share some early processing but ultimately depend on largely distinct specialized heads. Overall, we provide the first layer- and head-level account of localization in VLMs, revealing narrow computational pathways that can guide future model design and grounding objectives.",
-      "authors": [
-        "Timothy Schaumlöffel",
-        "Martina G. Vilas",
-        "Gemma Roig"
-      ],
-      "categories": [
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CV",
-      "absUrl": "https://arxiv.org/abs/2605.19792v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19792v1",
-      "publishedAt": "2026-05-19T12:56:32.000Z",
-      "updatedAt": "2026-05-19T12:56:32.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19766v1",
-      "title": "Synthesis and Evaluation of Long-term History-aware Medical Dialogue",
-      "summary": "An effective healthcare agent must be able to recall and reason over a patient's longitudinal medical history. However, the absence of datasets with realistic long-term dialogue timelines limits systematic evaluation. Real clinical text is constrained by privacy and ethics, while existing benchmarks focus on isolated interactions, failing to capture cross-session reasoning. We introduce a framework for synthesizing high-quality, long-term medical dialogues with LLMs. Our approach entails a knowledge-guided decomposition into three stages: constructing synthetic patient profiles with diverse disease and complication trajectories, generating multi-turn dialogues per encounter, and integrating them into a coherent longitudinal history dataset, MediLongChat. We establish three benchmark tasks-In-dialogue Reasoning, Cross-dialogue Reasoning, and Synthesis Reasoning-to evaluate the memory capabilities of healthcare agents. To assess data quality, we introduce a multi-dimensional evaluation framework combining vector-based metrics with LLM-as-a-judge assessments. Specifically, we define automatic measures-Faithfulness, Coherence, and Diversity-together with two LLM-based evaluations: Correctness and Realism. Benchmark experiments show that even state-of-the-art LLMs struggle with MediLongChat. These findings highlight the benchmark's applicability and underscore the need for tailored methods to advance healthcare agents.",
-      "authors": [
-        "Hebin Hu",
-        "Renke Dai",
-        "Ah-Hwee Tan",
-        "Yilin Kang"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19766v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19766v1",
-      "publishedAt": "2026-05-19T12:38:41.000Z",
-      "updatedAt": "2026-05-19T12:38:41.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19762v1",
-      "title": "What Really Improves Mathematical Reasoning: Structured Reasoning Signals Beyond Pure Code",
-      "summary": "Code has become a standard component of modern foundation language model (LM) training, yet its role beyond programming remains unclear. We revisit the claim that code improves reasoning through controlled pretraining experiments on a 10T-token corpus with fine-grained domain separation. Our findings are threefold. First, when code is restricted to standalone executable programs and Code-NL data are controlled for, code substantially improves programming ability but does not act as a general reasoning enhancer; instead, it competes with knowledge-intensive tasks, especially complex mathematical reasoning. Second, the reasoning gains often attributed to code are better explained by cross-domain structured reasoning traces, such as code-text and math-text mixtures, rather than by executable code alone. Third, increasing the density of structured math-domain samples within a fixed math budget yields substantial gains on difficult mathematical reasoning while largely preserving programming performance, suggesting that cognitive scaffolds offer a targeted way to mitigate cross-domain trade-offs. Finally, routing analyses show that data-composition effects are reflected in expert-activation patterns, providing mechanism-level evidence for competitive and synergistic interactions across domains. Our results clarify which data characteristics transfer across capability dimensions and point to more precise data-centric optimization strategies.",
-      "authors": [
-        "Yuze Zhao",
-        "Junpeng Fang",
-        "Lu Yu",
-        "Zhenya Huang",
-        "Kai Zhang",
-        "Qing Cui",
-        "Qi Liu",
-        "Jun Zhou",
-        "Enhong Chen"
-      ],
-      "categories": [
-        "cs.AI",
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19762v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19762v1",
-      "publishedAt": "2026-05-19T12:37:01.000Z",
-      "updatedAt": "2026-05-19T12:37:01.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19738v1",
-      "title": "TERGAD: Structure-Aware Text-Enhanced Representations for Graph Anomaly Detection",
-      "summary": "Graph Anomaly Detection (GAD) aims to identify atypical graph entities, such as nodes, edges, or substructures, that deviate significantly from the majority. While existing text-rich approaches typically integrate structural context into the data representation pipeline using raw textual features, they often neglect the structural context of nodes. This limitation hinders their ability to detect sophisticated anomalies arising from inconsistencies between a node's inherent content and its topological role. To bridge this gap, we propose TERGAD (Structure-aware Text-enhanced Representations for Graph Anomaly Detection), A novel data augmentation framework that enriches structural semantics for GAD via the semantic reasoning capabilities of Large Language Models (LLMs). Specifically, TERGAD translates node-level topological properties into descriptive natural language narratives, which are subsequently processed by an LLM to derive high-level semantic embeddings. These embeddings are then adaptively fused with original node attributes through a gated dual-branch autoencoder to jointly reconstruct both graph structure and node features. The anomaly score is computed based on the integrated reconstruction error, effectively capturing deviations in both observable attributes and LLM-informed semantic expectations. Extensive experiments on six real-world datasets demonstrate that TERGAD consistently outperforms state-of-the-art baselines. Furthermore, our ablation studies validate the indispensable role of structural semantic guidance and the efficacy of the gated fusion mechanism. Code is available at https://github.com/Kantorakitty/TERGAD-main.",
-      "authors": [
-        "Wen Shi",
-        "Zhe Wang",
-        "Huafei Huang",
-        "Qing Qing",
-        "Ziqi Xu",
-        "Qixin Zhang",
-        "Xikun Zhang",
-        "Renqiang Luo",
-        "Feng Xia"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19738v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19738v1",
-      "publishedAt": "2026-05-19T12:09:36.000Z",
-      "updatedAt": "2026-05-19T12:09:36.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19735v1",
-      "title": "ContextRAG: Extraction-Free Hierarchical Graph Construction for Retrieval-Augmented Generation",
-      "summary": "Graph-structured retrieval-augmented generation (RAG) systems can improve answer quality on multi-hop questions, but many current systems rely on large language models (LLMs) to extract entities, relations, and summaries during indexing. These calls add token and wall-clock costs that grow with corpus size. We present ContextRAG, a graph RAG system whose graph topology is constructed without LLM-based entity or relation extraction. ContextRAG derives a fuzzy concept graph over chunk embeddings using residual-quantization k-means and Formal Concept Analysis with Lukasiewicz residuated logic. Bridge-like and meet-derived context nodes are induced by soft fuzzy join and meet operations, rather than by LLM-written graph edges. On a 130-task UltraDomain subset, ContextRAG builds its index with 30 LLM calls and 22,073 tokens. In contrast, a local HiRAG reproduction stress test required 870 indexing calls and 3.54M tokens on a 20-task subset before failing during graph construction; linear extrapolation to 130 tasks implies over 23M indexing tokens. ContextRAG obtains 33.6% F1 overall and 36.8% F1 on multi-hop tasks. An activation analysis shows that queries retrieving at least one lattice-derived node in the top five achieve +3.9 percentage points F1 over queries that do not; this association is diagnostic rather than causal.",
-      "authors": [
-        "Roman Prosvirnin",
-        "Sergei Kuznetsov",
-        "Seungmin Jin"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19735v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19735v1",
-      "publishedAt": "2026-05-19T12:08:19.000Z",
-      "updatedAt": "2026-05-19T12:08:19.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19723v1",
-      "title": "Mathematical Reasoning in Large Language Models: Benchmarks, Architectures, Evaluation, and Open Challenges",
-      "summary": "Mathematical reasoning is essential for problem-solving in education, science, and industry, serving as a crucial benchmark for evaluating artificial intelligence systems. As Large Language Models (LLMs) improve their reasoning capabilities, understanding how well they perform mathematical reasoning has become increasingly important. This survey synthesizes recent advancements in mathematical reasoning with LLMs through a structured analysis of datasets, architectures, training strategies, and evaluation protocols. Our systematic review encompasses approximately 120 peer-reviewed studies and preprints, examining the evolution of this research area and providing a unified analytical framework to understand current progress and limitations. Our study particularly introduces a unified taxonomy of mathematical datasets, distinguishing between pretraining corpora, supervised fine-tuning resources, and evaluation benchmarks across varying levels of reasoning complexity. A systematic analysis of reasoning architectures and training strategies, including tool integration, verifier-guided reasoning, and parameter-efficient adaptation, is presented to assess their effects on reasoning robustness and generalization. Moreover, a comparative evaluation of existing metrics highlights the gap between final-answer accuracy and process-level reasoning verification. By synthesizing insights across these areas, our analysis identifies recurring failure modes, such as reasoning faithfulness issues, benchmark biases, and generalization limitations, and outlines key research directions toward improving symbolic grounding, evaluation reliability, and the development of more robust and trustworthy LLM-based reasoning systems.",
-      "authors": [
-        "Husnain Amjad",
-        "Raja Khurram Shahzad",
-        "Aamir Shahzad",
-        "Mehwish Fatima"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19723v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19723v1",
-      "publishedAt": "2026-05-19T11:56:03.000Z",
-      "updatedAt": "2026-05-19T11:56:03.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19718v1",
-      "title": "CAIT: A Syntactic Parsing Toolkit for Child-Adult InTeractions",
-      "summary": "CHILDES is a paramount resource for language acquisition studies -- yet computational tools for analyzing its syntactic structure remain limited. Leveraging the recent release of the UD-English-CHILDES treebank with gold-standard Universal Dependencies (UD) annotations, we train a state-of-the-art dependency parser specifically tailored to CHILDES. The parser more accurately captures syntactic patterns in child--adult interactions, outperforming widely used off-the-shelf English parsers, including SpaCy and Stanza. Alongside the parser, we also release a Part-of-Speech tagger and an utterance-level construction tagger, which together form the open-source Syntactic Parsing Toolkit for Child--Adult InTeractions (CAIT). Through a detailed error analysis and a case study tracking the distribution of syntactic constructions across developmental time in CHILDES, we demonstrate the practical utility of the toolkit for large-scale, reproducible research on language acquisition.",
-      "authors": [
-        "Francesca Padovani",
-        "Xiulin Yang",
-        "Bastian Bunzeck",
-        "Jaap Jumelet",
-        "Yevgen Matusevych",
-        "Nathan Schneider",
-        "Arianna Bisazza"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19718v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19718v1",
-      "publishedAt": "2026-05-19T11:53:08.000Z",
-      "updatedAt": "2026-05-19T11:53:08.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19714v1",
-      "title": "LLM-Based Financial Sentiment Analysis in Arabic: Evidence from Saudi Markets",
-      "summary": "Investor sentiment shapes financial markets, yet modeling sentiment in Arabic financial contexts remains challenging due to linguistic complexity and limited resources. We present an Arabic NLP framework for large-scale financial sentiment analysis tailored to the Saudi market, integrating official financial news and social media to capture institutional and public investor sentiment. The framework constructs a large Arabic financial corpus through a multi-stage pipeline encompassing data collection, cleaning, deduplication, entity linking, and sentiment annotation. Transformer-based NER combined with a curated company lexicon links textual mentions to canonical company identifiers, with sentiment labels assigned using a five-class scheme. The resulting dataset of 84K samples supports company-level sentiment aggregation and analysis of sentiment dynamics relative to stock market behavior on the Saudi Exchange. Experimental results demonstrate reliable and scalable Arabic financial sentiment analysis.",
-      "authors": [
-        "Mona H. Albaqawi",
-        "Eman M. Albalkhi",
-        "Joud A. Albaiti",
-        "Enrico Lopedoto"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19714v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19714v1",
-      "publishedAt": "2026-05-19T11:50:33.000Z",
-      "updatedAt": "2026-05-19T11:50:33.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19711v1",
-      "title": "Can Large Language Models Reliably Correct Errors in Low-Resource ASR? A Contamination-Aware Case Study on West Frisian",
-      "summary": "Automatic speech recognition (ASR) has improved substantially in recent years, yet performance remains limited for low-resource languages. Large language models (LLMs) have shown promise for improving ASR through generative error correction (GER), but their effectiveness in low-resource settings remains underexplored. In addition, it remains unclear to what extent data contamination influences the reported improvements in LLM-based GER. This study investigates LLM-based GER for low-resource Frisian. In addition to a public corpus, we construct and use a Frisian offline dataset with non-public texts for evaluation to control for potential data contamination. Results show that GER improves ASR performance in most settings, with the best GPT-5.1 results surpassing oracle WERs. Comparable gains on the offline dataset indicate that improvements reflect true correction ability. We further provide a detailed error analysis revealing model correction patterns.",
-      "authors": [
-        "Yun Hao",
-        "Reihaneh Amooie",
-        "Wietse de Vries",
-        "Rik van Noord",
-        "Martijn Wieling"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19711v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19711v1",
-      "publishedAt": "2026-05-19T11:48:32.000Z",
-      "updatedAt": "2026-05-19T11:48:32.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19660v1",
-      "title": "OScaR: The Occam's Razor for Extreme KV Cache Quantization in LLMs and Beyond",
-      "summary": "The rapid advancement toward long-context reasoning and multi-modal intelligence has made the memory footprint of the Key-Value (KV) cache a dominant memory bottleneck for efficient deployment. While the established per-channel quantization effectively accommodates intrinsic channel-wise outliers in Key tensors, its efficacy diminishes under extreme compression. In this work, we revisit the inherent limitations of the per-channel quantization paradigm from both empirical and theoretical perspectives. Our analysis identifies Token Norm Imbalance (TNI) as the primary bottleneck to quantization fidelity. We demonstrate that TNI systematically amplifies errors when shared quantization parameters are required to span token groups exhibiting substantial norm disparities. Instead of relying on intricate quantization pipelines (e.g., TurboQuant), we propose OScaR (Omni-Scaled Canalized Rotation), an accurate and lightweight KV cache compression framework for X-LLMs (i.e., text-only, multi-modal, and omni-modal LLMs). Advancing the per-channel paradigm, OScaR employs Canalized Rotation followed by Omni-Token Scaling to mitigate TNI-induced sequence-dimensional variance both effectively and efficiently, further supported by our optimized system design and CUDA kernels. Extensive evaluations across X-LLMs show that OScaR consistently outperforms existing methods and achieves near-lossless performance under INT2 quantization, establishing it as a robust, low-complexity, and universal framework that defines a new Pareto front. Compared with the BF16 FlashDecoding-v2 baseline, our OScaR implementation achieves a notable up to 3.0x speedup in decoding, reduces memory footprint by 5.3x, and increases throughput by 4.1x. The code for OScaR is publicly available at https://github.com/ZunhaiSu/OScaR-KV-Quant.",
-      "authors": [
-        "Zunhai Su",
-        "Rui Yang",
-        "Chao Zhang",
-        "Yaxiu Liu",
-        "Yifan Zhang",
-        "Wei Wu",
-        "Jing Xiong",
-        "Dayou Du",
-        "Xialie Zhuang",
-        "Yulei Qian",
-        "Yuchen Xie",
-        "Yik-Chung Wu",
-        "Hongxia Yang",
-        "Ngai Wong"
-      ],
-      "categories": [
-        "cs.LG",
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.LG",
-      "absUrl": "https://arxiv.org/abs/2605.19660v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19660v1",
-      "publishedAt": "2026-05-19T10:53:03.000Z",
-      "updatedAt": "2026-05-19T10:53:03.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19645v1",
-      "title": "K-Quantization and its Impact on Output Performance",
-      "summary": "Recent advancements in large language models (LLMs) have shown their remarkable capacities in many NLP tasks. However, their substantial size often presents challenges for deployment. This necessitates efficient techniques for model compression, with quantization emerging as a prominent solution. Despite its benefits, the exact impact of quantization (from 2- to 6-bit) on the performance and accuracy of LLMs remains an active area of research. This paper investigates the performance of eight LLMs at various quantization levels, focusing on tasks such as MMLU-Pro for knowledge processing and reasoning, CRUXEval for code comprehension, and MuSR for reading comprehension. Our results show a consistent trend where higher precision (e.g., 8-bit Q8\\_0) yields improved performance, albeit with diminishing returns. Aggressive quantization (e.g., 2-bit Q2\\_K) usually retains acceptable accuracy, though some models show a substantial loss in performance. Our findings indicate that while lower bit precision generally reduces performance, the impact varies across models and tasks. Larger models show greater resilience to aggressive quantization, but can still undergo significant drops at lower precision levels. Mid-sized models in the 7-9 billion parameter range strike an optimal balance between efficiency and resource usage. Such results provide insights into the trade-offs between model size, quantization, and performance.",
-      "authors": [
-        "Robin Baki Davidsson",
-        "Pierre Nugues"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19645v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19645v1",
-      "publishedAt": "2026-05-19T10:31:47.000Z",
-      "updatedAt": "2026-05-19T10:31:47.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19633v1",
-      "title": "optimize_anything: A Universal API for Optimizing any Text Parameter",
-      "summary": "Can a single LLM-based optimization system match specialized tools across fundamentally different domains? We show that when optimization problems are formulated as improving a text artifact evaluated by a scoring function, a single AI-based optimization system-supporting single-task search, multi-task search with cross-problem transfer, and generalization to unseen inputs-achieves state-of-the-art results across six diverse tasks. Our system discovers agent architectures that nearly triple Gemini Flash's ARC-AGI accuracy (32.5% to 89.5%), finds scheduling algorithms that cut cloud costs by 40%, generates CUDA kernels where 87% match or beat PyTorch, and outperforms AlphaEvolve's reported circle packing solution (n=26). Ablations across three domains reveal that actionable side information yields faster convergence and substantially higher final scores than score-only feedback, and that multi-task search outperforms independent optimization given equivalent per-problem budget through cross-task transfer, with benefits scaling with the number of related tasks. Together, we show for the first time that text optimization with LLM-based search is a general-purpose problem-solving paradigm, unifying tasks traditionally requiring domain-specific algorithms under a single framework. We open-source optimize\\_anything with support for multiple backends as part of the GEPA project at https://github.com/gepa-ai/gepa .",
-      "authors": [
-        "Lakshya A Agrawal",
-        "Donghyun Lee",
-        "Shangyin Tan",
-        "Wenjie Ma",
-        "Karim Elmaaroufi",
-        "Rohit Sandadi",
-        "Sanjit A. Seshia",
-        "Koushik Sen",
-        "Dan Klein",
-        "Ion Stoica",
-        "Joseph E. Gonzalez",
-        "Omar Khattab",
-        "Alexandros G. Dimakis",
-        "Matei Zaharia"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI",
-        "cs.LG",
-        "cs.NE",
-        "cs.SE"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19633v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19633v1",
-      "publishedAt": "2026-05-19T10:18:12.000Z",
-      "updatedAt": "2026-05-19T10:18:12.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19597v1",
-      "title": "LLMEval-Logic: A Solver-Verified Chinese Benchmark for Logical Reasoning of LLMs with Adversarial Hardening",
-      "summary": "Evaluating large language models (LLMs) on natural-language logical reasoning is essential because rule-governed tasks require conclusions to follow strictly from stated premises. Many existing logical-reasoning benchmarks are generated by templating natural-language items from sampled formulas, provide only coarse or unaudited formal annotations, and are now quickly saturated by frontier reasoning models. We present LLMEval-Logic, a Chinese logical reasoning benchmark built from realistic situational scenarios. Its pipeline forward-authors and expert-audits natural-language items together with their reference formalizations, verifies annotated answers with Z3, constructs expert rubrics for natural-to-formal grading, and hardens selected items through a closed-loop adversarial workflow. The benchmark is released in two paired subsets: a 246-item Base subset shipped with 1,400 expert-developed rubric atoms, and a 190-item Hard subset with 938 multi-step sub-questions over closed model spaces. Evaluating 14 frontier LLMs on LLMEval-Logic reveals substantial gaps in current models: the best model reaches only 37.5% Hard Item Accuracy, and even with reference symbols the highest joint Z3+Rubric formalization score among evaluated models reaches only 60.16%. Our benchmark is publicly available at https://github.com/llmeval/LLMEval-Logic.",
-      "authors": [
-        "Ming Zhang",
-        "Qiyuan Peng",
-        "Yinxi Wei",
-        "Yujiong Shen",
-        "Kexin Tan",
-        "Yuhui Wang",
-        "Zhenghao Xiang",
-        "Junjie Ye",
-        "Zhangyue Yin",
-        "Zhiheng Xi",
-        "Shihan Dou",
-        "Tao Gui",
-        "Maxm Pan",
-        "Ruizhi Yang",
-        "Qi Zhang",
-        "Xuanjing Huang"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19597v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19597v1",
-      "publishedAt": "2026-05-19T09:40:29.000Z",
-      "updatedAt": "2026-05-19T09:40:29.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19577v1",
-      "title": "GoLongRL: Capability-Oriented Long Context Reinforcement Learning with Multitask Alignment",
-      "summary": "We present GoLongRL, a fully open-source, capability-oriented post-training recipe for long-context reinforcement learning with verifiable rewards (RLVR). Existing long-context RL methods often treat data construction as a matter of designing increasingly complex retrieval paths, leading to homogeneous task coverage and reward formulations that inadequately reflect practical long-context requirements. Our work offers two contributions. (1) Capability-oriented data construction with full open release. We openly release a dataset of 23K RLVR samples, the complete construction pipeline, and all training code. Guided by a taxonomy of long-context capabilities, the dataset spans 9 task types, each paired with its natural evaluation metric. It comprises curated open-source samples from established corpora and synthetic samples whose QA pairs are generated from real source documents such as books, academic papers, and multi-turn dialogues. Under the same vanilla GRPO setup, our dataset alone outperforms the closed-source QwenLong-L1.5 dataset. Moreover, our Qwen3-30B-A3B model trained on this data delivers long-context performance comparable to DeepSeek-R1-0528 and Qwen3-235B-A22B-Thinking-2507, suggesting that broader coverage and greater reward diversity substantially benefit long-context capability improvement. (2) TMN-Reweight for heterogeneous multitask optimization. To address optimization challenges from heterogeneous rewards, we propose TMN-Reweight, which combines task-level mean normalization for cross-task reward scale alignment with difficulty-adaptive weighting for more reliable advantage estimation. TMN-Reweight further improves average performance over vanilla GRPO, with general capabilities preserved or improved across reported evaluations.",
-      "authors": [
-        "Minxuan Lv",
-        "Tiehua Mei",
-        "Tanlong Du",
-        "Junmin Chen",
-        "Zhenpeng Su",
-        "Ziyang Chen",
-        "Ziqi Wang",
-        "Zhennan Wu",
-        "Ruotong Pan",
-        "jian Liang",
-        "Ruiming Tang",
-        "Han Li"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19577v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19577v1",
-      "publishedAt": "2026-05-19T09:21:09.000Z",
-      "updatedAt": "2026-05-19T09:21:09.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19576v1",
-      "title": "Library Drift: Diagnosing and Fixing a Silent Failure Mode in Self-Evolving LLM Skill Libraries",
-      "summary": "Self-evolving skill libraries face a silent failure mode we term \\emph{library drift}: unbounded skill accumulation without outcome-driven lifecycle management causes retrieval degradation, false-positive injections, and performance stagnation. Recent evaluation confirms the symptom--LLM-authored skills deliver +0.0pp gain while human-curated ones deliver +16.2pp (SkillsBench)--yet the underlying mechanism has not been isolated. We provide (1) a reproducible trigger: ablations that isolate drift--one disables skill injection (flat floor, +0.002), one imposes premature retirement (active harm, $-$0.019); (2) trace-level diagnostics: an append-only evidence log with per-skill contribution scores, attribution verdicts, and router engagement metrics that make the failure visible before it reaches end-task scores; and (3) a verified fix: a minimal governance recipe (outcome-driven retirement + bounded active-cap + meta-skill authoring prior) that lifts held-out pass@1 from a 0.258 baseline to a late-window mean of 0.584 (rolling gain $+$0.328) on MBPP+ hard-100 over 100 rounds. Eight ablations decompose which governance mechanisms are load-bearing and which are subsumed, providing a concrete playbook for diagnosing library drift in any self-evolving agent.",
-      "authors": [
-        "Xing Zhang",
-        "Yanwei Cui",
-        "Guanghui Wang",
-        "Ziyuan Li",
-        "Wei Qiu",
-        "Bing Zhu",
-        "Peiyang He"
-      ],
-      "categories": [
-        "cs.AI",
-        "cs.CL",
-        "cs.SE"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19576v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19576v1",
-      "publishedAt": "2026-05-19T09:19:56.000Z",
-      "updatedAt": "2026-05-19T09:19:56.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19575v1",
-      "title": "A Data-Driven Approach to Idiomaticity Based on Experts' Criteria in Theoretical Linguistics",
-      "summary": "The article observes data analysis of 286 multi-word expressions (MWEs) based on 16 lexical, grammatical and other criteria described in theoretical books and papers on the notion of idiomaticity. MWEs were collected from the same theoretical sources, and a set of experts in linguistics annotated them with these categories. The distribution of categories shows that there are no absolutely idiomatic expressions. Lexical criteria seem to be the most influential; grammatical criteria are bound to certain conditions; presence of obsolete words and grammar influence ability of an MWE to be replaced with one word.",
-      "authors": [
-        "Elena Mikhalkova",
-        "Anastasiya Vishnyakova",
-        "Anastasiya Drozdova",
-        "Polina Gavin",
-        "Aleksander Zhmykhov",
-        "Timofey Protasov"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19575v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19575v1",
-      "publishedAt": "2026-05-19T09:19:26.000Z",
-      "updatedAt": "2026-05-19T09:19:26.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19568v1",
-      "title": "m3BERT: A Modern, Multi-lingual, Matryoshka Bidirectional Encoder",
-      "summary": "Embedding models are pivotal in industrial information retrieval systems like search and advertising. However, existing pretrained models often exhibit fixed architectures and embedding dimensionalities, posing significant challenges when adapting them to diverse deployment scenarios with varying business-driven constraints. A common practice involves fine-tuning with partial parameter initialization from larger pretrained models for resource-constrained tasks. This method is often suboptimal as the misalignment between pretraining and downstream usage prevents full realization of pretraining benefits. To address this limitation, we introduce m3BERT: a Modern, Multi-lingual, Matryoshka Bidirectional Encoder, which features a novel pretraining strategy that jointly optimizes representations across both transformer layers and multiple embedding dimensions. This enables a single model to be tailored to varied resource and accuracy targets while maintaining consistency with pretraining. Incorporating recent architectural improvements, m3BERT uses a three-stage pretraining: monolingual pretraining, multilingual adaptation to serve diverse user bases, and crucial continual pretraining on a massive web domain corpus to enhance utility in commercial retrieval. m3BERT significantly outperforms state-of-the-art embedding models in Bing-Click, a large-scale industrial retrieval dataset, showcasing its practical versatility as an efficient foundation for resource-aware industrial retrieval systems. Further experiments on public datasets also confirm the general effectiveness of our multigranular Matryoshka pretraining strategy.",
-      "authors": [
-        "Yaoxiang Wang",
-        "Simiao Zuo",
-        "Qingguo Hu",
-        "Yucheng Ding",
-        "Yeyun Gong",
-        "Jian Jiao",
-        "Jinsong Su"
-      ],
-      "categories": [
-        "cs.CL"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19568v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19568v1",
-      "publishedAt": "2026-05-19T09:13:49.000Z",
-      "updatedAt": "2026-05-19T09:13:49.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19523v1",
-      "title": "Investigating Cross-Modal Skill Injection: Scenarios, Methods, and Hyperparameters",
-      "summary": "Vision-Language Models (VLMs) have demonstrated remarkable proficiency in general multi-modal understanding; yet they struggle to efficiently acquire continually evolving domain-specific skills. Conventional approaches to enhancing VLM capabilities, such as Supervised Fine-Tuning (SFT), require extensive dataset curation and substantial computational resources. Model merging has emerged as an efficient alternative that enables the transfer of domain-specific expertise from Large Language Models (LLMs) to VLMs without incurring additional training data requirements or significant computational overhead. Unlike conventional merging of homogeneous LLMs, which mainly aggregates existing capabilities, cross-modal skill injection aims to induce emergent cross-modal capabilities by integrating a domain-expert LLM into a VLM. However, existing research lacks a systematic analysis of the applicability and methodology of cross-modal skill injection. In this study, we investigate cross-modal skill injection across three main aspects: scenarios, methods, and hyperparameters. For scenarios, we find that cross-modal skill injection generally performs well in instruction-following and cross-lingual settings, yet struggles with mathematical reasoning. For methods, we find that classic approaches such as TA and DARE consistently achieve superior performance over alternative merging methods. We also provide a systematic and quantitative analysis of the hyperparameter tuning that these classic methods critically depend on.",
-      "authors": [
-        "Zhiyu Xu",
-        "Lean Wang",
-        "Yuanxin Liu",
-        "Lei Li",
-        "Hao Zhou",
-        "Fandong Meng",
-        "Jie Zhou",
-        "Xu Sun"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI",
-        "cs.CV"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19523v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19523v1",
-      "publishedAt": "2026-05-19T08:24:19.000Z",
-      "updatedAt": "2026-05-19T08:24:19.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19516v1",
-      "title": "Base Models Look Human To AI Detectors",
-      "summary": "As AI-generated text enters the real-world at scale, institutions increasingly use commercial AI-text detectors, especially in education and academic-integrity workflows. We report a surprising empirical finding about such systems: when evaluated by GPTZero and Pangram, generated text from base models is often judged overwhelmingly human, whereas text generated by their instruction-tuned counterparts is not. Building on this observation, we propose Humanization by Iterative Paraphrasing (HIP), a detector-agnostic pipeline that minimally fine-tunes a base model into a paraphraser and applies it iteratively. Compared with the baselines we test, HIP yields a stronger trade-off between semantic preservation and detector evasion on commercial detectors. Across Llama-3 and Qwen-3 families, spanning model sizes from 0.6B to 70B, HIP consistently improves detector human-likeness. Our findings suggest that current detectors are tracking artifacts of instruction tuning and local context more than any invariant notion of machine-generated text. This, in turn, calls for detector designs that model these factors more explicitly.",
-      "authors": [
-        "Yixuan Even Xu",
-        "Ziqian Zhong",
-        "Aditi Raghunathan",
-        "Fei Fang",
-        "J. Zico Kolter"
-      ],
-      "categories": [
-        "cs.CL",
-        "cs.AI",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.CL",
-      "absUrl": "https://arxiv.org/abs/2605.19516v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19516v1",
-      "publishedAt": "2026-05-19T08:13:12.000Z",
-      "updatedAt": "2026-05-19T08:13:12.000Z",
-      "linkedRepos": []
-    },
-    {
-      "arxivId": "2605.19514v1",
-      "title": "Position: The Turing-Completeness of Real-World Autoregressive Transformers Relies Heavily on Context Management",
-      "summary": "Many works make the eye-catching claim that Transformers are Turing-complete. However, the literature often conflates two distinct settings: (i) a fixed Transformer system setting, in which a fixed autoregressive Transformer is coupled with a fixed context-management method to process inputs of different lengths step by step, and (ii) a scaling-family setting, in which a family of different models (with increasing context-window length or numerical precision) is used to handle different input lengths. Existing proofs of Transformer Turing-completeness are frequently established in setting (ii), whereas real-world LLM deployment and the standard notion of Turing-completeness correspond more naturally to setting (i). In this paper, we first formalize the fixed-system setting, thereby providing a concrete characterization of how real-world LLMs operate. We then argue that results proved in the scaling-family setting provide theoretically meaningful resource bounds but do not establish Turing-completeness, thereby clarifying a common misinterpretation of existing results. Finally, we show that different context-management methods can yield sharply different computational power, and we advocate the position that context management is a central component that critically determines the computational power of real-world autoregressive Transformers.",
-      "authors": [
-        "Guanyu Cui",
-        "Zhewei Wei",
-        "Kun He"
-      ],
-      "categories": [
-        "cs.AI",
-        "cs.CL",
-        "cs.LG"
-      ],
-      "primaryCategory": "cs.AI",
-      "absUrl": "https://arxiv.org/abs/2605.19514v1",
-      "pdfUrl": "https://arxiv.org/pdf/2605.19514v1",
-      "publishedAt": "2026-05-19T08:12:33.000Z",
-      "updatedAt": "2026-05-19T08:12:33.000Z",
+      "absUrl": "https://arxiv.org/abs/2605.20813v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.20813v1",
+      "publishedAt": "2026-05-20T07:06:54.000Z",
+      "updatedAt": "2026-05-20T07:06:54.000Z",
       "linkedRepos": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26206410657

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.