### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T19:28:41Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-21T17:18:16.468Z",
+  "ts": "2026-05-21T19:28:41.714Z",
   "count": 1,
-  "durationMs": 4552,
+  "durationMs": 4205,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T17:18:11.936Z",
+  "fetchedAt": "2026-05-21T19:28:37.530Z",
   "windowDays": 7,
-  "scannedStories": 80,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T17:18:11.936Z",
+  "fetchedAt": "2026-05-21T19:28:37.530Z",
   "windowHours": 72,
-  "scannedTotal": 80,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -191,6 +191,23 @@
       "trendingScore": 2.233560741562192,
       "tags": [
         "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "fxqjqu",
+      "title": "Flipper One — we need your help",
+      "url": "https://blog.flipper.net/flipper-one-we-need-your-help/",
+      "commentsUrl": "https://lobste.rs/s/fxqjqu/flipper_one_we_need_your_help",
+      "by": "",
+      "score": 16,
+      "commentCount": 3,
+      "createdUtc": 1779385078,
+      "ageHours": 1.8441666666666667,
+      "trendingScore": 2.122837103886969,
+      "tags": [
+        "hardware"
       ],
       "description": "",
       "linkedRepos": []
@@ -877,24 +894,6 @@
       "tags": [
         "javascript",
         "rust"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "2fqahd",
-      "title": "I am not a Software Engineer",
-      "url": "https://huronbikes.mataroa.blog/blog/i-am-not-a-software-engineer/",
-      "commentsUrl": "https://lobste.rs/s/2fqahd/i_am_not_software_engineer",
-      "by": "",
-      "score": 3,
-      "commentCount": 1,
-      "createdUtc": 1779221169,
-      "ageHours": 0.18388888888888888,
-      "trendingScore": 0.9295557606879611,
-      "tags": [
-        "practices",
-        "vibecoding"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26248248198

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.