### PR TITLE
fix(sre): split cron-pipeline-ingest into 2 phases to dodge Vercel 300s timeout (D.4)

### DIFF
--- a/.github/workflows/cron-pipeline-ingest.yml
+++ b/.github/workflows/cron-pipeline-ingest.yml
@@ -32,7 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: POST /api/pipeline/ingest
+      # AGN-859: split into two sequential phases so each call only does
+      # ~half the work. Vercel's per-call wall-clock cap was returning 504
+      # FUNCTION_INVOCATION_TIMEOUT on the single full-run path. Two ~250s
+      # calls (each capped at 330s by --max-time, well under the 600s
+      # maxDuration on the route) preserve sequential ordering and give
+      # each phase generous headroom.
+      - name: POST /api/pipeline/ingest?phase=1
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
@@ -41,7 +47,7 @@ jobs:
             exit 1
           fi
           code=$(curl -sS --retry 2 --retry-delay 5 --max-time 330 -o /tmp/out -w "%{http_code}" -X POST \
-            "$BASE_URL/api/pipeline/ingest" \
+            "$BASE_URL/api/pipeline/ingest?phase=1" \
             -H "Authorization: Bearer $CRON_SECRET" \
             -H "Content-Type: application/json" \
             -d '{"recomputeAfter":false}')
@@ -53,6 +59,31 @@ jobs:
           fi
           echo
           if [ "$code" != "200" ]; then
-            echo "::error::pipeline/ingest call failed ($code)"
+            echo "::error::pipeline/ingest phase=1 call failed ($code)"
+            exit 1
+          fi
+
+      - name: POST /api/pipeline/ingest?phase=2
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET is unset — refusing to fire unauthenticated"
+            exit 1
+          fi
+          code=$(curl -sS --retry 2 --retry-delay 5 --max-time 330 -o /tmp/out -w "%{http_code}" -X POST \
+            "$BASE_URL/api/pipeline/ingest?phase=2" \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            -H "Content-Type: application/json" \
+            -d '{"recomputeAfter":false}')
+          echo "HTTP $code"
+          if command -v jq >/dev/null 2>&1 && jq . /tmp/out >/dev/null 2>&1; then
+            jq . /tmp/out | head -c 2000
+          else
+            head -c 2000 /tmp/out
+          fi
+          echo
+          if [ "$code" != "200" ]; then
+            echo "::error::pipeline/ingest phase=2 call failed ($code)"
             exit 1
           fi

--- a/.github/workflows/cron-pipeline-ingest.yml
+++ b/.github/workflows/cron-pipeline-ingest.yml
@@ -71,11 +71,15 @@ jobs:
             echo "::error::CRON_SECRET is unset — refusing to fire unauthenticated"
             exit 1
           fi
+          # Phase=2 omits `recomputeAfter` so route defaults to true (per its
+          # `phase === 1 ? false : (recomputeAfter ?? true)` logic). Without
+          # this, phase=2 would inherit phase=1's recomputeAfter:false and
+          # pipeline.recomputeAll() would NEVER fire from the scheduled cron.
           code=$(curl -sS --retry 2 --retry-delay 5 --max-time 330 -o /tmp/out -w "%{http_code}" -X POST \
             "$BASE_URL/api/pipeline/ingest?phase=2" \
             -H "Authorization: Bearer $CRON_SECRET" \
             -H "Content-Type: application/json" \
-            -d '{"recomputeAfter":false}')
+            -d '{}')
           echo "HTTP $code"
           if command -v jq >/dev/null 2>&1 && jq . /tmp/out >/dev/null 2>&1; then
             jq . /tmp/out | head -c 2000

--- a/src/app/api/pipeline/ingest/route.ts
+++ b/src/app/api/pipeline/ingest/route.ts
@@ -39,11 +39,20 @@ export const runtime = "nodejs";
 // pipeline.recomputeAll(). The default 10s Vercel function timeout is way
 // too tight — sibling pipeline routes (cleanup/enrich/backfill/rebuild) all
 // run at 300s for the same reason. Cron 504s on this route were the symptom.
-export const maxDuration = 300;
+//
+// AGN-859: even at 300s the full sequential aggregator was hitting the
+// Vercel wall-clock cap and returning HTTP 504 FUNCTION_INVOCATION_TIMEOUT
+// to the GH Actions cron. Forward fix: bump per-call ceiling to 600s here
+// AND mirror the override in vercel.json (deploy-time enforcement); split
+// the work into two phases driven by `?phase=1` / `?phase=2` so each call
+// only does ~half the work and stays well under the ceiling.
+export const maxDuration = 600;
 
 const FULL_NAME_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 const MAX_BATCH_SIZE = 50;
 const FULL_NAME_MAX_LEN = 200;
+const VALID_PHASES = new Set([1, 2] as const);
+type IngestPhase = 1 | 2;
 
 // Zod schema for the request body. Matches the field structure documented
 // in the GET handler below: `fullNames` is an optional array of owner/repo
@@ -66,6 +75,10 @@ const BodySchema = z
       .optional(),
     useMock: z.boolean().optional(),
     recomputeAfter: z.boolean().optional(),
+    // AGN-859: optional phase param so the cron can split work across two
+    // calls. Zod accepts the raw value here; `readPhase` validates 1|2 and
+    // also accepts the value via `?phase=` query string.
+    phase: z.union([z.literal(1), z.literal(2)]).optional(),
   })
   .strict();
 
@@ -117,6 +130,7 @@ export interface IngestResponse {
   ok: true;
   batch: IngestBatchResult;
   recomputed: boolean;
+  phase: 1 | 2 | null;
   durationMs: number;
 }
 
@@ -178,6 +192,44 @@ function parseBody(raw: unknown): {
   };
 }
 
+/**
+ * AGN-859 phase support. The hourly cron used to fire a single POST that
+ * sequentially ingested up to 50 repos × N social adapters and then ran
+ * pipeline.recomputeAll(); on a cold lambda this regularly blew past the
+ * 300s function ceiling and Vercel returned 504 FUNCTION_INVOCATION_TIMEOUT.
+ *
+ * Forward-only fix: callers may pass `?phase=1` / `?phase=2` (query string
+ * or JSON body field), which slices `fullNames` along the midpoint so each
+ * invocation does roughly half the work. `phase` is additive — when it is
+ * absent the route still performs the full run, preserving every existing
+ * caller. The recompute step is suppressed on `phase=1` so we recompute
+ * exactly once after `phase=2` lands the second slice.
+ */
+function readPhase(request: NextRequest, body: { phase?: unknown }): {
+  ok: true;
+  phase: IngestPhase | null;
+} | { ok: false; error: string } {
+  const fromQuery = request.nextUrl.searchParams.get("phase");
+  const raw = fromQuery !== null ? fromQuery : body.phase;
+  if (raw === undefined || raw === null || raw === "") {
+    return { ok: true, phase: null };
+  }
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isInteger(n) || !VALID_PHASES.has(n as IngestPhase)) {
+    return { ok: false, error: "phase must be 1 or 2" };
+  }
+  return { ok: true, phase: n as IngestPhase };
+}
+
+/** Slice fullNames by phase. `phase=1` is the first half (rounded up so it
+ * never returns an empty slice on an odd batch), `phase=2` is the
+ * remainder, `null` means full run.  */
+function slicePhase(fullNames: string[], phase: IngestPhase | null): string[] {
+  if (phase === null) return fullNames;
+  const mid = Math.ceil(fullNames.length / 2);
+  return phase === 1 ? fullNames.slice(0, mid) : fullNames.slice(mid);
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   Sentry.setTag("route", "api/pipeline/ingest");
   const startedAt = Date.now();
@@ -203,14 +255,28 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
+  const phaseParse = readPhase(
+    request,
+    raw as { phase?: unknown },
+  );
+  if (!phaseParse.ok) {
+    return NextResponse.json(
+      { ok: false, error: phaseParse.error },
+      { status: 400 },
+    );
+  }
+  const phase = phaseParse.phase;
+
   const { fullNames: explicitFullNames, useMock, recomputeAfter } = parsed.value;
-  const fullNames = explicitFullNames ?? autoDiscoverFullNames();
+  const allFullNames = explicitFullNames ?? autoDiscoverFullNames();
   const autoDiscovered = explicitFullNames === undefined;
+  const fullNames = slicePhase(allFullNames, phase);
 
   Sentry.setTag("ingest.autoDiscovered", String(autoDiscovered));
   Sentry.setTag("ingest.batchSize", String(fullNames.length));
+  Sentry.setTag("ingest.phase", phase === null ? "full" : String(phase));
 
-  if (fullNames.length === 0) {
+  if (allFullNames.length === 0) {
     return NextResponse.json(
       {
         ok: false,
@@ -219,6 +285,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       },
       { status: 503 },
     );
+  }
+
+  // A non-empty source list with an empty phase slice (e.g. phase=2 on a
+  // single-repo batch) is a no-op success: the other phase already covered
+  // the work. Returning 200 here keeps the cron's two-call sequence happy.
+  if (fullNames.length === 0) {
+    const now = new Date().toISOString();
+    const emptyBatch: IngestBatchResult = {
+      startedAt: now,
+      finishedAt: now,
+      total: 0,
+      ok: 0,
+      failed: 0,
+      rateLimitRemaining: null,
+      results: [],
+    };
+    return NextResponse.json({
+      ok: true,
+      batch: emptyBatch,
+      recomputed: false,
+      phase,
+      durationMs: Date.now() - startedAt,
+    });
   }
 
   try {
@@ -251,8 +340,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       const summary = Object.entries(socialAdapters.counters)
         .map(([id, c]) => `${id}=${c.mentions}${c.failures > 0 ? `(${c.failures} fail)` : ""}`)
         .join(" ");
+      const phaseTag = phase === null ? "full" : `phase=${phase}`;
       console.log(
-        `[pipeline:ingest] social adapters summary repos=${fullNames.length}${autoDiscovered ? " auto" : ""} ${summary}`,
+        `[pipeline:ingest] social adapters summary ${phaseTag} repos=${fullNames.length}${autoDiscovered ? " auto" : ""} ${summary}`,
       );
       const redditMentions = socialAdapters.counters["reddit-public-json"]?.mentions ?? 0;
       if (redditMentions > 0) {
@@ -264,7 +354,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
     }
 
-    const shouldRecompute = recomputeAfter ?? true;
+    // Recompute exactly once. When the cron runs phase=1 then phase=2 we
+    // want the full recompute to happen after the second slice has landed,
+    // so phase=1 always skips it and phase=2 / full honour `recomputeAfter`
+    // (default true). Callers explicitly passing `recomputeAfter:false`
+    // (the cron does this) still get a no-op recompute regardless of phase.
+    const shouldRecompute = phase === 1 ? false : (recomputeAfter ?? true);
     if (shouldRecompute) {
       await pipeline.recomputeAll();
     }
@@ -273,6 +368,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       ok: true,
       batch,
       recomputed: shouldRecompute,
+      phase,
       durationMs: Date.now() - startedAt,
     });
   } catch (err) {
@@ -280,6 +376,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       tags: {
         route: "api/pipeline/ingest",
         autoDiscovered: String(autoDiscovered),
+        phase: phase === null ? "full" : String(phase),
       },
       extra: {
         batchSize: fullNames.length,

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,10 @@
     { "path": "/api/cron/alerts/dispatch", "schedule": "* * * * *" },
     { "path": "/api/cron/alerts/cleanup", "schedule": "5 0 * * *" },
     { "path": "/api/cron/referrals/qualify", "schedule": "0 * * * *" }
-  ]
+  ],
+  "functions": {
+    "src/app/api/pipeline/ingest/route.ts": {
+      "maxDuration": 600
+    }
+  }
 }


### PR DESCRIPTION
## Root cause

The `cron-pipeline-ingest` workflow fires a single POST to `/api/pipeline/ingest`. That route runs the full sequential aggregator (up to 50 repos x N social adapters + `pipeline.recomputeAll()`), which on a cold lambda blows past Vercel's per-call 300s function ceiling. Cloudflare then surfaces a 524 / 504 `FUNCTION_INVOCATION_TIMEOUT` to GitHub Actions, the run fails, and `data/trending.json` goes stale.

This is the long-standing AGN-859. A fix existed on orphaned `data/*` branches but never landed on `main`:

| Orphan commit | What it did |
| --- | --- |
| [`17620ed4`](https://github.com/0motionguy/starscreener/commit/17620ed4) | split ingest into 2 phases + bump maxDuration to 600s |
| [`f545d368`](https://github.com/0motionguy/starscreener/commit/f545d368) | wire cron to two-phase ingest curl sequence |

This PR re-applies both fixes surgically against current `main` (the orphans were authored on a pre-zod-schema base and could not be cherry-picked cleanly — preserved `BodySchema`, the reddit-freshness touch, and `vercel.json`'s existing `ignoreCommand` + `crons`).

## Changes

### Commit 1 - route + config (`0a3c14a1`)

`src/app/api/pipeline/ingest/route.ts`
- `export const maxDuration = 600;` (was 300)
- new `readPhase()` helper: reads `?phase=` query string first, body `phase` second, validates 1 | 2
- new `slicePhase()` helper: `phase=1` -> first half (`Math.ceil(n/2)`), `phase=2` -> remainder, `null` -> full
- `phase` added to `BodySchema` (zod literal union) so body-side phase works alongside query-string
- empty phase slice (e.g. `phase=2` on a single-repo batch) returns a no-op 200 to keep the cron's two-call sequence happy
- `phase=1` skips recompute; `phase=2` / full honours `recomputeAfter` so we recompute exactly once
- `IngestResponse` interface gains `phase: 1 | 2 | null`
- `Sentry.setTag("ingest.phase", ...)` + phase tag in the social-adapters log + error tag

`vercel.json`
- new `functions` block: `src/app/api/pipeline/ingest/route.ts` pinned to `maxDuration: 600` at deploy time (matches the runtime export so a Vercel build won't silently downgrade)
- preserves existing `ignoreCommand` + `crons`

### Commit 2 - workflow (`420b7b06`)

`.github/workflows/cron-pipeline-ingest.yml`
- single curl replaced with two sequential `?phase=1` -> `?phase=2` calls
- each call: `--max-time 330 --retry 2 --retry-delay 5` (well under the new 600s ceiling, gives each phase ~250s headroom)
- error messages name the phase so a flake is greppable

## Why this works

- Each phase does ~half the work so each curl finishes in ~250s.
- `--max-time 330` aborts the call if Vercel chokes mid-flight (still well under the 600s route ceiling).
- `--retry 2` covers transient 5xx without nuking the whole 2h cadence.
- `phase=1` defers recompute; `phase=2` runs the single recompute pass after the second slice lands, so we still recompute exactly once per scheduled cron fire.
- Forward-only: any caller that omits `phase` still gets the full sequential path. Auth, the social-adapter circuit breaker, and Sentry tagging are all preserved.

## Verification (post-merge, for Mirko)

1. Workflow dispatch on `Cron - pipeline ingest` -> both `phase=1` and `phase=2` steps return HTTP 200.
2. Next scheduled `15 */2 * * *` cron should succeed in ~250-300s per phase, total wall ~500s.
3. `gh run list --workflow=cron-pipeline-ingest.yml` should go green after deploy.
4. Sentry will show `ingest.phase=1` / `ingest.phase=2` tags on subsequent runs.

## Out of scope (left alone per K3)

The orphan `17620ed4` also touched five unrelated files (`git-commit-data/action.yml`, `cron-agent-commerce.yml`, `enrich-repo-profiles.yml`, `sitemap-pages.xml/route.ts`, `trends/page.tsx`). Those are not part of the D.4 fix and were intentionally NOT included here.

## Refs

- Diagnosis: AGN-859 (D.4)
- Originals: `17620ed4`, `f545d368` (both orphaned on `data/*` refresh branches)

Drafted because the cron is on a 2h cadence — surface CI before un-drafting.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>