### PR TITLE
chore(data): refresh huggingface space signals 2026-05-22T04:48:25Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-21T20:25:44.490Z",
+  "ts": "2026-05-22T04:48:25.029Z",
   "count": 1,
-  "durationMs": 6228,
+  "durationMs": 6352,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-21T20:25:38.265Z",
+  "fetchedAt": "2026-05-22T04:48:18.679Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -95,8 +95,8 @@
       "id": "mikeee/qwen-7b-chat",
       "author": "mikeee",
       "url": "https://huggingface.co/spaces/mikeee/qwen-7b-chat",
-      "likes": 328,
-      "trendingScore": 109,
+      "likes": 335,
+      "trendingScore": 111,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -244,6 +244,22 @@
     },
     {
       "rank": 15,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 68,
+      "trendingScore": 66,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-20T10:03:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 16,
       "id": "ysharma/fast-image-studio",
       "author": "ysharma",
       "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
@@ -256,22 +272,6 @@
       ],
       "createdAt": "2026-04-29T14:15:57.000Z",
       "lastModified": "2026-04-30T12:10:32.000Z",
-      "models": []
-    },
-    {
-      "rank": 16,
-      "id": "HuggingFaceBio/carbon-demo",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 64,
-      "trendingScore": 63,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T14:18:55.000Z",
-      "lastModified": "2026-05-20T10:03:33.000Z",
       "models": []
     },
     {
@@ -624,7 +624,7 @@
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 28,
+      "likes": 29,
       "trendingScore": 26,
       "sdk": "gradio",
       "tags": [
@@ -742,7 +742,7 @@
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
-      "likes": 28,
+      "likes": 30,
       "trendingScore": 22,
       "sdk": "gradio",
       "tags": [
@@ -754,7 +754,7 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T02:42:26.000Z",
-      "lastModified": "2026-05-21T00:35:04.000Z",
+      "lastModified": "2026-05-22T03:20:51.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26268955414

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.