### PR TITLE
chore(data): refresh huggingface space signals 2026-05-21T20:25:44Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-21T16:00:30.415Z",
+  "ts": "2026-05-21T20:25:44.490Z",
   "count": 1,
-  "durationMs": 6269,
+  "durationMs": 6228,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T16:00:24.148Z",
+  "fetchedAt": "2026-05-21T20:25:38.265Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -95,8 +95,8 @@
       "id": "mikeee/qwen-7b-chat",
       "author": "mikeee",
       "url": "https://huggingface.co/spaces/mikeee/qwen-7b-chat",
-      "likes": 327,
-      "trendingScore": 108,
+      "likes": 328,
+      "trendingScore": 109,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -263,8 +263,8 @@
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 63,
-      "trendingScore": 62,
+      "likes": 64,
+      "trendingScore": 63,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -624,8 +624,8 @@
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 27,
-      "trendingScore": 25,
+      "likes": 28,
+      "trendingScore": 26,
       "sdk": "gradio",
       "tags": [
         "gradio",


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26251067081

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.