### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-21T17:34:22Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-21T14:18:16.849Z",
+  "ts": "2026-05-21T17:34:22.264Z",
   "count": 1,
-  "durationMs": 10393,
+  "durationMs": 12249,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-21T14:18:14.038Z",
+  "lastFetchedAt": "2026-05-21T17:34:19.239Z",
   "windowDays": 7,
   "launches": [
     {
@@ -795,6 +795,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152148",
+      "name": "Tycoon AI ",
+      "tagline": "Run one-person companies entirely with AI agents",
+      "description": "Tycoon.us enables you to run an entire company with AI agents, powered by Astra, an AI CEO, and 10+ ready-to-use AI agents you can choose from, from CMO who manages X to CTO who codes. Astra also manages Claude Code/Hermes. Give Astra a KPI or project, like “10x traffic this month,” or “launch onboarding flows.” She creates a plan, assigns agents, tracks progress, and asks for approval when needed. Every agent is out of box, so no setup, coding, or API keys required.",
+      "url": "https://www.producthunt.com/products/tycoon-us?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/RL4GWQKCKC4Y5K",
+      "votesCount": 309,
+      "commentsCount": 64,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/8148cb1b-0da3-4574-9f71-08798b552316.svg?auto=format",
+      "topics": [
+        "marketing",
+        "artificial-intelligence",
+        "tech"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1136169",
       "name": "Fere AI",
       "tagline": "AI agents that turn signals into crypto + Polymarket trades",
@@ -1533,48 +1575,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1152148",
-      "name": "Tycoon AI ",
-      "tagline": "Run one-person companies entirely with AI agents",
-      "description": "Tycoon.us enables you to run an entire company with AI agents, powered by Astra, an AI CEO, and 10+ ready-to-use AI agents you can choose from, from CMO who manages X to CTO who codes. Astra also manages Claude Code/Hermes. Give Astra a KPI or project, like “10x traffic this month,” or “launch onboarding flows.” She creates a plan, assigns agents, tracks progress, and asks for approval when needed. Every agent is out of box, so no setup, coding, or API keys required.",
-      "url": "https://www.producthunt.com/products/tycoon-us?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/RL4GWQKCKC4Y5K",
-      "votesCount": 241,
-      "commentsCount": 45,
-      "createdAt": "2026-05-21T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/8148cb1b-0da3-4574-9f71-08798b552316.svg?auto=format",
-      "topics": [
-        "marketing",
-        "artificial-intelligence",
-        "tech"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1140851",
       "name": "Tendem by Toloka",
       "tagline": "AI platform to hand off any task to a human expert",
@@ -1684,6 +1684,29 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151355",
+      "name": "Google Antigravity 2.0",
+      "tagline": "Orchestrate multi-agent workflows from a desktop app",
+      "description": "Google Antigravity 2.0 is a standalone desktop app for orchestrating multiple AI agents in parallel, with scheduled background tasks, subagent workflows, and native integrations with AI Studio, Firebase, and Android. Built for developers building production apps.",
+      "url": "https://www.producthunt.com/products/google-antigravity?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/BVJYKCZ724TDTG",
+      "votesCount": 231,
+      "commentsCount": 11,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/64f05fed-5478-434e-b175-80b218391f8c.png?auto=format",
+      "topics": [
+        "task-management",
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1142238",
       "name": "InvestorFinder",
       "tagline": "Find investors who've backed founders just like you",
@@ -1724,6 +1747,126 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
+    },
+    {
+      "id": "779554",
+      "name": "WeWeb 3.0",
+      "tagline": "Vibe-code apps with the safety net of a no-code editor",
+      "description": "WeWeb is the only AI app builder that gives full editing control to non-coders. Prompt AI to generate your app, then refine every screen, workflow, and database in a powerful no-code editor where you always understand what’s happening under the hood. No more black box.",
+      "url": "https://www.producthunt.com/products/weweb-io?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/XOSAFL3LHXMWZZ",
+      "votesCount": 212,
+      "commentsCount": 67,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/63f91d11-901f-4ea3-88e2-a60dc4764fe1.webp?auto=format",
+      "topics": [
+        "website-builder",
+        "artificial-intelligence",
+        "no-code"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
     },
     {
       "id": "1137047",
@@ -1935,29 +2078,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1151355",
-      "name": "Google Antigravity 2.0",
-      "tagline": "Orchestrate multi-agent workflows from a desktop app",
-      "description": "Google Antigravity 2.0 is a standalone desktop app for orchestrating multiple AI agents in parallel, with scheduled background tasks, subagent workflows, and native integrations with AI Studio, Firebase, and Android. Built for developers building production apps.",
-      "url": "https://www.producthunt.com/products/google-antigravity?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/BVJYKCZ724TDTG",
-      "votesCount": 202,
-      "commentsCount": 8,
-      "createdAt": "2026-05-21T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/64f05fed-5478-434e-b175-80b218391f8c.png?auto=format",
-      "topics": [
-        "task-management",
-        "developer-tools",
-        "artificial-intelligence"
-      ],
-      "makers": [],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1139500",
       "name": "deepsec",
       "tagline": "Open-source coding security harness",
@@ -2126,6 +2246,54 @@
       "aiAdjacent": true
     },
     {
+      "id": "1148000",
+      "name": "Mintlify Workflows",
+      "tagline": "Self-updating knowledge bases",
+      "description": "Keep your docs moving as fast as your product. Mintlify Workflows lets teams turn on pre-built automations that update knowledge bases, generate changelogs, maintain translations, and handle repetitive documentation tasks whenever triggered. Instead of chasing every product change manually, teams can set up Workflows once and let Mintlify keep docs accurate, current, and ready for users.",
+      "url": "https://www.producthunt.com/products/mintlify?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3CNKWNRFX4MONH",
+      "votesCount": 189,
+      "commentsCount": 19,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/5daa9b0c-dec8-45be-856c-36a7e4957c32.png?auto=format",
+      "topics": [
+        "notes",
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1142848",
       "name": "Hyperswitch Prism",
       "tagline": "Library to plug-n-switch payment processors",
@@ -2190,72 +2358,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1139758",
-      "name": "GPT‑5.5 Instant",
-      "tagline": "Smarter, more personal answers as ChatGPT's new default",
-      "description": "GPT-5.5 Instant replaces GPT-5.3 as ChatGPT's default model with smarter, more concise answers, improved personalization from past chats and connected Gmail, and memory source controls. For ChatGPT users on all plans.",
-      "url": "https://www.producthunt.com/products/openai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/WJ4IBNQEJUGBI6",
-      "votesCount": 178,
-      "commentsCount": 4,
-      "createdAt": "2026-05-07T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/f904aec8-e324-4aed-ae3b-ff68795ce44f.png?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence",
-        "bots"
-      ],
-      "makers": [],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1130462",
-      "name": "Lingo.dev v1",
-      "tagline": "Localization engineering platform for consistent translation",
-      "description": "On Lingo.dev, teams configure localization engines: Stateful translation APIs with glossaries, brand voice rules, per-locale model chains, and AI quality scoring, and then call them via API, CLI, CI/CD, or MCP.",
-      "url": "https://www.producthunt.com/products/lingodotdev?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/IVEPQYVA4UMJAQ",
-      "votesCount": 178,
-      "commentsCount": 23,
-      "createdAt": "2026-05-07T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/782b3127-7490-4f72-8e53-95695093cc46.png?auto=format",
-      "topics": [
-        "api-1",
-        "developer-tools",
-        "artificial-intelligence",
-        "github"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26242441336

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.