### PR TITLE
chore(data): refresh mcp liveness 2026-05-21T10:27:19Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T05:01:46.140Z",
+  "fetchedAt": "2026-05-21T10:27:14.652Z",
   "summary": {
     "ethanhenrickson/math-mcp": {
       "isStdio": true,
@@ -17,11 +17,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "reddit": {
+    "gmail": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "gmail": {
+    "reddit": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -33,15 +33,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "deniselewis200081/rail": {
+    "hugeicons/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
     "agentmail": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hugeicons/mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -57,15 +53,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "martin111ma-za5d/swiss-truth-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "zwldarren/akshare-one-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "gantta/gantta-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -73,7 +61,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "clay-inc/clay-mcp": {
+    "gantta/gantta-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "upstash/context7-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -85,11 +77,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "upstash/context7-mcp": {
+    "titansneaker/paper-search-mcp-openai-v2": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "titansneaker/paper-search-mcp-openai-v2": {
+    "microsoft/learn_mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "etweisberg/mlb-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "deniselewis200081/rail": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -101,7 +101,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "etweisberg/mlb-mcp": {
+    "ciprianpater/srv-d7aoqmh5pdvs7391dcqg": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -109,23 +109,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ciprianpater/srv-d7aoqmh5pdvs7391dcqg": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rashforddamion/rivalsearch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "icons8community/icons8mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "microsoft/learn_mcp": {
+    "martin111ma-za5d/swiss-truth-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
     "slack": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "clay-inc/clay-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "rashforddamion/rivalsearch": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -134,14 +130,6 @@
       "livenessInferred": true
     },
     "vdineshk/ai-compliance-monitor": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bh-rat/context-awesome": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "cloud101.kr/cloud101kr": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -157,7 +145,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "quantoracle/quantoracle": {
+    "googledrive": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -169,23 +157,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "sincetomorrow/cultural-intelligence": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "googledrive": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "re-rank/uiux-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "do-droid/seoul-essentials": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tbakerx/instant-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -193,15 +165,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "info-g03l/catalunya-2022": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "settlegrid/settlegrid-discovery": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "waldzellai/clear-thought": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "info-g03l/catalunya-2022": {
+    "bh-rat/context-awesome": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -209,11 +181,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "integsec/turbopentest": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alexandria-shai-eden/caselaw": {
+    "googletasks": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -221,23 +189,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "integsec/turbopentest": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kkjdaniel/bgg-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "github": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ayni-protocol/ayni": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bitpoort/on-chain-data": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "linxule/mcp-music-studio": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "googletasks": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sigai/cancersupport": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -249,7 +213,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "apogeoapi/apogeoapi-mcp": {
+    "linxule/mcp-music-studio": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "icons8community/icons8mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -257,23 +225,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "github": {
+    "apogeoapi/apogeoapi-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "minitim222/harvard-mit-course-recommendation": {
+    "waldzellai/clear-thought": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kkjdaniel/bgg-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "labsofuniverse/legacy-mcp-analyzer": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "enji/ai-marketing-agent": {
+    "sincetomorrow/cultural-intelligence": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -281,11 +241,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "modellix/modellix-docs": {
+    "blake365/macrostrat-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "blake365/macrostrat-mcp": {
+    "do-droid/seoul-essentials": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "enji/ai-marketing-agent": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -293,19 +257,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "spyfree/mingli-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "chuhuoyuan/cloudflare": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "nexgendata-apify/developer-tools-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "pinkpixel-dev/web-scout-mcp": {
+    "spyfree/mingli-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -313,7 +269,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "quantoracle/quantoracle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "parallel/search": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pinkpixel-dev/web-scout-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -321,7 +285,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "arizeai/docs": {
+    "cloud101.kr/cloud101kr": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bitpoort/on-chain-data": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hola-ps65/siil-ostomy-store": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -329,7 +301,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hola-ps65/siil-ostomy-store": {
+    "sigai/cancersupport": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -341,6 +313,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "minitim222/harvard-mit-course-recommendation": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "youtube": {
       "isStdio": true,
       "livenessInferred": true
@@ -349,11 +325,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "aguskenari86-8bo7/cryptoiz-mcp": {
+    "smithery-ai/national-weather-service": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "smithery-ai/national-weather-service": {
+    "aguskenari86-8bo7/cryptoiz-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -361,43 +337,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "googlecalendar": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "imviky-zzzr/tickerr-live-status": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "nekzus/npm-sentinel-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "bartek-ywte/gaproll": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hellokitty-v/smithery-mcp-servers": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jarvis-stark1985/superhero-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arjunkmrm/grep": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jacksmith3888/wuwa-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "janmacher02-xl8y/czech-vat-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ucpchecker/ucp-checker": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "trello": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -405,11 +349,27 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "sfiorini/youtube-mcp": {
+    "nekzus/npm-sentinel-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "agonzalez/prueba-mcp-seeker": {
+    "alexandria-shai-eden/caselaw": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jacksmith3888/wuwa-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hellokitty-v/smithery-mcp-servers": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "arjunkmrm/grep": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tbakerx/instant-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -417,7 +377,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "kwp-lab/rss-reader-mcp": {
+    "trello": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "sfiorini/youtube-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ucpchecker/ucp-checker": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -425,7 +393,31 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "kwp-lab/rss-reader-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agonzalez/prueba-mcp-seeker": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "labsofuniverse/legacy-mcp-analyzer": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "contrastcyber/contrastapi": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "modellix/modellix-docs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "chuhuoyuan/cloudflare": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "onetrip/pulse": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -437,15 +429,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "onetrip/pulse": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "googlecalendar": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "gamzadongza/danbooru-tags-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "arizeai/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -461,10 +449,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "glassnode/glassnode-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "caullenomdahl/nextjs-react-tailwind-assistant": {
       "isStdio": true,
       "livenessInferred": true
@@ -473,7 +457,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "glassnode/glassnode-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "outlook": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "agentidx/agentcrawl": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jarvis-stark1985/superhero-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -481,7 +477,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "bopmarket/marketplace": {
+    "tavily": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -489,11 +485,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "wtf-just-happened/stock-moves-explained": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "agentidx/zarq-risk": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "tavily": {
+    "bartek-ywte/gaproll": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "janmacher02-xl8y/czech-vat-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -505,15 +509,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "wtf-just-happened/stock-moves-explained": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "outlook": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "phantom/connect-sdk": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "linear": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -533,15 +533,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rubenayla/partle": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "suseendar1414/auditsnap": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jbb1988/wheretohit": {
+    "rubenayla/partle": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "bopmarket/marketplace": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -553,23 +553,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "hirofumitorato/japan-ani-search-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "nutribalance/nutribalance-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "pranaviate/statscan-mcp": {
+    "workos": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "agentpact/marketplace": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aitutor3/calculator-mcp-test": {
+    "hirofumitorato/japan-ani-search-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -581,6 +573,14 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "aitutor3/calculator-mcp-test": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agentpact/marketplace": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "notion": {
       "isStdio": true,
       "livenessInferred": true
@@ -589,11 +589,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "convrgent/aeo-scanner": {
+    "info-sjbg/webcamexplore": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "info-sjbg/webcamexplore": {
+    "kennyckk/mcp_hkbus": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jbb1988/wheretohit": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -601,11 +605,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/la-final": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kennyckk/mcp_hkbus": {
+    "convrgent/aeo-scanner": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -621,6 +621,14 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "vercel/grep": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "fruitflies/connect": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "gigachadtrey/websimm": {
       "isStdio": true,
       "livenessInferred": true
@@ -629,23 +637,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "jthora/archangel-agency-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "fruitflies/connect": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ing-christopherleon/preciomx": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "onesignal/onesignal": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "aws/docs": {
+    "jthora/archangel-agency-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -653,11 +649,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "coupang-mcp/coupang": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aparajithn/agent-utils": {
+    "aws/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -665,11 +657,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "agentwings/exa-mcp-server": {
+    "docfork/mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "docfork/mcp": {
+    "aparajithn/agent-utils": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "coupang-mcp/coupang": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agentwings/exa-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -677,15 +677,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "jalpp/chessagine": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "plith/plith": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hoklims/stacksfinder-mcp": {
+    "santiago.blanco.vilchez/la-final": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -693,15 +685,27 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "plith/plith": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "jalpp/chessagine": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ing-christopherleon/preciomx": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "pranaviate/statscan-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "outtolunch/outtolunch": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "ragalgo/ragalgo-mcp-server-v1": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "santiago.blanco.vilchez/aaa": {
+    "hoklims/stacksfinder-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -713,6 +717,18 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "ragalgo/ragalgo-mcp-server-v1": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "santiago.blanco.vilchez/aaa": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "arabimaak/gulf-arabic": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "koreafintech/korean-crypto-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -721,11 +737,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ateam-ai/ateam": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "arabimaak/gulf-arabic": {
+    "zerion/zerion-api": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -733,15 +745,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "zerion/zerion-api": {
+    "ateam-ai/ateam": {
       "isStdio": true,
       "livenessInferred": true
     },
     "actiongate/actiongate": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "browserbase": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -757,11 +765,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "icons8community/icons8mpc": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "christos/eoa-intermediaries": {
+    "browserbase": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -769,15 +773,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "christos/eoa-intermediaries": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "petabloom/podcasts": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "icons8community/icons8mpc": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "clarityai": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "lenderwiki/lending-data": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "naimterrache/bjj-belt-progress": {
+    "docfork/docfork": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -786,6 +798,10 @@
       "livenessInferred": true
     },
     "getkin/agent-infrastructure": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "naimterrache/bjj-belt-progress": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -805,19 +821,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "petabloom/podcasts": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "mavengence/ustidnr-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ren89752/aidroid": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "info-kk33/askmia_app": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -825,15 +829,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "securityscan-api/securityscan": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "garfield-bb/hap_paas2025": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "secureship/docs": {
+    "ren89752/aidroid": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -841,11 +837,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "reitsmasieto-wq/overcome-stress": {
+    "secureship/docs": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "hithereiamaliff/mcp-keywords-everywhere": {
+    "info-kk33/askmia_app": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "garfield-bb/hap_paas2025": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "securityscan-api/securityscan": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "reitsmasieto-wq/overcome-stress": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -857,7 +865,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "hithereiamaliff/mcp-keywords-everywhere": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aryankeluskar/canvas-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "composio/context7": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "lenderwiki/lending-data": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -869,15 +889,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "infobip-mcp/search": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aryankeluskar/canvas-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "coachsync/barbell-tools": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "infobip-mcp/search": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -885,11 +901,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "alperenkocyigit/authorprofilemcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "chirag127/clear-thought-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "alperenkocyigit/authorprofilemcp": {
+    "rabqatab/lexlink-ko-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -898,10 +918,6 @@
       "livenessInferred": true
     },
     "arjunkmrm/devin": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rabqatab/lexlink-ko-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -921,11 +937,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "eren-solutions/report-needs": {
+    "underground-district/ucd-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "underground-district/ucd-mcp": {
+    "googledocs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "eren-solutions/report-needs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -941,6 +961,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "voidly/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "invarium-ai/invarium": {
       "isStdio": true,
       "livenessInferred": true
@@ -949,7 +973,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "voidly/mcp-server": {
+    "google_search_console": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -958,6 +982,10 @@
       "livenessInferred": true
     },
     "compress-new/compress-tokens": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "databutton/databutton-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -981,14 +1009,6 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "rahular101/test-101": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "intake-triage/steadyfetch": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "janwilmake/x-search-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -997,11 +1017,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "santiago.blanco.vilchez/asd": {
+    "rahular101/test-101": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "intake-triage/steadyfetch": {
       "isStdio": true,
       "livenessInferred": true
     },
     "petrsovadina/sukl-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "santiago.blanco.vilchez/asd": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1025,11 +1053,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "nicks-brn/promptscan": {
+    "atars-mcp/aarnaai": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "atars-mcp/aarnaai": {
+    "nicks-brn/promptscan": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1037,11 +1065,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "sidearmdrm/sidearm": {
+    "symdex-100/symdex": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "symdex-100/symdex": {
+    "sidearmdrm/sidearm": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1053,7 +1081,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ahmed2real/thinkzone": {
+    "jan-krat-kj4q/tulugar-real-estate": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1061,11 +1089,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "ebenova/legal-docs": {
+    "ahmed2real/thinkzone": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "koumoul/ademe-opendata": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "alex-kenny-lee-vfjv/panko-food-safety": {
       "isStdio": true,
       "livenessInferred": true
     },
     "preetrajdeo/autoapply-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ebenova/legal-docs": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1085,15 +1125,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "lochmueller/muell-io": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "iamalexander/readwise-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "jan-krat-kj4q/tulugar-real-estate": {
+    "lochmueller/muell-io": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1105,15 +1141,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "koumoul/ademe-opendata": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "rlhf-loop/mcp-memory-gateway-v2": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "skymoore/grokipedia-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1121,11 +1149,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "skymoore/grokipedia-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "devbrother2024/my-mcp-server-250925": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "alex-kenny-lee-vfjv/panko-food-safety": {
+    "shokjak/travel-deals-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1153,6 +1185,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "philidor/defi": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "easyreg/private-number-plates": {
       "isStdio": true,
       "livenessInferred": true
@@ -1161,11 +1197,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "stockfilm/stockfilm-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "xjtlumedia/x23": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "stockfilm/stockfilm-mcp": {
+    "rafsilva85/skillflow": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1173,7 +1213,7 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "philidor/defi": {
+    "saurabhsharma2u/call-for-papers": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1185,11 +1225,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "gaopengbin/cesium-mcp-runtime": {
+    "demomagic/lucy-apro": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "demomagic/lucy-apro": {
+    "gaopengbin/cesium-mcp-runtime": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1218,10 +1258,6 @@
       "livenessInferred": true
     },
     "mgao/jobdatalake": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rafsilva85/skillflow": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1265,15 +1301,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "refund-decide/notary": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "saurabhsharma2u/call-for-papers": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "science/mcp-atomictoolkit": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "refund-decide/notary": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1313,6 +1345,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "naimterrache/frigolog-haccp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "achilles-safehavencalls/pentagonal": {
       "isStdio": true,
       "livenessInferred": true
@@ -1325,6 +1361,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "kapoost/humanmcp-marketplace": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "ksruthi1992/vsftest": {
       "isStdio": true,
       "livenessInferred": true
@@ -1333,19 +1373,19 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "gsudheer123/vsf": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "sidharth-5u15/cupshup-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kishvisamadd/vsf-club": {
+    "gsudheer123/vsf": {
       "isStdio": true,
       "livenessInferred": true
     },
     "leonid-rise/base44-sdk-docs": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "kishvisamadd/vsf-club": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1357,6 +1397,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "rei02061986/patent-space-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "conner-m4el/helium-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -1365,15 +1409,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "srimaan.yarram/vsfclubmcpsrimaan": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "nicholasemccormick/docpulse-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "rei02061986/patent-space-mcp": {
+    "srimaan.yarram/vsfclubmcpsrimaan": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1393,11 +1433,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "naimterrache/frigolog-haccp": {
+    "kishore.venkata.m/weathermcpmvk": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "kishore.venkata.m/weathermcpmvk": {
+    "cyanheads/openalex-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1405,11 +1445,23 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "zobr-script/zobr-script": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "hithereiamaliff/mcp-ltadatamallsg": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "zobr-script/zobr-script": {
+    "cyanheads/pubmed-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agentclear-ai/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cyanheads/arxiv-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1434,10 +1486,6 @@
       "livenessInferred": true
     },
     "resumeoptimizerpro/resume-optimizer-pro": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kapoost/humanmcp-marketplace": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1497,15 +1545,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "cyanheads/pubmed-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "plural-online/pinelab": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "cyanheads/arxiv-mcp-server": {
+    "top/yappers": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1514,6 +1558,10 @@
       "livenessInferred": true
     },
     "kaparnashilpa/vsfclubshilpa": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "maxsambento/morfex": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1529,6 +1577,10 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "govbase/govbase": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "pinkpixel-dev/mindbridge-mcp": {
       "isStdio": true,
       "livenessInferred": true
@@ -1537,7 +1589,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "cyanheads/openalex-mcp-server": {
+    "cyanheads/clinicaltrialsgov-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ralf/fyndling": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1549,7 +1605,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "maxsambento/morfex": {
+    "mosesy5688/free2aitools": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dimitry/parse-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1557,15 +1617,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
+    "janmacher02-xl8y/sec-edgar-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
     "vivid/vivid-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "govbase/govbase": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ralf/fyndling": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1589,19 +1645,11 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "janmacher02-xl8y/sec-edgar-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
     "ebenova/vigil-fraud-alert": {
       "isStdio": true,
       "livenessInferred": true
     },
     "acedatacloud-mcp/mcp-seedance": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dimitry/parse-mcp": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1614,10 +1662,6 @@
       "livenessInferred": true
     },
     "spacemolt/gameserver": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "cyanheads/clinicaltrialsgov-mcp-server": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -1737,247 +1781,15 @@
       "isStdio": true,
       "livenessInferred": true
     },
-    "vitalini/ebb-ai": {
+    "bouch/whatdotheyknow": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "aurasoph/klone-mcp": {
+    "pineapple-ai/skill-history": {
       "isStdio": true,
       "livenessInferred": true
     },
-    "pipeworx-io/mcp-spoonacular": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pipeworx-io/twelvedata": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pipeworx-io/mcp-deepl": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "yuechen/plaid-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "saikandikatta/cheapflights-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pipeworx-io/mapbox mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jrolstad/ambient-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "skeego/opendata-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "questsystems-ai/fal-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "amichae2/math mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "satsuj1n/xp-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pipeworx-io/mcp-clinicaltables": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "survivorforge/agentalmanac-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "voftec/bora-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "dajun666/schoology-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pras-labs/bichon-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "sravannerella/anypoint mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jlavoieca/access self-hosted mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "semiotronika/linza-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ktg-one/stac2026": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pitstop-hq/pitstop": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mrankitvish/rag-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "octen-team/octen-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "waeckerlinfederowicz66-sketch/flowspeech mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vishaltorc/subconscious-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "michielinksee/cockpit-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "rauls-kjarners/claude-to-agy": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vassiliylakhonin/agenda intelligence": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "hng2725/math addition mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "pauliowest/campaign monitor mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "planit-tech/lawbster": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "renanpires-tech/gpa backend test analyst mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shdomi8599/vibie-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kapillamba4/code memory": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kapillamba4/meta-prompt-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alikarami/mikromcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "jrslyce/idelrpg": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ericm1018/skillfm beacon": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "kioie/tiny-go-mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "tushariitr-19/patents-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "aliasunder/vault-cortex": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "automatelab-tech/content distribution mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "prmbr42-bot/smartsheet mcp server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "openaccountants/openaccountants": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "svgicons-com/svg/icons mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "alfredoizdev/contextforge-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mnemexa/mnemexa mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "ai.calendarmcp/server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "mosesy5688/free2aitools": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "top/yappers": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "agentclear-ai/mcp-server": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "shokjak/travel-deals-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "databutton/databutton-mcp": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "workos": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "vercel/grep": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "google_search_console": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "docfork/docfork": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "googledocs": {
-      "isStdio": true,
-      "livenessInferred": true
-    },
-    "linear": {
+    "hello-uvza/sansfiction": {
       "isStdio": true,
       "livenessInferred": true
     },
@@ -3998,6 +3810,194 @@
       "livenessInferred": true
     },
     "moksh555/githubmcpserver": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "eaveluo/1panel mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "synapbus/synapbus": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "traia-io/nager mcp v201 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "wooxogh/adr-skills": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "cjmontgom/task manager mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gethopp/figma mcp bridge": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "parth-unjiya/odoo-mcp-gateway": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "psychosmiley/mcp-to-mcp tic-tac-toe": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "traia-io/nager mcp v202 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aarna-ai/atars mcp by aarna": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "minhoyoo-iotrust/waiaas": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "legalengineering/sk-registers-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dieselpro1111/tradespro": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "hanshuebner/symbolics-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "qune-tech/qune-tech/ocds-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "andrewpetecoleman-cloud/agentmemo-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "daiji-sshr/redmine-mcp-stateless": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "excalimate/@excalimate/mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "traia-io/nager mcp v203 mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ikoskela/precision-desktop": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "0-co/agent-friend": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "anarcyst/youtube mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "juanisidoro/securecode": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "securitytalent/malware analysis mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "trayders/trayd": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "badchars/osint-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ismaileneskucuk/electronic markets tr": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agent-billy/agent billy mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "yusufkaraaslan/skill seekers": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "mctlhq/mctl": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "tuckerschreiber/need": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "martingeidobler/android-mcp-server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "birdinthetree/zotero-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "gabrielbbaldez/notify-hub": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "asgcompute/asg card": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "doc-api-llc/docapi mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "itsnikhile/claude mcp data engineer server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dsgarage/maxrefmcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ironjesus74-hub/remote mcp server on cloudflare": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "open-agent-id/oaid-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "dbf100/plaud mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "agentwebprotocol/awp mcp server": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "ebrahimpleite/mcp conta azul": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aarons22/paprika-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "aviman1109/garmin multi-account mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "darktw/agentdrop-mcp": {
+      "isStdio": true,
+      "livenessInferred": true
+    },
+    "alex-gon/the game crafter": {
       "isStdio": true,
       "livenessInferred": true
     }


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26220343788

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.