### PR TITLE
chore(data): refresh lobsters signals 2026-05-21T22:51:58Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-21T19:28:41.714Z",
+  "ts": "2026-05-21T22:51:58.392Z",
   "count": 1,
-  "durationMs": 4205,
+  "durationMs": 5198,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T19:28:37.530Z",
+  "fetchedAt": "2026-05-21T22:51:53.215Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-21T19:28:37.530Z",
+  "fetchedAt": "2026-05-21T22:51:53.215Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -881,19 +881,21 @@
       "linkedRepos": []
     },
     {
-      "shortId": "lapqbz",
-      "title": "Bun's Rust rewrite has been merged",
-      "url": "https://www.reddit.com/r/rust/comments/1tcrmjs/rewrite_bun_in_rust_has_been_merged/",
-      "commentsUrl": "https://lobste.rs/s/lapqbz/bun_s_rust_rewrite_has_been_merged",
+      "shortId": "r6lw7v",
+      "title": "How to open calc.exe from S&Box",
+      "url": "https://slugcat.systems/post/26-05-21-how-to-open-calc-exe-from-sbox/",
+      "commentsUrl": "https://lobste.rs/s/r6lw7v/how_open_calc_exe_from_s_box",
       "by": "",
-      "score": 80,
-      "commentCount": 88,
-      "createdUtc": 1778764586,
-      "ageHours": 17.456944444444446,
-      "trendingScore": 0.9321333118078383,
+      "score": 10,
+      "commentCount": 0,
+      "createdUtc": 1779393659,
+      "ageHours": 2.848333333333333,
+      "trendingScore": 0.9367232368575993,
       "tags": [
-        "javascript",
-        "rust"
+        "debugging",
+        "dotnet",
+        "reversing",
+        "security"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26257668274

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.