### PR TITLE
chore(data): refresh huggingface space signals 2026-05-21T10:24:12Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-21T04:56:41.327Z",
+  "ts": "2026-05-21T10:24:12.618Z",
   "count": 1,
-  "durationMs": 5551,
+  "durationMs": 5508,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T04:56:35.778Z",
+  "fetchedAt": "2026-05-21T10:24:07.112Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -95,8 +95,8 @@
       "id": "mikeee/qwen-7b-chat",
       "author": "mikeee",
       "url": "https://huggingface.co/spaces/mikeee/qwen-7b-chat",
-      "likes": 319,
-      "trendingScore": 106,
+      "likes": 322,
+      "trendingScore": 107,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -131,8 +131,8 @@
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 94,
-      "trendingScore": 82,
+      "likes": 99,
+      "trendingScore": 85,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -279,8 +279,8 @@
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 59,
-      "trendingScore": 58,
+      "likes": 61,
+      "trendingScore": 60,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -409,8 +409,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 54,
-      "trendingScore": 38,
+      "likes": 56,
+      "trendingScore": 40,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -621,6 +621,22 @@
     },
     {
       "rank": 38,
+      "id": "multimodalart/scenema-audio",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
+      "likes": 27,
+      "trendingScore": 25,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T10:12:08.000Z",
+      "lastModified": "2026-05-16T00:07:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 39,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -640,7 +656,7 @@
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -654,22 +670,6 @@
       ],
       "createdAt": "2025-12-28T08:15:28.000Z",
       "lastModified": "2025-12-29T13:46:27.000Z",
-      "models": []
-    },
-    {
-      "rank": 40,
-      "id": "multimodalart/scenema-audio",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 26,
-      "trendingScore": 24,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T10:12:08.000Z",
-      "lastModified": "2026-05-16T00:07:35.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26220199787

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.