### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-21T20:15:00Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-21T15:54:26.059Z",
+  "ts": "2026-05-21T20:15:00.558Z",
   "count": 1,
-  "durationMs": 2910,
+  "durationMs": 3426,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T15:54:23.151Z",
+  "fetchedAt": "2026-05-21T20:14:57.135Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -195,8 +195,8 @@
       "author": "5CD-AI",
       "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
       "downloads": 321,
-      "likes": 45,
-      "trendingScore": 40,
+      "likes": 46,
+      "trendingScore": 41,
       "tags": [
         "task_categories:image-to-text",
         "language:vi",
@@ -288,6 +288,34 @@
     },
     {
       "rank": 10,
+      "id": "TeichAI/DeepSeek-v4-Pro-Agent",
+      "author": "TeichAI",
+      "url": "https://huggingface.co/datasets/TeichAI/DeepSeek-v4-Pro-Agent",
+      "downloads": 2738,
+      "likes": 47,
+      "trendingScore": 34,
+      "tags": [
+        "size_categories:1K<n<10K",
+        "format:json",
+        "format:agent-traces",
+        "modality:tabular",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "region:us",
+        "agent-traces",
+        "pi",
+        "distillation",
+        "deepseek/deepseek-v4-pro",
+        "teich"
+      ],
+      "createdAt": "2026-05-09T06:15:11.000Z",
+      "lastModified": "2026-05-12T04:27:13.000Z"
+    },
+    {
+      "rank": 11,
       "id": "Jackrong/DeepSeek-V4-Distill-8000x",
       "author": "Jackrong",
       "url": "https://huggingface.co/datasets/Jackrong/DeepSeek-V4-Distill-8000x",
@@ -315,34 +343,6 @@
       ],
       "createdAt": "2026-04-24T07:17:06.000Z",
       "lastModified": "2026-04-24T08:32:56.000Z"
-    },
-    {
-      "rank": 11,
-      "id": "TeichAI/DeepSeek-v4-Pro-Agent",
-      "author": "TeichAI",
-      "url": "https://huggingface.co/datasets/TeichAI/DeepSeek-v4-Pro-Agent",
-      "downloads": 2738,
-      "likes": 43,
-      "trendingScore": 31,
-      "tags": [
-        "size_categories:1K<n<10K",
-        "format:json",
-        "format:agent-traces",
-        "modality:tabular",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "region:us",
-        "agent-traces",
-        "pi",
-        "distillation",
-        "deepseek/deepseek-v4-pro",
-        "teich"
-      ],
-      "createdAt": "2026-05-09T06:15:11.000Z",
-      "lastModified": "2026-05-12T04:27:13.000Z"
     },
     {
       "rank": 12,
@@ -495,7 +495,7 @@
       "author": "Modotte",
       "url": "https://huggingface.co/datasets/Modotte/CodeX-2M-Thinking",
       "downloads": 6071,
-      "likes": 103,
+      "likes": 105,
       "trendingScore": 25,
       "tags": [
         "task_categories:text-generation",
@@ -719,6 +719,43 @@
     },
     {
       "rank": 24,
+      "id": "actava/chi-bench",
+      "author": "actava",
+      "url": "https://huggingface.co/datasets/actava/chi-bench",
+      "downloads": 1232,
+      "likes": 25,
+      "trendingScore": 22,
+      "tags": [
+        "task_categories:text-generation",
+        "language:en",
+        "license:apache-2.0",
+        "size_categories:n<1K",
+        "format:json",
+        "modality:document",
+        "modality:tabular",
+        "modality:text",
+        "library:datasets",
+        "library:pandas",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2605.16679",
+        "region:us",
+        "benchmark",
+        "agents",
+        "healthcare",
+        "clinical",
+        "prior-authorization",
+        "care-management",
+        "utilization-management",
+        "long-horizon",
+        "tool-use",
+        "mcp"
+      ],
+      "createdAt": "2026-05-03T06:52:20.000Z",
+      "lastModified": "2026-05-21T19:32:01.000Z"
+    },
+    {
+      "rank": 25,
       "id": "SALT-NLP/SWE-chat",
       "author": "SALT-NLP",
       "url": "https://huggingface.co/datasets/SALT-NLP/SWE-chat",
@@ -751,7 +788,7 @@
       "lastModified": "2026-04-29T15:05:22.000Z"
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "r0b0tlab/deepseek-hermes-reasoning-traces",
       "author": "r0b0tlab",
       "url": "https://huggingface.co/datasets/r0b0tlab/deepseek-hermes-reasoning-traces",
@@ -786,7 +823,7 @@
       "lastModified": "2026-05-04T00:18:27.000Z"
     },
     {
-      "rank": 26,
+      "rank": 27,
       "id": "ShadenA/MathNet",
       "author": "ShadenA",
       "url": "https://huggingface.co/datasets/ShadenA/MathNet",
@@ -829,7 +866,7 @@
       "lastModified": "2026-04-27T23:48:47.000Z"
     },
     {
-      "rank": 27,
+      "rank": 28,
       "id": "SWE-bench/SWE-bench_Verified",
       "author": "SWE-bench",
       "url": "https://huggingface.co/datasets/SWE-bench/SWE-bench_Verified",
@@ -852,7 +889,7 @@
       "lastModified": "2026-02-27T20:36:38.000Z"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "unh1nge/comfyui-character-composer",
       "author": "unh1nge",
       "url": "https://huggingface.co/datasets/unh1nge/comfyui-character-composer",
@@ -880,7 +917,7 @@
       "lastModified": "2026-05-07T19:19:01.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "HuggingFaceFW/fineweb",
       "author": "HuggingFaceFW",
       "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb",
@@ -904,7 +941,7 @@
       "lastModified": "2025-07-11T20:16:53.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "HuggingFaceFW/fineweb-edu",
       "author": "HuggingFaceFW",
       "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu",
@@ -934,7 +971,7 @@
       "lastModified": "2025-07-11T20:16:53.000Z"
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "junwatu/indonesian-recipes",
       "author": "junwatu",
       "url": "https://huggingface.co/datasets/junwatu/indonesian-recipes",
@@ -964,7 +1001,7 @@
       "lastModified": "2026-05-09T06:36:26.000Z"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "LukaDev13/Liminal-Dreamcore-1K",
       "author": "LukaDev13",
       "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
@@ -985,7 +1022,7 @@
       "lastModified": "2026-05-18T22:03:11.000Z"
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "HuggingFaceBio/carbon-pretraining-corpus",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/datasets/HuggingFaceBio/carbon-pretraining-corpus",
@@ -1013,7 +1050,7 @@
       "lastModified": "2026-05-14T12:41:15.000Z"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "GD-ML/TransitLM",
       "author": "GD-ML",
       "url": "https://huggingface.co/datasets/GD-ML/TransitLM",
@@ -1044,7 +1081,7 @@
       "lastModified": "2026-05-13T11:01:47.000Z"
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "ning423/deepseek-hermes-reasoning-traces",
       "author": "ning423",
       "url": "https://huggingface.co/datasets/ning423/deepseek-hermes-reasoning-traces",
@@ -1079,7 +1116,7 @@
       "lastModified": "2026-05-04T00:18:27.000Z"
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "AlicanKiraz0/Cybersecurity-Dataset-Fenrir-v2.1",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/datasets/AlicanKiraz0/Cybersecurity-Dataset-Fenrir-v2.1",
@@ -1106,7 +1143,7 @@
       "lastModified": "2026-04-22T10:29:32.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "sequelbox/Tachibana4-DeepSeek-V4-Pro",
       "author": "sequelbox",
       "url": "https://huggingface.co/datasets/sequelbox/Tachibana4-DeepSeek-V4-Pro",
@@ -1149,7 +1186,7 @@
       "lastModified": "2026-05-07T01:09:32.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "cais/mmlu",
       "author": "cais",
       "url": "https://huggingface.co/datasets/cais/mmlu",
@@ -1182,7 +1219,7 @@
       "lastModified": "2024-03-08T20:36:26.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "camvsl/Articraft-10K",
       "author": "camvsl",
       "url": "https://huggingface.co/datasets/camvsl/Articraft-10K",
@@ -1197,7 +1234,7 @@
       "lastModified": "2026-05-15T05:05:02.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "Exgentic/agent-llm-traces",
       "author": "Exgentic",
       "url": "https://huggingface.co/datasets/Exgentic/agent-llm-traces",
@@ -1227,7 +1264,7 @@
       "lastModified": "2026-05-14T18:50:50.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "OwnedByDanes/Usenet-Corpus-1980-2013",
       "author": "OwnedByDanes",
       "url": "https://huggingface.co/datasets/OwnedByDanes/Usenet-Corpus-1980-2013",
@@ -1268,7 +1305,7 @@
       "lastModified": "2026-05-05T16:17:39.000Z"
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "badlogicgames/pi-mono",
       "author": "badlogicgames",
       "url": "https://huggingface.co/datasets/badlogicgames/pi-mono",
@@ -1298,7 +1335,7 @@
       "lastModified": "2026-04-06T13:10:36.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
       "author": "sequelbox",
       "url": "https://huggingface.co/datasets/sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
@@ -1341,7 +1378,7 @@
       "lastModified": "2026-04-30T17:12:47.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "Inferact/codex_swebenchpro_traces",
       "author": "Inferact",
       "url": "https://huggingface.co/datasets/Inferact/codex_swebenchpro_traces",
@@ -1363,7 +1400,7 @@
       "lastModified": "2026-05-07T01:13:21.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "5551z/VisCoR_Contrast",
       "author": "5551z",
       "url": "https://huggingface.co/datasets/5551z/VisCoR_Contrast",
@@ -1386,7 +1423,7 @@
       "lastModified": "2026-04-30T01:37:13.000Z"
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "llm-jp/Jagle",
       "author": "llm-jp",
       "url": "https://huggingface.co/datasets/llm-jp/Jagle",
@@ -1404,7 +1441,7 @@
       "lastModified": "2026-05-12T00:53:55.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "tinixai/ocr_annual_financials",
       "author": "tinixai",
       "url": "https://huggingface.co/datasets/tinixai/ocr_annual_financials",
@@ -1425,38 +1462,6 @@
       ],
       "createdAt": "2026-05-12T15:11:00.000Z",
       "lastModified": "2026-05-18T15:35:53.000Z"
-    },
-    {
-      "rank": 48,
-      "id": "actava/chi-bench",
-      "author": "actava",
-      "url": "https://huggingface.co/datasets/actava/chi-bench",
-      "downloads": 1232,
-      "likes": 15,
-      "trendingScore": 14,
-      "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "license:apache-2.0",
-        "size_categories:n<1K",
-        "modality:document",
-        "library:datasets",
-        "library:mlcroissant",
-        "arxiv:2605.16679",
-        "region:us",
-        "benchmark",
-        "agents",
-        "healthcare",
-        "clinical",
-        "prior-authorization",
-        "care-management",
-        "utilization-management",
-        "long-horizon",
-        "tool-use",
-        "mcp"
-      ],
-      "createdAt": "2026-05-03T06:52:20.000Z",
-      "lastModified": "2026-05-19T04:40:32.000Z"
     },
     {
       "rank": 49,


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26250533374

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.