### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T13:47:51Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-21T10:12:45.892Z",
+  "ts": "2026-05-21T13:47:50.991Z",
   "count": 1,
-  "durationMs": 3950,
+  "durationMs": 4250,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T10:12:41.963Z",
+  "fetchedAt": "2026-05-21T13:47:46.761Z",
   "windowDays": 7,
-  "scannedStories": 80,
+  "scannedStories": 82,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T10:12:41.963Z",
+  "fetchedAt": "2026-05-21T13:47:46.761Z",
   "windowHours": 72,
-  "scannedTotal": 80,
+  "scannedTotal": 82,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -231,6 +231,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "fu5qzo",
+      "title": "On Google declaring war on the Web",
+      "url": "https://tante.cc/2026/05/20/on-google-declaring-war-on-the-web/",
+      "commentsUrl": "https://lobste.rs/s/fu5qzo/on_google_declaring_war_on_web",
+      "by": "",
+      "score": 44,
+      "commentCount": 6,
+      "createdUtc": 1779346754,
+      "ageHours": 6.808888888888889,
+      "trendingScore": 1.6829490894836991,
+      "tags": [
+        "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "vbit2a",
       "title": "I Will Not Add Query Strings to Your URLs",
       "url": "https://susam.net/no-query-strings.html",
@@ -408,23 +425,6 @@
       "tags": [
         "browsers",
         "security"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "fu5qzo",
-      "title": "On Google declaring war on the Web",
-      "url": "https://tante.cc/2026/05/20/on-google-declaring-war-on-the-web/",
-      "commentsUrl": "https://lobste.rs/s/fu5qzo/on_google_declaring_war_on_web",
-      "by": "",
-      "score": 15,
-      "commentCount": 0,
-      "createdUtc": 1779346754,
-      "ageHours": 3.2241666666666666,
-      "trendingScore": 1.2562200576759592,
-      "tags": [
-        "web"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26230004821

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.