### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T17:18:16Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-21T13:47:50.991Z",
+  "ts": "2026-05-21T17:18:16.468Z",
   "count": 1,
-  "durationMs": 4250,
+  "durationMs": 4552,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T13:47:46.761Z",
+  "fetchedAt": "2026-05-21T17:18:11.936Z",
   "windowDays": 7,
-  "scannedStories": 82,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T13:47:46.761Z",
+  "fetchedAt": "2026-05-21T17:18:11.936Z",
   "windowHours": 72,
-  "scannedTotal": 82,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -580,6 +580,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "r87zln",
+      "title": "Internships for early university / no former employment",
+      "url": "",
+      "commentsUrl": "https://lobste.rs/s/r87zln/internships_for_early_university_no",
+      "by": "",
+      "score": 9,
+      "commentCount": 4,
+      "createdUtc": 1779376172,
+      "ageHours": 2.1441666666666666,
+      "trendingScore": 1.0668090460783293,
+      "tags": [
+        "ask",
+        "job"
+      ],
+      "description": "<p>As a rising freshman beginning an undergraduate computer science degree this fall, I wonder what internship opportunities (FOSS preferred) are there, for applicants in early university or who otherwise have no former employment experience (despite, perhaps, contributions to FOSS).</p>\n<p>Possible template, adapted from previous <code>t/job</code> posts:</p>\n<pre><code>**Company:** XYZ\r\n\r\n**Company website:** WWW\r\n\r\n**Position(s):** ABC\r\n\r\n**Target applicant pool:** XXX (for example, \"graduati",
+      "linkedRepos": []
+    },
+    {
       "shortId": "lwihzw",
       "title": "The React2Shell Story and What Happened Next.js",
       "url": "https://sylvie.fyi/posts/react2shell/",
@@ -877,23 +895,6 @@
       "tags": [
         "practices",
         "vibecoding"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "ktqfov",
-      "title": "Open Source Resistance",
-      "url": "https://ossresistance.com/",
-      "commentsUrl": "https://lobste.rs/s/ktqfov/open_source_resistance",
-      "by": "",
-      "score": 9,
-      "commentCount": 1,
-      "createdUtc": 1778850292,
-      "ageHours": 2.5575,
-      "trendingScore": 0.9250229194251076,
-      "tags": [
-        "practices"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26241606449

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.