### PR TITLE
chore(data): refresh staleness report 2026-05-22T06:12:44Z

### DIFF
--- a/data/staleness-report.json
+++ b/data/staleness-report.json
@@ -1,24 +1,24 @@
 {
-  "generatedAt": "2026-05-21T06:14:57.199Z",
+  "generatedAt": "2026-05-22T06:12:43.186Z",
   "sources": [
     {
       "slug": "trending",
-      "total": 2988,
+      "total": 3000,
       "stale": 0,
       "thresholdHours": 4,
       "examples": [],
       "notes": [
-        "2988/2988 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
+        "3000/3000 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
       ]
     },
     {
       "slug": "repo-profiles",
-      "total": 2613,
+      "total": 2950,
       "stale": 0,
       "thresholdHours": 4,
       "examples": [],
       "notes": [
-        "2613/2613 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
+        "2950/2950 records have no lastRefreshedAt — pre-B2 data, recount on next cron"
       ]
     },
     {


### PR DESCRIPTION
Automated data refresh from `Sweep staleness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26271617947

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.