### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T21:15:46Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-21T19:28:41.714Z",
+  "ts": "2026-05-21T21:15:46.551Z",
   "count": 1,
-  "durationMs": 4205,
+  "durationMs": 5068,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T19:28:37.530Z",
+  "fetchedAt": "2026-05-21T21:15:41.505Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 81,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T19:28:37.530Z",
+  "fetchedAt": "2026-05-21T21:15:41.505Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 81,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -201,11 +201,11 @@
       "url": "https://blog.flipper.net/flipper-one-we-need-your-help/",
       "commentsUrl": "https://lobste.rs/s/fxqjqu/flipper_one_we_need_your_help",
       "by": "",
-      "score": 16,
-      "commentCount": 3,
+      "score": 29,
+      "commentCount": 6,
       "createdUtc": 1779385078,
-      "ageHours": 1.8441666666666667,
-      "trendingScore": 2.122837103886969,
+      "ageHours": 3.6286111111111112,
+      "trendingScore": 2.171681503426927,
       "tags": [
         "hardware"
       ],
@@ -497,6 +497,26 @@
       "tags": [
         "editors",
         "release"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "r6lw7v",
+      "title": "How to open calc.exe from S&Box",
+      "url": "https://slugcat.systems/post/26-05-21-how-to-open-calc-exe-from-sbox/",
+      "commentsUrl": "https://lobste.rs/s/r6lw7v/how_open_calc_exe_from_s_box",
+      "by": "",
+      "score": 7,
+      "commentCount": 0,
+      "createdUtc": 1779393659,
+      "ageHours": 1.245,
+      "trendingScore": 1.1975012855388545,
+      "tags": [
+        "debugging",
+        "dotnet",
+        "reversing",
+        "security"
       ],
       "description": "",
       "linkedRepos": []
@@ -876,24 +896,6 @@
         "practices",
         "rust",
         "zig"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "lapqbz",
-      "title": "Bun's Rust rewrite has been merged",
-      "url": "https://www.reddit.com/r/rust/comments/1tcrmjs/rewrite_bun_in_rust_has_been_merged/",
-      "commentsUrl": "https://lobste.rs/s/lapqbz/bun_s_rust_rewrite_has_been_merged",
-      "by": "",
-      "score": 80,
-      "commentCount": 88,
-      "createdUtc": 1778764586,
-      "ageHours": 17.456944444444446,
-      "trendingScore": 0.9321333118078383,
-      "tags": [
-        "javascript",
-        "rust"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26253501389

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.