### PR TITLE
chore(data): refresh huggingface signals 2026-05-22T06:49:36Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-22T04:41:05.484Z",
+  "ts": "2026-05-22T06:49:36.869Z",
   "count": 1,
-  "durationMs": 8732,
+  "durationMs": 6722,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T04:40:56.754Z",
+  "fetchedAt": "2026-05-22T06:49:30.148Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -40,8 +40,8 @@
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/Lance",
       "downloads": 739,
-      "likes": 585,
-      "trendingScore": 573,
+      "likes": 593,
+      "trendingScore": 581,
       "pipelineTag": "any-to-any",
       "libraryName": "Lance",
       "tags": [
@@ -287,8 +287,8 @@
       "author": "NemoStation",
       "url": "https://huggingface.co/NemoStation/Marlin-2B",
       "downloads": 2353,
-      "likes": 223,
-      "trendingScore": 217,
+      "likes": 225,
+      "trendingScore": 219,
       "pipelineTag": "video-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -414,6 +414,51 @@
     },
     {
       "rank": 16,
+      "id": "tencent/Hy-MT2-1.8B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
+      "downloads": 17,
+      "likes": 202,
+      "trendingScore": 194,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hunyuan_v1_dense",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T08:22:10.000Z",
+      "lastModified": "2026-05-22T05:09:24.000Z"
+    },
+    {
+      "rank": 17,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/Dramabox",
@@ -442,7 +487,7 @@
       "lastModified": "2026-05-13T16:39:38.000Z"
     },
     {
-      "rank": 17,
+      "rank": 18,
       "id": "SeeSee21/Z-Anime",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Anime",
@@ -475,7 +520,7 @@
       "lastModified": "2026-04-27T01:13:30.000Z"
     },
     {
-      "rank": 18,
+      "rank": 19,
       "id": "TenStrip/LTX2.3-10Eros",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
@@ -493,12 +538,12 @@
       "lastModified": "2026-05-07T01:24:09.000Z"
     },
     {
-      "rank": 19,
+      "rank": 20,
       "id": "froggeric/Qwen-Fixed-Chat-Templates",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
       "downloads": 0,
-      "likes": 357,
+      "likes": 358,
       "trendingScore": 161,
       "pipelineTag": null,
       "libraryName": "mlx",
@@ -521,7 +566,7 @@
       "lastModified": "2026-05-16T13:44:07.000Z"
     },
     {
-      "rank": 20,
+      "rank": 21,
       "id": "CohereLabs/command-a-plus-05-2026-w4a4",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
@@ -566,13 +611,13 @@
       "lastModified": "2026-05-21T17:11:48.000Z"
     },
     {
-      "rank": 21,
+      "rank": 22,
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "downloads": 24412,
-      "likes": 151,
-      "trendingScore": 149,
+      "likes": 152,
+      "trendingScore": 150,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -609,7 +654,7 @@
       "lastModified": "2026-05-19T23:41:58.000Z"
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -638,7 +683,7 @@
       "lastModified": "2026-04-28T07:01:37.000Z"
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/TencentARC/Pixal3D",
@@ -657,7 +702,7 @@
       "lastModified": "2026-05-12T23:37:47.000Z"
     },
     {
-      "rank": 24,
+      "rank": 25,
       "id": "Qwen/Qwen3.6-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
@@ -682,7 +727,7 @@
       "lastModified": "2026-04-24T02:39:16.000Z"
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "mistralai/Mistral-Medium-3.5-128B",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B",
@@ -727,7 +772,7 @@
       "lastModified": "2026-05-04T14:16:22.000Z"
     },
     {
-      "rank": 26,
+      "rank": 27,
       "id": "Qwen/Qwen3.6-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
@@ -752,7 +797,7 @@
       "lastModified": "2026-04-24T02:53:42.000Z"
     },
     {
-      "rank": 27,
+      "rank": 28,
       "id": "google/gemma-4-26B-A4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-assistant",
@@ -775,7 +820,7 @@
       "lastModified": "2026-05-11T07:50:08.000Z"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -817,7 +862,7 @@
       "lastModified": "2026-05-07T02:39:32.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
@@ -850,7 +895,7 @@
       "lastModified": "2026-04-12T13:42:43.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -876,7 +921,7 @@
       "lastModified": "2026-05-06T04:18:09.000Z"
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "sensenova/SenseNova-U1-8B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
@@ -904,7 +949,7 @@
       "lastModified": "2026-05-07T08:00:27.000Z"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "jackxinning/Leanly_AI",
       "author": "jackxinning",
       "url": "https://huggingface.co/jackxinning/Leanly_AI",
@@ -928,7 +973,7 @@
       "lastModified": "2026-05-04T07:50:46.000Z"
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
@@ -952,13 +997,13 @@
       "lastModified": "2026-05-15T10:40:24.000Z"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
       "downloads": 10046,
-      "likes": 97,
-      "trendingScore": 96,
+      "likes": 99,
+      "trendingScore": 98,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -997,7 +1042,7 @@
       "lastModified": "2026-05-21T17:11:25.000Z"
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "google/gemma-4-31B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B-it",
@@ -1024,7 +1069,7 @@
       "lastModified": "2026-05-07T07:39:17.000Z"
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "ScenemaAI/scenema-audio",
       "author": "ScenemaAI",
       "url": "https://huggingface.co/ScenemaAI/scenema-audio",
@@ -1063,7 +1108,7 @@
       "lastModified": "2026-05-14T03:19:58.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "microsoft/Fara-7B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Fara-7B",
@@ -1090,7 +1135,7 @@
       "lastModified": "2026-05-19T15:37:05.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -1119,7 +1164,7 @@
       "lastModified": "2026-05-05T12:57:20.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
@@ -1145,7 +1190,7 @@
       "lastModified": "2026-04-25T21:33:07.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "unsloth/Qwen3.6-27B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
@@ -1173,7 +1218,7 @@
       "lastModified": "2026-04-22T16:01:39.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "Cactus-Compute/needle",
       "author": "Cactus-Compute",
       "url": "https://huggingface.co/Cactus-Compute/needle",
@@ -1198,7 +1243,7 @@
       "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "internlm/Intern-S2-Preview",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview",
@@ -1222,7 +1267,7 @@
       "lastModified": "2026-05-19T08:01:07.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "inclusionAI/Ring-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
@@ -1247,7 +1292,7 @@
       "lastModified": "2026-05-18T09:47:28.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/k2-fsa/OmniVoice",
@@ -1292,7 +1337,7 @@
       "lastModified": "2026-05-07T15:45:07.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
@@ -1319,7 +1364,7 @@
       "lastModified": "2026-05-10T15:43:51.000Z"
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "antirez/deepseek-v4-gguf",
       "author": "antirez",
       "url": "https://huggingface.co/antirez/deepseek-v4-gguf",
@@ -1357,7 +1402,7 @@
       "lastModified": "2026-05-12T16:08:16.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -1385,7 +1430,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "facebook/VGGT-Omega",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/VGGT-Omega",
@@ -1405,7 +1450,7 @@
       "lastModified": "2026-05-14T21:23:21.000Z"
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1434,7 +1479,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 50,
+      "rank": 51,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -1460,7 +1505,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 51,
+      "rank": 52,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -1489,7 +1534,7 @@
       "lastModified": "2026-04-20T12:42:25.000Z"
     },
     {
-      "rank": 52,
+      "rank": 53,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -1522,7 +1567,7 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 53,
+      "rank": 54,
       "id": "Efficient-Large-Model/SANA-WM_bidirectional",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
@@ -1547,7 +1592,7 @@
       "lastModified": "2026-05-19T06:57:12.000Z"
     },
     {
-      "rank": 54,
+      "rank": 55,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -1580,7 +1625,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 55,
+      "rank": 56,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -1625,7 +1670,7 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 56,
+      "rank": 57,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -1645,7 +1690,7 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 57,
+      "rank": 58,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -1668,7 +1713,7 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 58,
+      "rank": 59,
       "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
@@ -1700,7 +1745,52 @@
       "lastModified": "2026-05-14T17:07:52.000Z"
     },
     {
-      "rank": 59,
+      "rank": 60,
+      "id": "tencent/Hy-MT2-30B-A3B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
+      "downloads": 43,
+      "likes": 69,
+      "trendingScore": 68,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hy_v3",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T07:43:51.000Z",
+      "lastModified": "2026-05-22T05:15:55.000Z"
+    },
+    {
+      "rank": 61,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -1732,7 +1822,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 60,
+      "rank": 62,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -1757,7 +1847,7 @@
       "lastModified": "2026-05-12T14:25:54.000Z"
     },
     {
-      "rank": 61,
+      "rank": 63,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1802,7 +1892,7 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 62,
+      "rank": 64,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -1829,7 +1919,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 63,
+      "rank": 65,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -1862,7 +1952,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 64,
+      "rank": 66,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -1894,7 +1984,7 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 65,
+      "rank": 67,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -1923,13 +2013,13 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 66,
+      "rank": 68,
       "id": "numind/NuExtract3",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3",
       "downloads": 3322,
-      "likes": 61,
-      "trendingScore": 60,
+      "likes": 62,
+      "trendingScore": 61,
       "pipelineTag": "image-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1960,120 +2050,13 @@
       "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
-      "rank": 67,
-      "id": "AIDC-AI/Ovis2.6-80B-A3B",
-      "author": "AIDC-AI",
-      "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
-      "downloads": 87,
-      "likes": 59,
-      "trendingScore": 59,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "ovis2_6_next",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "arxiv:2508.11737",
-        "arxiv:2405.20797",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T07:57:36.000Z",
-      "lastModified": "2026-05-14T08:44:07.000Z"
-    },
-    {
-      "rank": 68,
-      "id": "ibm-granite/granite-4.1-8b",
-      "author": "ibm-granite",
-      "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
-      "downloads": 24099,
-      "likes": 162,
-      "trendingScore": 58,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "granite",
-        "text-generation",
-        "language",
-        "granite-4.1",
-        "conversational",
-        "arxiv:0000.00000",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-06T13:18:47.000Z",
-      "lastModified": "2026-05-04T17:36:29.000Z"
-    },
-    {
       "rank": 69,
-      "id": "google/gemma-4-E4B-it",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-E4B-it",
-      "downloads": 5494056,
-      "likes": 945,
-      "trendingScore": 58,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "any-to-any",
-        "base_model:google/gemma-4-E4B",
-        "base_model:finetune:google/gemma-4-E4B",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-03-02T19:57:40.000Z",
-      "lastModified": "2026-05-07T07:39:39.000Z"
-    },
-    {
-      "rank": 70,
-      "id": "google/gemma-4-26B-A4B-it",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
-      "downloads": 7179265,
-      "likes": 932,
-      "trendingScore": 58,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "conversational",
-        "base_model:google/gemma-4-26B-A4B",
-        "base_model:finetune:google/gemma-4-26B-A4B",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-03-11T21:25:57.000Z",
-      "lastModified": "2026-05-07T07:39:32.000Z"
-    },
-    {
-      "rank": 71,
       "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "downloads": 13470,
-      "likes": 61,
-      "trendingScore": 58,
+      "likes": 63,
+      "trendingScore": 60,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -2111,7 +2094,114 @@
       "lastModified": "2026-05-19T23:43:59.000Z"
     },
     {
+      "rank": 70,
+      "id": "AIDC-AI/Ovis2.6-80B-A3B",
+      "author": "AIDC-AI",
+      "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
+      "downloads": 87,
+      "likes": 59,
+      "trendingScore": 59,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "ovis2_6_next",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "arxiv:2508.11737",
+        "arxiv:2405.20797",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T07:57:36.000Z",
+      "lastModified": "2026-05-14T08:44:07.000Z"
+    },
+    {
+      "rank": 71,
+      "id": "ibm-granite/granite-4.1-8b",
+      "author": "ibm-granite",
+      "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
+      "downloads": 24099,
+      "likes": 162,
+      "trendingScore": 58,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "granite",
+        "text-generation",
+        "language",
+        "granite-4.1",
+        "conversational",
+        "arxiv:0000.00000",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-06T13:18:47.000Z",
+      "lastModified": "2026-05-04T17:36:29.000Z"
+    },
+    {
       "rank": 72,
+      "id": "google/gemma-4-E4B-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-E4B-it",
+      "downloads": 5494056,
+      "likes": 945,
+      "trendingScore": 58,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "any-to-any",
+        "base_model:google/gemma-4-E4B",
+        "base_model:finetune:google/gemma-4-E4B",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T19:57:40.000Z",
+      "lastModified": "2026-05-07T07:39:39.000Z"
+    },
+    {
+      "rank": 73,
+      "id": "google/gemma-4-26B-A4B-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
+      "downloads": 7179265,
+      "likes": 932,
+      "trendingScore": 58,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "conversational",
+        "base_model:google/gemma-4-26B-A4B",
+        "base_model:finetune:google/gemma-4-26B-A4B",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-03-11T21:25:57.000Z",
+      "lastModified": "2026-05-07T07:39:32.000Z"
+    },
+    {
+      "rank": 74,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -2134,7 +2224,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 73,
+      "rank": 75,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -2165,7 +2255,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 74,
+      "rank": 76,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -2195,7 +2285,7 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 75,
+      "rank": 77,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2239,7 +2329,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 76,
+      "rank": 78,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -2257,7 +2347,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 77,
+      "rank": 79,
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
@@ -2284,7 +2374,33 @@
       "lastModified": "2026-05-14T02:37:15.000Z"
     },
     {
-      "rank": 78,
+      "rank": 80,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 951,
+      "likes": 54,
+      "trendingScore": 54,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 81,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -2311,7 +2427,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 79,
+      "rank": 82,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2344,33 +2460,7 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 80,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 951,
-      "likes": 53,
-      "trendingScore": 53,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
-    },
-    {
-      "rank": 81,
+      "rank": 83,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2415,7 +2505,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 82,
+      "rank": 84,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2442,7 +2532,7 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 83,
+      "rank": 85,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2470,52 +2560,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 84,
-      "id": "tencent/Hy-MT2-30B-A3B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
-      "downloads": 43,
-      "likes": 50,
-      "trendingScore": 50,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hy_v3",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T07:43:51.000Z",
-      "lastModified": "2026-05-21T12:26:34.000Z"
-    },
-    {
-      "rank": 85,
+      "rank": 86,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2549,7 +2594,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2579,7 +2624,7 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -2599,7 +2644,35 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 88,
+      "rank": 89,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 48,
+      "trendingScore": 48,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
+    },
+    {
+      "rank": 90,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -2630,7 +2703,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 89,
+      "rank": 91,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -2655,7 +2728,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 90,
+      "rank": 92,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -2692,7 +2765,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 91,
+      "rank": 93,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -2729,35 +2802,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 92,
-      "id": "stabilityai/stable-audio-3-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
-      "downloads": 0,
-      "likes": 47,
-      "trendingScore": 47,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
-    },
-    {
-      "rank": 93,
+      "rank": 94,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -2785,7 +2830,7 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
@@ -2809,7 +2854,7 @@
       "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 95,
+      "rank": 96,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -2832,7 +2877,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 96,
+      "rank": 97,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
@@ -2859,7 +2904,7 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 97,
+      "rank": 98,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -2892,7 +2937,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 98,
+      "rank": 99,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -2923,7 +2968,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 99,
+      "rank": 100,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -2937,51 +2982,6 @@
       ],
       "createdAt": "2026-05-07T06:04:26.000Z",
       "lastModified": "2026-05-09T01:15:32.000Z"
-    },
-    {
-      "rank": 100,
-      "id": "tencent/Hy-MT2-1.8B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
-      "downloads": 17,
-      "likes": 43,
-      "trendingScore": 42,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hunyuan_v1_dense",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T08:22:10.000Z",
-      "lastModified": "2026-05-21T12:27:36.000Z"
     },
     {
       "rank": 101,
@@ -3308,6 +3308,35 @@
     },
     {
       "rank": 113,
+      "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
+      "author": "OBLITERATUS",
+      "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
+      "downloads": 336798,
+      "likes": 645,
+      "trendingScore": 35,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "gguf",
+        "gemma4",
+        "abliterated",
+        "uncensored",
+        "obliteratus",
+        "refusal-removal",
+        "text-generation",
+        "conversational",
+        "base_model:google/gemma-4-E4B-it",
+        "base_model:quantized:google/gemma-4-E4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-15T01:22:42.000Z",
+      "lastModified": "2026-04-19T21:43:06.000Z"
+    },
+    {
+      "rank": 114,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -3331,7 +3360,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 114,
+      "rank": 115,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -3348,7 +3377,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 115,
+      "rank": 116,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -3372,7 +3401,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3398,7 +3427,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -3414,7 +3443,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -3439,35 +3468,6 @@
       ],
       "createdAt": "2026-04-01T14:42:04.000Z",
       "lastModified": "2026-05-04T09:02:45.000Z"
-    },
-    {
-      "rank": 119,
-      "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
-      "author": "OBLITERATUS",
-      "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
-      "downloads": 318168,
-      "likes": 636,
-      "trendingScore": 34,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gguf",
-        "gemma4",
-        "abliterated",
-        "uncensored",
-        "obliteratus",
-        "refusal-removal",
-        "text-generation",
-        "conversational",
-        "base_model:google/gemma-4-E4B-it",
-        "base_model:quantized:google/gemma-4-E4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-15T01:22:42.000Z",
-      "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
       "rank": 120,
@@ -3984,6 +3984,36 @@
     },
     {
       "rank": 135,
+      "id": "ByteDance-Seed/Cola-DLM",
+      "author": "ByteDance-Seed",
+      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
+      "downloads": 0,
+      "likes": 31,
+      "trendingScore": 31,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "text-generation",
+        "language-model",
+        "diffusion",
+        "latent-diffusion",
+        "flow-matching",
+        "text-vae",
+        "pytorch",
+        "research",
+        "en",
+        "arxiv:2605.06548",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T07:55:26.000Z",
+      "lastModified": "2026-05-15T09:38:05.000Z"
+    },
+    {
+      "rank": 136,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4009,7 +4039,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 136,
+      "rank": 137,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4041,7 +4071,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 137,
+      "rank": 138,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4068,7 +4098,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 138,
+      "rank": 139,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -4102,7 +4132,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 139,
+      "rank": 140,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4122,36 +4152,6 @@
       ],
       "createdAt": "2026-05-13T09:22:55.000Z",
       "lastModified": "2026-05-13T19:23:38.000Z"
-    },
-    {
-      "rank": 140,
-      "id": "ByteDance-Seed/Cola-DLM",
-      "author": "ByteDance-Seed",
-      "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
-      "downloads": 0,
-      "likes": 30,
-      "trendingScore": 30,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "text-generation",
-        "language-model",
-        "diffusion",
-        "latent-diffusion",
-        "flow-matching",
-        "text-vae",
-        "pytorch",
-        "research",
-        "en",
-        "arxiv:2605.06548",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T07:55:26.000Z",
-      "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
       "rank": 141,
@@ -4366,6 +4366,33 @@
     },
     {
       "rank": 148,
+      "id": "stabilityai/stable-audio-3-small-music",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "downloads": 0,
+      "likes": 30,
+      "trendingScore": 29,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-music-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:33.000Z",
+      "lastModified": "2026-05-19T20:02:42.000Z"
+    },
+    {
+      "rank": 149,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -4387,7 +4414,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 149,
+      "rank": 150,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -4424,7 +4451,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 150,
+      "rank": 151,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -4446,7 +4473,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 151,
+      "rank": 152,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -4479,7 +4506,7 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 152,
+      "rank": 153,
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
@@ -4507,7 +4534,7 @@
       "lastModified": "2026-05-19T21:32:32.000Z"
     },
     {
-      "rank": 153,
+      "rank": 154,
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
@@ -4552,7 +4579,7 @@
       "lastModified": "2026-05-21T17:10:45.000Z"
     },
     {
-      "rank": 154,
+      "rank": 155,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -4592,7 +4619,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 155,
+      "rank": 156,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -4629,7 +4656,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 156,
+      "rank": 157,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -4672,7 +4699,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 157,
+      "rank": 158,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -4692,7 +4719,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 158,
+      "rank": 159,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -4717,7 +4744,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 159,
+      "rank": 160,
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
@@ -4742,7 +4769,7 @@
       "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 160,
+      "rank": 161,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -4787,7 +4814,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 161,
+      "rank": 162,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -4814,7 +4841,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 162,
+      "rank": 163,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -4859,7 +4886,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 163,
+      "rank": 164,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -4885,7 +4912,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 164,
+      "rank": 165,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -4907,7 +4934,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 165,
+      "rank": 166,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -4923,7 +4950,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 166,
+      "rank": 167,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -4959,7 +4986,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 167,
+      "rank": 168,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -4977,7 +5004,7 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 168,
+      "rank": 169,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -5000,33 +5027,6 @@
       ],
       "createdAt": "2026-05-16T02:00:22.000Z",
       "lastModified": "2026-05-16T04:32:12.000Z"
-    },
-    {
-      "rank": 169,
-      "id": "stabilityai/stable-audio-3-small-music",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
-      "downloads": 0,
-      "likes": 27,
-      "trendingScore": 26,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-music-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:33.000Z",
-      "lastModified": "2026-05-19T20:02:42.000Z"
     },
     {
       "rank": 170,
@@ -5368,68 +5368,12 @@
     },
     {
       "rank": 182,
-      "id": "nvidia/Gemma-4-31B-IT-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
-      "downloads": 2268523,
-      "likes": 461,
-      "trendingScore": 24,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "gemma4",
-        "nvidia",
-        "ModelOpt",
-        "Gemma-4-31B-IT",
-        "lighthouse",
-        "quantized",
-        "NVFP4",
-        "text-generation",
-        "conversational",
-        "base_model:google/gemma-4-31B-it",
-        "base_model:quantized:google/gemma-4-31B-it",
-        "license:other",
-        "modelopt",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-02T16:47:30.000Z",
-      "lastModified": "2026-05-08T03:33:34.000Z"
-    },
-    {
-      "rank": 183,
-      "id": "wikeeyang/Flux2-Klein-9B-True-V2",
-      "author": "wikeeyang",
-      "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
-      "downloads": 24174,
-      "likes": 103,
-      "trendingScore": 24,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "gguf",
-        "text-to-image",
-        "en",
-        "zh",
-        "base_model:black-forest-labs/FLUX.2-klein-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-9B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T08:44:12.000Z",
-      "lastModified": "2026-04-16T01:57:36.000Z"
-    },
-    {
-      "rank": 184,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
       "downloads": 259912583,
-      "likes": 4814,
-      "trendingScore": 24,
+      "likes": 4816,
+      "trendingScore": 25,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
       "tags": [
@@ -5468,7 +5412,162 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
+      "rank": 183,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2657816,
+      "likes": 2026,
+      "trendingScore": 25,
+      "pipelineTag": "mask-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
+    },
+    {
+      "rank": 184,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 2656,
+      "likes": 25,
+      "trendingScore": 25,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
       "rank": 185,
+      "id": "tencent/Hy-MT2-7B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
+      "downloads": 19,
+      "likes": 25,
+      "trendingScore": 25,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hunyuan_v1_dense",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T14:56:58.000Z",
+      "lastModified": "2026-05-22T05:16:06.000Z"
+    },
+    {
+      "rank": 186,
+      "id": "nvidia/Gemma-4-31B-IT-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
+      "downloads": 2268523,
+      "likes": 461,
+      "trendingScore": 24,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "gemma4",
+        "nvidia",
+        "ModelOpt",
+        "Gemma-4-31B-IT",
+        "lighthouse",
+        "quantized",
+        "NVFP4",
+        "text-generation",
+        "conversational",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:quantized:google/gemma-4-31B-it",
+        "license:other",
+        "modelopt",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-02T16:47:30.000Z",
+      "lastModified": "2026-05-08T03:33:34.000Z"
+    },
+    {
+      "rank": 187,
+      "id": "wikeeyang/Flux2-Klein-9B-True-V2",
+      "author": "wikeeyang",
+      "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
+      "downloads": 24174,
+      "likes": 103,
+      "trendingScore": 24,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "gguf",
+        "text-to-image",
+        "en",
+        "zh",
+        "base_model:black-forest-labs/FLUX.2-klein-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T08:44:12.000Z",
+      "lastModified": "2026-04-16T01:57:36.000Z"
+    },
+    {
+      "rank": 188,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -5495,7 +5594,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 186,
+      "rank": 189,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -5520,7 +5619,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 187,
+      "rank": 190,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -5556,12 +5655,12 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 188,
+      "rank": 191,
       "id": "pyannote/speaker-diarization-3.1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 10399399,
-      "likes": 1862,
+      "downloads": 10342124,
+      "likes": 1911,
       "trendingScore": 24,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "pyannote-audio",
@@ -5588,7 +5687,7 @@
       "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 189,
+      "rank": 192,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -5604,7 +5703,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 190,
+      "rank": 193,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -5625,61 +5724,39 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 191,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2657816,
-      "likes": 2025,
+      "rank": 194,
+      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "author": "fal",
+      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "downloads": 44999,
+      "likes": 1326,
       "trendingScore": 24,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
-        "feature-extraction",
-        "sam3",
-        "mask-generation",
+        "diffusers",
+        "qwen",
+        "qwen-image-edit",
+        "qwen-image-edit-2511",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "camera-control",
+        "image-editing",
+        "image-to-image",
+        "gaussian-splatting",
+        "fal",
         "en",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
+      "createdAt": "2026-01-07T17:01:15.000Z",
+      "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
-      "rank": 192,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 2656,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
-    },
-    {
-      "rank": 193,
+      "rank": 195,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -5706,7 +5783,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 194,
+      "rank": 196,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -5735,7 +5812,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 195,
+      "rank": 197,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -5752,7 +5829,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 196,
+      "rank": 198,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -5773,7 +5850,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 197,
+      "rank": 199,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -5794,12 +5871,12 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 198,
+      "rank": 200,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
       "downloads": 27886899,
-      "likes": 3023,
+      "likes": 3026,
       "trendingScore": 23,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -5826,7 +5903,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 199,
+      "rank": 201,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -5847,7 +5924,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 200,
+      "rank": 202,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -5879,7 +5956,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 201,
+      "rank": 203,
       "id": "oron1208/OOO_Anima",
       "author": "oron1208",
       "url": "https://huggingface.co/oron1208/OOO_Anima",
@@ -5906,7 +5983,7 @@
       "lastModified": "2026-05-21T15:24:20.000Z"
     },
     {
-      "rank": 202,
+      "rank": 204,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
@@ -5932,7 +6009,7 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 203,
+      "rank": 205,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -5977,52 +6054,34 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 204,
-      "id": "tencent/Hy-MT2-7B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
-      "downloads": 19,
+      "rank": 206,
+      "id": "stabilityai/stable-audio-3-small-sfx",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
+      "downloads": 0,
       "likes": 23,
       "trendingScore": 23,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
       "tags": [
-        "transformers",
+        "stable-audio-3",
         "safetensors",
-        "hunyuan_v1_dense",
-        "text-generation",
-        "translation",
-        "zh",
+        "audio-generation",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
         "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-sfx-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
+        "license:other",
+        "region:us"
       ],
-      "createdAt": "2026-05-11T14:56:58.000Z",
-      "lastModified": "2026-05-21T12:27:04.000Z"
+      "createdAt": "2026-05-17T01:51:16.000Z",
+      "lastModified": "2026-05-19T20:02:45.000Z"
     },
     {
-      "rank": 205,
+      "rank": 207,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6053,7 +6112,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 206,
+      "rank": 208,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6082,7 +6141,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 207,
+      "rank": 209,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6127,7 +6186,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 208,
+      "rank": 210,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6154,7 +6213,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 209,
+      "rank": 211,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -6180,7 +6239,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 210,
+      "rank": 212,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -6204,7 +6263,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 211,
+      "rank": 213,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -6242,66 +6301,24 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 212,
-      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "author": "fal",
-      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "downloads": 44999,
-      "likes": 1324,
-      "trendingScore": 22,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "qwen",
-        "qwen-image-edit",
-        "qwen-image-edit-2511",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "camera-control",
-        "image-editing",
-        "image-to-image",
-        "gaussian-splatting",
-        "fal",
-        "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-07T17:01:15.000Z",
-      "lastModified": "2026-01-07T17:06:01.000Z"
-    },
-    {
-      "rank": 213,
-      "id": "stabilityai/stable-audio-3-small-sfx",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
+      "rank": 214,
+      "id": "liujiafeng/Khala-MusicGeneration-v1.0",
+      "author": "liujiafeng",
+      "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
       "downloads": 0,
       "likes": 22,
       "trendingScore": 22,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
+      "pipelineTag": null,
+      "libraryName": null,
       "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-sfx-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
-        "license:other",
+        "license:cc-by-nc-4.0",
         "region:us"
       ],
-      "createdAt": "2026-05-17T01:51:16.000Z",
-      "lastModified": "2026-05-19T20:02:45.000Z"
+      "createdAt": "2026-04-20T09:45:29.000Z",
+      "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 214,
+      "rank": 215,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -6346,7 +6363,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 215,
+      "rank": 216,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -6374,7 +6391,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 216,
+      "rank": 217,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -6408,23 +6425,6 @@
       ],
       "createdAt": "2026-04-01T22:06:51.000Z",
       "lastModified": "2026-05-17T10:58:34.000Z"
-    },
-    {
-      "rank": 217,
-      "id": "liujiafeng/Khala-MusicGeneration-v1.0",
-      "author": "liujiafeng",
-      "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
-      "downloads": 0,
-      "likes": 21,
-      "trendingScore": 21,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T09:45:29.000Z",
-      "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
       "rank": 218,
@@ -6486,6 +6486,56 @@
     },
     {
       "rank": 220,
+      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "downloads": 0,
+      "likes": 22,
+      "trendingScore": 21,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "audio-text-to-video",
+        "audio-image-text-to-video",
+        "audio-driven-video-continuation",
+        "transformers",
+        "avatar",
+        "video-generation",
+        "en",
+        "zh",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:05:55.000Z",
+      "lastModified": "2026-05-22T02:58:39.000Z"
+    },
+    {
+      "rank": 221,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 0,
+      "likes": 21,
+      "trendingScore": 21,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-22T05:15:52.000Z"
+    },
+    {
+      "rank": 222,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -6513,7 +6563,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 221,
+      "rank": 223,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -6546,7 +6596,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 222,
+      "rank": 224,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -6571,7 +6621,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 223,
+      "rank": 225,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -6608,7 +6658,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 224,
+      "rank": 226,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -6651,7 +6701,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 225,
+      "rank": 227,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -6675,7 +6725,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 226,
+      "rank": 228,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -6699,7 +6749,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 227,
+      "rank": 229,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -6731,7 +6781,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 228,
+      "rank": 230,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -6760,7 +6810,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 229,
+      "rank": 231,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -6791,7 +6841,7 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 230,
+      "rank": 232,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -6809,7 +6859,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 231,
+      "rank": 233,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -6854,7 +6904,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 232,
+      "rank": 234,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -6877,7 +6927,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 233,
+      "rank": 235,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -6922,35 +6972,59 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 234,
-      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
-      "downloads": 0,
-      "likes": 21,
+      "rank": 236,
+      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "downloads": 25305,
+      "likes": 20,
       "trendingScore": 20,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
-        "onnx",
-        "safetensors",
-        "audio-text-to-video",
-        "audio-image-text-to-video",
-        "audio-driven-video-continuation",
         "transformers",
-        "avatar",
-        "video-generation",
-        "en",
-        "zh",
-        "license:mit",
-        "region:us"
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-122B-A10B",
+        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-21T09:05:55.000Z",
-      "lastModified": "2026-05-22T02:58:39.000Z"
+      "createdAt": "2026-05-15T19:03:18.000Z",
+      "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 235,
+      "rank": 237,
+      "id": "LatitudeGames/Equinox-31B",
+      "author": "LatitudeGames",
+      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
+      "downloads": 0,
+      "likes": 20,
+      "trendingScore": 20,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "gemma4",
+        "text adventure",
+        "roleplay",
+        "en",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:finetune:google/gemma-4-31B-it",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:45:53.000Z",
+      "lastModified": "2026-05-22T04:55:49.000Z"
+    },
+    {
+      "rank": 238,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -6995,7 +7069,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 236,
+      "rank": 239,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -7028,7 +7102,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 237,
+      "rank": 240,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -7050,7 +7124,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 238,
+      "rank": 241,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -7077,7 +7151,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 239,
+      "rank": 242,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -7093,12 +7167,12 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 240,
+      "rank": 243,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
       "downloads": 0,
-      "likes": 308,
+      "likes": 326,
       "trendingScore": 19,
       "pipelineTag": null,
       "libraryName": null,
@@ -7110,7 +7184,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 241,
+      "rank": 244,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -7133,7 +7207,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 242,
+      "rank": 245,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -7158,7 +7232,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 243,
+      "rank": 246,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -7194,7 +7268,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 244,
+      "rank": 247,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -7223,7 +7297,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 245,
+      "rank": 248,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -7253,7 +7327,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 246,
+      "rank": 249,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -7298,7 +7372,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 247,
+      "rank": 250,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -7325,7 +7399,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 248,
+      "rank": 251,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -7351,7 +7425,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 249,
+      "rank": 252,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -7379,35 +7453,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 250,
-      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "downloads": 25305,
-      "likes": 19,
-      "trendingScore": 19,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-122B-A10B",
-        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T19:03:18.000Z",
-      "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 251,
+      "rank": 253,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -7436,7 +7482,33 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 252,
+      "rank": 254,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 24,
+      "trendingScore": 19,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-21T14:39:01.000Z"
+    },
+    {
+      "rank": 255,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -7458,7 +7530,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 253,
+      "rank": 256,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -7492,7 +7564,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 254,
+      "rank": 257,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -7516,7 +7588,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 255,
+      "rank": 258,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7542,7 +7614,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 256,
+      "rank": 259,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -7564,7 +7636,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 257,
+      "rank": 260,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -7593,7 +7665,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 258,
+      "rank": 261,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -7625,12 +7697,12 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 259,
+      "rank": 262,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
-      "downloads": 7550707,
-      "likes": 4618,
+      "downloads": 7882008,
+      "likes": 4629,
       "trendingScore": 18,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -7654,7 +7726,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 260,
+      "rank": 263,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -7676,7 +7748,7 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 261,
+      "rank": 264,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -7694,7 +7766,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 262,
+      "rank": 265,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -7723,7 +7795,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 263,
+      "rank": 266,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7750,7 +7822,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 264,
+      "rank": 267,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -7768,7 +7840,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 265,
+      "rank": 268,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -7792,7 +7864,36 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 266,
+      "rank": 269,
+      "id": "stabilityai/stable-diffusion-xl-base-1.0",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "downloads": 1926286,
+      "likes": 7738,
+      "trendingScore": 18,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "text-to-image",
+        "stable-diffusion",
+        "arxiv:2307.01952",
+        "arxiv:2211.01324",
+        "arxiv:2108.01073",
+        "arxiv:2112.10752",
+        "license:openrail++",
+        "endpoints_compatible",
+        "diffusers:StableDiffusionXLPipeline",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2023-07-25T13:25:51.000Z",
+      "lastModified": "2023-10-30T16:03:47.000Z"
+    },
+    {
+      "rank": 270,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -7837,7 +7938,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 267,
+      "rank": 271,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -7866,7 +7967,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 268,
+      "rank": 272,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -7895,7 +7996,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 269,
+      "rank": 273,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -7927,7 +8028,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 270,
+      "rank": 274,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -7957,7 +8058,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 271,
+      "rank": 275,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -7978,7 +8079,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 272,
+      "rank": 276,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -8023,7 +8124,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 273,
+      "rank": 277,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -8052,7 +8153,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 274,
+      "rank": 278,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -8080,7 +8181,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 275,
+      "rank": 279,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -8105,7 +8206,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 276,
+      "rank": 280,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -8128,7 +8229,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 277,
+      "rank": 281,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -8155,7 +8256,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 278,
+      "rank": 282,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -8181,7 +8282,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 279,
+      "rank": 283,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -8210,36 +8311,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 280,
-      "id": "stabilityai/stable-diffusion-xl-base-1.0",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
-      "downloads": 1926286,
-      "likes": 7737,
-      "trendingScore": 17,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "onnx",
-        "safetensors",
-        "text-to-image",
-        "stable-diffusion",
-        "arxiv:2307.01952",
-        "arxiv:2211.01324",
-        "arxiv:2108.01073",
-        "arxiv:2112.10752",
-        "license:openrail++",
-        "endpoints_compatible",
-        "diffusers:StableDiffusionXLPipeline",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2023-07-25T13:25:51.000Z",
-      "lastModified": "2023-10-30T16:03:47.000Z"
-    },
-    {
-      "rank": 281,
+      "rank": 284,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -8264,7 +8336,7 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 282,
+      "rank": 285,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -8289,7 +8361,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 283,
+      "rank": 286,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -8324,7 +8396,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 284,
+      "rank": 287,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -8369,7 +8441,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 285,
+      "rank": 288,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -8396,7 +8468,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 286,
+      "rank": 289,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -8425,7 +8497,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 287,
+      "rank": 290,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -8448,7 +8520,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 288,
+      "rank": 291,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -8492,7 +8564,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 289,
+      "rank": 292,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -8537,7 +8609,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 290,
+      "rank": 293,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -8555,7 +8627,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 291,
+      "rank": 294,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -8600,7 +8672,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 292,
+      "rank": 295,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -8638,7 +8710,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 293,
+      "rank": 296,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -8658,7 +8730,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 294,
+      "rank": 297,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -8691,7 +8763,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 295,
+      "rank": 298,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -8721,7 +8793,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 296,
+      "rank": 299,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -8753,7 +8825,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 297,
+      "rank": 300,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -8778,36 +8850,10 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 298,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
-      "downloads": 0,
-      "likes": 21,
-      "trendingScore": 16,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
-        "en",
-        "zh",
-        "arxiv:2605.19833",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-21T14:39:01.000Z"
-    },
-    {
-      "rank": 299,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "rank": 301,
+      "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "downloads": 0,
       "likes": 16,
       "trendingScore": 16,
@@ -8815,40 +8861,18 @@
       "libraryName": null,
       "tags": [
         "gguf",
-        "arxiv:2512.24092",
+        "arxiv:2605.22064",
         "base_model:tencent/Hy-MT2-1.8B",
         "base_model:quantized:tencent/Hy-MT2-1.8B",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-21T09:18:01.000Z"
+      "createdAt": "2026-05-20T09:26:32.000Z",
+      "lastModified": "2026-05-22T05:15:40.000Z"
     },
     {
-      "rank": 300,
-      "id": "LatitudeGames/Equinox-31B",
-      "author": "LatitudeGames",
-      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
-      "downloads": 0,
-      "likes": 16,
-      "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gemma4",
-        "text adventure",
-        "roleplay",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:45:53.000Z",
-      "lastModified": "2026-05-20T18:51:13.000Z"
-    },
-    {
-      "rank": 301,
+      "rank": 302,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -8875,7 +8899,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 302,
+      "rank": 303,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -8920,7 +8944,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 303,
+      "rank": 304,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -8950,7 +8974,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 304,
+      "rank": 305,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -8980,7 +9004,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 305,
+      "rank": 306,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -9025,7 +9049,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 306,
+      "rank": 307,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -9060,7 +9084,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 307,
+      "rank": 308,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9088,7 +9112,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 308,
+      "rank": 309,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -9117,7 +9141,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 309,
+      "rank": 310,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -9142,7 +9166,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 310,
+      "rank": 311,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -9170,7 +9194,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 311,
+      "rank": 312,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -9198,7 +9222,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 312,
+      "rank": 313,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -9229,7 +9253,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 313,
+      "rank": 314,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -9274,7 +9298,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 314,
+      "rank": 315,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -9306,7 +9330,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 315,
+      "rank": 316,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -9333,7 +9357,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 316,
+      "rank": 317,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -9356,7 +9380,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 317,
+      "rank": 318,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -9389,7 +9413,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 318,
+      "rank": 319,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -9416,7 +9440,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 319,
+      "rank": 320,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9435,7 +9459,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 320,
+      "rank": 321,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -9458,7 +9482,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 321,
+      "rank": 322,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -9484,7 +9508,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 322,
+      "rank": 323,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -9514,7 +9538,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 323,
+      "rank": 324,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -9541,7 +9565,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 324,
+      "rank": 325,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9571,7 +9595,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 325,
+      "rank": 326,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -9602,7 +9626,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 326,
+      "rank": 327,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -9630,7 +9654,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 327,
+      "rank": 328,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
@@ -9656,12 +9680,12 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 328,
+      "rank": 329,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
       "downloads": 218354,
-      "likes": 1002,
+      "likes": 1003,
       "trendingScore": 15,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -9680,7 +9704,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 329,
+      "rank": 330,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -9712,29 +9736,30 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 330,
-      "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "downloads": 0,
-      "likes": 15,
+      "rank": 331,
+      "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
+      "author": "bartowski",
+      "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
+      "downloads": 164460,
+      "likes": 93,
       "trendingScore": 15,
-      "pipelineTag": null,
+      "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
         "gguf",
-        "arxiv:2512.24092",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-20T09:26:32.000Z",
-      "lastModified": "2026-05-21T09:15:46.000Z"
+      "createdAt": "2026-04-16T14:23:44.000Z",
+      "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 331,
+      "rank": 332,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -9758,7 +9783,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 332,
+      "rank": 333,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -9785,7 +9810,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 333,
+      "rank": 334,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -9813,7 +9838,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 334,
+      "rank": 335,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -9832,7 +9857,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 335,
+      "rank": 336,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -9864,7 +9889,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 336,
+      "rank": 337,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -9893,7 +9918,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 337,
+      "rank": 338,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -9920,7 +9945,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 338,
+      "rank": 339,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -9946,7 +9971,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 339,
+      "rank": 340,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -9977,7 +10002,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 340,
+      "rank": 341,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -10005,7 +10030,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 341,
+      "rank": 342,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -10028,7 +10053,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 342,
+      "rank": 343,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -10062,7 +10087,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 343,
+      "rank": 344,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -10088,7 +10113,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 344,
+      "rank": 345,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -10130,7 +10155,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 345,
+      "rank": 346,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -10168,7 +10193,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 346,
+      "rank": 347,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -10187,7 +10212,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 347,
+      "rank": 348,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -10207,7 +10232,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 348,
+      "rank": 349,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -10234,7 +10259,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 349,
+      "rank": 350,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -10260,7 +10285,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 350,
+      "rank": 351,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -10285,7 +10310,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 351,
+      "rank": 352,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -10314,7 +10339,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 352,
+      "rank": 353,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -10359,7 +10384,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 353,
+      "rank": 354,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -10386,7 +10411,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 354,
+      "rank": 355,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10429,29 +10454,6 @@
       ],
       "createdAt": "2026-04-17T08:46:23.000Z",
       "lastModified": "2026-05-03T03:53:41.000Z"
-    },
-    {
-      "rank": 355,
-      "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
-      "author": "bartowski",
-      "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
-      "downloads": 164460,
-      "likes": 92,
-      "trendingScore": 14,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-16T14:23:44.000Z",
-      "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
       "rank": 356,
@@ -10513,6 +10515,32 @@
     },
     {
       "rank": 358,
+      "id": "stabilityai/stable-audio-3-medium-base",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
+      "downloads": 0,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:44:44.000Z",
+      "lastModified": "2026-05-19T20:02:40.000Z"
+    },
+    {
+      "rank": 359,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -10541,7 +10569,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 359,
+      "rank": 360,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -10586,7 +10614,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 360,
+      "rank": 361,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -10615,7 +10643,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 361,
+      "rank": 362,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -10642,7 +10670,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 362,
+      "rank": 363,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -10669,7 +10697,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 363,
+      "rank": 364,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -10700,7 +10728,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 364,
+      "rank": 365,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -10724,7 +10752,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 365,
+      "rank": 366,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -10748,7 +10776,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 366,
+      "rank": 367,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -10793,7 +10821,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 367,
+      "rank": 368,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -10820,7 +10848,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 368,
+      "rank": 369,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -10856,7 +10884,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 369,
+      "rank": 370,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -10887,7 +10915,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 370,
+      "rank": 371,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -10918,7 +10946,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 371,
+      "rank": 372,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -10951,7 +10979,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 372,
+      "rank": 373,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -10980,7 +11008,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 373,
+      "rank": 374,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -11006,7 +11034,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 374,
+      "rank": 375,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -11036,7 +11064,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 375,
+      "rank": 376,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -11054,7 +11082,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 376,
+      "rank": 377,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -11085,7 +11113,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 377,
+      "rank": 378,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -11106,7 +11134,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 378,
+      "rank": 379,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -11126,7 +11154,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 379,
+      "rank": 380,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -11154,7 +11182,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 380,
+      "rank": 381,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -11181,7 +11209,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 381,
+      "rank": 382,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -11211,7 +11239,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 382,
+      "rank": 383,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -11228,7 +11256,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 383,
+      "rank": 384,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -11255,7 +11283,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 384,
+      "rank": 385,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11286,7 +11314,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 385,
+      "rank": 386,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -11312,32 +11340,6 @@
       ],
       "createdAt": "2026-05-19T05:52:43.000Z",
       "lastModified": "2026-05-19T08:16:03.000Z"
-    },
-    {
-      "rank": 386,
-      "id": "stabilityai/stable-audio-3-medium-base",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
-      "downloads": 0,
-      "likes": 13,
-      "trendingScore": 13,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:44:44.000Z",
-      "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
       "rank": 387,
@@ -11367,6 +11369,51 @@
     },
     {
       "rank": 388,
+      "id": "tencent/Hy-MT2-7B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
+      "downloads": 0,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-7B",
+        "base_model:quantized:tencent/Hy-MT2-7B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:31.000Z",
+      "lastModified": "2026-05-22T05:16:12.000Z"
+    },
+    {
+      "rank": 389,
+      "id": "microsoft/Lens",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 133,
+      "likes": 14,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
+    },
+    {
+      "rank": 390,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -11411,7 +11458,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 389,
+      "rank": 391,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -11438,7 +11485,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 390,
+      "rank": 392,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -11466,7 +11513,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 391,
+      "rank": 393,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -11499,7 +11546,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 392,
+      "rank": 394,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -11515,7 +11562,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 393,
+      "rank": 395,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -11538,7 +11585,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 394,
+      "rank": 396,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -11572,7 +11619,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 395,
+      "rank": 397,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -11592,7 +11639,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 396,
+      "rank": 398,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -11627,7 +11674,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 397,
+      "rank": 399,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -11657,7 +11704,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 398,
+      "rank": 400,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -11678,7 +11725,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 399,
+      "rank": 401,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -11707,7 +11754,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 400,
+      "rank": 402,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -11737,7 +11784,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 401,
+      "rank": 403,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -11765,7 +11812,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 402,
+      "rank": 404,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -11794,7 +11841,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 403,
+      "rank": 405,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -11826,7 +11873,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 404,
+      "rank": 406,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -11855,7 +11902,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 405,
+      "rank": 407,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -11890,7 +11937,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 406,
+      "rank": 408,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -11912,7 +11959,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 407,
+      "rank": 409,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -11950,7 +11997,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 408,
+      "rank": 410,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -11989,7 +12036,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 409,
+      "rank": 411,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -12026,7 +12073,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 410,
+      "rank": 412,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -12050,7 +12097,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 411,
+      "rank": 413,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -12068,7 +12115,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 412,
+      "rank": 414,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -12087,7 +12134,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 413,
+      "rank": 415,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -12115,7 +12162,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 414,
+      "rank": 416,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -12156,7 +12203,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 415,
+      "rank": 417,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -12178,7 +12225,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 416,
+      "rank": 418,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -12215,7 +12262,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 417,
+      "rank": 419,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -12245,7 +12292,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 418,
+      "rank": 420,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -12274,7 +12321,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 419,
+      "rank": 421,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -12302,7 +12349,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 420,
+      "rank": 422,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -12342,7 +12389,7 @@
       "lastModified": "2026-05-18T20:11:08.000Z"
     },
     {
-      "rank": 421,
+      "rank": 423,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -12367,7 +12414,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 422,
+      "rank": 424,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -12385,29 +12432,50 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 423,
-      "id": "tencent/Hy-MT2-7B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 0,
+      "rank": 425,
+      "id": "Jackrong/Qwopus3.5-9B-Coder",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
+      "downloads": 1153,
       "likes": 12,
       "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "gguf",
-        "arxiv:2512.24092",
-        "base_model:tencent/Hy-MT2-7B",
-        "base_model:quantized:tencent/Hy-MT2-7B",
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "agent",
+        "tool-use",
+        "function-calling",
+        "coder",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:lambda/hermes-agent-reasoning-traces",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "region:us"
       ],
-      "createdAt": "2026-05-20T06:21:31.000Z",
-      "lastModified": "2026-05-21T09:17:32.000Z"
+      "createdAt": "2026-05-15T08:15:06.000Z",
+      "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 424,
+      "rank": 426,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -12452,7 +12520,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 425,
+      "rank": 427,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -12494,7 +12562,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 426,
+      "rank": 428,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -12520,7 +12588,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 427,
+      "rank": 429,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -12545,7 +12613,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 428,
+      "rank": 430,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -12562,7 +12630,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 429,
+      "rank": 431,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -12590,7 +12658,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 430,
+      "rank": 432,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -12616,7 +12684,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 431,
+      "rank": 433,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -12643,7 +12711,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 432,
+      "rank": 434,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -12671,7 +12739,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 433,
+      "rank": 435,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -12704,7 +12772,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 434,
+      "rank": 436,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -12738,7 +12806,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 435,
+      "rank": 437,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -12767,7 +12835,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 436,
+      "rank": 438,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -12796,7 +12864,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 437,
+      "rank": 439,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -12829,7 +12897,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 438,
+      "rank": 440,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -12856,7 +12924,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 439,
+      "rank": 441,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -12886,7 +12954,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 440,
+      "rank": 442,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -12909,7 +12977,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 441,
+      "rank": 443,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -12935,7 +13003,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 442,
+      "rank": 444,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -12959,7 +13027,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 443,
+      "rank": 445,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -12986,7 +13054,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 444,
+      "rank": 446,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -13016,7 +13084,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 445,
+      "rank": 447,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -13050,7 +13118,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 446,
+      "rank": 448,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -13066,7 +13134,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 447,
+      "rank": 449,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -13097,7 +13165,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 448,
+      "rank": 450,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -13119,7 +13187,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 449,
+      "rank": 451,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -13139,7 +13207,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 450,
+      "rank": 452,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -13161,7 +13229,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 451,
+      "rank": 453,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -13190,7 +13258,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 452,
+      "rank": 454,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -13215,7 +13283,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 453,
+      "rank": 455,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -13240,7 +13308,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 454,
+      "rank": 456,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -13275,7 +13343,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 455,
+      "rank": 457,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -13299,7 +13367,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 456,
+      "rank": 458,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -13330,7 +13398,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 457,
+      "rank": 459,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -13357,7 +13425,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 458,
+      "rank": 460,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -13383,7 +13451,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 459,
+      "rank": 461,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -13413,7 +13481,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 460,
+      "rank": 462,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -13439,7 +13507,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 461,
+      "rank": 463,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -13484,7 +13552,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 462,
+      "rank": 464,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -13511,7 +13579,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 463,
+      "rank": 465,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -13537,7 +13605,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 464,
+      "rank": 466,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -13578,50 +13646,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 465,
-      "id": "Jackrong/Qwopus3.5-9B-Coder",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
-      "downloads": 1153,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "agent",
-        "tool-use",
-        "function-calling",
-        "coder",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:lambda/hermes-agent-reasoning-traces",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:15:06.000Z",
-      "lastModified": "2026-05-19T08:45:22.000Z"
-    },
-    {
-      "rank": 466,
+      "rank": 467,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -13647,7 +13672,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 467,
+      "rank": 468,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -13680,7 +13705,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 468,
+      "rank": 469,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -13709,7 +13734,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 469,
+      "rank": 470,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -13736,7 +13761,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 470,
+      "rank": 471,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -13781,7 +13806,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 471,
+      "rank": 472,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -13807,7 +13832,58 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 472,
+      "rank": 473,
+      "id": "stabilityai/SAME-L",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/SAME-L",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": null,
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "music",
+        "sound-effects",
+        "audio",
+        "autoencoder",
+        "en",
+        "arxiv:2605.18613",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T02:18:14.000Z",
+      "lastModified": "2026-05-19T20:11:14.000Z"
+    },
+    {
+      "rank": 474,
+      "id": "stabilityai/stable-audio-3-optimized",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "onnx",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T19:38:34.000Z",
+      "lastModified": "2026-05-20T20:49:04.000Z"
+    },
+    {
+      "rank": 475,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -13836,7 +13912,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 473,
+      "rank": 476,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -13870,7 +13946,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 474,
+      "rank": 477,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -13915,7 +13991,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 475,
+      "rank": 478,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -13944,7 +14020,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 476,
+      "rank": 479,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -13969,7 +14045,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 477,
+      "rank": 480,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -14004,7 +14080,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 478,
+      "rank": 481,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -14031,7 +14107,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 479,
+      "rank": 482,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -14076,7 +14152,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 480,
+      "rank": 483,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -14098,7 +14174,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 481,
+      "rank": 484,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -14130,7 +14206,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 482,
+      "rank": 485,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -14155,7 +14231,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 483,
+      "rank": 486,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -14179,7 +14255,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 484,
+      "rank": 487,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -14207,7 +14283,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 485,
+      "rank": 488,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -14250,7 +14326,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 486,
+      "rank": 489,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -14274,7 +14350,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 487,
+      "rank": 490,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -14319,7 +14395,7 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 488,
+      "rank": 491,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -14348,7 +14424,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 489,
+      "rank": 492,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -14380,7 +14456,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 490,
+      "rank": 493,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -14404,7 +14480,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 491,
+      "rank": 494,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -14426,7 +14502,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 492,
+      "rank": 495,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -14451,7 +14527,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 493,
+      "rank": 496,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -14479,7 +14555,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 494,
+      "rank": 497,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -14503,7 +14579,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 495,
+      "rank": 498,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -14530,7 +14606,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 496,
+      "rank": 499,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -14555,7 +14631,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 497,
+      "rank": 500,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -14572,7 +14648,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 498,
+      "rank": 501,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -14596,7 +14672,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 499,
+      "rank": 502,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -14620,7 +14696,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 500,
+      "rank": 503,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -14653,7 +14729,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 501,
+      "rank": 504,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -14687,7 +14763,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 502,
+      "rank": 505,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -14709,7 +14785,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 503,
+      "rank": 506,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -14732,7 +14808,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 504,
+      "rank": 507,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -14752,7 +14828,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 505,
+      "rank": 508,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -14784,7 +14860,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 506,
+      "rank": 509,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -14823,7 +14899,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 507,
+      "rank": 510,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -14857,7 +14933,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 508,
+      "rank": 511,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -14881,7 +14957,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 509,
+      "rank": 512,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -14914,7 +14990,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 510,
+      "rank": 513,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -14934,7 +15010,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 511,
+      "rank": 514,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -14963,7 +15039,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 512,
+      "rank": 515,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -14985,7 +15061,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 513,
+      "rank": 516,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -15017,7 +15093,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 514,
+      "rank": 517,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -15044,7 +15120,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 515,
+      "rank": 518,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -15088,7 +15164,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 516,
+      "rank": 519,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -15106,7 +15182,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 517,
+      "rank": 520,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -15145,7 +15221,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 518,
+      "rank": 521,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -15184,7 +15260,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 519,
+      "rank": 522,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -15218,7 +15294,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 520,
+      "rank": 523,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -15246,7 +15322,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 521,
+      "rank": 524,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -15268,7 +15344,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 522,
+      "rank": 525,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -15296,7 +15372,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 523,
+      "rank": 526,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -15314,7 +15390,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 524,
+      "rank": 527,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -15342,7 +15418,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 525,
+      "rank": 528,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -15373,7 +15449,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 526,
+      "rank": 529,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -15389,7 +15465,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 527,
+      "rank": 530,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -15416,7 +15492,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 528,
+      "rank": 531,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -15445,7 +15521,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 529,
+      "rank": 532,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -15473,7 +15549,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 530,
+      "rank": 533,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -15502,7 +15578,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 531,
+      "rank": 534,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -15531,7 +15607,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 532,
+      "rank": 535,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -15552,7 +15628,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 533,
+      "rank": 536,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -15573,7 +15649,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 534,
+      "rank": 537,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -15598,37 +15674,12 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 535,
-      "id": "stabilityai/SAME-L",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/SAME-L",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "music",
-        "sound-effects",
-        "audio",
-        "autoencoder",
-        "en",
-        "arxiv:2605.18613",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T02:18:14.000Z",
-      "lastModified": "2026-05-19T20:11:14.000Z"
-    },
-    {
-      "rank": 536,
+      "rank": 538,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
       "downloads": 7924282,
-      "likes": 1416,
+      "likes": 1418,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -15661,7 +15712,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 537,
+      "rank": 539,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
@@ -15688,7 +15739,7 @@
       "lastModified": "2026-05-21T02:10:38.000Z"
     },
     {
-      "rank": 538,
+      "rank": 540,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -15733,7 +15784,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 539,
+      "rank": 541,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -15762,7 +15813,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 540,
+      "rank": 542,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -15782,7 +15833,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 541,
+      "rank": 543,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -15814,7 +15865,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 542,
+      "rank": 544,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -15843,56 +15894,45 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 543,
-      "id": "stabilityai/stable-audio-3-optimized",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "onnx",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T19:38:34.000Z",
-      "lastModified": "2026-05-20T20:49:04.000Z"
-    },
-    {
-      "rank": 544,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 133,
-      "likes": 11,
-      "trendingScore": 10,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
-    },
-    {
       "rank": 545,
+      "id": "meta-llama/Llama-3.2-3B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
+      "downloads": 2205212,
+      "likes": 2140,
+      "trendingScore": 10,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:19:20.000Z",
+      "lastModified": "2024-10-24T15:07:29.000Z"
+    },
+    {
+      "rank": 546,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -15919,7 +15959,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 546,
+      "rank": 547,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -15945,7 +15985,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 547,
+      "rank": 548,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -15973,7 +16013,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 548,
+      "rank": 549,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -15999,7 +16039,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 549,
+      "rank": 550,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -16043,7 +16083,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 550,
+      "rank": 551,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -16083,7 +16123,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 551,
+      "rank": 552,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -16119,7 +16159,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 552,
+      "rank": 553,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -16163,7 +16203,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 553,
+      "rank": 554,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -16188,7 +16228,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 554,
+      "rank": 555,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -16233,7 +16273,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 555,
+      "rank": 556,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -16252,7 +16292,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 556,
+      "rank": 557,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -16277,7 +16317,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 557,
+      "rank": 558,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -16316,7 +16356,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 558,
+      "rank": 559,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -16333,7 +16373,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 559,
+      "rank": 560,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -16361,7 +16401,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 560,
+      "rank": 561,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -16390,7 +16430,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 561,
+      "rank": 562,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -16415,7 +16455,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 562,
+      "rank": 563,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -16450,7 +16490,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 563,
+      "rank": 564,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -16480,7 +16520,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 564,
+      "rank": 565,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -16516,7 +16556,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 565,
+      "rank": 566,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -16539,7 +16579,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 566,
+      "rank": 567,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -16556,7 +16596,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 567,
+      "rank": 568,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -16576,7 +16616,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 568,
+      "rank": 569,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -16603,7 +16643,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 569,
+      "rank": 570,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -16627,7 +16667,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 570,
+      "rank": 571,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -16649,7 +16689,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 571,
+      "rank": 572,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -16681,7 +16721,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 572,
+      "rank": 573,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -16709,7 +16749,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 573,
+      "rank": 574,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -16727,7 +16767,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 574,
+      "rank": 575,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -16752,7 +16792,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 575,
+      "rank": 576,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -16775,7 +16815,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 576,
+      "rank": 577,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -16793,7 +16833,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 577,
+      "rank": 578,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -16828,7 +16868,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 578,
+      "rank": 579,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -16856,7 +16896,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 579,
+      "rank": 580,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -16878,7 +16918,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 580,
+      "rank": 581,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -16905,7 +16945,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 581,
+      "rank": 582,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -16930,7 +16970,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 582,
+      "rank": 583,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -16964,7 +17004,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 583,
+      "rank": 584,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -16991,7 +17031,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 584,
+      "rank": 585,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -17018,7 +17058,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 585,
+      "rank": 586,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -17059,7 +17099,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 586,
+      "rank": 587,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -17089,7 +17129,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 587,
+      "rank": 588,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -17126,7 +17166,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 588,
+      "rank": 589,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -17158,7 +17198,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 589,
+      "rank": 590,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -17200,7 +17240,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 590,
+      "rank": 591,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -17230,7 +17270,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 591,
+      "rank": 592,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -17275,7 +17315,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 592,
+      "rank": 593,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -17302,7 +17342,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 593,
+      "rank": 594,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -17334,7 +17374,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 594,
+      "rank": 595,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -17368,7 +17408,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 595,
+      "rank": 596,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -17398,7 +17438,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 596,
+      "rank": 597,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -17423,12 +17463,12 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 597,
+      "rank": 598,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
-      "downloads": 1668130,
-      "likes": 2789,
+      "downloads": 1552886,
+      "likes": 2792,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -17450,7 +17490,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 598,
+      "rank": 599,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -17482,7 +17522,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 599,
+      "rank": 600,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -17527,7 +17567,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 600,
+      "rank": 601,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -17555,7 +17595,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 601,
+      "rank": 602,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -17594,7 +17634,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 602,
+      "rank": 603,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -17620,7 +17660,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 603,
+      "rank": 604,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -17650,7 +17690,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 604,
+      "rank": 605,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -17679,7 +17719,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 605,
+      "rank": 606,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -17719,44 +17759,6 @@
       ],
       "createdAt": "2026-05-07T17:15:51.000Z",
       "lastModified": "2026-05-07T17:23:36.000Z"
-    },
-    {
-      "rank": 606,
-      "id": "meta-llama/Llama-3.2-3B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
-      "downloads": 2205212,
-      "likes": 2139,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:19:20.000Z",
-      "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
       "rank": 607,
@@ -17938,6 +17940,8 @@
         "text adventure",
         "roleplay",
         "en",
+        "base_model:LatitudeGames/Equinox-31B",
+        "base_model:quantized:LatitudeGames/Equinox-31B",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
@@ -17945,10 +17949,39 @@
         "conversational"
       ],
       "createdAt": "2026-05-20T07:57:51.000Z",
-      "lastModified": "2026-05-20T18:47:18.000Z"
+      "lastModified": "2026-05-22T04:56:16.000Z"
     },
     {
       "rank": 613,
+      "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
+      "author": "aifeifei798",
+      "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
+      "downloads": 873,
+      "likes": 31,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "roleplay",
+        "llama3",
+        "sillytavern",
+        "idol",
+        "en",
+        "arxiv:2403.19522",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-07-21T23:20:43.000Z",
+      "lastModified": "2024-07-23T10:35:13.000Z"
+    },
+    {
+      "rank": 614,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -17975,7 +18008,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 614,
+      "rank": 615,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -17999,7 +18032,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 615,
+      "rank": 616,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -18019,7 +18052,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 616,
+      "rank": 617,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -18046,7 +18079,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 617,
+      "rank": 618,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -18065,7 +18098,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 618,
+      "rank": 619,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -18099,7 +18132,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 619,
+      "rank": 620,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -18131,7 +18164,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 620,
+      "rank": 621,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -18153,7 +18186,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 621,
+      "rank": 622,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -18198,7 +18231,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 622,
+      "rank": 623,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -18217,7 +18250,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 623,
+      "rank": 624,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -18251,7 +18284,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 624,
+      "rank": 625,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -18279,7 +18312,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 625,
+      "rank": 626,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -18307,7 +18340,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 626,
+      "rank": 627,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -18330,7 +18363,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 627,
+      "rank": 628,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -18357,7 +18390,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 628,
+      "rank": 629,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -18402,7 +18435,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 629,
+      "rank": 630,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -18438,7 +18471,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 630,
+      "rank": 631,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -18478,7 +18511,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 631,
+      "rank": 632,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -18507,7 +18540,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 632,
+      "rank": 633,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -18535,7 +18568,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 633,
+      "rank": 634,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -18554,7 +18587,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 634,
+      "rank": 635,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -18573,7 +18606,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 635,
+      "rank": 636,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -18605,7 +18638,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 636,
+      "rank": 637,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -18632,7 +18665,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 637,
+      "rank": 638,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -18654,7 +18687,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 638,
+      "rank": 639,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -18672,7 +18705,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 639,
+      "rank": 640,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -18701,7 +18734,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 640,
+      "rank": 641,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -18722,7 +18755,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 641,
+      "rank": 642,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -18750,7 +18783,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 642,
+      "rank": 643,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -18771,7 +18804,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 643,
+      "rank": 644,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -18807,7 +18840,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 644,
+      "rank": 645,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -18852,7 +18885,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 645,
+      "rank": 646,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -18878,7 +18911,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 646,
+      "rank": 647,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -18901,7 +18934,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 647,
+      "rank": 648,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -18926,7 +18959,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 648,
+      "rank": 649,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -18961,7 +18994,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 649,
+      "rank": 650,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -19006,7 +19039,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 650,
+      "rank": 651,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -19033,7 +19066,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 651,
+      "rank": 652,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -19062,7 +19095,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 652,
+      "rank": 653,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -19081,7 +19114,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 653,
+      "rank": 654,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -19102,7 +19135,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 654,
+      "rank": 655,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -19128,7 +19161,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 655,
+      "rank": 656,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -19154,7 +19187,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 656,
+      "rank": 657,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -19191,7 +19224,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 657,
+      "rank": 658,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -19236,7 +19269,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 658,
+      "rank": 659,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -19261,7 +19294,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 659,
+      "rank": 660,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -19278,7 +19311,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 660,
+      "rank": 661,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -19305,7 +19338,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 661,
+      "rank": 662,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -19323,7 +19356,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 662,
+      "rank": 663,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -19348,7 +19381,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 663,
+      "rank": 664,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -19380,7 +19413,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 664,
+      "rank": 665,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -19401,7 +19434,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 665,
+      "rank": 666,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -19420,7 +19453,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 666,
+      "rank": 667,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -19451,7 +19484,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 667,
+      "rank": 668,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -19474,7 +19507,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 668,
+      "rank": 669,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -19491,7 +19524,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 669,
+      "rank": 670,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -19519,7 +19552,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 670,
+      "rank": 671,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -19536,7 +19569,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 671,
+      "rank": 672,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -19572,7 +19605,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 672,
+      "rank": 673,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -19602,7 +19635,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 673,
+      "rank": 674,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -19631,7 +19664,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 674,
+      "rank": 675,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -19654,7 +19687,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 675,
+      "rank": 676,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -19687,7 +19720,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 676,
+      "rank": 677,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -19718,7 +19751,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 677,
+      "rank": 678,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -19741,7 +19774,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 678,
+      "rank": 679,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -19774,7 +19807,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 679,
+      "rank": 680,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -19797,7 +19830,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 680,
+      "rank": 681,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -19827,7 +19860,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 681,
+      "rank": 682,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -19854,7 +19887,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 682,
+      "rank": 683,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -19883,7 +19916,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 683,
+      "rank": 684,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -19912,7 +19945,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 684,
+      "rank": 685,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -19948,7 +19981,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 685,
+      "rank": 686,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -19971,7 +20004,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 686,
+      "rank": 687,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -19996,7 +20029,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 687,
+      "rank": 688,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -20021,35 +20054,6 @@
       ],
       "createdAt": "2025-06-12T05:29:16.000Z",
       "lastModified": "2026-04-24T13:52:18.000Z"
-    },
-    {
-      "rank": 688,
-      "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "author": "aifeifei798",
-      "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "downloads": 873,
-      "likes": 30,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "roleplay",
-        "llama3",
-        "sillytavern",
-        "idol",
-        "en",
-        "arxiv:2403.19522",
-        "license:llama3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-07-21T23:20:43.000Z",
-      "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
       "rank": 689,
@@ -20344,6 +20348,55 @@
     },
     {
       "rank": 698,
+      "id": "stabilityai/stable-audio-3-small-music-base",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T23:40:30.000Z",
+      "lastModified": "2026-05-20T15:19:54.000Z"
+    },
+    {
+      "rank": 699,
+      "id": "tori29umai/QwenImageEdit2511_LoRA",
+      "author": "tori29umai",
+      "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-image",
+      "libraryName": null,
+      "tags": [
+        "lora",
+        "qwen-image-edit",
+        "image-to-image",
+        "ja",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit",
+        "base_model:adapter:Qwen/Qwen-Image-Edit",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T23:38:39.000Z",
+      "lastModified": "2026-05-16T08:11:00.000Z"
+    },
+    {
+      "rank": 700,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -20369,7 +20422,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 699,
+      "rank": 701,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -20386,7 +20439,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 700,
+      "rank": 702,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -20414,7 +20467,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 701,
+      "rank": 703,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -20449,7 +20502,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 702,
+      "rank": 704,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -20474,7 +20527,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 703,
+      "rank": 705,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -20504,7 +20557,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 704,
+      "rank": 706,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -20533,7 +20586,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 705,
+      "rank": 707,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -20560,7 +20613,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 706,
+      "rank": 708,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -20586,7 +20639,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 707,
+      "rank": 709,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -20617,7 +20670,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 708,
+      "rank": 710,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -20635,7 +20688,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 709,
+      "rank": 711,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -20664,7 +20717,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 710,
+      "rank": 712,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -20687,7 +20740,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 711,
+      "rank": 713,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -20732,7 +20785,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 712,
+      "rank": 714,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -20758,7 +20811,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 713,
+      "rank": 715,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -20786,7 +20839,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 714,
+      "rank": 716,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -20824,7 +20877,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 715,
+      "rank": 717,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -20851,7 +20904,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 716,
+      "rank": 718,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -20877,7 +20930,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 717,
+      "rank": 719,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -20895,7 +20948,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 718,
+      "rank": 720,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -20921,7 +20974,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 719,
+      "rank": 721,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -20945,7 +20998,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 720,
+      "rank": 722,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -20986,7 +21039,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 721,
+      "rank": 723,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -21003,7 +21056,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 722,
+      "rank": 724,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -21036,7 +21089,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 723,
+      "rank": 725,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -21070,7 +21123,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 724,
+      "rank": 726,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -21109,7 +21162,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 725,
+      "rank": 727,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -21139,7 +21192,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 726,
+      "rank": 728,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -21175,7 +21228,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 727,
+      "rank": 729,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -21201,7 +21254,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 728,
+      "rank": 730,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -21237,7 +21290,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 729,
+      "rank": 731,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -21267,7 +21320,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 730,
+      "rank": 732,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -21305,7 +21358,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 731,
+      "rank": 733,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -21340,7 +21393,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 732,
+      "rank": 734,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -21365,7 +21418,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 733,
+      "rank": 735,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -21382,7 +21435,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 734,
+      "rank": 736,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -21424,7 +21477,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 735,
+      "rank": 737,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -21454,7 +21507,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 736,
+      "rank": 738,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -21479,7 +21532,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 737,
+      "rank": 739,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -21507,7 +21560,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 738,
+      "rank": 740,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -21524,7 +21577,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 739,
+      "rank": 741,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -21551,7 +21604,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 740,
+      "rank": 742,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -21594,7 +21647,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 741,
+      "rank": 743,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -21634,7 +21687,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 742,
+      "rank": 744,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -21658,7 +21711,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 743,
+      "rank": 745,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -21687,7 +21740,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 744,
+      "rank": 746,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -21713,7 +21766,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 745,
+      "rank": 747,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -21741,7 +21794,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 746,
+      "rank": 748,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -21780,7 +21833,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 747,
+      "rank": 749,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -21804,7 +21857,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 748,
+      "rank": 750,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -21832,7 +21885,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 749,
+      "rank": 751,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -21864,7 +21917,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 750,
+      "rank": 752,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -21894,7 +21947,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 751,
+      "rank": 753,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -21923,7 +21976,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 752,
+      "rank": 754,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -21956,7 +22009,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 753,
+      "rank": 755,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -21985,7 +22038,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 754,
+      "rank": 756,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -22005,7 +22058,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 755,
+      "rank": 757,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -22034,7 +22087,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 756,
+      "rank": 758,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -22058,7 +22111,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 757,
+      "rank": 759,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -22088,7 +22141,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 758,
+      "rank": 760,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -22118,7 +22171,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 759,
+      "rank": 761,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -22136,7 +22189,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 760,
+      "rank": 762,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -22153,7 +22206,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 761,
+      "rank": 763,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -22189,7 +22242,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 762,
+      "rank": 764,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -22220,7 +22273,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 763,
+      "rank": 765,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -22251,7 +22304,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 764,
+      "rank": 766,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -22284,7 +22337,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 765,
+      "rank": 767,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -22312,7 +22365,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 766,
+      "rank": 768,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -22337,7 +22390,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 767,
+      "rank": 769,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -22360,7 +22413,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 768,
+      "rank": 770,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -22388,7 +22441,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 769,
+      "rank": 771,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -22421,7 +22474,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 770,
+      "rank": 772,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -22451,7 +22504,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 771,
+      "rank": 773,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -22486,7 +22539,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 772,
+      "rank": 774,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -22518,7 +22571,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 773,
+      "rank": 775,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -22543,7 +22596,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 774,
+      "rank": 776,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -22566,7 +22619,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 775,
+      "rank": 777,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -22593,7 +22646,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 776,
+      "rank": 778,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -22616,7 +22669,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 777,
+      "rank": 779,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -22661,7 +22714,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 778,
+      "rank": 780,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -22693,7 +22746,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 779,
+      "rank": 781,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -22720,7 +22773,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 780,
+      "rank": 782,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -22746,7 +22799,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 781,
+      "rank": 783,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -22778,7 +22831,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 782,
+      "rank": 784,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -22807,7 +22860,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 783,
+      "rank": 785,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -22839,7 +22892,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 784,
+      "rank": 786,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -22869,7 +22922,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 785,
+      "rank": 787,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -22886,7 +22939,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 786,
+      "rank": 788,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -22906,7 +22959,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 787,
+      "rank": 789,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -22945,7 +22998,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 788,
+      "rank": 790,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -22983,7 +23036,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 789,
+      "rank": 791,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -23011,7 +23064,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 790,
+      "rank": 792,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -23056,7 +23109,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 791,
+      "rank": 793,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -23080,7 +23133,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 792,
+      "rank": 794,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -23110,7 +23163,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 793,
+      "rank": 795,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -23137,7 +23190,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 794,
+      "rank": 796,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -23163,7 +23216,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 795,
+      "rank": 797,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -23191,7 +23244,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 796,
+      "rank": 798,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -23220,7 +23273,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 797,
+      "rank": 799,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -23238,7 +23291,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 798,
+      "rank": 800,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -23258,7 +23311,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 799,
+      "rank": 801,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -23290,7 +23343,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 800,
+      "rank": 802,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -23317,7 +23370,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 801,
+      "rank": 803,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -23333,7 +23386,7 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 802,
+      "rank": 804,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -23363,7 +23416,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 803,
+      "rank": 805,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -23381,7 +23434,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 804,
+      "rank": 806,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -23408,7 +23461,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 805,
+      "rank": 807,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -23432,7 +23485,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 806,
+      "rank": 808,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -23477,32 +23530,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 807,
-      "id": "stabilityai/stable-audio-3-small-music-base",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T23:40:30.000Z",
-      "lastModified": "2026-05-20T15:19:54.000Z"
-    },
-    {
-      "rank": 808,
+      "rank": 809,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -23533,7 +23561,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 809,
+      "rank": 810,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -23558,7 +23586,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 810,
+      "rank": 811,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -23598,7 +23626,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 811,
+      "rank": 812,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -23623,7 +23651,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 812,
+      "rank": 813,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -23654,12 +23682,12 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 813,
+      "rank": 814,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
       "downloads": 208046,
-      "likes": 1307,
+      "likes": 1308,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
       "libraryName": "dots_ocr",
@@ -23688,7 +23716,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 814,
+      "rank": 815,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -23706,7 +23734,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 815,
+      "rank": 816,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -23743,7 +23771,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 816,
+      "rank": 817,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -23788,7 +23816,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 817,
+      "rank": 818,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -23833,7 +23861,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 818,
+      "rank": 819,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -23859,7 +23887,7 @@
       "lastModified": "2026-05-19T18:52:45.000Z"
     },
     {
-      "rank": 819,
+      "rank": 820,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -23884,7 +23912,7 @@
       "lastModified": "2026-05-22T04:33:05.000Z"
     },
     {
-      "rank": 820,
+      "rank": 821,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -23911,12 +23939,37 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 821,
+      "rank": 822,
+      "id": "stabilityai/SAME-S",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/SAME-S",
+      "downloads": 0,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "music",
+        "sound-effects",
+        "audio",
+        "autoencoder",
+        "en",
+        "arxiv:2605.18613",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T02:17:58.000Z",
+      "lastModified": "2026-05-19T20:11:16.000Z"
+    },
+    {
+      "rank": 823,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
-      "downloads": 3387039,
-      "likes": 6531,
+      "downloads": 2617119,
+      "likes": 6542,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -23939,12 +23992,12 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 822,
+      "rank": 824,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
-      "downloads": 827493,
-      "likes": 2754,
+      "downloads": 980693,
+      "likes": 2771,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -23978,7 +24031,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 823,
+      "rank": 825,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -24011,7 +24064,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 824,
+      "rank": 826,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -24040,7 +24093,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 825,
+      "rank": 827,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -24085,7 +24138,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 826,
+      "rank": 828,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -24114,7 +24167,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 827,
+      "rank": 829,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -24159,7 +24212,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 828,
+      "rank": 830,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -24203,7 +24256,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 829,
+      "rank": 831,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -24229,7 +24282,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 830,
+      "rank": 832,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -24255,7 +24308,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 831,
+      "rank": 833,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -24287,7 +24340,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 832,
+      "rank": 834,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -24310,7 +24363,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 833,
+      "rank": 835,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -24353,7 +24406,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 834,
+      "rank": 836,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -24398,7 +24451,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 835,
+      "rank": 837,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -24443,7 +24496,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 836,
+      "rank": 838,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -24470,7 +24523,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 837,
+      "rank": 839,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -24497,7 +24550,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 838,
+      "rank": 840,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -24522,7 +24575,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 839,
+      "rank": 841,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -24561,7 +24614,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 840,
+      "rank": 842,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -24586,7 +24639,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 841,
+      "rank": 843,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -24614,7 +24667,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 842,
+      "rank": 844,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -24639,7 +24692,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 843,
+      "rank": 845,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -24655,7 +24708,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 844,
+      "rank": 846,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -24682,7 +24735,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 845,
+      "rank": 847,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -24714,7 +24767,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 846,
+      "rank": 848,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -24744,7 +24797,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 847,
+      "rank": 849,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -24776,7 +24829,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 848,
+      "rank": 850,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -24804,7 +24857,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 849,
+      "rank": 851,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -24830,7 +24883,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 850,
+      "rank": 852,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -24855,7 +24908,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 851,
+      "rank": 853,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -24884,7 +24937,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 852,
+      "rank": 854,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -24926,7 +24979,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 853,
+      "rank": 855,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -24953,7 +25006,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 854,
+      "rank": 856,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -24998,7 +25051,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 855,
+      "rank": 857,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -25024,7 +25077,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 856,
+      "rank": 858,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -25044,7 +25097,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 857,
+      "rank": 859,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -25071,7 +25124,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 858,
+      "rank": 860,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -25113,7 +25166,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 859,
+      "rank": 861,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -25140,7 +25193,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 860,
+      "rank": 862,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -25174,7 +25227,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 861,
+      "rank": 863,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -25203,7 +25256,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 862,
+      "rank": 864,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -25230,7 +25283,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 863,
+      "rank": 865,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -25257,7 +25310,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 864,
+      "rank": 866,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -25284,7 +25337,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 865,
+      "rank": 867,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -25312,7 +25365,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 866,
+      "rank": 868,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -25335,7 +25388,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 867,
+      "rank": 869,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -25366,7 +25419,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 868,
+      "rank": 870,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -25411,7 +25464,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 869,
+      "rank": 871,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -25433,7 +25486,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 870,
+      "rank": 872,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -25459,7 +25512,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 871,
+      "rank": 873,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -25485,7 +25538,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 872,
+      "rank": 874,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -25516,7 +25569,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 873,
+      "rank": 875,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -25539,7 +25592,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 874,
+      "rank": 876,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -25569,7 +25622,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 875,
+      "rank": 877,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -25601,7 +25654,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 876,
+      "rank": 878,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -25630,7 +25683,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 877,
+      "rank": 879,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -25662,7 +25715,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 878,
+      "rank": 880,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -25694,7 +25747,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 879,
+      "rank": 881,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -25725,7 +25778,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 880,
+      "rank": 882,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -25756,7 +25809,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 881,
+      "rank": 883,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -25779,7 +25832,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 882,
+      "rank": 884,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -25806,7 +25859,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 883,
+      "rank": 885,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -25851,7 +25904,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 884,
+      "rank": 886,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -25869,7 +25922,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 885,
+      "rank": 887,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -25892,7 +25945,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 886,
+      "rank": 888,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -25922,7 +25975,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 887,
+      "rank": 889,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -25961,7 +26014,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 888,
+      "rank": 890,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -25999,7 +26052,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 889,
+      "rank": 891,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -26044,7 +26097,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 890,
+      "rank": 892,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -26069,7 +26122,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 891,
+      "rank": 893,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -26103,7 +26156,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 892,
+      "rank": 894,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -26128,7 +26181,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 893,
+      "rank": 895,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -26161,7 +26214,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 894,
+      "rank": 896,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -26188,7 +26241,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 895,
+      "rank": 897,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -26218,7 +26271,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 896,
+      "rank": 898,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -26250,7 +26303,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 897,
+      "rank": 899,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -26283,7 +26336,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 898,
+      "rank": 900,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -26301,7 +26354,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 899,
+      "rank": 901,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -26324,7 +26377,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 900,
+      "rank": 902,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -26356,7 +26409,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 901,
+      "rank": 903,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -26401,7 +26454,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 902,
+      "rank": 904,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -26442,7 +26495,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 903,
+      "rank": 905,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -26481,7 +26534,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 904,
+      "rank": 906,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -26508,7 +26561,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 905,
+      "rank": 907,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -26545,7 +26598,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 906,
+      "rank": 908,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -26581,7 +26634,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 907,
+      "rank": 909,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -26599,7 +26652,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 908,
+      "rank": 910,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -26638,7 +26691,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 909,
+      "rank": 911,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -26667,7 +26720,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 910,
+      "rank": 912,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -26694,7 +26747,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 911,
+      "rank": 913,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -26721,7 +26774,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 912,
+      "rank": 914,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -26751,7 +26804,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 913,
+      "rank": 915,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -26778,7 +26831,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 914,
+      "rank": 916,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -26809,7 +26862,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 915,
+      "rank": 917,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -26828,7 +26881,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 916,
+      "rank": 918,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -26855,7 +26908,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 917,
+      "rank": 919,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -26880,7 +26933,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 918,
+      "rank": 920,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -26910,7 +26963,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 919,
+      "rank": 921,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -26932,7 +26985,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 920,
+      "rank": 922,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -26953,7 +27006,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 921,
+      "rank": 923,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -26989,7 +27042,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 922,
+      "rank": 924,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -27012,7 +27065,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 923,
+      "rank": 925,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -27057,7 +27110,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 924,
+      "rank": 926,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -27079,7 +27132,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 925,
+      "rank": 927,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -27109,7 +27162,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 926,
+      "rank": 928,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -27134,7 +27187,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 927,
+      "rank": 929,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -27167,7 +27220,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 928,
+      "rank": 930,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -27190,7 +27243,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 929,
+      "rank": 931,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -27210,7 +27263,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 930,
+      "rank": 932,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -27255,7 +27308,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 931,
+      "rank": 933,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -27276,7 +27329,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 932,
+      "rank": 934,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -27309,7 +27362,7 @@
       "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 933,
+      "rank": 935,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -27337,12 +27390,12 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 934,
+      "rank": 936,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
-      "downloads": 8459029,
-      "likes": 319,
+      "downloads": 8581139,
+      "likes": 323,
       "trendingScore": 6,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -27382,7 +27435,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 935,
+      "rank": 937,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -27407,7 +27460,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 936,
+      "rank": 938,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -27435,7 +27488,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 937,
+      "rank": 939,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -27460,7 +27513,7 @@
       "lastModified": "2026-05-18T05:58:18.000Z"
     },
     {
-      "rank": 938,
+      "rank": 940,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
@@ -27491,7 +27544,7 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 939,
+      "rank": 941,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
@@ -27510,7 +27563,7 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 940,
+      "rank": 942,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -27536,7 +27589,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 941,
+      "rank": 943,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -27563,7 +27616,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 942,
+      "rank": 944,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
@@ -27595,7 +27648,7 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 943,
+      "rank": 945,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -27613,7 +27666,7 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 944,
+      "rank": 946,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -27636,7 +27689,7 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 945,
+      "rank": 947,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
@@ -27663,7 +27716,7 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 946,
+      "rank": 948,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
@@ -27695,7 +27748,7 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 947,
+      "rank": 949,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
@@ -27713,7 +27766,7 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 948,
+      "rank": 950,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
@@ -27746,7 +27799,7 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 949,
+      "rank": 951,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -27778,7 +27831,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 950,
+      "rank": 952,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -27805,7 +27858,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 951,
+      "rank": 953,
       "id": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
       "author": "Ttimofeyka",
       "url": "https://huggingface.co/Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
@@ -27830,12 +27883,12 @@
       "lastModified": "2024-02-10T11:41:00.000Z"
     },
     {
-      "rank": 952,
+      "rank": 954,
       "id": "HuggingFaceTB/SmolLM2-135M-Instruct",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct",
-      "downloads": 1742823,
-      "likes": 323,
+      "downloads": 1647127,
+      "likes": 325,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -27861,7 +27914,7 @@
       "lastModified": "2025-09-22T20:43:15.000Z"
     },
     {
-      "rank": 953,
+      "rank": 955,
       "id": "mistralai/Ministral-3-8B-Instruct-2512-GGUF",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF",
@@ -27896,7 +27949,7 @@
       "lastModified": "2026-01-15T11:18:05.000Z"
     },
     {
-      "rank": 954,
+      "rank": 956,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -27941,7 +27994,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 955,
+      "rank": 957,
       "id": "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
       "author": "hampsonw",
       "url": "https://huggingface.co/hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
@@ -27967,7 +28020,7 @@
       "lastModified": "2026-05-14T19:42:51.000Z"
     },
     {
-      "rank": 956,
+      "rank": 958,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -28006,32 +28059,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 957,
-      "id": "stabilityai/SAME-S",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/SAME-S",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "music",
-        "sound-effects",
-        "audio",
-        "autoencoder",
-        "en",
-        "arxiv:2605.18613",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T02:17:58.000Z",
-      "lastModified": "2026-05-19T20:11:16.000Z"
-    },
-    {
-      "rank": 958,
+      "rank": 959,
       "id": "Qwen/QwQ-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/QwQ-32B",
@@ -28062,7 +28090,7 @@
       "lastModified": "2025-03-11T12:15:48.000Z"
     },
     {
-      "rank": 959,
+      "rank": 960,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -28090,7 +28118,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 960,
+      "rank": 961,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -28106,7 +28134,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 961,
+      "rank": 962,
       "id": "inclusionAI/ARGenSeg-8B",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/ARGenSeg-8B",
@@ -28126,7 +28154,7 @@
       "lastModified": "2026-05-15T02:36:20.000Z"
     },
     {
-      "rank": 962,
+      "rank": 963,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -28152,7 +28180,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 963,
+      "rank": 964,
       "id": "Wan-AI/Wan2.2-Animate-14B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B",
@@ -28176,7 +28204,7 @@
       "lastModified": "2025-11-05T10:15:40.000Z"
     },
     {
-      "rank": 964,
+      "rank": 965,
       "id": "dx8152/LTX2.3-Multifunctional",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/LTX2.3-Multifunctional",
@@ -28197,7 +28225,7 @@
       "lastModified": "2026-04-30T07:06:19.000Z"
     },
     {
-      "rank": 965,
+      "rank": 966,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
@@ -28230,7 +28258,7 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 966,
+      "rank": 967,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -28259,7 +28287,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 967,
+      "rank": 968,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
@@ -28287,7 +28315,7 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 968,
+      "rank": 969,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -28305,12 +28333,12 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 969,
+      "rank": 970,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "downloads": 137794,
-      "likes": 250,
+      "likes": 251,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -28337,7 +28365,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 970,
+      "rank": 971,
       "id": "FINAL-Bench/Darwin-2B-Opus-LoRA",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-2B-Opus-LoRA",
@@ -28363,7 +28391,7 @@
       "lastModified": "2026-05-15T02:29:20.000Z"
     },
     {
-      "rank": 971,
+      "rank": 972,
       "id": "FINAL-Bench/Darwin-28B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Opus",
@@ -28408,30 +28436,6 @@
       "lastModified": "2026-05-15T02:27:32.000Z"
     },
     {
-      "rank": 972,
-      "id": "tori29umai/QwenImageEdit2511_LoRA",
-      "author": "tori29umai",
-      "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
-      "tags": [
-        "lora",
-        "qwen-image-edit",
-        "image-to-image",
-        "ja",
-        "en",
-        "base_model:Qwen/Qwen-Image-Edit",
-        "base_model:adapter:Qwen/Qwen-Image-Edit",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T23:38:39.000Z",
-      "lastModified": "2026-05-16T08:11:00.000Z"
-    },
-    {
       "rank": 973,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
@@ -28466,6 +28470,249 @@
     },
     {
       "rank": 974,
+      "id": "meta-llama/Llama-3.2-1B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
+      "downloads": 1949029,
+      "likes": 2391,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:03:14.000Z",
+      "lastModified": "2024-10-24T15:08:03.000Z"
+    },
+    {
+      "rank": 975,
+      "id": "meituan-longcat/LongCat-Video",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
+      "downloads": 1278,
+      "likes": 477,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "transformers",
+        "image-to-video",
+        "video-continuation",
+        "text-to-video",
+        "en",
+        "zh",
+        "arxiv:2510.22200",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-10-24T16:04:08.000Z",
+      "lastModified": "2025-10-29T06:22:46.000Z"
+    },
+    {
+      "rank": 976,
+      "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
+      "author": "Baraje",
+      "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
+      "downloads": 26347,
+      "likes": 11,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "text-to-image",
+        "lora",
+        "template:diffusion-lora",
+        "base_model:Qwen/Qwen-Image",
+        "base_model:adapter:Qwen/Qwen-Image",
+        "license:artistic-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T06:19:31.000Z",
+      "lastModified": "2026-04-22T06:19:53.000Z"
+    },
+    {
+      "rank": 977,
+      "id": "cross-encoder/ettin-reranker-17m-v1",
+      "author": "cross-encoder",
+      "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
+      "downloads": 608,
+      "likes": 7,
+      "trendingScore": 6,
+      "pipelineTag": "text-ranking",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "onnx",
+        "safetensors",
+        "openvino",
+        "modernbert",
+        "cross-encoder",
+        "reranker",
+        "generated_from_trainer",
+        "dataset_size:143393475",
+        "loss:MSELoss",
+        "text-ranking",
+        "en",
+        "arxiv:1908.10084",
+        "base_model:jhu-clsp/ettin-encoder-17m",
+        "base_model:quantized:jhu-clsp/ettin-encoder-17m",
+        "license:apache-2.0",
+        "model-index",
+        "text-embeddings-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T09:08:41.000Z",
+      "lastModified": "2026-05-19T13:58:35.000Z"
+    },
+    {
+      "rank": 978,
+      "id": "stabilityai/stable-audio-3-small-sfx-base",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
+      "downloads": 0,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:05:35.000Z",
+      "lastModified": "2026-05-20T15:05:26.000Z"
+    },
+    {
+      "rank": 979,
+      "id": "baidu/ERNIE-Image-Aes",
+      "author": "baidu",
+      "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
+      "downloads": 62,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "internvl_chat",
+        "custom_code",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T09:12:17.000Z",
+      "lastModified": "2026-05-20T14:14:45.000Z"
+    },
+    {
+      "rank": 980,
+      "id": "numind/NuExtract3-GGUF",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3-GGUF",
+      "downloads": 643,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "image-text-to-text",
+        "safetensors",
+        "qwen3_5",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "base_model:numind/NuExtract3",
+        "base_model:quantized:numind/NuExtract3",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T16:24:32.000Z",
+      "lastModified": "2026-05-20T10:49:42.000Z"
+    },
+    {
+      "rank": 981,
+      "id": "netease-youdao/Confucius4",
+      "author": "netease-youdao",
+      "url": "https://huggingface.co/netease-youdao/Confucius4",
+      "downloads": 96,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T10:13:40.000Z",
+      "lastModified": "2026-05-20T08:42:10.000Z"
+    },
+    {
+      "rank": 982,
+      "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
+      "downloads": 0,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T09:26:12.000Z",
+      "lastModified": "2026-05-22T05:15:45.000Z"
+    },
+    {
+      "rank": 983,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -28492,7 +28739,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 975,
+      "rank": 984,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -28528,7 +28775,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 976,
+      "rank": 985,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -28573,7 +28820,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 977,
+      "rank": 986,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -28618,7 +28865,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 978,
+      "rank": 987,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -28653,7 +28900,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 979,
+      "rank": 988,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -28679,7 +28926,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 980,
+      "rank": 989,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -28705,7 +28952,7 @@
       "lastModified": "2026-05-06T20:09:03.000Z"
     },
     {
-      "rank": 981,
+      "rank": 990,
       "id": "TheDrummer/Skyfall-31B-v4.2",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
@@ -28725,7 +28972,7 @@
       "lastModified": "2026-04-03T20:52:19.000Z"
     },
     {
-      "rank": 982,
+      "rank": 991,
       "id": "LiquidAI/LFM2-24B-A2B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
@@ -28763,7 +29010,7 @@
       "lastModified": "2026-03-30T12:54:26.000Z"
     },
     {
-      "rank": 983,
+      "rank": 992,
       "id": "nvidia/GR00T-N1.7-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
@@ -28783,7 +29030,7 @@
       "lastModified": "2026-04-23T19:09:30.000Z"
     },
     {
-      "rank": 984,
+      "rank": 993,
       "id": "Aratako/Irodori-TTS-500M",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
@@ -28806,7 +29053,7 @@
       "lastModified": "2026-03-18T11:03:56.000Z"
     },
     {
-      "rank": 985,
+      "rank": 994,
       "id": "Qwen/Qwen3.5-0.8B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
@@ -28829,7 +29076,7 @@
       "lastModified": "2026-04-23T11:14:09.000Z"
     },
     {
-      "rank": 986,
+      "rank": 995,
       "id": "z-lab/Qwen3.5-9B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
@@ -28862,7 +29109,7 @@
       "lastModified": "2026-04-07T14:29:47.000Z"
     },
     {
-      "rank": 987,
+      "rank": 996,
       "id": "Winnougan/Must_Have_Klein_9b_loras",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
@@ -28884,7 +29131,7 @@
       "lastModified": "2026-03-26T22:03:08.000Z"
     },
     {
-      "rank": 988,
+      "rank": 997,
       "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
@@ -28911,7 +29158,7 @@
       "lastModified": "2026-04-05T16:05:28.000Z"
     },
     {
-      "rank": 989,
+      "rank": 998,
       "id": "100percentrobot/LTX-2.3-Audio-Reactive-LORA",
       "author": "100percentrobot",
       "url": "https://huggingface.co/100percentrobot/LTX-2.3-Audio-Reactive-LORA",
@@ -28935,7 +29182,7 @@
       "lastModified": "2026-04-10T15:12:18.000Z"
     },
     {
-      "rank": 990,
+      "rank": 999,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -28962,7 +29209,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 991,
+      "rank": 1000,
       "id": "YJX-Xiaomi/ControlFoley",
       "author": "YJX-Xiaomi",
       "url": "https://huggingface.co/YJX-Xiaomi/ControlFoley",
@@ -28984,232 +29231,6 @@
       ],
       "createdAt": "2026-04-13T13:52:30.000Z",
       "lastModified": "2026-04-22T02:02:09.000Z"
-    },
-    {
-      "rank": 992,
-      "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
-      "author": "hesamation",
-      "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
-      "downloads": 10192,
-      "likes": 77,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "qwen",
-        "qwen3.6",
-        "moe",
-        "unsloth",
-        "trl",
-        "reasoning",
-        "chain-of-thought",
-        "conversational",
-        "text-generation-inference",
-        "vllm",
-        "en",
-        "dataset:nohurry/Opus-4.6-Reasoning-3000x-filtered",
-        "dataset:Jackrong/Qwen3.5-reasoning-700x",
-        "dataset:Roman1111111/claude-opus-4.6-10000x",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "model-index",
-        "endpoints_compatible",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2026-04-17T23:49:06.000Z",
-      "lastModified": "2026-04-19T00:19:49.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "lovis93/crt-animation-terminal-ltx-2.3-lora",
-      "author": "lovis93",
-      "url": "https://huggingface.co/lovis93/crt-animation-terminal-ltx-2.3-lora",
-      "downloads": 0,
-      "likes": 53,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-video",
-      "libraryName": null,
-      "tags": [
-        "text-to-video",
-        "lora",
-        "ltx-video",
-        "ltx-2.3",
-        "crt",
-        "retro",
-        "animation",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T15:45:25.000Z",
-      "lastModified": "2026-04-20T16:33:16.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "uva-cv-lab/OmniShotCut",
-      "author": "uva-cv-lab",
-      "url": "https://huggingface.co/uva-cv-lab/OmniShotCut",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "arxiv:2604.24762",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-21T22:35:29.000Z",
-      "lastModified": "2026-04-28T14:59:54.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "Yutian10/AnyRecon",
-      "author": "Yutian10",
-      "url": "https://huggingface.co/Yutian10/AnyRecon",
-      "downloads": 79,
-      "likes": 11,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "anyrecon",
-        "arxiv:2604.19747",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T02:10:37.000Z",
-      "lastModified": "2026-04-27T02:17:02.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
-      "author": "cyankiwi",
-      "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4",
-      "downloads": 282504,
-      "likes": 30,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "compressed-tensors",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T18:52:23.000Z",
-      "lastModified": "2026-04-30T21:34:35.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
-      "author": "vrgamedevgirl84",
-      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Crisp_Enhance_Style_LoRa",
-      "downloads": 4796,
-      "likes": 19,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ltx-video",
-        "text-to-video",
-        "safetensors",
-        "base_model:Lightricks/LTX-Video",
-        "base_model:adapter:Lightricks/LTX-Video",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T00:22:51.000Z",
-      "lastModified": "2026-04-24T02:25:18.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "Comfy-Org/void-model",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/void-model",
-      "downloads": 0,
-      "likes": 16,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T10:42:08.000Z",
-      "lastModified": "2026-05-07T10:17:55.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-      "author": "TeichAI",
-      "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-      "downloads": 1042,
-      "likes": 19,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3.6",
-        "conversational",
-        "dataset:TeichAI/claude-4.5-opus-high-reasoning-250x",
-        "dataset:TeichAI/Claude-Opus-4.6-Reasoning-887x",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:finetune:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-25T05:21:20.000Z",
-      "lastModified": "2026-04-27T23:59:16.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "TheBurgstall/ltx-2.3-bodypositivity-lora",
-      "author": "TheBurgstall",
-      "url": "https://huggingface.co/TheBurgstall/ltx-2.3-bodypositivity-lora",
-      "downloads": 425,
-      "likes": 16,
-      "trendingScore": 5,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "ltx-2",
-        "ltx-2.3",
-        "text-to-video",
-        "image-to-video",
-        "lora",
-        "body-positivity",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-26T10:30:53.000Z",
-      "lastModified": "2026-04-26T10:38:55.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26272915477

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.