### PR TITLE
chore(data): refresh scoring shadow report 2026-05-22T05:58:11Z

### DIFF
--- a/data/scoring-shadow-report.json
+++ b/data/scoring-shadow-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-21T06:01:22.523Z",
+  "generatedAt": "2026-05-22T05:58:09.408Z",
   "reports": [
     {
       "domainKey": "skill",
@@ -8,301 +8,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.477,
+          "momentum": 9.538,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 8.487,
+          "momentum": 8.345,
           "rank": 2
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 8.264,
+          "momentum": 8.128,
           "rank": 3
-        },
-        {
-          "id": "agricidaniel-claude-ads",
-          "title": "claude-ads",
-          "momentum": 8.043,
-          "rank": 4
-        },
-        {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 7.967,
-          "rank": 5
-        },
-        {
-          "id": "agents365-ai-drawio-skill",
-          "title": "drawio-skill",
-          "momentum": 7.645,
-          "rank": 6
-        },
-        {
-          "id": "eugeniughelbur-obsidian-second-brain",
-          "title": "obsidian-second-brain",
-          "momentum": 7.556,
-          "rank": 7
-        },
-        {
-          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
-          "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.362,
-          "rank": 8
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.361,
-          "rank": 9
-        },
-        {
-          "id": "agricidaniel-claude-blog",
-          "title": "claude-blog",
-          "momentum": 7.127,
-          "rank": 10
         },
         {
           "id": "glitternetwork-pinme",
           "title": "pinme",
-          "momentum": 7.088,
-          "rank": 11
+          "momentum": 8.078,
+          "rank": 4
         },
         {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 6.873,
-          "rank": 12
+          "id": "agricidaniel-claude-ads",
+          "title": "claude-ads",
+          "momentum": 7.915,
+          "rank": 5
+        },
+        {
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.889,
+          "rank": 6
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 7.831,
+          "rank": 7
+        },
+        {
+          "id": "eugeniughelbur-obsidian-second-brain",
+          "title": "obsidian-second-brain",
+          "momentum": 7.545,
+          "rank": 8
+        },
+        {
+          "id": "agents365-ai-drawio-skill",
+          "title": "drawio-skill",
+          "momentum": 7.532,
+          "rank": 9
+        },
+        {
+          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
+          "title": "nano-banana-pro-prompts-recommend-skill",
+          "momentum": 7.316,
+          "rank": 10
+        },
+        {
+          "id": "agricidaniel-claude-blog",
+          "title": "claude-blog",
+          "momentum": 7.031,
+          "rank": 11
         },
         {
           "id": "alexgreensh-token-optimizer",
           "title": "token-optimizer",
-          "momentum": 6.71,
-          "rank": 13
+          "momentum": 6.889,
+          "rank": 12
         },
         {
-          "id": "mohitagw15856-pm-claude-skills",
-          "title": "pm-claude-skills",
-          "momentum": 6.622,
-          "rank": 14
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.754,
+          "rank": 13
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.485,
-          "rank": 15
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.17,
-          "rank": 16
-        },
-        {
-          "id": "juneyaooo-gpt-image2-ppt-skills",
-          "title": "gpt-image2-ppt-skills",
-          "momentum": 6.092,
-          "rank": 17
-        },
-        {
-          "id": "denissergeevitch-agents-best-practices",
-          "title": "agents-best-practices",
-          "momentum": 6.033,
-          "rank": 18
-        },
-        {
-          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
-          "title": "Claude-Mythos-AI-Anthropic-App",
-          "momentum": 6.027,
-          "rank": 19
-        },
-        {
-          "id": "pegasi-ai-reins",
-          "title": "reins",
-          "momentum": 5.845,
-          "rank": 20
-        },
-        {
-          "id": "wuyoscar-gpt-image2-skill",
-          "title": "GPT-Image2-Skill",
-          "momentum": 5.778,
-          "rank": 21
-        },
-        {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 5.643,
-          "rank": 22
-        },
-        {
-          "id": "alirezarezvani-claudeforge",
-          "title": "ClaudeForge",
-          "momentum": 5.631,
-          "rank": 23
-        },
-        {
-          "id": "alirezarezvani-claude-code-aso-skill",
-          "title": "claude-code-aso-skill",
-          "momentum": 5.57,
-          "rank": 24
+          "momentum": 6.658,
+          "rank": 14
         },
         {
           "id": "avdlee-rocketsimapp",
           "title": "RocketSimApp",
-          "momentum": 5.542,
+          "momentum": 6.551,
+          "rank": 15
+        },
+        {
+          "id": "mohitagw15856-pm-claude-skills",
+          "title": "pm-claude-skills",
+          "momentum": 6.521,
+          "rank": 16
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.069,
+          "rank": 17
+        },
+        {
+          "id": "juneyaooo-gpt-image2-ppt-skills",
+          "title": "gpt-image2-ppt-skills",
+          "momentum": 6.007,
+          "rank": 18
+        },
+        {
+          "id": "denissergeevitch-agents-best-practices",
+          "title": "agents-best-practices",
+          "momentum": 5.959,
+          "rank": 19
+        },
+        {
+          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
+          "title": "Claude-Mythos-AI-Anthropic-App",
+          "momentum": 5.901,
+          "rank": 20
+        },
+        {
+          "id": "pegasi-ai-reins",
+          "title": "reins",
+          "momentum": 5.744,
+          "rank": 21
+        },
+        {
+          "id": "wuyoscar-gpt-image2-skill",
+          "title": "GPT-Image2-Skill",
+          "momentum": 5.687,
+          "rank": 22
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 5.554,
+          "rank": 23
+        },
+        {
+          "id": "alirezarezvani-claudeforge",
+          "title": "ClaudeForge",
+          "momentum": 5.534,
+          "rank": 24
+        },
+        {
+          "id": "alirezarezvani-claude-code-aso-skill",
+          "title": "claude-code-aso-skill",
+          "momentum": 5.485,
           "rank": 25
         },
         {
           "id": "mrgediao-shuorenhua",
           "title": "shuorenhua",
-          "momentum": 5.387,
+          "momentum": 5.3,
           "rank": 26
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.347,
+          "momentum": 5.255,
           "rank": 27
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.322,
+          "momentum": 5.234,
           "rank": 28
         },
         {
           "id": "bitwize-music-studio-claude-ai-music-skills",
           "title": "claude-ai-music-skills",
-          "momentum": 5.268,
+          "momentum": 5.192,
           "rank": 29
         },
         {
           "id": "vast-ai-vast-cli",
           "title": "vast-cli",
-          "momentum": 5.227,
+          "momentum": 5.137,
           "rank": 30
         },
         {
           "id": "memtensor-skills-vote",
           "title": "skills-vote",
-          "momentum": 5.209,
+          "momentum": 5.128,
           "rank": 31
         },
         {
           "id": "aspegio-nelson",
           "title": "nelson",
-          "momentum": 5.2,
+          "momentum": 5.108,
           "rank": 32
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.176,
-          "rank": 33
         },
         {
           "id": "ximilalaxiang-delive",
           "title": "DeLive",
-          "momentum": 5.161,
+          "momentum": 5.073,
+          "rank": 33
+        },
+        {
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.011,
           "rank": 34
-        },
-        {
-          "id": "agents365-ai-asta-skill",
-          "title": "asta-skill",
-          "momentum": 4.959,
-          "rank": 35
-        },
-        {
-          "id": "ylsssq926-relic-skill",
-          "title": "relic.skill",
-          "momentum": 4.953,
-          "rank": 36
-        },
-        {
-          "id": "agents365-ai-paper-fetch",
-          "title": "paper-fetch",
-          "momentum": 4.856,
-          "rank": 37
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 4.82,
-          "rank": 38
         },
         {
           "id": "eriemon-verilog-generator",
           "title": "verilog-generator",
-          "momentum": 4.808,
-          "rank": 39
+          "momentum": 4.974,
+          "rank": 35
+        },
+        {
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 4.882,
+          "rank": 36
+        },
+        {
+          "id": "ylsssq926-relic-skill",
+          "title": "relic.skill",
+          "momentum": 4.879,
+          "rank": 37
         },
         {
           "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.794,
+          "momentum": 4.812,
+          "rank": 38
+        },
+        {
+          "id": "agents365-ai-paper-fetch",
+          "title": "paper-fetch",
+          "momentum": 4.791,
+          "rank": 39
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 4.745,
           "rank": 40
         },
         {
           "id": "greekr4-playwright-bot-bypass",
           "title": "playwright-bot-bypass",
-          "momentum": 4.753,
+          "momentum": 4.672,
           "rank": 41
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.639,
+          "momentum": 4.568,
           "rank": 42
         },
         {
           "id": "luoling8192-technical-writing",
           "title": "technical-writing",
-          "momentum": 4.618,
+          "momentum": 4.544,
           "rank": 43
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 4.612,
+          "momentum": 4.537,
           "rank": 44
         },
         {
           "id": "myurikanao-src-hunter-skill",
           "title": "src-hunter-skill",
-          "momentum": 4.483,
+          "momentum": 4.473,
           "rank": 45
         },
         {
           "id": "jeecgboot-skills",
           "title": "skills",
-          "momentum": 4.471,
+          "momentum": 4.401,
           "rank": 46
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.44,
+          "momentum": 4.392,
           "rank": 47
         },
         {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.398,
+          "id": "modoojunko-awesome-novel-skill",
+          "title": "awesome-novel-skill",
+          "momentum": 4.375,
           "rank": 48
         },
         {
           "id": "likaku-mck-ppt-design-skill",
           "title": "Mck-ppt-design-skill",
-          "momentum": 4.392,
+          "momentum": 4.336,
           "rank": 49
         },
         {
-          "id": "modoojunko-awesome-novel-skill",
-          "title": "awesome-novel-skill",
-          "momentum": 4.381,
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.331,
           "rank": 50
         }
       ],
@@ -310,301 +310,301 @@
         {
           "id": "mksglu-context-mode",
           "title": "context-mode",
-          "momentum": 9.477,
+          "momentum": 9.538,
           "rank": 1
         },
         {
           "id": "zarazhangrui-frontend-slides",
           "title": "frontend-slides",
-          "momentum": 8.487,
+          "momentum": 8.345,
           "rank": 2
         },
         {
           "id": "agricidaniel-claude-seo",
           "title": "claude-seo",
-          "momentum": 8.264,
+          "momentum": 8.128,
           "rank": 3
-        },
-        {
-          "id": "agricidaniel-claude-ads",
-          "title": "claude-ads",
-          "momentum": 8.043,
-          "rank": 4
-        },
-        {
-          "id": "htdt-godogen",
-          "title": "godogen",
-          "momentum": 7.967,
-          "rank": 5
-        },
-        {
-          "id": "agents365-ai-drawio-skill",
-          "title": "drawio-skill",
-          "momentum": 7.645,
-          "rank": 6
-        },
-        {
-          "id": "eugeniughelbur-obsidian-second-brain",
-          "title": "obsidian-second-brain",
-          "momentum": 7.556,
-          "rank": 7
-        },
-        {
-          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
-          "title": "nano-banana-pro-prompts-recommend-skill",
-          "momentum": 7.362,
-          "rank": 8
-        },
-        {
-          "id": "manavarya09-design-extract",
-          "title": "design-extract",
-          "momentum": 7.361,
-          "rank": 9
-        },
-        {
-          "id": "agricidaniel-claude-blog",
-          "title": "claude-blog",
-          "momentum": 7.127,
-          "rank": 10
         },
         {
           "id": "glitternetwork-pinme",
           "title": "pinme",
-          "momentum": 7.088,
-          "rank": 11
+          "momentum": 8.078,
+          "rank": 4
         },
         {
-          "id": "wuji-labs-nopua",
-          "title": "nopua",
-          "momentum": 6.873,
-          "rank": 12
+          "id": "agricidaniel-claude-ads",
+          "title": "claude-ads",
+          "momentum": 7.915,
+          "rank": 5
+        },
+        {
+          "id": "manavarya09-design-extract",
+          "title": "design-extract",
+          "momentum": 7.889,
+          "rank": 6
+        },
+        {
+          "id": "htdt-godogen",
+          "title": "godogen",
+          "momentum": 7.831,
+          "rank": 7
+        },
+        {
+          "id": "eugeniughelbur-obsidian-second-brain",
+          "title": "obsidian-second-brain",
+          "momentum": 7.545,
+          "rank": 8
+        },
+        {
+          "id": "agents365-ai-drawio-skill",
+          "title": "drawio-skill",
+          "momentum": 7.532,
+          "rank": 9
+        },
+        {
+          "id": "youmind-openlab-nano-banana-pro-prompts-recommend-skill",
+          "title": "nano-banana-pro-prompts-recommend-skill",
+          "momentum": 7.316,
+          "rank": 10
+        },
+        {
+          "id": "agricidaniel-claude-blog",
+          "title": "claude-blog",
+          "momentum": 7.031,
+          "rank": 11
         },
         {
           "id": "alexgreensh-token-optimizer",
           "title": "token-optimizer",
-          "momentum": 6.71,
-          "rank": 13
+          "momentum": 6.889,
+          "rank": 12
         },
         {
-          "id": "mohitagw15856-pm-claude-skills",
-          "title": "pm-claude-skills",
-          "momentum": 6.622,
-          "rank": 14
+          "id": "wuji-labs-nopua",
+          "title": "nopua",
+          "momentum": 6.754,
+          "rank": 13
         },
         {
           "id": "can4hou6joeng4-boss-agent-cli",
           "title": "boss-agent-cli",
-          "momentum": 6.485,
-          "rank": 15
-        },
-        {
-          "id": "storybloq-storybloq",
-          "title": "storybloq",
-          "momentum": 6.17,
-          "rank": 16
-        },
-        {
-          "id": "juneyaooo-gpt-image2-ppt-skills",
-          "title": "gpt-image2-ppt-skills",
-          "momentum": 6.092,
-          "rank": 17
-        },
-        {
-          "id": "denissergeevitch-agents-best-practices",
-          "title": "agents-best-practices",
-          "momentum": 6.033,
-          "rank": 18
-        },
-        {
-          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
-          "title": "Claude-Mythos-AI-Anthropic-App",
-          "momentum": 6.027,
-          "rank": 19
-        },
-        {
-          "id": "pegasi-ai-reins",
-          "title": "reins",
-          "momentum": 5.845,
-          "rank": 20
-        },
-        {
-          "id": "wuyoscar-gpt-image2-skill",
-          "title": "GPT-Image2-Skill",
-          "momentum": 5.778,
-          "rank": 21
-        },
-        {
-          "id": "bhanunamikaze-agentic-seo-skill",
-          "title": "Agentic-SEO-Skill",
-          "momentum": 5.643,
-          "rank": 22
-        },
-        {
-          "id": "alirezarezvani-claudeforge",
-          "title": "ClaudeForge",
-          "momentum": 5.631,
-          "rank": 23
-        },
-        {
-          "id": "alirezarezvani-claude-code-aso-skill",
-          "title": "claude-code-aso-skill",
-          "momentum": 5.57,
-          "rank": 24
+          "momentum": 6.658,
+          "rank": 14
         },
         {
           "id": "avdlee-rocketsimapp",
           "title": "RocketSimApp",
-          "momentum": 5.542,
+          "momentum": 6.551,
+          "rank": 15
+        },
+        {
+          "id": "mohitagw15856-pm-claude-skills",
+          "title": "pm-claude-skills",
+          "momentum": 6.521,
+          "rank": 16
+        },
+        {
+          "id": "storybloq-storybloq",
+          "title": "storybloq",
+          "momentum": 6.069,
+          "rank": 17
+        },
+        {
+          "id": "juneyaooo-gpt-image2-ppt-skills",
+          "title": "gpt-image2-ppt-skills",
+          "momentum": 6.007,
+          "rank": 18
+        },
+        {
+          "id": "denissergeevitch-agents-best-practices",
+          "title": "agents-best-practices",
+          "momentum": 5.959,
+          "rank": 19
+        },
+        {
+          "id": "abhishekk130804-claude-mythos-ai-anthropic-app",
+          "title": "Claude-Mythos-AI-Anthropic-App",
+          "momentum": 5.901,
+          "rank": 20
+        },
+        {
+          "id": "pegasi-ai-reins",
+          "title": "reins",
+          "momentum": 5.744,
+          "rank": 21
+        },
+        {
+          "id": "wuyoscar-gpt-image2-skill",
+          "title": "GPT-Image2-Skill",
+          "momentum": 5.687,
+          "rank": 22
+        },
+        {
+          "id": "bhanunamikaze-agentic-seo-skill",
+          "title": "Agentic-SEO-Skill",
+          "momentum": 5.554,
+          "rank": 23
+        },
+        {
+          "id": "alirezarezvani-claudeforge",
+          "title": "ClaudeForge",
+          "momentum": 5.534,
+          "rank": 24
+        },
+        {
+          "id": "alirezarezvani-claude-code-aso-skill",
+          "title": "claude-code-aso-skill",
+          "momentum": 5.485,
           "rank": 25
         },
         {
           "id": "mrgediao-shuorenhua",
           "title": "shuorenhua",
-          "momentum": 5.387,
+          "momentum": 5.3,
           "rank": 26
         },
         {
           "id": "aaronjmars-soul-md",
           "title": "soul.md",
-          "momentum": 5.347,
+          "momentum": 5.255,
           "rank": 27
         },
         {
           "id": "giuseppe-trisciuoglio-developer-kit",
           "title": "developer-kit",
-          "momentum": 5.322,
+          "momentum": 5.234,
           "rank": 28
         },
         {
           "id": "bitwize-music-studio-claude-ai-music-skills",
           "title": "claude-ai-music-skills",
-          "momentum": 5.268,
+          "momentum": 5.192,
           "rank": 29
         },
         {
           "id": "vast-ai-vast-cli",
           "title": "vast-cli",
-          "momentum": 5.227,
+          "momentum": 5.137,
           "rank": 30
         },
         {
           "id": "memtensor-skills-vote",
           "title": "skills-vote",
-          "momentum": 5.209,
+          "momentum": 5.128,
           "rank": 31
         },
         {
           "id": "aspegio-nelson",
           "title": "nelson",
-          "momentum": 5.2,
+          "momentum": 5.108,
           "rank": 32
-        },
-        {
-          "id": "mikesheehan54-claude-code-design-ai",
-          "title": "Claude-Code-Design-AI",
-          "momentum": 5.176,
-          "rank": 33
         },
         {
           "id": "ximilalaxiang-delive",
           "title": "DeLive",
-          "momentum": 5.161,
+          "momentum": 5.073,
+          "rank": 33
+        },
+        {
+          "id": "mikesheehan54-claude-code-design-ai",
+          "title": "Claude-Code-Design-AI",
+          "momentum": 5.011,
           "rank": 34
-        },
-        {
-          "id": "agents365-ai-asta-skill",
-          "title": "asta-skill",
-          "momentum": 4.959,
-          "rank": 35
-        },
-        {
-          "id": "ylsssq926-relic-skill",
-          "title": "relic.skill",
-          "momentum": 4.953,
-          "rank": 36
-        },
-        {
-          "id": "agents365-ai-paper-fetch",
-          "title": "paper-fetch",
-          "momentum": 4.856,
-          "rank": 37
-        },
-        {
-          "id": "agents365-ai-video-podcast-maker",
-          "title": "video-podcast-maker",
-          "momentum": 4.82,
-          "rank": 38
         },
         {
           "id": "eriemon-verilog-generator",
           "title": "verilog-generator",
-          "momentum": 4.808,
-          "rank": 39
+          "momentum": 4.974,
+          "rank": 35
+        },
+        {
+          "id": "agents365-ai-asta-skill",
+          "title": "asta-skill",
+          "momentum": 4.882,
+          "rank": 36
+        },
+        {
+          "id": "ylsssq926-relic-skill",
+          "title": "relic.skill",
+          "momentum": 4.879,
+          "rank": 37
         },
         {
           "id": "oaustegard-claude-skills",
           "title": "claude-skills",
-          "momentum": 4.794,
+          "momentum": 4.812,
+          "rank": 38
+        },
+        {
+          "id": "agents365-ai-paper-fetch",
+          "title": "paper-fetch",
+          "momentum": 4.791,
+          "rank": 39
+        },
+        {
+          "id": "agents365-ai-video-podcast-maker",
+          "title": "video-podcast-maker",
+          "momentum": 4.745,
           "rank": 40
         },
         {
           "id": "greekr4-playwright-bot-bypass",
           "title": "playwright-bot-bypass",
-          "momentum": 4.753,
+          "momentum": 4.672,
           "rank": 41
         },
         {
           "id": "nikolai-vysotskyi-trace-mcp",
           "title": "trace-mcp",
-          "momentum": 4.639,
+          "momentum": 4.568,
           "rank": 42
         },
         {
           "id": "luoling8192-technical-writing",
           "title": "technical-writing",
-          "momentum": 4.618,
+          "momentum": 4.544,
           "rank": 43
         },
         {
           "id": "agricidaniel-claude-obsidian",
           "title": "claude-obsidian",
-          "momentum": 4.612,
+          "momentum": 4.537,
           "rank": 44
         },
         {
           "id": "myurikanao-src-hunter-skill",
           "title": "src-hunter-skill",
-          "momentum": 4.483,
+          "momentum": 4.473,
           "rank": 45
         },
         {
           "id": "jeecgboot-skills",
           "title": "skills",
-          "momentum": 4.471,
+          "momentum": 4.401,
           "rank": 46
         },
         {
           "id": "zouchenzhen-thesis-defense-pptx-skill",
           "title": "thesis-defense-pptx-skill",
-          "momentum": 4.44,
+          "momentum": 4.392,
           "rank": 47
         },
         {
-          "id": "ndjordjevic-pin-llm-wiki",
-          "title": "pin-llm-wiki",
-          "momentum": 4.398,
+          "id": "modoojunko-awesome-novel-skill",
+          "title": "awesome-novel-skill",
+          "momentum": 4.375,
           "rank": 48
         },
         {
           "id": "likaku-mck-ppt-design-skill",
           "title": "Mck-ppt-design-skill",
-          "momentum": 4.392,
+          "momentum": 4.336,
           "rank": 49
         },
         {
-          "id": "modoojunko-awesome-novel-skill",
-          "title": "awesome-novel-skill",
-          "momentum": 4.381,
+          "id": "ndjordjevic-pin-llm-wiki",
+          "title": "pin-llm-wiki",
+          "momentum": 4.331,
           "rank": 50
         }
       ],
@@ -613,7 +613,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-21T06:01:20.634Z",
+      "generatedAt": "2026-05-22T05:58:07.461Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     },
@@ -1229,7 +1229,7 @@
       "setOverlapTop50": 1,
       "top10Churn": 0,
       "rankChanges": [],
-      "generatedAt": "2026-05-21T06:01:21.584Z",
+      "generatedAt": "2026-05-22T05:58:08.425Z",
       "cutoverGatePass": true,
       "cutoverGateReason": "Spearman ρ 1.000 ≥ 0.6, top-10 overlap 10/10"
     }


### PR DESCRIPTION
Automated data refresh from `Run shadow scoring`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26271117766

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.