### PR TITLE
chore(data): refresh scoring shadow report 2026-05-21T06:01:24Z

### DIFF
--- a/data/scoring-shadow-report.json
+++ b/data/scoring-shadow-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-20T05:57:37.175Z",
+  "generatedAt": "2026-05-21T06:01:22.523Z",
   "reports": [
     {
       "domainKey": "skill",
@@ -8,301 +8,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.626,
+          "momentum": 9.477,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 8.776,
+          "momentum": 8.487,
           "rank": 2
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 8.544,
+          "momentum": 8.264,
           "rank": 3
         },
         {
           "id": "agricidaniel-claude-ads",
           "title": "claude-ads",
-          "momentum": 8.319,
+          "momentum": 8.043,
           "rank": 4
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 7.967,
+          "rank": 5
         },
         {
           "id": "agents365-ai-drawio-skill",
           "title": "drawio-skill",
-          "momentum": 7.871,
-          "rank": 5
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.58,
+          "momentum": 7.645,
           "rank": 6
         },
         {
           "id": "eugeniughelbur-obsidian-second-brain",
           "title": "obsidian-second-brain",
-          "momentum": 7.444,
+          "momentum": 7.556,
           "rank": 7
         },
         {
           "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
           "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.353,
+          "momentum": 7.362,
           "rank": 8
         },
         {
-          "id": "glitternetwork-pinme",
-          "title": "pinme",
-          "momentum": 7.337,
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.361,
           "rank": 9
-        },
-        {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 7.116,
-          "rank": 10
-        },
-        {
-          "id": "alexgreensh-token-optimizer",
-          "title": "token-optimizer",
-          "momentum": 6.934,
-          "rank": 11
-        },
-        {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 6.536,
-          "rank": 12
         },
         {
           "id": "agricidaniel-claude-blog",
           "title": "claude-blog",
-          "momentum": 6.478,
+          "momentum": 7.127,
+          "rank": 10
+        },
+        {
+          "id": "glitternetwork-pinme",
+          "title": "pinme",
+          "momentum": 7.088,
+          "rank": 11
+        },
+        {
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.873,
+          "rank": 12
+        },
+        {
+          "id": "alexgreensh-token-optimizer",
+          "title": "token-optimizer",
+          "momentum": 6.71,
           "rank": 13
+        },
+        {
+          "id": "mohitagw15856-pm-claude-skills",
+          "title": "pm-claude-skills",
+          "momentum": 6.622,
+          "rank": 14
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.404,
-          "rank": 14
-        },
-        {
-          "id": "juneyaooo-gpt-image2-ppt-skills",
-          "title": "gpt-image2-ppt-skills",
-          "momentum": 6.268,
+          "momentum": 6.485,
           "rank": 15
         },
         {
           "id": "storybloq-storybloq",
           "title": "storybloq",
-          "momentum": 6.225,
+          "momentum": 6.17,
           "rank": 16
+        },
+        {
+          "id": "juneyaooo-gpt-image2-ppt-skills",
+          "title": "gpt-image2-ppt-skills",
+          "momentum": 6.092,
+          "rank": 17
         },
         {
           "id": "denissergeevitch-agents-best-practices",
           "title": "agents-best-practices",
-          "momentum": 6.17,
-          "rank": 17
-        },
-        {
-          "id": "pegasi-ai-reins",
-          "title": "reins",
-          "momentum": 6.006,
+          "momentum": 6.033,
           "rank": 18
-        },
-        {
-          "id": "wuyoscar-gpt-image2-skill",
-          "title": "GPT-Image2-Skill",
-          "momentum": 5.963,
-          "rank": 19
         },
         {
           "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
           "title": "Claude-Mythos-AI-Anthropic-App",
-          "momentum": 5.954,
+          "momentum": 6.027,
+          "rank": 19
+        },
+        {
+          "id": "pegasi-ai-reins",
+          "title": "reins",
+          "momentum": 5.845,
           "rank": 20
+        },
+        {
+          "id": "wuyoscar-gpt-image2-skill",
+          "title": "GPT-Image2-Skill",
+          "momentum": 5.778,
+          "rank": 21
         },
         {
           "id": "bhanunamikaze-agentic-seo-skill",
           "title": "Agentic-SEO-Skill",
-          "momentum": 5.827,
-          "rank": 21
+          "momentum": 5.643,
+          "rank": 22
         },
         {
           "id": "alirezarezvani-claudeforge",
           "title": "ClaudeForge",
-          "momentum": 5.824,
-          "rank": 22
+          "momentum": 5.631,
+          "rank": 23
         },
         {
           "id": "alirezarezvani-claude-code-aso-skill",
           "title": "claude-code-aso-skill",
-          "momentum": 5.763,
-          "rank": 23
+          "momentum": 5.57,
+          "rank": 24
         },
         {
           "id": "avdlee-rocketsimapp",
           "title": "RocketSimApp",
-          "momentum": 5.738,
-          "rank": 24
+          "momentum": 5.542,
+          "rank": 25
         },
         {
           "id": "mrgediao-shuorenhua",
           "title": "shuorenhua",
-          "momentum": 5.577,
-          "rank": 25
+          "momentum": 5.387,
+          "rank": 26
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.532,
-          "rank": 26
+          "momentum": 5.347,
+          "rank": 27
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.509,
-          "rank": 27
-        },
-        {
-          "id": "bharathkumarsuresh-claude-design-system-hooks",
-          "title": "claude-design-system-hooks",
-          "momentum": 5.412,
+          "momentum": 5.322,
           "rank": 28
-        },
-        {
-          "id": "aspegio-nelson",
-          "title": "nelson",
-          "momentum": 5.378,
-          "rank": 29
-        },
-        {
-          "id": "memtensor-skills-vote",
-          "title": "skills-vote",
-          "momentum": 5.349,
-          "rank": 30
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.28,
-          "rank": 31
-        },
-        {
-          "id": "vast-ai-vast-cli",
-          "title": "vast-cli",
-          "momentum": 5.149,
-          "rank": 32
-        },
-        {
-          "id": "agents365-ai-asta-skill",
-          "title": "asta-skill",
-          "momentum": 5.088,
-          "rank": 33
-        },
-        {
-          "id": "agents365-ai-paper-fetch",
-          "title": "paper-fetch",
-          "momentum": 5,
-          "rank": 34
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 4.982,
-          "rank": 35
         },
         {
           "id": "bitwize-music-studio-claude-ai-music-skills",
           "title": "claude-ai-music-skills",
-          "momentum": 4.95,
-          "rank": 36
+          "momentum": 5.268,
+          "rank": 29
         },
         {
-          "id": "greekr4-playwright-bot-bypass",
-          "title": "playwright-bot-bypass",
-          "momentum": 4.921,
-          "rank": 37
+          "id": "vast-ai-vast-cli",
+          "title": "vast-cli",
+          "momentum": 5.227,
+          "rank": 30
         },
         {
-          "id": "agricidaniel-claude-obsidian",
-          "title": "claude-obsidian",
-          "momentum": 4.767,
-          "rank": 38
+          "id": "memtensor-skills-vote",
+          "title": "skills-vote",
+          "momentum": 5.209,
+          "rank": 31
         },
         {
-          "id": "nikolai-vysotskyi-trace-mcp",
-          "title": "trace-mcp",
-          "momentum": 4.761,
-          "rank": 39
+          "id": "aspegio-nelson",
+          "title": "nelson",
+          "momentum": 5.2,
+          "rank": 32
         },
         {
-          "id": "luoling8192-technical-writing",
-          "title": "technical-writing",
-          "momentum": 4.755,
-          "rank": 40
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.176,
+          "rank": 33
         },
         {
-          "id": "keerthanapranesh-claude-code-swarm-toolkit",
-          "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.676,
-          "rank": 41
+          "id": "ximilalaxiang-delive",
+          "title": "DeLive",
+          "momentum": 5.161,
+          "rank": 34
         },
         {
-          "id": "jeecgboot-skills",
-          "title": "skills",
-          "momentum": 4.621,
-          "rank": 42
-        },
-        {
-          "id": "oaustegard-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.614,
-          "rank": 43
-        },
-        {
-          "id": "zouchenzhen-thesis-defense-pptx-skill",
-          "title": "thesis-defense-pptx-skill",
-          "momentum": 4.526,
-          "rank": 44
-        },
-        {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.522,
-          "rank": 45
-        },
-        {
-          "id": "likaku-mck-ppt-design-skill",
-          "title": "Mck-ppt-design-skill",
-          "momentum": 4.507,
-          "rank": 46
-        },
-        {
-          "id": "secondsky-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.456,
-          "rank": 47
-        },
-        {
-          "id": "xquik-dev-x-twitter-scraper",
-          "title": "x-twitter-scraper",
-          "momentum": 4.403,
-          "rank": 48
-        },
-        {
-          "id": "agents365-ai-excalidraw-skill",
-          "title": "excalidraw-skill",
-          "momentum": 4.391,
-          "rank": 49
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 4.959,
+          "rank": 35
         },
         {
           "id": "ylsssq926-relic-skill",
           "title": "relic.skill",
-          "momentum": 4.356,
+          "momentum": 4.953,
+          "rank": 36
+        },
+        {
+          "id": "agents365-ai-paper-fetch",
+          "title": "paper-fetch",
+          "momentum": 4.856,
+          "rank": 37
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 4.82,
+          "rank": 38
+        },
+        {
+          "id": "eriemon-verilog-generator",
+          "title": "verilog-generator",
+          "momentum": 4.808,
+          "rank": 39
+        },
+        {
+          "id": "oaustegard-claude-skills",
+          "title": "claude-skills",
+          "momentum": 4.794,
+          "rank": 40
+        },
+        {
+          "id": "greekr4-playwright-bot-bypass",
+          "title": "playwright-bot-bypass",
+          "momentum": 4.753,
+          "rank": 41
+        },
+        {
+          "id": "nikolai-vysotskyi-trace-mcp",
+          "title": "trace-mcp",
+          "momentum": 4.639,
+          "rank": 42
+        },
+        {
+          "id": "luoling8192-technical-writing",
+          "title": "technical-writing",
+          "momentum": 4.618,
+          "rank": 43
+        },
+        {
+          "id": "agricidaniel-claude-obsidian",
+          "title": "claude-obsidian",
+          "momentum": 4.612,
+          "rank": 44
+        },
+        {
+          "id": "myurikanao-src-hunter-skill",
+          "title": "src-hunter-skill",
+          "momentum": 4.483,
+          "rank": 45
+        },
+        {
+          "id": "jeecgboot-skills",
+          "title": "skills",
+          "momentum": 4.471,
+          "rank": 46
+        },
+        {
+          "id": "zouchenzhen-thesis-defense-pptx-skill",
+          "title": "thesis-defense-pptx-skill",
+          "momentum": 4.44,
+          "rank": 47
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.398,
+          "rank": 48
+        },
+        {
+          "id": "likaku-mck-ppt-design-skill",
+          "title": "Mck-ppt-design-skill",
+          "momentum": 4.392,
+          "rank": 49
+        },
+        {
+          "id": "modoojunko-awesome-novel-skill",
+          "title": "awesome-novel-skill",
+          "momentum": 4.381,
           "rank": 50
         }
       ],
@@ -310,301 +310,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.626,
+          "momentum": 9.477,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 8.776,
+          "momentum": 8.487,
           "rank": 2
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 8.544,
+          "momentum": 8.264,
           "rank": 3
         },
         {
           "id": "agricidaniel-claude-ads",
           "title": "claude-ads",
-          "momentum": 8.319,
+          "momentum": 8.043,
           "rank": 4
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 7.967,
+          "rank": 5
         },
         {
           "id": "agents365-ai-drawio-skill",
           "title": "drawio-skill",
-          "momentum": 7.871,
-          "rank": 5
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.58,
+          "momentum": 7.645,
           "rank": 6
         },
         {
           "id": "eugeniughelbur-obsidian-second-brain",
           "title": "obsidian-second-brain",
-          "momentum": 7.444,
+          "momentum": 7.556,
           "rank": 7
         },
         {
           "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
           "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.353,
+          "momentum": 7.362,
           "rank": 8
         },
         {
-          "id": "glitternetwork-pinme",
-          "title": "pinme",
-          "momentum": 7.337,
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.361,
           "rank": 9
-        },
-        {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 7.116,
-          "rank": 10
-        },
-        {
-          "id": "alexgreensh-token-optimizer",
-          "title": "token-optimizer",
-          "momentum": 6.934,
-          "rank": 11
-        },
-        {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 6.536,
-          "rank": 12
         },
         {
           "id": "agricidaniel-claude-blog",
           "title": "claude-blog",
-          "momentum": 6.478,
+          "momentum": 7.127,
+          "rank": 10
+        },
+        {
+          "id": "glitternetwork-pinme",
+          "title": "pinme",
+          "momentum": 7.088,
+          "rank": 11
+        },
+        {
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.873,
+          "rank": 12
+        },
+        {
+          "id": "alexgreensh-token-optimizer",
+          "title": "token-optimizer",
+          "momentum": 6.71,
           "rank": 13
+        },
+        {
+          "id": "mohitagw15856-pm-claude-skills",
+          "title": "pm-claude-skills",
+          "momentum": 6.622,
+          "rank": 14
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.404,
-          "rank": 14
-        },
-        {
-          "id": "juneyaooo-gpt-image2-ppt-skills",
-          "title": "gpt-image2-ppt-skills",
-          "momentum": 6.268,
+          "momentum": 6.485,
           "rank": 15
         },
         {
           "id": "storybloq-storybloq",
           "title": "storybloq",
-          "momentum": 6.225,
+          "momentum": 6.17,
           "rank": 16
+        },
+        {
+          "id": "juneyaooo-gpt-image2-ppt-skills",
+          "title": "gpt-image2-ppt-skills",
+          "momentum": 6.092,
+          "rank": 17
         },
         {
           "id": "denissergeevitch-agents-best-practices",
           "title": "agents-best-practices",
-          "momentum": 6.17,
-          "rank": 17
-        },
-        {
-          "id": "pegasi-ai-reins",
-          "title": "reins",
-          "momentum": 6.006,
+          "momentum": 6.033,
           "rank": 18
-        },
-        {
-          "id": "wuyoscar-gpt-image2-skill",
-          "title": "GPT-Image2-Skill",
-          "momentum": 5.963,
-          "rank": 19
         },
         {
           "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
           "title": "Claude-Mythos-AI-Anthropic-App",
-          "momentum": 5.954,
+          "momentum": 6.027,
+          "rank": 19
+        },
+        {
+          "id": "pegasi-ai-reins",
+          "title": "reins",
+          "momentum": 5.845,
           "rank": 20
+        },
+        {
+          "id": "wuyoscar-gpt-image2-skill",
+          "title": "GPT-Image2-Skill",
+          "momentum": 5.778,
+          "rank": 21
         },
         {
           "id": "bhanunamikaze-agentic-seo-skill",
           "title": "Agentic-SEO-Skill",
-          "momentum": 5.827,
-          "rank": 21
+          "momentum": 5.643,
+          "rank": 22
         },
         {
           "id": "alirezarezvani-claudeforge",
           "title": "ClaudeForge",
-          "momentum": 5.824,
-          "rank": 22
+          "momentum": 5.631,
+          "rank": 23
         },
         {
           "id": "alirezarezvani-claude-code-aso-skill",
           "title": "claude-code-aso-skill",
-          "momentum": 5.763,
-          "rank": 23
+          "momentum": 5.57,
+          "rank": 24
         },
         {
           "id": "avdlee-rocketsimapp",
           "title": "RocketSimApp",
-          "momentum": 5.738,
-          "rank": 24
+          "momentum": 5.542,
+          "rank": 25
         },
         {
           "id": "mrgediao-shuorenhua",
           "title": "shuorenhua",
-          "momentum": 5.577,
-          "rank": 25
+          "momentum": 5.387,
+          "rank": 26
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.532,
-          "rank": 26
+          "momentum": 5.347,
+          "rank": 27
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.509,
-          "rank": 27
-        },
-        {
-          "id": "bharathkumarsuresh-claude-design-system-hooks",
-          "title": "claude-design-system-hooks",
-          "momentum": 5.412,
+          "momentum": 5.322,
           "rank": 28
-        },
-        {
-          "id": "aspegio-nelson",
-          "title": "nelson",
-          "momentum": 5.378,
-          "rank": 29
-        },
-        {
-          "id": "memtensor-skills-vote",
-          "title": "skills-vote",
-          "momentum": 5.349,
-          "rank": 30
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.28,
-          "rank": 31
-        },
-        {
-          "id": "vast-ai-vast-cli",
-          "title": "vast-cli",
-          "momentum": 5.149,
-          "rank": 32
-        },
-        {
-          "id": "agents365-ai-asta-skill",
-          "title": "asta-skill",
-          "momentum": 5.088,
-          "rank": 33
-        },
-        {
-          "id": "agents365-ai-paper-fetch",
-          "title": "paper-fetch",
-          "momentum": 5,
-          "rank": 34
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 4.982,
-          "rank": 35
         },
         {
           "id": "bitwize-music-studio-claude-ai-music-skills",
           "title": "claude-ai-music-skills",
-          "momentum": 4.95,
-          "rank": 36
+          "momentum": 5.268,
+          "rank": 29
         },
         {
-          "id": "greekr4-playwright-bot-bypass",
-          "title": "playwright-bot-bypass",
-          "momentum": 4.921,
-          "rank": 37
+          "id": "vast-ai-vast-cli",
+          "title": "vast-cli",
+          "momentum": 5.227,
+          "rank": 30
         },
         {
-          "id": "agricidaniel-claude-obsidian",
-          "title": "claude-obsidian",
-          "momentum": 4.767,
-          "rank": 38
+          "id": "memtensor-skills-vote",
+          "title": "skills-vote",
+          "momentum": 5.209,
+          "rank": 31
         },
         {
-          "id": "nikolai-vysotskyi-trace-mcp",
-          "title": "trace-mcp",
-          "momentum": 4.761,
-          "rank": 39
+          "id": "aspegio-nelson",
+          "title": "nelson",
+          "momentum": 5.2,
+          "rank": 32
         },
         {
-          "id": "luoling8192-technical-writing",
-          "title": "technical-writing",
-          "momentum": 4.755,
-          "rank": 40
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.176,
+          "rank": 33
         },
         {
-          "id": "keerthanapranesh-claude-code-swarm-toolkit",
-          "title": "Claude-Code-Swarm-Toolkit",
-          "momentum": 4.676,
-          "rank": 41
+          "id": "ximilalaxiang-delive",
+          "title": "DeLive",
+          "momentum": 5.161,
+          "rank": 34
         },
         {
-          "id": "jeecgboot-skills",
-          "title": "skills",
-          "momentum": 4.621,
-          "rank": 42
-        },
-        {
-          "id": "oaustegard-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.614,
-          "rank": 43
-        },
-        {
-          "id": "zouchenzhen-thesis-defense-pptx-skill",
-          "title": "thesis-defense-pptx-skill",
-          "momentum": 4.526,
-          "rank": 44
-        },
-        {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.522,
-          "rank": 45
-        },
-        {
-          "id": "likaku-mck-ppt-design-skill",
-          "title": "Mck-ppt-design-skill",
-          "momentum": 4.507,
-          "rank": 46
-        },
-        {
-          "id": "secondsky-claude-skills",
-          "title": "claude-skills",
-          "momentum": 4.456,
-          "rank": 47
-        },
-        {
-          "id": "xquik-dev-x-twitter-scraper",
-          "title": "x-twitter-scraper",
-          "momentum": 4.403,
-          "rank": 48
-        },
-        {
-          "id": "agents365-ai-excalidraw-skill",
-          "title": "excalidraw-skill",
-          "momentum": 4.391,
-          "rank": 49
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 4.959,
+          "rank": 35
         },
         {
           "id": "ylsssq926-relic-skill",
           "title": "relic.skill",
-          "momentum": 4.356,
+          "momentum": 4.953,
+          "rank": 36
+        },
+        {
+          "id": "agents365-ai-paper-fetch",
+          "title": "paper-fetch",
+          "momentum": 4.856,
+          "rank": 37
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 4.82,
+          "rank": 38
+        },
+        {
+          "id": "eriemon-verilog-generator",
+          "title": "verilog-generator",
+          "momentum": 4.808,
+          "rank": 39
+        },
+        {
+          "id": "oaustegard-claude-skills",
+          "title": "claude-skills",
+          "momentum": 4.794,
+          "rank": 40
+        },
+        {
+          "id": "greekr4-playwright-bot-bypass",
+          "title": "playwright-bot-bypass",
+          "momentum": 4.753,
+          "rank": 41
+        },
+        {
+          "id": "nikolai-vysotskyi-trace-mcp",
+          "title": "trace-mcp",
+          "momentum": 4.639,
+          "rank": 42
+        },
+        {
+          "id": "luoling8192-technical-writing",
+          "title": "technical-writing",
+          "momentum": 4.618,
+          "rank": 43
+        },
+        {
+          "id": "agricidaniel-claude-obsidian",
+          "title": "claude-obsidian",
+          "momentum": 4.612,
+          "rank": 44
+        },
+        {
+          "id": "myurikanao-src-hunter-skill",
+          "title": "src-hunter-skill",
+          "momentum": 4.483,
+          "rank": 45
+        },
+        {
+          "id": "jeecgboot-skills",
+          "title": "skills",
+          "momentum": 4.471,
+          "rank": 46
+        },
+        {
+          "id": "zouchenzhen-thesis-defense-pptx-skill",
+          "title": "thesis-defense-pptx-skill",
+          "momentum": 4.44,
+          "rank": 47
+        },
+        {
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.398,
+          "rank": 48
+        },
+        {
+          "id": "likaku-mck-ppt-design-skill",
+          "title": "Mck-ppt-design-skill",
+          "momentum": 4.392,
+          "rank": 49
+        },
+        {
+          "id": "modoojunko-awesome-novel-skill",
+          "title": "awesome-novel-skill",
+          "momentum": 4.381,
           "rank": 50
         }
       ],
@@ -613,7 +613,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-20T05:57:35.617Z",
+      "generatedAt": "2026-05-21T06:01:20.634Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     },
@@ -634,20 +634,20 @@
           "rank": 2
         },
         {
-          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
-          "title": "Gantta",
+          "id": "8e2eb2b1-b3fb-4cc5-b3fb-1fa7cb6177fb",
+          "title": "Google Sheets",
           "momentum": 0,
           "rank": 3
         },
         {
-          "id": "8e2eb2b1-b3fb-4cc5-b3fb-1fa7cb6177fb",
-          "title": "Google Sheets",
+          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
+          "title": "Exa Search",
           "momentum": 0,
           "rank": 4
         },
         {
-          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
-          "title": "Exa Search",
+          "id": "267b4011-98f0-4231-a2df-9bb31067c24e",
+          "title": "Gmail",
           "momentum": 0,
           "rank": 5
         },
@@ -658,32 +658,32 @@
           "rank": 6
         },
         {
-          "id": "267b4011-98f0-4231-a2df-9bb31067c24e",
-          "title": "Gmail",
-          "momentum": 0,
-          "rank": 7
-        },
-        {
           "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
           "title": "AI Research Assistant",
           "momentum": 0,
-          "rank": 8
+          "rank": 7
         },
         {
           "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
           "title": "MCP Server for Singapore Government Open Data",
           "momentum": 0,
-          "rank": 9
+          "rank": 8
         },
         {
-          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
-          "title": "12306 Ticket Search Server",
+          "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
+          "title": "Hugeicons MCP Server",
           "momentum": 0,
-          "rank": 10
+          "rank": 9
         },
         {
           "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
           "title": "AgentMail",
+          "momentum": 0,
+          "rank": 10
+        },
+        {
+          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
+          "title": "Flight Search MCP Server",
           "momentum": 0,
           "rank": 11
         },
@@ -694,230 +694,230 @@
           "rank": 12
         },
         {
-          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
-          "title": "Flight Search MCP Server",
-          "momentum": 0,
-          "rank": 13
-        },
-        {
           "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
           "title": "Linkup",
           "momentum": 0,
-          "rank": 14
-        },
-        {
-          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
-          "title": "KRDS Design System",
-          "momentum": 0,
-          "rank": 15
-        },
-        {
-          "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
-          "title": "Hugeicons MCP Server",
-          "momentum": 0,
-          "rank": 16
-        },
-        {
-          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
-          "title": "Swiss Truth MCP",
-          "momentum": 0,
-          "rank": 17
+          "rank": 13
         },
         {
           "id": "9a58e6b6-6486-47c2-b05d-5362e3b85da7",
           "title": "AKShare One MCP Server",
           "momentum": 0,
-          "rank": 18
+          "rank": 14
         },
         {
           "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
           "title": "sbb-mcp",
           "momentum": 0,
-          "rank": 19
+          "rank": 15
         },
         {
-          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
-          "title": "Paper Search",
+          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
+          "title": "Gantta",
           "momentum": 0,
-          "rank": 20
-        },
-        {
-          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
-          "title": "Brave Search",
-          "momentum": 0,
-          "rank": 21
+          "rank": 16
         },
         {
           "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
           "title": "Context7",
           "momentum": 0,
-          "rank": 22
+          "rank": 17
         },
         {
-          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
-          "title": "Mesh MCP",
+          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
+          "title": "Paper Search",
           "momentum": 0,
-          "rank": 23
+          "rank": 18
+        },
+        {
+          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
+          "title": "Brave Search",
+          "momentum": 0,
+          "rank": 19
         },
         {
           "id": "b2099458-8711-4f83-a029-eebf247ebe64",
           "title": "paper-search-mcp-openai-v2",
           "momentum": 0,
-          "rank": 24
-        },
-        {
-          "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
-          "title": "Senzing",
-          "momentum": 0,
-          "rank": 25
-        },
-        {
-          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
-          "title": "Blockscout MCP Server",
-          "momentum": 0,
-          "rank": 26
-        },
-        {
-          "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
-          "title": "Ternary Intelligence Stack",
-          "momentum": 0,
-          "rank": 27
-        },
-        {
-          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
-          "title": "rivalsearch",
-          "momentum": 0,
-          "rank": 28
-        },
-        {
-          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
-          "title": "srv-d7aoqmh5pdvs7391dcqg",
-          "momentum": 0,
-          "rank": 29
-        },
-        {
-          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
-          "title": "Supabase",
-          "momentum": 0,
-          "rank": 30
-        },
-        {
-          "id": "706d98f8-dc33-453d-9103-d28364976e58",
-          "title": "icons8mcp",
-          "momentum": 0,
-          "rank": 31
-        },
-        {
-          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
-          "title": "MLB Stats Server",
-          "momentum": 0,
-          "rank": 32
+          "rank": 20
         },
         {
           "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
           "title": "Microsoft Learn MCP",
           "momentum": 0,
-          "rank": 33
+          "rank": 21
         },
         {
-          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
-          "title": "Octomil",
+          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
+          "title": "MLB Stats Server",
           "momentum": 0,
-          "rank": 34
+          "rank": 22
         },
         {
-          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
-          "title": "Context Awesome",
+          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
+          "title": "12306 Ticket Search Server",
           "momentum": 0,
-          "rank": 35
+          "rank": 23
         },
         {
-          "id": "ffebb7a1-9654-4ddc-8d0a-3018cf8ca05d",
-          "title": "ai-compliance-monitor",
+          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
+          "title": "Blockscout MCP Server",
           "momentum": 0,
-          "rank": 36
+          "rank": 24
+        },
+        {
+          "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
+          "title": "Ternary Intelligence Stack",
+          "momentum": 0,
+          "rank": 25
+        },
+        {
+          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
+          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "momentum": 0,
+          "rank": 26
+        },
+        {
+          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
+          "title": "Supabase",
+          "momentum": 0,
+          "rank": 27
+        },
+        {
+          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
+          "title": "Swiss Truth MCP",
+          "momentum": 0,
+          "rank": 28
         },
         {
           "id": "69f8e0df-fb64-4f79-a684-6cfbdc2ba7ad",
           "title": "Slack",
           "momentum": 0,
-          "rank": 37
+          "rank": 29
+        },
+        {
+          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
+          "title": "Mesh MCP",
+          "momentum": 0,
+          "rank": 30
+        },
+        {
+          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
+          "title": "rivalsearch",
+          "momentum": 0,
+          "rank": 31
+        },
+        {
+          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
+          "title": "Octomil",
+          "momentum": 0,
+          "rank": 32
+        },
+        {
+          "id": "ffebb7a1-9654-4ddc-8d0a-3018cf8ca05d",
+          "title": "ai-compliance-monitor",
+          "momentum": 0,
+          "rank": 33
         },
         {
           "id": "0401fdd4-89a4-4cb3-b951-3df1975e978b",
           "title": "DuckDuckGo & Felo AI Search",
           "momentum": 0,
-          "rank": 38
-        },
-        {
-          "id": "33d15eec-1ccf-4070-9323-6ebe58759b50",
-          "title": "Cloud101 Korea",
-          "momentum": 0,
-          "rank": 39
+          "rank": 34
         },
         {
           "id": "9223f566-1b23-4ffc-a085-95f0bc769bed",
           "title": "Instagram",
           "momentum": 0,
-          "rank": 40
+          "rank": 35
         },
         {
           "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
           "title": "Standard Accounting Public MCP",
           "momentum": 0,
-          "rank": 41
-        },
-        {
-          "id": "ffa3bd03-4c4e-4547-a440-79a1951d9bcd",
-          "title": "quantoracle",
-          "momentum": 0,
-          "rank": 42
-        },
-        {
-          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
-          "title": "ai-agent-index",
-          "momentum": 0,
-          "rank": 43
-        },
-        {
-          "id": "5507b60f-1d64-4085-a1fb-0a270e7d3e35",
-          "title": "AI Skill Store",
-          "momentum": 0,
-          "rank": 44
-        },
-        {
-          "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
-          "title": "cultural-intelligence",
-          "momentum": 0,
-          "rank": 45
-        },
-        {
-          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
-          "title": "Seoul Essentials",
-          "momentum": 0,
-          "rank": 46
+          "rank": 36
         },
         {
           "id": "0f77dd5e-d60e-4f48-90d0-151b4876a3ca",
           "title": "Google Drive",
           "momentum": 0,
-          "rank": 47
+          "rank": 37
+        },
+        {
+          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
+          "title": "ai-agent-index",
+          "momentum": 0,
+          "rank": 38
+        },
+        {
+          "id": "5507b60f-1d64-4085-a1fb-0a270e7d3e35",
+          "title": "AI Skill Store",
+          "momentum": 0,
+          "rank": 39
+        },
+        {
+          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
+          "title": "KRDS Design System",
+          "momentum": 0,
+          "rank": 40
+        },
+        {
+          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
+          "title": "Saju Insights",
+          "momentum": 0,
+          "rank": 41
+        },
+        {
+          "id": "eb9488e1-5131-4823-b7a7-101ca4d636e4",
+          "title": "Catalunya 2022",
+          "momentum": 0,
+          "rank": 42
         },
         {
           "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
           "title": "settlegrid-discovery",
           "momentum": 0,
+          "rank": 43
+        },
+        {
+          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
+          "title": "Context Awesome",
+          "momentum": 0,
+          "rank": 44
+        },
+        {
+          "id": "c379873f-69ec-49ac-9ff3-823925cf6d47",
+          "title": "Weather MCP Server",
+          "momentum": 0,
+          "rank": 45
+        },
+        {
+          "id": "5b94d6c3-9f92-4551-b50e-1ea34a648692",
+          "title": "Google Tasks",
+          "momentum": 0,
+          "rank": 46
+        },
+        {
+          "id": "b05d3831-7bb2-4169-9922-57ecf2e94a1b",
+          "title": "troystack",
+          "momentum": 0,
+          "rank": 47
+        },
+        {
+          "id": "9afac889-3ff6-4d11-95da-4bcf1131ab33",
+          "title": "TurboPentest",
+          "momentum": 0,
           "rank": 48
         },
         {
-          "id": "c1fa01dc-1a02-4ca1-81a6-9042a0731a69",
-          "title": "Instant Domain Search",
+          "id": "6204aa60-67e4-4154-ad1e-7c631c6b7d02",
+          "title": "BoardGameGeek",
           "momentum": 0,
           "rank": 49
         },
         {
-          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
-          "title": "Saju Insights",
+          "id": "772f88a0-ee50-46f1-8817-70362a2b578f",
+          "title": "GitHub",
           "momentum": 0,
           "rank": 50
         }
@@ -936,20 +936,20 @@
           "rank": 2
         },
         {
-          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
-          "title": "Gantta",
+          "id": "8e2eb2b1-b3fb-4cc5-b3fb-1fa7cb6177fb",
+          "title": "Google Sheets",
           "momentum": 0,
           "rank": 3
         },
         {
-          "id": "8e2eb2b1-b3fb-4cc5-b3fb-1fa7cb6177fb",
-          "title": "Google Sheets",
+          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
+          "title": "Exa Search",
           "momentum": 0,
           "rank": 4
         },
         {
-          "id": "0da1e4cd-c829-4cef-84aa-11680cc3d6e0",
-          "title": "Exa Search",
+          "id": "267b4011-98f0-4231-a2df-9bb31067c24e",
+          "title": "Gmail",
           "momentum": 0,
           "rank": 5
         },
@@ -960,32 +960,32 @@
           "rank": 6
         },
         {
-          "id": "267b4011-98f0-4231-a2df-9bb31067c24e",
-          "title": "Gmail",
-          "momentum": 0,
-          "rank": 7
-        },
-        {
           "id": "896f33a6-d1cc-4979-b8ba-c91fcaa3430b",
           "title": "AI Research Assistant",
           "momentum": 0,
-          "rank": 8
+          "rank": 7
         },
         {
           "id": "f32ac05b-a44a-4e86-9e7f-0a663b52e1fa",
           "title": "MCP Server for Singapore Government Open Data",
           "momentum": 0,
-          "rank": 9
+          "rank": 8
         },
         {
-          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
-          "title": "12306 Ticket Search Server",
+          "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
+          "title": "Hugeicons MCP Server",
           "momentum": 0,
-          "rank": 10
+          "rank": 9
         },
         {
           "id": "1c81d6d5-01db-45bf-8ad9-570c74b2e2eb",
           "title": "AgentMail",
+          "momentum": 0,
+          "rank": 10
+        },
+        {
+          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
+          "title": "Flight Search MCP Server",
           "momentum": 0,
           "rank": 11
         },
@@ -996,230 +996,230 @@
           "rank": 12
         },
         {
-          "id": "9b1e5970-ccdc-4691-91c1-ef3822ee4e17",
-          "title": "Flight Search MCP Server",
-          "momentum": 0,
-          "rank": 13
-        },
-        {
           "id": "584915f4-95f0-407e-9d0e-d2d7527c8e4f",
           "title": "Linkup",
           "momentum": 0,
-          "rank": 14
-        },
-        {
-          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
-          "title": "KRDS Design System",
-          "momentum": 0,
-          "rank": 15
-        },
-        {
-          "id": "d16be436-ee2a-45f0-8789-49a74dfad8be",
-          "title": "Hugeicons MCP Server",
-          "momentum": 0,
-          "rank": 16
-        },
-        {
-          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
-          "title": "Swiss Truth MCP",
-          "momentum": 0,
-          "rank": 17
+          "rank": 13
         },
         {
           "id": "9a58e6b6-6486-47c2-b05d-5362e3b85da7",
           "title": "AKShare One MCP Server",
           "momentum": 0,
-          "rank": 18
+          "rank": 14
         },
         {
           "id": "fd04d8ea-3b86-4e77-8c46-6917434eae59",
           "title": "sbb-mcp",
           "momentum": 0,
-          "rank": 19
+          "rank": 15
         },
         {
-          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
-          "title": "Paper Search",
+          "id": "b103c698-40b2-4749-a84c-8faa5cf7ca64",
+          "title": "Gantta",
           "momentum": 0,
-          "rank": 20
-        },
-        {
-          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
-          "title": "Brave Search",
-          "momentum": 0,
-          "rank": 21
+          "rank": 16
         },
         {
           "id": "a87ff84e-0968-46e8-b9e6-de5dd3ddf60f",
           "title": "Context7",
           "momentum": 0,
-          "rank": 22
+          "rank": 17
         },
         {
-          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
-          "title": "Mesh MCP",
+          "id": "1ec4ea04-5cf9-4774-af2b-b165b8e452c7",
+          "title": "Paper Search",
           "momentum": 0,
-          "rank": 23
+          "rank": 18
+        },
+        {
+          "id": "93b89069-bd9f-441e-a506-f92fc2cea326",
+          "title": "Brave Search",
+          "momentum": 0,
+          "rank": 19
         },
         {
           "id": "b2099458-8711-4f83-a029-eebf247ebe64",
           "title": "paper-search-mcp-openai-v2",
           "momentum": 0,
-          "rank": 24
-        },
-        {
-          "id": "674f3daa-4563-4099-ac0a-fd6da1237123",
-          "title": "Senzing",
-          "momentum": 0,
-          "rank": 25
-        },
-        {
-          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
-          "title": "Blockscout MCP Server",
-          "momentum": 0,
-          "rank": 26
-        },
-        {
-          "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
-          "title": "Ternary Intelligence Stack",
-          "momentum": 0,
-          "rank": 27
-        },
-        {
-          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
-          "title": "rivalsearch",
-          "momentum": 0,
-          "rank": 28
-        },
-        {
-          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
-          "title": "srv-d7aoqmh5pdvs7391dcqg",
-          "momentum": 0,
-          "rank": 29
-        },
-        {
-          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
-          "title": "Supabase",
-          "momentum": 0,
-          "rank": 30
-        },
-        {
-          "id": "706d98f8-dc33-453d-9103-d28364976e58",
-          "title": "icons8mcp",
-          "momentum": 0,
-          "rank": 31
-        },
-        {
-          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
-          "title": "MLB Stats Server",
-          "momentum": 0,
-          "rank": 32
+          "rank": 20
         },
         {
           "id": "d43420f4-a44d-4cd2-919b-6e686cf9946b",
           "title": "Microsoft Learn MCP",
           "momentum": 0,
-          "rank": 33
+          "rank": 21
         },
         {
-          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
-          "title": "Octomil",
+          "id": "3f65291f-0cdf-4eca-9096-f8f687c7851d",
+          "title": "MLB Stats Server",
           "momentum": 0,
-          "rank": 34
+          "rank": 22
         },
         {
-          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
-          "title": "Context Awesome",
+          "id": "59adfa7a-c251-4ee0-b027-8877371585b2",
+          "title": "12306 Ticket Search Server",
           "momentum": 0,
-          "rank": 35
+          "rank": 23
         },
         {
-          "id": "ffebb7a1-9654-4ddc-8d0a-3018cf8ca05d",
-          "title": "ai-compliance-monitor",
+          "id": "46eba66f-f6d7-4c5a-8bf6-e295442d0f64",
+          "title": "Blockscout MCP Server",
           "momentum": 0,
-          "rank": 36
+          "rank": 24
+        },
+        {
+          "id": "9d42051a-b29a-4b67-a546-85c7e2dc6271",
+          "title": "Ternary Intelligence Stack",
+          "momentum": 0,
+          "rank": 25
+        },
+        {
+          "id": "a8197a29-4216-4e79-b114-207b18b2964b",
+          "title": "srv-d7aoqmh5pdvs7391dcqg",
+          "momentum": 0,
+          "rank": 26
+        },
+        {
+          "id": "4e94056b-50f0-4cae-82d1-b528e604916b",
+          "title": "Supabase",
+          "momentum": 0,
+          "rank": 27
+        },
+        {
+          "id": "8ee5f436-074f-4239-8f55-b77d52e1194f",
+          "title": "Swiss Truth MCP",
+          "momentum": 0,
+          "rank": 28
         },
         {
           "id": "69f8e0df-fb64-4f79-a684-6cfbdc2ba7ad",
           "title": "Slack",
           "momentum": 0,
-          "rank": 37
+          "rank": 29
+        },
+        {
+          "id": "1ae1bdfd-d977-4517-b7de-01ecf99fdf64",
+          "title": "Mesh MCP",
+          "momentum": 0,
+          "rank": 30
+        },
+        {
+          "id": "2398de37-f60d-4c20-bdc6-0ad765f1dd4d",
+          "title": "rivalsearch",
+          "momentum": 0,
+          "rank": 31
+        },
+        {
+          "id": "a73fb8fc-464b-4825-9bde-ffe9825b1b7c",
+          "title": "Octomil",
+          "momentum": 0,
+          "rank": 32
+        },
+        {
+          "id": "ffebb7a1-9654-4ddc-8d0a-3018cf8ca05d",
+          "title": "ai-compliance-monitor",
+          "momentum": 0,
+          "rank": 33
         },
         {
           "id": "0401fdd4-89a4-4cb3-b951-3df1975e978b",
           "title": "DuckDuckGo & Felo AI Search",
           "momentum": 0,
-          "rank": 38
-        },
-        {
-          "id": "33d15eec-1ccf-4070-9323-6ebe58759b50",
-          "title": "Cloud101 Korea",
-          "momentum": 0,
-          "rank": 39
+          "rank": 34
         },
         {
           "id": "9223f566-1b23-4ffc-a085-95f0bc769bed",
           "title": "Instagram",
           "momentum": 0,
-          "rank": 40
+          "rank": 35
         },
         {
           "id": "4927ba3d-f922-4992-81c0-de6633a68d02",
           "title": "Standard Accounting Public MCP",
           "momentum": 0,
-          "rank": 41
-        },
-        {
-          "id": "ffa3bd03-4c4e-4547-a440-79a1951d9bcd",
-          "title": "quantoracle",
-          "momentum": 0,
-          "rank": 42
-        },
-        {
-          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
-          "title": "ai-agent-index",
-          "momentum": 0,
-          "rank": 43
-        },
-        {
-          "id": "5507b60f-1d64-4085-a1fb-0a270e7d3e35",
-          "title": "AI Skill Store",
-          "momentum": 0,
-          "rank": 44
-        },
-        {
-          "id": "96dda6c5-c31a-4c94-908f-6ca3773fe422",
-          "title": "cultural-intelligence",
-          "momentum": 0,
-          "rank": 45
-        },
-        {
-          "id": "7fca3556-4fe3-427a-8f57-f3c8fcebaebd",
-          "title": "Seoul Essentials",
-          "momentum": 0,
-          "rank": 46
+          "rank": 36
         },
         {
           "id": "0f77dd5e-d60e-4f48-90d0-151b4876a3ca",
           "title": "Google Drive",
           "momentum": 0,
-          "rank": 47
+          "rank": 37
+        },
+        {
+          "id": "573a7e96-ac38-4f63-aff9-f12d1a324e01",
+          "title": "ai-agent-index",
+          "momentum": 0,
+          "rank": 38
+        },
+        {
+          "id": "5507b60f-1d64-4085-a1fb-0a270e7d3e35",
+          "title": "AI Skill Store",
+          "momentum": 0,
+          "rank": 39
+        },
+        {
+          "id": "0ebcf7ee-cc1f-4114-b123-de83a63b8639",
+          "title": "KRDS Design System",
+          "momentum": 0,
+          "rank": 40
+        },
+        {
+          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
+          "title": "Saju Insights",
+          "momentum": 0,
+          "rank": 41
+        },
+        {
+          "id": "eb9488e1-5131-4823-b7a7-101ca4d636e4",
+          "title": "Catalunya 2022",
+          "momentum": 0,
+          "rank": 42
         },
         {
           "id": "9cb82f72-5a66-42dc-9b03-c96209c97ad3",
           "title": "settlegrid-discovery",
           "momentum": 0,
+          "rank": 43
+        },
+        {
+          "id": "008181fa-8b89-4d02-8337-fed1ef0092dc",
+          "title": "Context Awesome",
+          "momentum": 0,
+          "rank": 44
+        },
+        {
+          "id": "c379873f-69ec-49ac-9ff3-823925cf6d47",
+          "title": "Weather MCP Server",
+          "momentum": 0,
+          "rank": 45
+        },
+        {
+          "id": "5b94d6c3-9f92-4551-b50e-1ea34a648692",
+          "title": "Google Tasks",
+          "momentum": 0,
+          "rank": 46
+        },
+        {
+          "id": "b05d3831-7bb2-4169-9922-57ecf2e94a1b",
+          "title": "troystack",
+          "momentum": 0,
+          "rank": 47
+        },
+        {
+          "id": "9afac889-3ff6-4d11-95da-4bcf1131ab33",
+          "title": "TurboPentest",
+          "momentum": 0,
           "rank": 48
         },
         {
-          "id": "c1fa01dc-1a02-4ca1-81a6-9042a0731a69",
-          "title": "Instant Domain Search",
+          "id": "6204aa60-67e4-4154-ad1e-7c631c6b7d02",
+          "title": "BoardGameGeek",
           "momentum": 0,
           "rank": 49
         },
         {
-          "id": "efeac83a-ec83-4b70-887e-c1008ffad4f5",
-          "title": "Saju Insights",
+          "id": "772f88a0-ee50-46f1-8817-70362a2b578f",
+          "title": "GitHub",
           "momentum": 0,
           "rank": 50
         }
@@ -1229,7 +1229,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-20T05:57:36.380Z",
+      "generatedAt": "2026-05-21T06:01:21.584Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     }


### PR DESCRIPTION
Automated data refresh from `Run shadow scoring`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26208435657

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.