### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T05:51:43Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-21T01:33:09.988Z",
+  "ts": "2026-05-21T05:51:42.859Z",
   "count": 1,
-  "durationMs": 3820,
+  "durationMs": 4176,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T01:33:06.187Z",
+  "fetchedAt": "2026-05-21T05:51:38.704Z",
   "windowDays": 7,
-  "scannedStories": 80,
+  "scannedStories": 82,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T01:33:06.187Z",
+  "fetchedAt": "2026-05-21T05:51:38.704Z",
   "windowHours": 72,
-  "scannedTotal": 80,
+  "scannedTotal": 82,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -224,6 +224,23 @@
       "createdUtc": 1778343177,
       "ageHours": 2.348333333333333,
       "trendingScore": 1.65427236943472,
+      "tags": [
+        "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "k21pdb",
+      "title": "Aggressive AI scrapers are making it kinda suck to run wikis",
+      "url": "https://weirdgloop.org/blog/clankers",
+      "commentsUrl": "https://lobste.rs/s/k21pdb/aggressive_ai_scrapers_are_making_it",
+      "by": "",
+      "score": 13,
+      "commentCount": 0,
+      "createdUtc": 1779335461,
+      "ageHours": 2.0102777777777776,
+      "trendingScore": 1.6187570346453364,
       "tags": [
         "web"
       ],
@@ -878,23 +895,6 @@
       "tags": [
         "practices",
         "programming"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "7a6atx",
-      "title": "Moving away from Tailwind, and learning to structure my CSS",
-      "url": "https://jvns.ca/blog/2026/05/15/moving-away-from-tailwind--and-learning-to-structure-my-css-/",
-      "commentsUrl": "https://lobste.rs/s/7a6atx/moving_away_from_tailwind_learning",
-      "by": "",
-      "score": 21,
-      "commentCount": 3,
-      "createdUtc": 1778862497,
-      "ageHours": 6.086944444444445,
-      "trendingScore": 0.9131510131737931,
-      "tags": [
-        "css"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26208093032

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.