### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-21T14:18:17Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-21T00:16:36.795Z",
+  "ts": "2026-05-21T14:18:16.849Z",
   "count": 1,
-  "durationMs": 9939,
+  "durationMs": 10393,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-21T00:16:34.014Z",
+  "lastFetchedAt": "2026-05-21T14:18:14.038Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1533,6 +1533,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152148",
+      "name": "Tycoon AI ",
+      "tagline": "Run one-person companies entirely with AI agents",
+      "description": "Tycoon.us enables you to run an entire company with AI agents, powered by Astra, an AI CEO, and 10+ ready-to-use AI agents you can choose from, from CMO who manages X to CTO who codes. Astra also manages Claude Code/Hermes. Give Astra a KPI or project, like “10x traffic this month,” or “launch onboarding flows.” She creates a plan, assigns agents, tracks progress, and asks for approval when needed. Every agent is out of box, so no setup, coding, or API keys required.",
+      "url": "https://www.producthunt.com/products/tycoon-us?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/RL4GWQKCKC4Y5K",
+      "votesCount": 241,
+      "commentsCount": 45,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/8148cb1b-0da3-4574-9f71-08798b552316.svg?auto=format",
+      "topics": [
+        "marketing",
+        "artificial-intelligence",
+        "tech"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1140851",
       "name": "Tendem by Toloka",
       "tagline": "AI platform to hand off any task to a human expert",
@@ -1893,6 +1935,29 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151355",
+      "name": "Google Antigravity 2.0",
+      "tagline": "Orchestrate multi-agent workflows from a desktop app",
+      "description": "Google Antigravity 2.0 is a standalone desktop app for orchestrating multiple AI agents in parallel, with scheduled background tasks, subagent workflows, and native integrations with AI Studio, Firebase, and Android. Built for developers building production apps.",
+      "url": "https://www.producthunt.com/products/google-antigravity?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/BVJYKCZ724TDTG",
+      "votesCount": 202,
+      "commentsCount": 8,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/64f05fed-5478-434e-b175-80b218391f8c.png?auto=format",
+      "topics": [
+        "task-management",
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1139500",
       "name": "deepsec",
       "tagline": "Open-source coding security harness",
@@ -2173,76 +2238,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1148297",
-      "name": "Kirki",
-      "tagline": "WordPress finally has a freeform canvas website builder.",
-      "description": "Kirki gives WordPress designers a freeform infinite canvas — design freely without structure imposed. Built-in CMS, real-time collaboration, visual interaction timeline, and 100+ template kits. Free for everyone.",
-      "url": "https://www.producthunt.com/products/kirki?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/OLRRY6YJ3LNAUB",
-      "votesCount": 173,
-      "commentsCount": 7,
-      "createdAt": "2026-05-17T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/b605c592-de55-4306-af8c-2cb8b1f5f0d6.webp?auto=format",
-      "topics": [
-        "design-tools",
-        "wordpress",
-        "website-builder"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
-      "id": "1140632",
-      "name": "Prism",
-      "tagline": "Hire the best candidates, not just the available",
-      "description": "Most recruiting agencies start with who they already know. Prism starts with who is actually best for the role. We search beyond existing networks, agency databases, and active job seekers to find high-fit candidates across the open talent market. Then we help engage them with speed, precision, and personalization, giving companies a faster way to reach the people they actually want to hire.",
-      "url": "https://www.producthunt.com/products/prism-26?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DIVTU6GNB4UXR5",
-      "votesCount": 172,
-      "commentsCount": 14,
-      "createdAt": "2026-05-09T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/e7e6aade-0ffd-4cce-a202-e014aba72c18.png?auto=format",
-      "topics": [
-        "artificial-intelligence"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26231698931

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.