### PR TITLE
chore(data): promote unknown mentions 2026-05-21T08:09:28Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-20T08:02:26.025Z",
-  "totalUnknownMentions": 212736,
-  "distinctRepos": 19525,
+  "generatedAt": "2026-05-21T08:09:26.844Z",
+  "totalUnknownMentions": 222406,
+  "distinctRepos": 20574,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
       "fullName": "oven-sh/bun",
-      "totalCount": 149,
+      "totalCount": 161,
       "sourceCount": 5,
       "sources": [
         "bluesky",
@@ -17,11 +17,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 79,
+      "totalCount": 84,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -31,11 +31,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
     },
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 172,
+      "totalCount": 184,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -44,11 +44,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
       "fullName": "vercel/next.js",
-      "totalCount": 156,
+      "totalCount": 160,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -57,7 +57,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "hmbown/deepseek-tui",
@@ -74,7 +74,7 @@
     },
     {
       "fullName": "vitejs/vite",
-      "totalCount": 87,
+      "totalCount": 91,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -83,7 +83,20 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "facebook/react",
+      "totalCount": 85,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
       "fullName": "antirez/ds4",
@@ -97,19 +110,6 @@
       ],
       "firstSeenAt": "2026-05-07T15:39:28.530Z",
       "lastSeenAt": "2026-05-18T03:31:51.517Z"
-    },
-    {
-      "fullName": "facebook/react",
-      "totalCount": 80,
-      "sourceCount": 4,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "kolapsis/maintenant",
@@ -126,7 +126,7 @@
     },
     {
       "fullName": "trycua/cua",
-      "totalCount": 34,
+      "totalCount": 35,
       "sourceCount": 4,
       "sources": [
         "awesome-skills",
@@ -135,7 +135,7 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
     },
     {
       "fullName": "aattaran/deepclaude",
@@ -151,20 +151,8 @@
       "lastSeenAt": "2026-05-18T19:48:27.935Z"
     },
     {
-      "fullName": "onyks-os/transparenttorproxy",
-      "totalCount": 158,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T11:34:16.788Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "microsoft/vscode",
-      "totalCount": 153,
+      "totalCount": 162,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -172,7 +160,19 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
+    },
+    {
+      "fullName": "onyks-os/transparenttorproxy",
+      "totalCount": 159,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T11:34:16.788Z",
+      "lastSeenAt": "2026-05-20T09:58:14.460Z"
     },
     {
       "fullName": "graemeg/blaise",
@@ -188,7 +188,7 @@
     },
     {
       "fullName": "ninjahawk/hollow-agentos",
-      "totalCount": 116,
+      "totalCount": 117,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -196,7 +196,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-20T09:58:14.460Z"
     },
     {
       "fullName": "minishlab/semble",
@@ -212,7 +212,7 @@
     },
     {
       "fullName": "manojmallick/sigmap",
-      "totalCount": 105,
+      "totalCount": 106,
       "sourceCount": 3,
       "sources": [
         "devto",
@@ -220,7 +220,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
       "fullName": "scosman/cursed_browser",
@@ -283,6 +283,30 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
+      "fullName": "reviewstage/stage-cli",
+      "totalCount": 96,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T17:19:14.533Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "naver/lispe",
+      "totalCount": 95,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+    },
+    {
       "fullName": "nvlabs/cuda-oxide",
       "totalCount": 93,
       "sourceCount": 3,
@@ -295,7 +319,7 @@
       "lastSeenAt": "2026-05-11T00:07:14.314Z"
     },
     {
-      "fullName": "reviewstage/stage-cli",
+      "fullName": "bring-shrubbery/ml-sharp-web",
       "totalCount": 92,
       "sourceCount": 3,
       "sources": [
@@ -303,24 +327,12 @@
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T17:19:14.533Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
-    },
-    {
-      "fullName": "bring-shrubbery/ml-sharp-web",
-      "totalCount": 91,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
       "firstSeenAt": "2026-05-03T10:35:18.415Z",
-      "lastSeenAt": "2026-05-12T14:51:56.628Z"
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
       "fullName": "luce-org/lucebox-hub",
-      "totalCount": 90,
+      "totalCount": 91,
       "sourceCount": 3,
       "sources": [
         "devto",
@@ -328,7 +340,19 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T15:36:14.012Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "lastSeenAt": "2026-05-20T09:42:17.769Z"
+    },
+    {
+      "fullName": "higangssh/homebutler",
+      "totalCount": 90,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
     },
     {
       "fullName": "shadcn-ui/ui",
@@ -344,7 +368,7 @@
     },
     {
       "fullName": "sifter-ai/sifter",
-      "totalCount": 86,
+      "totalCount": 87,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -352,19 +376,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
-    },
-    {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 85,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
     },
     {
       "fullName": "tanstack/router",
@@ -379,6 +391,42 @@
       "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
+      "fullName": "run-llama/llama_index",
+      "totalCount": 83,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-20T12:04:16.253Z"
+    },
+    {
+      "fullName": "snyk/agent-scan",
+      "totalCount": 82,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T18:13:43.732Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "torrix-ai/install",
+      "totalCount": 81,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
       "fullName": "waybarrios/opencode-power-pack",
       "totalCount": 81,
       "sourceCount": 3,
@@ -391,32 +439,8 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
-      "fullName": "snyk/agent-scan",
-      "totalCount": 79,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T18:13:43.732Z",
-      "lastSeenAt": "2026-05-12T08:49:51.709Z"
-    },
-    {
-      "fullName": "torrix-ai/install",
-      "totalCount": 76,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "fsnotify/fsnotify",
-      "totalCount": 76,
+      "totalCount": 80,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -424,11 +448,23 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "andyyyy64/whichllm",
+      "totalCount": 76,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T10:12:27.167Z",
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
       "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 74,
+      "totalCount": 75,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -436,7 +472,19 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+    },
+    {
+      "fullName": "codecrafters-io/build-your-own-x",
+      "totalCount": 67,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-03T17:17:34.365Z",
+      "lastSeenAt": "2026-05-20T22:44:07.574Z"
     },
     {
       "fullName": "sambigeara/pollen",
@@ -451,30 +499,6 @@
       "lastSeenAt": "2026-05-10T12:05:20.661Z"
     },
     {
-      "fullName": "codecrafters-io/build-your-own-x",
-      "totalCount": 65,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T17:17:34.365Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "andyyyy64/whichllm",
-      "totalCount": 64,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-15T10:12:27.167Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "genymobile/scrcpy",
       "totalCount": 64,
       "sourceCount": 3,
@@ -485,6 +509,30 @@
       ],
       "firstSeenAt": "2026-05-02T08:45:16.184Z",
       "lastSeenAt": "2026-05-19T18:33:33.494Z"
+    },
+    {
+      "fullName": "n8n-io/n8n",
+      "totalCount": 63,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "reddit",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "statewright/statewright",
+      "totalCount": 63,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T17:04:51.325Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
     },
     {
       "fullName": "ollama/ollama",
@@ -536,7 +584,7 @@
     },
     {
       "fullName": "jameslockman/griffin-powermate-driver",
-      "totalCount": 61,
+      "totalCount": 62,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -544,7 +592,31 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-11T21:52:07.915Z",
-      "lastSeenAt": "2026-05-18T21:27:26.803Z"
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
+    },
+    {
+      "fullName": "vercel/ai",
+      "totalCount": 61,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "localsend/localsend",
+      "totalCount": 61,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-20T12:04:16.253Z"
     },
     {
       "fullName": "redis/redis",
@@ -559,31 +631,7 @@
       "lastSeenAt": "2026-05-18T12:48:24.691Z"
     },
     {
-      "fullName": "localsend/localsend",
-      "totalCount": 60,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-12T12:19:51.467Z"
-    },
-    {
-      "fullName": "n8n-io/n8n",
-      "totalCount": 59,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "reddit",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
-    },
-    {
-      "fullName": "statewright/statewright",
+      "fullName": "navid-m/flightsim",
       "totalCount": 59,
       "sourceCount": 3,
       "sources": [
@@ -591,8 +639,8 @@
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-12T17:04:51.325Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
     },
     {
       "fullName": "manankharwar/fusioncore",
@@ -607,16 +655,16 @@
       "lastSeenAt": "2026-05-19T12:20:48.337Z"
     },
     {
-      "fullName": "vercel/ai",
-      "totalCount": 57,
+      "fullName": "v12-security/pocs",
+      "totalCount": 56,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "devto",
-        "npm"
+        "hackernews",
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "uw-syfi/vibe-serve",
@@ -631,18 +679,6 @@
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
-      "fullName": "navid-m/flightsim",
-      "totalCount": 55,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
-    },
-    {
       "fullName": "minio/minio",
       "totalCount": 54,
       "sourceCount": 3,
@@ -655,20 +691,8 @@
       "lastSeenAt": "2026-05-09T08:04:55.501Z"
     },
     {
-      "fullName": "v12-security/pocs",
-      "totalCount": 50,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "vllm-project/vllm",
-      "totalCount": 49,
+      "totalCount": 53,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -676,7 +700,19 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "rust-lang/rust",
+      "totalCount": 49,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -713,6 +749,42 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-07T10:14:50.031Z"
+    },
+    {
+      "fullName": "igorganapolsky/thumbgate",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+    },
+    {
+      "fullName": "jnuyens/modulejail",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-21T05:51:41.496Z"
+    },
+    {
+      "fullName": "junegunn/fzf",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
     },
     {
       "fullName": "anthropics/claude-for-legal",
@@ -763,6 +835,18 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
+      "fullName": "0xmassi/webclaw",
+      "totalCount": 44,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+    },
+    {
       "fullName": "simdjson/simdjson",
       "totalCount": 44,
       "sourceCount": 3,
@@ -775,40 +859,16 @@
       "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
-      "fullName": "0xmassi/webclaw",
+      "fullName": "zed-industries/zed",
       "totalCount": 43,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
-        "devto",
-        "reddit"
+        "bluesky",
+        "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
-    },
-    {
-      "fullName": "rust-lang/rust",
-      "totalCount": 43,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
-      "fullName": "junegunn/fzf",
-      "totalCount": 43,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
     },
     {
       "fullName": "iliaal/fastchart",
@@ -823,32 +883,8 @@
       "lastSeenAt": "2026-05-19T13:44:19.677Z"
     },
     {
-      "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 42,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
-    },
-    {
-      "fullName": "zed-industries/zed",
-      "totalCount": 41,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
-    },
-    {
       "fullName": "stardockcorp/wireloom",
-      "totalCount": 39,
+      "totalCount": 41,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -856,7 +892,31 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-20T12:39:36.429Z"
+    },
+    {
+      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
+      "totalCount": 39,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:43:54.808Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+    },
+    {
+      "fullName": "open-webui/open-webui",
+      "totalCount": 37,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T04:53:38.982Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "tabularisdb/tabularis",
@@ -883,28 +943,28 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
-      "totalCount": 35,
+      "fullName": "awslabs/mcp",
+      "totalCount": 36,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+    },
+    {
+      "fullName": "anishathalye/ai-agent-security-lecture",
+      "totalCount": 29,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "hackernews",
         "lobsters"
       ],
-      "firstSeenAt": "2026-05-15T06:43:54.808Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
-      "fullName": "open-webui/open-webui",
-      "totalCount": 32,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-07T04:53:38.982Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "firstSeenAt": "2026-05-18T16:34:28.470Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -919,20 +979,8 @@
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
     },
     {
-      "fullName": "anishathalye/ai-agent-security-lecture",
-      "totalCount": 24,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-18T16:34:28.470Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "anthropics/claude-cookbooks",
-      "totalCount": 22,
+      "totalCount": 23,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -940,7 +988,19 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+    },
+    {
+      "fullName": "sander110419/lightroom-cc-on-linux",
+      "totalCount": 21,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-18T12:48:24.691Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -955,6 +1015,18 @@
       "lastSeenAt": "2026-05-17T21:12:09.791Z"
     },
     {
+      "fullName": "xataio/deltax",
+      "totalCount": 18,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-19T19:17:55.212Z",
+      "lastSeenAt": "2026-05-21T05:51:41.496Z"
+    },
+    {
       "fullName": "skyhook-io/radar",
       "totalCount": 18,
       "sourceCount": 3,
@@ -967,20 +1039,8 @@
       "lastSeenAt": "2026-05-04T00:13:30.621Z"
     },
     {
-      "fullName": "sander110419/lightroom-cc-on-linux",
-      "totalCount": 17,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-18T12:48:24.691Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "duriantaco/skylos",
-      "totalCount": 16,
+      "totalCount": 17,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -988,11 +1048,11 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
     },
     {
       "fullName": "nodejs/node",
-      "totalCount": 7,
+      "totalCount": 11,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -1000,30 +1060,18 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T03:48:07.888Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
-      "fullName": "xataio/deltax",
-      "totalCount": 6,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-19T19:17:55.212Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 153,
+      "totalCount": 162,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-20T07:59:18.489Z"
+      "lastSeenAt": "2026-05-21T08:06:54.299Z"
     },
     {
       "fullName": "wojtczyk/trust",
@@ -1037,6 +1085,17 @@
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
+      "fullName": "jigjoy-ai/mozaik",
+      "totalCount": 131,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
       "fullName": "nexu-io/open-design",
       "totalCount": 129,
       "sourceCount": 2,
@@ -1046,17 +1105,6 @@
       ],
       "firstSeenAt": "2026-05-02T13:50:45.195Z",
       "lastSeenAt": "2026-05-11T19:17:39.871Z"
-    },
-    {
-      "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 127,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "translate-tools/transly",
@@ -1104,25 +1152,36 @@
     },
     {
       "fullName": "raiyanyahya/how-to-train-your-gpt",
-      "totalCount": 110,
+      "totalCount": 114,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "warwickwood-cell/gengeo-agent-registry",
-      "totalCount": 110,
+      "totalCount": 114,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+    },
+    {
+      "fullName": "drcathicks/learning-opportunities",
+      "totalCount": 112,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "jossephus/chuchu",
@@ -1134,17 +1193,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-16T00:18:32.194Z"
-    },
-    {
-      "fullName": "drcathicks/learning-opportunities",
-      "totalCount": 106,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "orhun/ratty",
@@ -1180,6 +1228,17 @@
       "lastSeenAt": "2026-05-19T01:56:00.808Z"
     },
     {
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 101,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-21T05:20:28.559Z"
+    },
+    {
       "fullName": "ifixai-ai/diagnostic",
       "totalCount": 101,
       "sourceCount": 2,
@@ -1213,17 +1272,6 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 94,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-19T20:52:58.618Z"
-    },
-    {
       "fullName": "avarok-cybersecurity/atlas",
       "totalCount": 94,
       "sourceCount": 2,
@@ -1255,6 +1303,17 @@
       ],
       "firstSeenAt": "2026-05-02T17:16:19.580Z",
       "lastSeenAt": "2026-05-17T23:08:31.913Z"
+    },
+    {
+      "fullName": "harnexa/nexa-gauge",
+      "totalCount": 91,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T01:29:16.934Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
     },
     {
       "fullName": "emad-elsaid/xlog",
@@ -1312,28 +1371,6 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "naver/lispe",
-      "totalCount": 88,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
-      "fullName": "harnexa/nexa-gauge",
-      "totalCount": 87,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T01:29:16.934Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "cubiczan/consensus-hardening-protocol",
       "totalCount": 87,
       "sourceCount": 2,
@@ -1343,6 +1380,28 @@
       ],
       "firstSeenAt": "2026-05-01T21:16:46.793Z",
       "lastSeenAt": "2026-05-08T19:48:01.671Z"
+    },
+    {
+      "fullName": "arriemeijer-creator/aerojax",
+      "totalCount": 85,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "v4bel/dirtyfrag",
+      "totalCount": 84,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T19:15:41.008Z",
+      "lastSeenAt": "2026-05-20T15:55:56.286Z"
     },
     {
       "fullName": "regent-vcs/re_gent",
@@ -1378,17 +1437,6 @@
       "lastSeenAt": "2026-05-19T03:43:08.866Z"
     },
     {
-      "fullName": "v4bel/dirtyfrag",
-      "totalCount": 83,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T19:15:41.008Z",
-      "lastSeenAt": "2026-05-15T19:56:10.460Z"
-    },
-    {
       "fullName": "eleata/resilient-llm-router",
       "totalCount": 83,
       "sourceCount": 2,
@@ -1422,6 +1470,17 @@
       "lastSeenAt": "2026-05-09T18:44:58.134Z"
     },
     {
+      "fullName": "yamafaktory/hypergraphz",
+      "totalCount": 82,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T21:12:41.505Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+    },
+    {
       "fullName": "dmarshaltu/coord",
       "totalCount": 82,
       "sourceCount": 2,
@@ -1433,26 +1492,15 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "run-llama/llama_index",
-      "totalCount": 82,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-12T14:38:16.802Z"
-    },
-    {
-      "fullName": "arriemeijer-creator/aerojax",
+      "fullName": "eleutherai/lm-evaluation-harness",
       "totalCount": 81,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
     },
     {
       "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
@@ -1475,6 +1523,28 @@
       ],
       "firstSeenAt": "2026-05-01T23:17:38.392Z",
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
+    },
+    {
+      "fullName": "scottgl9/skelm",
+      "totalCount": 80,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
+      "fullName": "tsirysndr/rockbox-zig",
+      "totalCount": 79,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T15:17:55.542Z",
+      "lastSeenAt": "2026-05-20T15:55:56.286Z"
     },
     {
       "fullName": "jher7/tokenyst",
@@ -1530,17 +1600,6 @@
       ],
       "firstSeenAt": "2026-05-03T10:34:44.583Z",
       "lastSeenAt": "2026-05-10T10:08:57.038Z"
-    },
-    {
-      "fullName": "tsirysndr/rockbox-zig",
-      "totalCount": 78,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T15:17:55.542Z",
-      "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
       "fullName": "dventimisupabase/pg_flight_recorder",
@@ -1609,6 +1668,17 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
+      "fullName": "enmanuelmag/heimdall-mcp",
+      "totalCount": 77,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
       "fullName": "wiaahmarketplace/typerion-oss",
       "totalCount": 77,
       "sourceCount": 2,
@@ -1631,17 +1701,6 @@
       "lastSeenAt": "2026-05-11T11:39:37.103Z"
     },
     {
-      "fullName": "scottgl9/skelm",
-      "totalCount": 76,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
-    },
-    {
       "fullName": "datadog/java-reggie",
       "totalCount": 76,
       "sourceCount": 2,
@@ -1662,17 +1721,6 @@
       ],
       "firstSeenAt": "2026-05-03T04:20:52.369Z",
       "lastSeenAt": "2026-05-10T16:09:01.639Z"
-    },
-    {
-      "fullName": "eleutherai/lm-evaluation-harness",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T14:30:15.363Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
       "fullName": "davesimoes/crustai",
@@ -1807,15 +1855,15 @@
       "lastSeenAt": "2026-05-09T15:42:37.217Z"
     },
     {
-      "fullName": "enmanuelmag/heimdall-mcp",
+      "fullName": "heyputer/puter",
       "totalCount": 73,
       "sourceCount": 2,
       "sources": [
-        "devto",
-        "hackernews"
+        "hackernews",
+        "twitter"
       ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-20T16:03:13.537Z"
     },
     {
       "fullName": "averygan/reclip",
@@ -1827,6 +1875,28 @@
       ],
       "firstSeenAt": "2026-05-02T21:01:52.519Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "chojs23/concord",
+      "totalCount": 72,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+    },
+    {
+      "fullName": "pion/rtwatch",
+      "totalCount": 72,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T14:44:37.003Z",
+      "lastSeenAt": "2026-05-20T15:55:56.286Z"
     },
     {
       "fullName": "heymrun/heym",
@@ -1961,15 +2031,15 @@
       "lastSeenAt": "2026-05-08T17:55:29.602Z"
     },
     {
-      "fullName": "pion/rtwatch",
+      "fullName": "c2sp/wycheproof",
       "totalCount": 71,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
-        "hackernews"
+        "hackernews",
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-09T14:44:37.003Z",
-      "lastSeenAt": "2026-05-18T12:12:25.407Z"
+      "firstSeenAt": "2026-05-02T10:30:24.305Z",
+      "lastSeenAt": "2026-05-21T00:00:52.233Z"
     },
     {
       "fullName": "cloudflare/workers-sdk",
@@ -2104,28 +2174,6 @@
       "lastSeenAt": "2026-05-04T11:06:19.016Z"
     },
     {
-      "fullName": "c2sp/wycheproof",
-      "totalCount": 68,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-02T10:30:24.305Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
-      "fullName": "chojs23/concord",
-      "totalCount": 68,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-20T05:57:56.260Z"
-    },
-    {
       "fullName": "valhalla/valhalla",
       "totalCount": 68,
       "sourceCount": 2,
@@ -2225,6 +2273,17 @@
       "lastSeenAt": "2026-05-09T21:15:18.927Z"
     },
     {
+      "fullName": "radotsvetkov/akmon",
+      "totalCount": 66,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-08T03:35:56.533Z",
+      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+    },
+    {
       "fullName": "backnotprop/rig",
       "totalCount": 66,
       "sourceCount": 2,
@@ -2245,61 +2304,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-15T11:31:13.243Z"
-    },
-    {
-      "fullName": "cpp2rust/cpp2rust",
-      "totalCount": 66,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T21:45:14.561Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "facebook/openzl",
-      "totalCount": 66,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T23:42:27.507Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "calebwin/gitgres",
-      "totalCount": 66,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-08T16:28:40.683Z"
-    },
-    {
-      "fullName": "advisories/ghsa-vp62-r36r-9xqp",
-      "totalCount": 64,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T04:35:37.145Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "insaneinfinity/balistic",
-      "totalCount": 64,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T08:08:25.290Z",
-      "lastSeenAt": "2026-05-09T07:04:12.114Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26213764121

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.