### PR TITLE
chore(data): refresh staleness report 2026-05-21T06:14:58Z

### DIFF
--- a/data/staleness-report.json
+++ b/data/staleness-report.json
@@ -1,24 +1,24 @@
 {
-  "generatedAt": "2026-05-20T06:13:03.876Z",
+  "generatedAt": "2026-05-21T06:14:57.199Z",
   "sources": [
     {
       "slug": "trending",
-      "total": 1500,
+      "total": 2988,
       "stale": 0,
       "thresholdHours": 4,
       "examples": [],
       "notes": [
-        "1500/1500 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
+        "2988/2988 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
       ]
     },
     {
       "slug": "repo-profiles",
-      "total": 2244,
+      "total": 2613,
       "stale": 0,
       "thresholdHours": 4,
       "examples": [],
       "notes": [
-        "2244/2244 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
+        "2613/2613 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
       ]
     },
     {


### PR DESCRIPTION
Automated data refresh from `Sweep staleness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26208935884

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.