### PR TITLE
chore(data): refresh arxiv signals 2026-05-21T10:26:34Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-21T05:01:37.754Z",
+  "ts": "2026-05-21T10:26:23.408Z",
   "count": 1,
-  "durationMs": 79162,
+  "durationMs": 63060,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T05:01:38.021Z",
+  "fetchedAt": "2026-05-21T10:26:23.698Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T05:00:18.615Z",
+  "fetchedAt": "2026-05-21T10:25:20.368Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26220260745

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.