### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-22T00:14:30Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-21T20:56:38.583Z",
+  "ts": "2026-05-22T00:14:30.310Z",
   "count": 1,
-  "durationMs": 14801,
+  "durationMs": 12565,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-21T20:56:35.325Z",
+  "lastFetchedAt": "2026-05-22T00:14:27.223Z",
   "windowDays": 7,
   "launches": [
     {
@@ -423,6 +423,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152148",
+      "name": "Tycoon AI ",
+      "tagline": "Run one-person companies entirely with AI agents",
+      "description": "Tycoon.us enables you to run an entire company with AI agents, powered by Astra, an AI CEO, and 10+ ready-to-use AI agents you can choose from, from CMO who manages X to CTO who codes. Astra also manages Claude Code/Hermes. Give Astra a KPI or project, like “10x traffic this month,” or “launch onboarding flows.” She creates a plan, assigns agents, tracks progress, and asks for approval when needed. Every agent is out of box, so no setup, coding, or API keys required.",
+      "url": "https://www.producthunt.com/products/tycoon-us?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/RL4GWQKCKC4Y5K",
+      "votesCount": 376,
+      "commentsCount": 85,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/8148cb1b-0da3-4574-9f71-08798b552316.svg?auto=format",
+      "topics": [
+        "marketing",
+        "artificial-intelligence",
+        "tech"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1124409",
       "name": "SocLeads 3.0",
       "tagline": "Scrape emails from socials and maps by location",
@@ -524,48 +566,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1152148",
-      "name": "Tycoon AI ",
-      "tagline": "Run one-person companies entirely with AI agents",
-      "description": "Tycoon.us enables you to run an entire company with AI agents, powered by Astra, an AI CEO, and 10+ ready-to-use AI agents you can choose from, from CMO who manages X to CTO who codes. Astra also manages Claude Code/Hermes. Give Astra a KPI or project, like “10x traffic this month,” or “launch onboarding flows.” She creates a plan, assigns agents, tracks progress, and asks for approval when needed. Every agent is out of box, so no setup, coding, or API keys required.",
-      "url": "https://www.producthunt.com/products/tycoon-us?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/RL4GWQKCKC4Y5K",
-      "votesCount": 345,
-      "commentsCount": 82,
-      "createdAt": "2026-05-21T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/8148cb1b-0da3-4574-9f71-08798b552316.svg?auto=format",
-      "topics": [
-        "marketing",
-        "artificial-intelligence",
-        "tech"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1438,6 +1438,54 @@
       "aiAdjacent": true
     },
     {
+      "id": "1148000",
+      "name": "Mintlify Workflows",
+      "tagline": "Self-updating knowledge bases",
+      "description": "Keep your docs moving as fast as your product. Mintlify Workflows lets teams turn on pre-built automations that update knowledge bases, generate changelogs, maintain translations, and handle repetitive documentation tasks whenever triggered. Instead of chasing every product change manually, teams can set up Workflows once and let Mintlify keep docs accurate, current, and ready for users.",
+      "url": "https://www.producthunt.com/products/mintlify?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3CNKWNRFX4MONH",
+      "votesCount": 260,
+      "commentsCount": 33,
+      "createdAt": "2026-05-21T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/5daa9b0c-dec8-45be-856c-36a7e4957c32.png?auto=format",
+      "topics": [
+        "notes",
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1141635",
       "name": "Ghost",
       "tagline": "Open-source, self-hosted game servers",
@@ -1581,8 +1629,8 @@
       "description": "Google Antigravity 2.0 is a standalone desktop app for orchestrating multiple AI agents in parallel, with scheduled background tasks, subagent workflows, and native integrations with AI Studio, Firebase, and Android. Built for developers building production apps.",
       "url": "https://www.producthunt.com/products/google-antigravity?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
       "website": "https://www.producthunt.com/r/BVJYKCZ724TDTG",
-      "votesCount": 240,
-      "commentsCount": 12,
+      "votesCount": 244,
+      "commentsCount": 13,
       "createdAt": "2026-05-21T07:01:00Z",
       "thumbnail": "https://ph-files.imgix.net/64f05fed-5478-434e-b175-80b218391f8c.png?auto=format",
       "topics": [
@@ -1598,123 +1646,14 @@
       "aiAdjacent": true
     },
     {
-      "id": "1140851",
-      "name": "Tendem by Toloka",
-      "tagline": "AI platform to hand off any task to a human expert",
-      "description": "Tendem is a platform where human experts and AI agents complete high-stakes tasks. Submit a task in plain language. AI agents handle the volume. Human experts level up the the final output. What comes back is complete, accurate, and ready to act on. Built by Toloka.ai, a company that has spent more than a decade building human-in-the-loop quality systems for frontier AI labs. Trusted by founders, operators, and AI-native users who need reliable results.",
-      "url": "https://www.producthunt.com/products/tendem-by-toloka?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/VU7DEOLLKRGOW4",
-      "votesCount": 235,
-      "commentsCount": 64,
-      "createdAt": "2026-05-14T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/b18f1c41-98fa-4ae8-a0da-549be2be9a72.jpeg?auto=format",
-      "topics": [
-        "design-tools",
-        "productivity",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1138787",
-      "name": "Open Vibe",
-      "tagline": "Ship your SaaS with AI, without getting stuck",
-      "description": "Build the skills of a pro coder while you ship a real SaaS app! Open Vibe turns Claude Code (or your agent of choice) into the ultimate SaaS tutor, teaching the most important concepts while you build.",
-      "url": "https://www.producthunt.com/products/open-vibe?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/74MX3XTFNJVI5S",
-      "votesCount": 234,
-      "commentsCount": 39,
-      "createdAt": "2026-05-12T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/fbaad5be-8e3d-452d-844f-3557574e0d3d.png?auto=format",
-      "topics": [
-        "education",
-        "saas",
-        "github",
-        "vibe-coding"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "779554",
       "name": "WeWeb 3.0",
       "tagline": "Vibe-code apps with the safety net of a no-code editor",
       "description": "WeWeb is the only AI app builder that gives full editing control to non-coders. Prompt AI to generate your app, then refine every screen, workflow, and database in a powerful no-code editor where you always understand what’s happening under the hood. No more black box.",
       "url": "https://www.producthunt.com/products/weweb-io?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
       "website": "https://www.producthunt.com/r/XOSAFL3LHXMWZZ",
-      "votesCount": 230,
-      "commentsCount": 69,
+      "votesCount": 237,
+      "commentsCount": 71,
       "createdAt": "2026-05-21T07:01:00Z",
       "thumbnail": "https://ph-files.imgix.net/63f91d11-901f-4ea3-88e2-a60dc4764fe1.webp?auto=format",
       "topics": [
@@ -1827,19 +1766,19 @@
       "aiAdjacent": true
     },
     {
-      "id": "1148000",
-      "name": "Mintlify Workflows",
-      "tagline": "Self-updating knowledge bases",
-      "description": "Keep your docs moving as fast as your product. Mintlify Workflows lets teams turn on pre-built automations that update knowledge bases, generate changelogs, maintain translations, and handle repetitive documentation tasks whenever triggered. Instead of chasing every product change manually, teams can set up Workflows once and let Mintlify keep docs accurate, current, and ready for users.",
-      "url": "https://www.producthunt.com/products/mintlify?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/3CNKWNRFX4MONH",
-      "votesCount": 224,
-      "commentsCount": 26,
-      "createdAt": "2026-05-21T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/5daa9b0c-dec8-45be-856c-36a7e4957c32.png?auto=format",
+      "id": "1140851",
+      "name": "Tendem by Toloka",
+      "tagline": "AI platform to hand off any task to a human expert",
+      "description": "Tendem is a platform where human experts and AI agents complete high-stakes tasks. Submit a task in plain language. AI agents handle the volume. Human experts level up the the final output. What comes back is complete, accurate, and ready to act on. Built by Toloka.ai, a company that has spent more than a decade building human-in-the-loop quality systems for frontier AI labs. Trusted by founders, operators, and AI-native users who need reliable results.",
+      "url": "https://www.producthunt.com/products/tendem-by-toloka?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/VU7DEOLLKRGOW4",
+      "votesCount": 235,
+      "commentsCount": 64,
+      "createdAt": "2026-05-14T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/b18f1c41-98fa-4ae8-a0da-549be2be9a72.jpeg?auto=format",
       "topics": [
-        "notes",
-        "developer-tools",
+        "design-tools",
+        "productivity",
         "artificial-intelligence"
       ],
       "makers": [
@@ -1855,6 +1794,67 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1138787",
+      "name": "Open Vibe",
+      "tagline": "Ship your SaaS with AI, without getting stuck",
+      "description": "Build the skills of a pro coder while you ship a real SaaS app! Open Vibe turns Claude Code (or your agent of choice) into the ultimate SaaS tutor, teaching the most important concepts while you build.",
+      "url": "https://www.producthunt.com/products/open-vibe?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/74MX3XTFNJVI5S",
+      "votesCount": 234,
+      "commentsCount": 39,
+      "createdAt": "2026-05-12T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/fbaad5be-8e3d-452d-844f-3557574e0d3d.png?auto=format",
+      "topics": [
+        "education",
+        "saas",
+        "github",
+        "vibe-coding"
+      ],
+      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26260661332

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.