### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T10:12:46Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-21T05:51:42.859Z",
+  "ts": "2026-05-21T10:12:45.892Z",
   "count": 1,
-  "durationMs": 4176,
+  "durationMs": 3950,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T05:51:38.704Z",
+  "fetchedAt": "2026-05-21T10:12:41.963Z",
   "windowDays": 7,
-  "scannedStories": 82,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T05:51:38.704Z",
+  "fetchedAt": "2026-05-21T10:12:41.963Z",
   "windowHours": 72,
-  "scannedTotal": 82,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -179,6 +179,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "k21pdb",
+      "title": "Aggressive AI scrapers are making it kinda suck to run wikis",
+      "url": "https://weirdgloop.org/blog/clankers",
+      "commentsUrl": "https://lobste.rs/s/k21pdb/aggressive_ai_scrapers_are_making_it",
+      "by": "",
+      "score": 54,
+      "commentCount": 15,
+      "createdUtc": 1779335461,
+      "ageHours": 6.361111111111111,
+      "trendingScore": 2.233560741562192,
+      "tags": [
+        "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "03djyt",
       "title": "New design for the FreeBSD website",
       "url": "https://www.freebsd.org/",
@@ -224,23 +241,6 @@
       "createdUtc": 1778343177,
       "ageHours": 2.348333333333333,
       "trendingScore": 1.65427236943472,
-      "tags": [
-        "web"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "k21pdb",
-      "title": "Aggressive AI scrapers are making it kinda suck to run wikis",
-      "url": "https://weirdgloop.org/blog/clankers",
-      "commentsUrl": "https://lobste.rs/s/k21pdb/aggressive_ai_scrapers_are_making_it",
-      "by": "",
-      "score": 13,
-      "commentCount": 0,
-      "createdUtc": 1779335461,
-      "ageHours": 2.0102777777777776,
-      "trendingScore": 1.6187570346453364,
       "tags": [
         "web"
       ],
@@ -408,6 +408,23 @@
       "tags": [
         "browsers",
         "security"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "fu5qzo",
+      "title": "On Google declaring war on the Web",
+      "url": "https://tante.cc/2026/05/20/on-google-declaring-war-on-the-web/",
+      "commentsUrl": "https://lobste.rs/s/fu5qzo/on_google_declaring_war_on_web",
+      "by": "",
+      "score": 15,
+      "commentCount": 0,
+      "createdUtc": 1779346754,
+      "ageHours": 3.2241666666666666,
+      "trendingScore": 1.2562200576759592,
+      "tags": [
+        "web"
       ],
       "description": "",
       "linkedRepos": []
@@ -877,24 +894,6 @@
       "trendingScore": 0.9250229194251076,
       "tags": [
         "practices"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "f47lxm",
-      "title": "Learning Software Architecture",
-      "url": "https://matklad.github.io/2026/05/12/software-architecture.html",
-      "commentsUrl": "https://lobste.rs/s/f47lxm/learning_software_architecture",
-      "by": "",
-      "score": 23,
-      "commentCount": 6,
-      "createdUtc": 1778586634,
-      "ageHours": 6.559444444444445,
-      "trendingScore": 0.9184583563467914,
-      "tags": [
-        "practices",
-        "programming"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26219680468

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.