### PR TITLE
chore(data): promote unknown mentions 2026-05-22T07:59:56Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-21T08:09:26.844Z",
-  "totalUnknownMentions": 222406,
-  "distinctRepos": 20574,
+  "generatedAt": "2026-05-22T07:59:56.143Z",
+  "totalUnknownMentions": 234462,
+  "distinctRepos": 21538,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
       "fullName": "oven-sh/bun",
-      "totalCount": 161,
+      "totalCount": 173,
       "sourceCount": 5,
       "sources": [
         "bluesky",
@@ -17,11 +17,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-21T05:20:28.559Z"
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 84,
+      "totalCount": 89,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -31,11 +31,25 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+    },
+    {
+      "fullName": "trycua/cua",
+      "totalCount": 38,
+      "sourceCount": 5,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto",
+        "hackernews",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
     },
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 184,
+      "totalCount": 198,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -44,11 +58,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-21T05:20:28.559Z"
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "vercel/next.js",
-      "totalCount": 160,
+      "totalCount": 168,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -57,7 +71,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "hmbown/deepseek-tui",
@@ -74,7 +88,7 @@
     },
     {
       "fullName": "vitejs/vite",
-      "totalCount": 91,
+      "totalCount": 95,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -83,11 +97,11 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "facebook/react",
-      "totalCount": 85,
+      "totalCount": 89,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -96,7 +110,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-21T05:20:28.559Z"
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "antirez/ds4",
@@ -125,19 +139,6 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "trycua/cua",
-      "totalCount": 35,
-      "sourceCount": 4,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "hackernews",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
-    },
-    {
       "fullName": "aattaran/deepclaude",
       "totalCount": 8,
       "sourceCount": 4,
@@ -152,7 +153,7 @@
     },
     {
       "fullName": "microsoft/vscode",
-      "totalCount": 162,
+      "totalCount": 170,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -160,7 +161,7 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-21T05:20:28.559Z"
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "onyks-os/transparenttorproxy",
@@ -223,6 +224,18 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
+      "fullName": "naver/lispe",
+      "totalCount": 103,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+    },
+    {
       "fullName": "scosman/cursed_browser",
       "totalCount": 103,
       "sourceCount": 3,
@@ -245,6 +258,18 @@
       ],
       "firstSeenAt": "2026-05-07T17:19:14.533Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "reviewstage/stage-cli",
+      "totalCount": 99,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T17:19:14.533Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
       "fullName": "leaningtech/browsercode",
@@ -283,28 +308,16 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "reviewstage/stage-cli",
-      "totalCount": 96,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T17:19:14.533Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
-      "fullName": "naver/lispe",
+      "fullName": "higangssh/homebutler",
       "totalCount": 95,
       "sourceCount": 3,
       "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
+        "awesome-skills",
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
     },
     {
       "fullName": "nvlabs/cuda-oxide",
@@ -317,6 +330,18 @@
       ],
       "firstSeenAt": "2026-05-07T21:45:14.561Z",
       "lastSeenAt": "2026-05-11T00:07:14.314Z"
+    },
+    {
+      "fullName": "andyyyy64/whichllm",
+      "totalCount": 92,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T10:12:27.167Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "bring-shrubbery/ml-sharp-web",
@@ -343,18 +368,6 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 90,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
-    },
-    {
       "fullName": "shadcn-ui/ui",
       "totalCount": 89,
       "sourceCount": 3,
@@ -368,7 +381,7 @@
     },
     {
       "fullName": "sifter-ai/sifter",
-      "totalCount": 87,
+      "totalCount": 88,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -376,7 +389,55 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+    },
+    {
+      "fullName": "snyk/agent-scan",
+      "totalCount": 86,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T18:13:43.732Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+    },
+    {
+      "fullName": "run-llama/llama_index",
+      "totalCount": 86,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
+    },
+    {
+      "fullName": "fsnotify/fsnotify",
+      "totalCount": 84,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T07:20:32.729Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+    },
+    {
+      "fullName": "torrix-ai/install",
+      "totalCount": 84,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
       "fullName": "tanstack/router",
@@ -391,42 +452,6 @@
       "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
-      "fullName": "run-llama/llama_index",
-      "totalCount": 83,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-20T12:04:16.253Z"
-    },
-    {
-      "fullName": "snyk/agent-scan",
-      "totalCount": 82,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T18:13:43.732Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
-      "fullName": "torrix-ai/install",
-      "totalCount": 81,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
       "fullName": "waybarrios/opencode-power-pack",
       "totalCount": 81,
       "sourceCount": 3,
@@ -439,32 +464,8 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
-      "fullName": "fsnotify/fsnotify",
-      "totalCount": 80,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
-      "fullName": "andyyyy64/whichllm",
-      "totalCount": 76,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-15T10:12:27.167Z",
-      "lastSeenAt": "2026-05-21T05:20:28.559Z"
-    },
-    {
       "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 75,
+      "totalCount": 76,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -472,7 +473,19 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+    },
+    {
+      "fullName": "n8n-io/n8n",
+      "totalCount": 67,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "reddit",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "codecrafters-io/build-your-own-x",
@@ -487,6 +500,30 @@
       "lastSeenAt": "2026-05-20T22:44:07.574Z"
     },
     {
+      "fullName": "ollama/ollama",
+      "totalCount": 66,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+    },
+    {
+      "fullName": "statewright/statewright",
+      "totalCount": 66,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T17:04:51.325Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
+    },
+    {
       "fullName": "sambigeara/pollen",
       "totalCount": 66,
       "sourceCount": 3,
@@ -499,6 +536,42 @@
       "lastSeenAt": "2026-05-10T12:05:20.661Z"
     },
     {
+      "fullName": "jnuyens/modulejail",
+      "totalCount": 65,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+    },
+    {
+      "fullName": "v12-security/pocs",
+      "totalCount": 64,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+    },
+    {
+      "fullName": "vercel/ai",
+      "totalCount": 64,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
+    },
+    {
       "fullName": "genymobile/scrcpy",
       "totalCount": 64,
       "sourceCount": 3,
@@ -509,42 +582,6 @@
       ],
       "firstSeenAt": "2026-05-02T08:45:16.184Z",
       "lastSeenAt": "2026-05-19T18:33:33.494Z"
-    },
-    {
-      "fullName": "n8n-io/n8n",
-      "totalCount": 63,
-      "sourceCount": 3,
-      "sources": [
-        "devto",
-        "reddit",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
-      "fullName": "statewright/statewright",
-      "totalCount": 63,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T17:04:51.325Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
-      "fullName": "ollama/ollama",
-      "totalCount": 63,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
     },
     {
       "fullName": "angular/angular",
@@ -583,6 +620,18 @@
       "lastSeenAt": "2026-05-07T12:21:38.823Z"
     },
     {
+      "fullName": "navid-m/flightsim",
+      "totalCount": 62,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
+    },
+    {
       "fullName": "jameslockman/griffin-powermate-driver",
       "totalCount": 62,
       "sourceCount": 3,
@@ -593,18 +642,6 @@
       ],
       "firstSeenAt": "2026-05-11T21:52:07.915Z",
       "lastSeenAt": "2026-05-21T05:20:28.559Z"
-    },
-    {
-      "fullName": "vercel/ai",
-      "totalCount": 61,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
     },
     {
       "fullName": "localsend/localsend",
@@ -631,18 +668,6 @@
       "lastSeenAt": "2026-05-18T12:48:24.691Z"
     },
     {
-      "fullName": "navid-m/flightsim",
-      "totalCount": 59,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
       "fullName": "manankharwar/fusioncore",
       "totalCount": 59,
       "sourceCount": 3,
@@ -655,16 +680,28 @@
       "lastSeenAt": "2026-05-19T12:20:48.337Z"
     },
     {
-      "fullName": "v12-security/pocs",
-      "totalCount": 56,
+      "fullName": "rust-lang/rust",
+      "totalCount": 57,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+    },
+    {
+      "fullName": "vllm-project/vllm",
+      "totalCount": 57,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T19:21:26.285Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "uw-syfi/vibe-serve",
@@ -691,28 +728,40 @@
       "lastSeenAt": "2026-05-09T08:04:55.501Z"
     },
     {
-      "fullName": "vllm-project/vllm",
-      "totalCount": 53,
+      "fullName": "junegunn/fzf",
+      "totalCount": 51,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+    },
+    {
+      "fullName": "cline/cline",
+      "totalCount": 51,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "reddit"
       ],
-      "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
-      "fullName": "rust-lang/rust",
-      "totalCount": 49,
+      "fullName": "igorganapolsky/thumbgate",
+      "totalCount": 50,
       "sourceCount": 3,
       "sources": [
+        "awesome-skills",
         "bluesky",
-        "devto",
-        "hackernews"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -751,42 +800,6 @@
       "lastSeenAt": "2026-05-07T10:14:50.031Z"
     },
     {
-      "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 47,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
-    },
-    {
-      "fullName": "jnuyens/modulejail",
-      "totalCount": 47,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-21T05:51:41.496Z"
-    },
-    {
-      "fullName": "junegunn/fzf",
-      "totalCount": 47,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
       "fullName": "anthropics/claude-for-legal",
       "totalCount": 47,
       "sourceCount": 3,
@@ -823,6 +836,42 @@
       "lastSeenAt": "2026-05-11T01:25:31.639Z"
     },
     {
+      "fullName": "0xmassi/webclaw",
+      "totalCount": 45,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+    },
+    {
+      "fullName": "open-webui/open-webui",
+      "totalCount": 45,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T04:53:38.982Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+    },
+    {
+      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
+      "totalCount": 45,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:43:54.808Z",
+      "lastSeenAt": "2026-05-21T23:40:25.563Z"
+    },
+    {
       "fullName": "mage0535/hermes-memory-installer",
       "totalCount": 45,
       "sourceCount": 3,
@@ -835,16 +884,28 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "0xmassi/webclaw",
+      "fullName": "zed-industries/zed",
       "totalCount": 44,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
-        "devto",
-        "reddit"
+        "bluesky",
+        "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+    },
+    {
+      "fullName": "iliaal/fastchart",
+      "totalCount": 44,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-21T19:16:46.402Z"
     },
     {
       "fullName": "simdjson/simdjson",
@@ -859,30 +920,6 @@
       "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
-      "fullName": "zed-industries/zed",
-      "totalCount": 43,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
-    },
-    {
-      "fullName": "iliaal/fastchart",
-      "totalCount": 43,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-19T13:44:19.677Z"
-    },
-    {
       "fullName": "stardockcorp/wireloom",
       "totalCount": 41,
       "sourceCount": 3,
@@ -895,28 +932,28 @@
       "lastSeenAt": "2026-05-20T12:39:36.429Z"
     },
     {
-      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
-      "totalCount": 39,
+      "fullName": "awslabs/mcp",
+      "totalCount": 37,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+    },
+    {
+      "fullName": "anishathalye/ai-agent-security-lecture",
+      "totalCount": 37,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "hackernews",
         "lobsters"
       ],
-      "firstSeenAt": "2026-05-15T06:43:54.808Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
-    },
-    {
-      "fullName": "open-webui/open-webui",
-      "totalCount": 37,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-07T04:53:38.982Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-18T16:34:28.470Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "tabularisdb/tabularis",
@@ -943,19 +980,7 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "awslabs/mcp",
-      "totalCount": 36,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
-    },
-    {
-      "fullName": "anishathalye/ai-agent-security-lecture",
+      "fullName": "sander110419/lightroom-cc-on-linux",
       "totalCount": 29,
       "sourceCount": 3,
       "sources": [
@@ -963,8 +988,20 @@
         "hackernews",
         "lobsters"
       ],
-      "firstSeenAt": "2026-05-18T16:34:28.470Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-18T12:48:24.691Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+    },
+    {
+      "fullName": "xataio/deltax",
+      "totalCount": 27,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-19T19:17:55.212Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -979,8 +1016,8 @@
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
     },
     {
-      "fullName": "anthropics/claude-cookbooks",
-      "totalCount": 23,
+      "fullName": "pydantic/pydantic-ai",
+      "totalCount": 25,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -988,19 +1025,31 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
     },
     {
-      "fullName": "sander110419/lightroom-cc-on-linux",
-      "totalCount": 21,
+      "fullName": "anthropics/claude-cookbooks",
+      "totalCount": 24,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+    },
+    {
+      "fullName": "nodejs/node",
+      "totalCount": 19,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-18T12:48:24.691Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-03T03:48:07.888Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -1015,16 +1064,16 @@
       "lastSeenAt": "2026-05-17T21:12:09.791Z"
     },
     {
-      "fullName": "xataio/deltax",
+      "fullName": "duriantaco/skylos",
       "totalCount": 18,
       "sourceCount": 3,
       "sources": [
+        "awesome-skills",
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-19T19:17:55.212Z",
-      "lastSeenAt": "2026-05-21T05:51:41.496Z"
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
     },
     {
       "fullName": "skyhook-io/radar",
@@ -1039,39 +1088,27 @@
       "lastSeenAt": "2026-05-04T00:13:30.621Z"
     },
     {
-      "fullName": "duriantaco/skylos",
-      "totalCount": 17,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
-    },
-    {
-      "fullName": "nodejs/node",
-      "totalCount": 11,
+      "fullName": "simstudioai/sim",
+      "totalCount": 4,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
-        "hackernews"
+        "twitter"
       ],
-      "firstSeenAt": "2026-05-03T03:48:07.888Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-12T00:13:00.312Z",
+      "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 162,
+      "totalCount": 171,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-21T08:06:54.299Z"
+      "lastSeenAt": "2026-05-22T07:57:06.565Z"
     },
     {
       "fullName": "wojtczyk/trust",
@@ -1086,14 +1123,14 @@
     },
     {
       "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 131,
+      "totalCount": 135,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "nexu-io/open-design",
@@ -1107,6 +1144,28 @@
       "lastSeenAt": "2026-05-11T19:17:39.871Z"
     },
     {
+      "fullName": "raiyanyahya/how-to-train-your-gpt",
+      "totalCount": 122,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+    },
+    {
+      "fullName": "warwickwood-cell/gengeo-agent-registry",
+      "totalCount": 120,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-21T23:40:25.563Z"
+    },
+    {
       "fullName": "translate-tools/transly",
       "totalCount": 120,
       "sourceCount": 2,
@@ -1116,6 +1175,17 @@
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
       "lastSeenAt": "2026-05-09T16:11:39.536Z"
+    },
+    {
+      "fullName": "drcathicks/learning-opportunities",
+      "totalCount": 116,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-21T21:09:29.632Z"
     },
     {
       "fullName": "raiyanyahya/kit",
@@ -1151,39 +1221,6 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
-      "fullName": "raiyanyahya/how-to-train-your-gpt",
-      "totalCount": 114,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
-    },
-    {
-      "fullName": "warwickwood-cell/gengeo-agent-registry",
-      "totalCount": 114,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
-    },
-    {
-      "fullName": "drcathicks/learning-opportunities",
-      "totalCount": 112,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
-    },
-    {
       "fullName": "jossephus/chuchu",
       "totalCount": 109,
       "sourceCount": 2,
@@ -1217,6 +1254,17 @@
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
     },
     {
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 104,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-22T04:41:30.451Z"
+    },
+    {
       "fullName": "facebookresearch/tuna-2",
       "totalCount": 102,
       "sourceCount": 2,
@@ -1226,17 +1274,6 @@
       ],
       "firstSeenAt": "2026-05-01T23:09:58.018Z",
       "lastSeenAt": "2026-05-19T01:56:00.808Z"
-    },
-    {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 101,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
       "fullName": "ifixai-ai/diagnostic",
@@ -1259,6 +1296,17 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
+    },
+    {
+      "fullName": "harnexa/nexa-gauge",
+      "totalCount": 99,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T01:29:16.934Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "mekickdemons-creator/mnemara",
@@ -1305,17 +1353,6 @@
       "lastSeenAt": "2026-05-17T23:08:31.913Z"
     },
     {
-      "fullName": "harnexa/nexa-gauge",
-      "totalCount": 91,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T01:29:16.934Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
-    },
-    {
       "fullName": "emad-elsaid/xlog",
       "totalCount": 91,
       "sourceCount": 2,
@@ -1325,6 +1362,17 @@
       ],
       "firstSeenAt": "2026-05-07T15:15:06.916Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "yamafaktory/hypergraphz",
+      "totalCount": 90,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T21:12:41.505Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "gfernandf/agent-skills",
@@ -1383,14 +1431,25 @@
     },
     {
       "fullName": "arriemeijer-creator/aerojax",
-      "totalCount": 85,
+      "totalCount": 86,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+      "lastSeenAt": "2026-05-21T09:46:35.015Z"
+    },
+    {
+      "fullName": "scottgl9/skelm",
+      "totalCount": 84,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "v4bel/dirtyfrag",
@@ -1470,15 +1529,15 @@
       "lastSeenAt": "2026-05-09T18:44:58.134Z"
     },
     {
-      "fullName": "yamafaktory/hypergraphz",
+      "fullName": "eleutherai/lm-evaluation-harness",
       "totalCount": 82,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-03T21:12:41.505Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-21T09:46:35.015Z"
     },
     {
       "fullName": "dmarshaltu/coord",
@@ -1492,15 +1551,15 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "eleutherai/lm-evaluation-harness",
+      "fullName": "enmanuelmag/heimdall-mcp",
       "totalCount": 81,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T14:30:15.363Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
@@ -1525,15 +1584,15 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "scottgl9/skelm",
+      "fullName": "chojs23/concord",
       "totalCount": 80,
       "sourceCount": 2,
       "sources": [
-        "devto",
+        "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "tsirysndr/rockbox-zig",
@@ -1668,17 +1727,6 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "enmanuelmag/heimdall-mcp",
-      "totalCount": 77,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
       "fullName": "wiaahmarketplace/typerion-oss",
       "totalCount": 77,
       "sourceCount": 2,
@@ -1721,6 +1769,17 @@
       ],
       "firstSeenAt": "2026-05-03T04:20:52.369Z",
       "lastSeenAt": "2026-05-10T16:09:01.639Z"
+    },
+    {
+      "fullName": "h4ckf0r0day/obscura",
+      "totalCount": 75,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-21T22:41:39.489Z"
     },
     {
       "fullName": "davesimoes/crustai",
@@ -1822,17 +1881,6 @@
       "lastSeenAt": "2026-05-13T00:23:31.968Z"
     },
     {
-      "fullName": "h4ckf0r0day/obscura",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-10T22:03:24.049Z"
-    },
-    {
       "fullName": "st-hannibal/arknet",
       "totalCount": 74,
       "sourceCount": 2,
@@ -1853,6 +1901,17 @@
       ],
       "firstSeenAt": "2026-05-02T04:02:25.023Z",
       "lastSeenAt": "2026-05-09T15:42:37.217Z"
+    },
+    {
+      "fullName": "phel-lang/phel-lang",
+      "totalCount": 73,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T21:05:05.911Z",
+      "lastSeenAt": "2026-05-22T04:41:30.451Z"
     },
     {
       "fullName": "heyputer/puter",
@@ -1877,15 +1936,15 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
-      "fullName": "chojs23/concord",
+      "fullName": "comfyanonymous/comfyui",
       "totalCount": 72,
       "sourceCount": 2,
       "sources": [
         "bluesky",
-        "hackernews"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-21T04:45:36.209Z"
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-22T04:41:30.451Z"
     },
     {
       "fullName": "pion/rtwatch",
@@ -1930,17 +1989,6 @@
       ],
       "firstSeenAt": "2026-05-04T08:58:50.862Z",
       "lastSeenAt": "2026-05-17T17:48:32.737Z"
-    },
-    {
-      "fullName": "phel-lang/phel-lang",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T21:05:05.911Z",
-      "lastSeenAt": "2026-05-15T16:32:57.762Z"
     },
     {
       "fullName": "gh0st68/cryptirc",
@@ -2097,6 +2145,17 @@
       "lastSeenAt": "2026-05-12T14:51:56.628Z"
     },
     {
+      "fullName": "openclaw/peekaboo",
+      "totalCount": 69,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-12T20:52:08.570Z",
+      "lastSeenAt": "2026-05-22T00:16:33.857Z"
+    },
+    {
       "fullName": "sudarshan8417/tfdrift",
       "totalCount": 69,
       "sourceCount": 2,
@@ -2229,6 +2288,17 @@
       "lastSeenAt": "2026-05-07T19:50:24.370Z"
     },
     {
+      "fullName": "npm/cli",
+      "totalCount": 67,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-22T04:41:30.451Z"
+    },
+    {
       "fullName": "trimooo/react-ai-stream",
       "totalCount": 67,
       "sourceCount": 2,
@@ -2238,72 +2308,6 @@
       ],
       "firstSeenAt": "2026-05-10T00:05:03.835Z",
       "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
-      "fullName": "mvanhorn/cli-printing-press",
-      "totalCount": 67,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T21:16:34.131Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "boxlite-ai/boxlite",
-      "totalCount": 67,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T09:05:56.174Z",
-      "lastSeenAt": "2026-05-10T06:47:04.169Z"
-    },
-    {
-      "fullName": "mahimairaja/voiceai",
-      "totalCount": 67,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T22:09:31.853Z",
-      "lastSeenAt": "2026-05-09T21:15:18.927Z"
-    },
-    {
-      "fullName": "radotsvetkov/akmon",
-      "totalCount": 66,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T03:35:56.533Z",
-      "lastSeenAt": "2026-05-21T03:55:37.401Z"
-    },
-    {
-      "fullName": "backnotprop/rig",
-      "totalCount": 66,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T20:50:24.350Z",
-      "lastSeenAt": "2026-05-19T19:17:55.212Z"
-    },
-    {
-      "fullName": "intel/auto-round",
-      "totalCount": 66,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-15T11:31:13.243Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26275843237

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.