### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-22T04:40:26Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-21T20:15:00.558Z",
+  "ts": "2026-05-22T04:40:26.470Z",
   "count": 1,
-  "durationMs": 3426,
+  "durationMs": 3379,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T20:14:57.135Z",
+  "fetchedAt": "2026-05-22T04:40:23.092Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -191,12 +191,43 @@
     },
     {
       "rank": 7,
+      "id": "GD-ML/TransitLM",
+      "author": "GD-ML",
+      "url": "https://huggingface.co/datasets/GD-ML/TransitLM",
+      "downloads": 522,
+      "likes": 50,
+      "trendingScore": 50,
+      "tags": [
+        "task_categories:text-generation",
+        "language:zh",
+        "license:cc-by-nc-4.0",
+        "size_categories:100K<n<1M",
+        "format:csv",
+        "modality:tabular",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "region:us",
+        "transportation",
+        "route-planning",
+        "public-transit",
+        "mobility",
+        "instruction-tuning",
+        "benchmark"
+      ],
+      "createdAt": "2026-05-03T05:31:52.000Z",
+      "lastModified": "2026-05-13T11:01:47.000Z"
+    },
+    {
+      "rank": 8,
       "id": "5CD-AI/Viet-Handwriting-OCR-v2",
       "author": "5CD-AI",
       "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
       "downloads": 321,
-      "likes": 46,
-      "trendingScore": 41,
+      "likes": 49,
+      "trendingScore": 44,
       "tags": [
         "task_categories:image-to-text",
         "language:vi",
@@ -221,7 +252,7 @@
       "lastModified": "2026-05-18T17:14:55.000Z"
     },
     {
-      "rank": 8,
+      "rank": 9,
       "id": "nvidia/Nemotron-Personas-Korea",
       "author": "nvidia",
       "url": "https://huggingface.co/datasets/nvidia/Nemotron-Personas-Korea",
@@ -253,7 +284,7 @@
       "lastModified": "2026-04-23T07:42:48.000Z"
     },
     {
-      "rank": 9,
+      "rank": 10,
       "id": "Jackrong/GLM-5.1-Reasoning-1M-Cleaned",
       "author": "Jackrong",
       "url": "https://huggingface.co/datasets/Jackrong/GLM-5.1-Reasoning-1M-Cleaned",
@@ -287,14 +318,16 @@
       "lastModified": "2026-04-19T05:05:17.000Z"
     },
     {
-      "rank": 10,
+      "rank": 11,
       "id": "TeichAI/DeepSeek-v4-Pro-Agent",
       "author": "TeichAI",
       "url": "https://huggingface.co/datasets/TeichAI/DeepSeek-v4-Pro-Agent",
       "downloads": 2738,
-      "likes": 47,
-      "trendingScore": 34,
+      "likes": 50,
+      "trendingScore": 37,
       "tags": [
+        "task_categories:text-generation",
+        "language:en",
         "size_categories:1K<n<10K",
         "format:json",
         "format:agent-traces",
@@ -312,10 +345,10 @@
         "teich"
       ],
       "createdAt": "2026-05-09T06:15:11.000Z",
-      "lastModified": "2026-05-12T04:27:13.000Z"
+      "lastModified": "2026-05-22T00:11:12.000Z"
     },
     {
-      "rank": 11,
+      "rank": 12,
       "id": "Jackrong/DeepSeek-V4-Distill-8000x",
       "author": "Jackrong",
       "url": "https://huggingface.co/datasets/Jackrong/DeepSeek-V4-Distill-8000x",
@@ -345,7 +378,7 @@
       "lastModified": "2026-04-24T08:32:56.000Z"
     },
     {
-      "rank": 12,
+      "rank": 13,
       "id": "5551z/VisCoR-55K",
       "author": "5551z",
       "url": "https://huggingface.co/datasets/5551z/VisCoR-55K",
@@ -368,7 +401,7 @@
       "lastModified": "2026-04-30T10:51:23.000Z"
     },
     {
-      "rank": 13,
+      "rank": 14,
       "id": "Roman1111111/claude-opus-4.6-10000x",
       "author": "Roman1111111",
       "url": "https://huggingface.co/datasets/Roman1111111/claude-opus-4.6-10000x",
@@ -390,7 +423,7 @@
       "lastModified": "2026-04-05T13:42:24.000Z"
     },
     {
-      "rank": 14,
+      "rank": 15,
       "id": "jamiequint/sf_criminal_court",
       "author": "jamiequint",
       "url": "https://huggingface.co/datasets/jamiequint/sf_criminal_court",
@@ -420,7 +453,7 @@
       "lastModified": "2026-05-04T23:34:38.000Z"
     },
     {
-      "rank": 15,
+      "rank": 16,
       "id": "lambda/hermes-agent-reasoning-traces",
       "author": "lambda",
       "url": "https://huggingface.co/datasets/lambda/hermes-agent-reasoning-traces",
@@ -453,7 +486,7 @@
       "lastModified": "2026-04-17T10:06:39.000Z"
     },
     {
-      "rank": 16,
+      "rank": 17,
       "id": "Qwen/WebWorldData",
       "author": "Qwen",
       "url": "https://huggingface.co/datasets/Qwen/WebWorldData",
@@ -490,7 +523,7 @@
       "lastModified": "2026-05-08T12:12:49.000Z"
     },
     {
-      "rank": 17,
+      "rank": 18,
       "id": "Modotte/CodeX-2M-Thinking",
       "author": "Modotte",
       "url": "https://huggingface.co/datasets/Modotte/CodeX-2M-Thinking",
@@ -529,7 +562,7 @@
       "lastModified": "2026-02-10T07:23:38.000Z"
     },
     {
-      "rank": 18,
+      "rank": 19,
       "id": "nvidia/Nemotron-Image-Training-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/datasets/nvidia/Nemotron-Image-Training-v3",
@@ -553,7 +586,7 @@
       "lastModified": "2026-04-28T08:35:01.000Z"
     },
     {
-      "rank": 19,
+      "rank": 20,
       "id": "apptek-com/apptek_callcenter_dialogues",
       "author": "apptek-com",
       "url": "https://huggingface.co/datasets/apptek-com/apptek_callcenter_dialogues",
@@ -587,7 +620,7 @@
       "lastModified": "2026-05-08T22:49:17.000Z"
     },
     {
-      "rank": 20,
+      "rank": 21,
       "id": "iletisim/dezenformasyon-bultenleri",
       "author": "iletisim",
       "url": "https://huggingface.co/datasets/iletisim/dezenformasyon-bultenleri",
@@ -622,7 +655,7 @@
       "lastModified": "2026-05-03T09:10:37.000Z"
     },
     {
-      "rank": 21,
+      "rank": 22,
       "id": "alibaba-multimodal-industrial-ai/IndustryBench",
       "author": "alibaba-multimodal-industrial-ai",
       "url": "https://huggingface.co/datasets/alibaba-multimodal-industrial-ai/IndustryBench",
@@ -651,7 +684,44 @@
       "lastModified": "2026-05-13T05:23:50.000Z"
     },
     {
-      "rank": 22,
+      "rank": 23,
+      "id": "actava/chi-bench",
+      "author": "actava",
+      "url": "https://huggingface.co/datasets/actava/chi-bench",
+      "downloads": 1232,
+      "likes": 27,
+      "trendingScore": 24,
+      "tags": [
+        "task_categories:text-generation",
+        "language:en",
+        "license:apache-2.0",
+        "size_categories:n<1K",
+        "format:json",
+        "modality:document",
+        "modality:tabular",
+        "modality:text",
+        "library:datasets",
+        "library:pandas",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2605.16679",
+        "region:us",
+        "benchmark",
+        "agents",
+        "healthcare",
+        "clinical",
+        "prior-authorization",
+        "care-management",
+        "utilization-management",
+        "long-horizon",
+        "tool-use",
+        "mcp"
+      ],
+      "createdAt": "2026-05-03T06:52:20.000Z",
+      "lastModified": "2026-05-21T23:52:17.000Z"
+    },
+    {
+      "rank": 24,
       "id": "openai/gsm8k",
       "author": "openai",
       "url": "https://huggingface.co/datasets/openai/gsm8k",
@@ -683,7 +753,7 @@
       "lastModified": "2026-03-23T10:18:13.000Z"
     },
     {
-      "rank": 23,
+      "rank": 25,
       "id": "blanchon/opencs2_dataset",
       "author": "blanchon",
       "url": "https://huggingface.co/datasets/blanchon/opencs2_dataset",
@@ -718,44 +788,31 @@
       "lastModified": "2026-05-04T15:38:59.000Z"
     },
     {
-      "rank": 24,
-      "id": "actava/chi-bench",
-      "author": "actava",
-      "url": "https://huggingface.co/datasets/actava/chi-bench",
-      "downloads": 1232,
-      "likes": 25,
-      "trendingScore": 22,
+      "rank": 26,
+      "id": "HuggingFaceFW/fineweb",
+      "author": "HuggingFaceFW",
+      "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb",
+      "downloads": 969629,
+      "likes": 2814,
+      "trendingScore": 21,
       "tags": [
         "task_categories:text-generation",
         "language:en",
-        "license:apache-2.0",
-        "size_categories:n<1K",
-        "format:json",
-        "modality:document",
+        "license:odc-by",
+        "size_categories:10B<n<100B",
         "modality:tabular",
         "modality:text",
-        "library:datasets",
-        "library:pandas",
-        "library:polars",
-        "library:mlcroissant",
-        "arxiv:2605.16679",
-        "region:us",
-        "benchmark",
-        "agents",
-        "healthcare",
-        "clinical",
-        "prior-authorization",
-        "care-management",
-        "utilization-management",
-        "long-horizon",
-        "tool-use",
-        "mcp"
+        "arxiv:2306.01116",
+        "arxiv:2109.07445",
+        "arxiv:2406.17557",
+        "doi:10.57967/hf/2493",
+        "region:us"
       ],
-      "createdAt": "2026-05-03T06:52:20.000Z",
-      "lastModified": "2026-05-21T19:32:01.000Z"
+      "createdAt": "2024-04-18T14:33:13.000Z",
+      "lastModified": "2025-07-11T20:16:53.000Z"
     },
     {
-      "rank": 25,
+      "rank": 27,
       "id": "SALT-NLP/SWE-chat",
       "author": "SALT-NLP",
       "url": "https://huggingface.co/datasets/SALT-NLP/SWE-chat",
@@ -788,7 +845,7 @@
       "lastModified": "2026-04-29T15:05:22.000Z"
     },
     {
-      "rank": 26,
+      "rank": 28,
       "id": "r0b0tlab/deepseek-hermes-reasoning-traces",
       "author": "r0b0tlab",
       "url": "https://huggingface.co/datasets/r0b0tlab/deepseek-hermes-reasoning-traces",
@@ -823,7 +880,7 @@
       "lastModified": "2026-05-04T00:18:27.000Z"
     },
     {
-      "rank": 27,
+      "rank": 29,
       "id": "ShadenA/MathNet",
       "author": "ShadenA",
       "url": "https://huggingface.co/datasets/ShadenA/MathNet",
@@ -866,7 +923,7 @@
       "lastModified": "2026-04-27T23:48:47.000Z"
     },
     {
-      "rank": 28,
+      "rank": 30,
       "id": "SWE-bench/SWE-bench_Verified",
       "author": "SWE-bench",
       "url": "https://huggingface.co/datasets/SWE-bench/SWE-bench_Verified",
@@ -889,7 +946,7 @@
       "lastModified": "2026-02-27T20:36:38.000Z"
     },
     {
-      "rank": 29,
+      "rank": 31,
       "id": "unh1nge/comfyui-character-composer",
       "author": "unh1nge",
       "url": "https://huggingface.co/datasets/unh1nge/comfyui-character-composer",
@@ -917,31 +974,28 @@
       "lastModified": "2026-05-07T19:19:01.000Z"
     },
     {
-      "rank": 30,
-      "id": "HuggingFaceFW/fineweb",
-      "author": "HuggingFaceFW",
-      "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb",
-      "downloads": 969629,
-      "likes": 2809,
-      "trendingScore": 18,
+      "rank": 32,
+      "id": "LukaDev13/Liminal-Dreamcore-1K",
+      "author": "LukaDev13",
+      "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
+      "downloads": 2235,
+      "likes": 18,
+      "trendingScore": 17,
       "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "license:odc-by",
-        "size_categories:10B<n<100B",
-        "modality:tabular",
-        "modality:text",
-        "arxiv:2306.01116",
-        "arxiv:2109.07445",
-        "arxiv:2406.17557",
-        "doi:10.57967/hf/2493",
-        "region:us"
+        "license:mit",
+        "modality:image",
+        "region:us",
+        "ai-generated",
+        "dreamcore",
+        "aesthetic",
+        "image-collection",
+        "gpt-image"
       ],
-      "createdAt": "2024-04-18T14:33:13.000Z",
-      "lastModified": "2025-07-11T20:16:53.000Z"
+      "createdAt": "2026-05-16T12:14:28.000Z",
+      "lastModified": "2026-05-18T22:03:11.000Z"
     },
     {
-      "rank": 31,
+      "rank": 33,
       "id": "HuggingFaceFW/fineweb-edu",
       "author": "HuggingFaceFW",
       "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu",
@@ -971,7 +1025,7 @@
       "lastModified": "2025-07-11T20:16:53.000Z"
     },
     {
-      "rank": 32,
+      "rank": 34,
       "id": "junwatu/indonesian-recipes",
       "author": "junwatu",
       "url": "https://huggingface.co/datasets/junwatu/indonesian-recipes",
@@ -1001,28 +1055,7 @@
       "lastModified": "2026-05-09T06:36:26.000Z"
     },
     {
-      "rank": 33,
-      "id": "LukaDev13/Liminal-Dreamcore-1K",
-      "author": "LukaDev13",
-      "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
-      "downloads": 2235,
-      "likes": 17,
-      "trendingScore": 16,
-      "tags": [
-        "license:mit",
-        "modality:image",
-        "region:us",
-        "ai-generated",
-        "dreamcore",
-        "aesthetic",
-        "image-collection",
-        "gpt-image"
-      ],
-      "createdAt": "2026-05-16T12:14:28.000Z",
-      "lastModified": "2026-05-18T22:03:11.000Z"
-    },
-    {
-      "rank": 34,
+      "rank": 35,
       "id": "HuggingFaceBio/carbon-pretraining-corpus",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/datasets/HuggingFaceBio/carbon-pretraining-corpus",
@@ -1048,37 +1081,6 @@
       ],
       "createdAt": "2026-05-07T11:46:53.000Z",
       "lastModified": "2026-05-14T12:41:15.000Z"
-    },
-    {
-      "rank": 35,
-      "id": "GD-ML/TransitLM",
-      "author": "GD-ML",
-      "url": "https://huggingface.co/datasets/GD-ML/TransitLM",
-      "downloads": 522,
-      "likes": 16,
-      "trendingScore": 16,
-      "tags": [
-        "task_categories:text-generation",
-        "language:zh",
-        "license:cc-by-nc-4.0",
-        "size_categories:100K<n<1M",
-        "format:csv",
-        "modality:tabular",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "region:us",
-        "transportation",
-        "route-planning",
-        "public-transit",
-        "mobility",
-        "instruction-tuning",
-        "benchmark"
-      ],
-      "createdAt": "2026-05-03T05:31:52.000Z",
-      "lastModified": "2026-05-13T11:01:47.000Z"
     },
     {
       "rank": 36,
@@ -1190,8 +1192,8 @@
       "id": "cais/mmlu",
       "author": "cais",
       "url": "https://huggingface.co/datasets/cais/mmlu",
-      "downloads": 520668,
-      "likes": 737,
+      "downloads": 548076,
+      "likes": 746,
       "trendingScore": 15,
       "tags": [
         "task_categories:question-answering",
@@ -1265,6 +1267,29 @@
     },
     {
       "rank": 42,
+      "id": "tinixai/ocr_annual_financials",
+      "author": "tinixai",
+      "url": "https://huggingface.co/datasets/tinixai/ocr_annual_financials",
+      "downloads": 6790,
+      "likes": 18,
+      "trendingScore": 15,
+      "tags": [
+        "task_categories:document-question-answering",
+        "task_categories:text-generation",
+        "language:vi",
+        "license:cc-by-nc-4.0",
+        "size_categories:10K<n<100K",
+        "modality:document",
+        "modality:text",
+        "library:datasets",
+        "library:mlcroissant",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T15:11:00.000Z",
+      "lastModified": "2026-05-18T15:35:53.000Z"
+    },
+    {
+      "rank": 43,
       "id": "OwnedByDanes/Usenet-Corpus-1980-2013",
       "author": "OwnedByDanes",
       "url": "https://huggingface.co/datasets/OwnedByDanes/Usenet-Corpus-1980-2013",
@@ -1305,7 +1330,7 @@
       "lastModified": "2026-05-05T16:17:39.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "badlogicgames/pi-mono",
       "author": "badlogicgames",
       "url": "https://huggingface.co/datasets/badlogicgames/pi-mono",
@@ -1335,7 +1360,7 @@
       "lastModified": "2026-04-06T13:10:36.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
       "author": "sequelbox",
       "url": "https://huggingface.co/datasets/sequelbox/Tachibana4-DeepSeek-V4-Pro-PREVIEW",
@@ -1378,7 +1403,7 @@
       "lastModified": "2026-04-30T17:12:47.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "Inferact/codex_swebenchpro_traces",
       "author": "Inferact",
       "url": "https://huggingface.co/datasets/Inferact/codex_swebenchpro_traces",
@@ -1400,7 +1425,7 @@
       "lastModified": "2026-05-07T01:13:21.000Z"
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "5551z/VisCoR_Contrast",
       "author": "5551z",
       "url": "https://huggingface.co/datasets/5551z/VisCoR_Contrast",
@@ -1423,7 +1448,7 @@
       "lastModified": "2026-04-30T01:37:13.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "llm-jp/Jagle",
       "author": "llm-jp",
       "url": "https://huggingface.co/datasets/llm-jp/Jagle",
@@ -1439,29 +1464,6 @@
       ],
       "createdAt": "2026-04-11T08:56:17.000Z",
       "lastModified": "2026-05-12T00:53:55.000Z"
-    },
-    {
-      "rank": 48,
-      "id": "tinixai/ocr_annual_financials",
-      "author": "tinixai",
-      "url": "https://huggingface.co/datasets/tinixai/ocr_annual_financials",
-      "downloads": 6790,
-      "likes": 17,
-      "trendingScore": 14,
-      "tags": [
-        "task_categories:document-question-answering",
-        "task_categories:text-generation",
-        "language:vi",
-        "license:cc-by-nc-4.0",
-        "size_categories:10K<n<100K",
-        "modality:document",
-        "modality:text",
-        "library:datasets",
-        "library:mlcroissant",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T15:11:00.000Z",
-      "lastModified": "2026-05-18T15:35:53.000Z"
     },
     {
       "rank": 49,


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26268728663

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.