### PR TITLE
chore(data): refresh bluesky signals 2026-05-22T08:33:16Z

### DIFF
--- a/data/_meta/bluesky.json
+++ b/data/_meta/bluesky.json
@@ -1,8 +1,8 @@
 {
   "source": "bluesky",
   "reason": "ok",
-  "ts": "2026-05-22T04:41:30.452Z",
+  "ts": "2026-05-22T08:33:16.413Z",
   "count": 1,
-  "durationMs": 14390,
+  "durationMs": 10350,
   "extra": {}
 }

--- a/data/bluesky-mentions.json
+++ b/data/bluesky-mentions.json
@@ -1,9 +1,9 @@
 {
-  "fetchedAt": "2026-05-22T04:41:16.359Z",
+  "fetchedAt": "2026-05-22T08:33:06.267Z",
   "windowDays": 7,
-  "scannedPosts": 199,
+  "scannedPosts": 300,
   "searchQuery": "github.com",
-  "pagesFetched": 2,
+  "pagesFetched": 3,
   "mentions": {
     "antirez/ds4": {
       "count7d": 2,
@@ -2441,25 +2441,54 @@
     },
     "chenglou/pretext": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
       "repliesSum7d": 1,
       "topPost": {
-        "uri": "at://did:plc:eq7w4z5l7t7zug24tkhollrt/app.bsky.feed.post/3mlc44fdnp62n",
-        "cid": "bafyreiezjupw4lnib2fzb2xco2splsvrddjuavdexkfp32nffciwfjc2ue",
-        "bskyUrl": "https://bsky.app/profile/kevindangoor.com/post/3mlc44fdnp62n",
-        "text": "Cheng Lou's pretext is an impressive frontend engineering feat. His thread is a great tour of what precise text measurement in the browser makes possible. github.com/chenglou/... x.com/_chenglou/stat...",
+        "uri": "at://did:plc:allu5vs3gnm2wm7jzf4rad3r/app.bsky.feed.post/3mmgbbwh53c22",
+        "cid": "bafyreiciwwkek37dblm6ohzlig4amwciw2briqf3nd5yxggbkpwjscmcwi",
+        "bskyUrl": "https://bsky.app/profile/isolyth.dev/post/3mmgbbwh53c22",
+        "text": "What if you added github.com/chenglou/pre...",
         "author": {
-          "handle": "kevindangoor.com",
-          "displayName": "Kevin Dangoor"
+          "handle": "isolyth.dev",
+          "displayName": "Eris"
         },
-        "likeCount": 0,
+        "likeCount": 2,
         "repostCount": 0,
         "replyCount": 1,
-        "createdAt": "2026-05-07T20:56:45.000Z",
-        "hoursSincePosted": 1.59
+        "createdAt": "2026-05-22T06:05:11.466Z",
+        "hoursSincePosted": 2.47
       },
       "posts": [
+        {
+          "uri": "at://did:plc:allu5vs3gnm2wm7jzf4rad3r/app.bsky.feed.post/3mmgbbwh53c22",
+          "cid": "bafyreiciwwkek37dblm6ohzlig4amwciw2briqf3nd5yxggbkpwjscmcwi",
+          "bskyUrl": "https://bsky.app/profile/isolyth.dev/post/3mmgbbwh53c22",
+          "text": "What if you added github.com/chenglou/pre...",
+          "author": {
+            "handle": "isolyth.dev",
+            "displayName": "Eris"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T06:05:11.466Z",
+          "createdUtc": 1779429911,
+          "ageHours": 2.47,
+          "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo",
+            "is-question"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "chenglou/pretext",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:eq7w4z5l7t7zug24tkhollrt/app.bsky.feed.post/3mlc44fdnp62n",
           "cid": "bafyreiezjupw4lnib2fzb2xco2splsvrddjuavdexkfp32nffciwfjc2ue",
@@ -13711,7 +13740,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-22T02:15:14.454Z",
-        "hoursSincePosted": 2.43
+        "hoursSincePosted": 6.3
       },
       "posts": [
         {
@@ -13761,7 +13790,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T02:15:14.454Z",
           "createdUtc": 1779416114,
-          "ageHours": 2.43,
+          "ageHours": 6.3,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
@@ -17080,7 +17109,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-22T02:15:29.716Z",
-        "hoursSincePosted": 2.43
+        "hoursSincePosted": 6.29
       },
       "posts": [
         {
@@ -17135,7 +17164,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T02:15:29.716Z",
           "createdUtc": 1779416129,
-          "ageHours": 2.43,
+          "ageHours": 6.29,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
@@ -17570,9 +17599,9 @@
     },
     "sipeed/picoclaw": {
       "count7d": 1,
-      "likesSum7d": 0,
-      "repostsSum7d": 0,
-      "repliesSum7d": 0,
+      "likesSum7d": 9,
+      "repostsSum7d": 1,
+      "repliesSum7d": 1,
       "topPost": {
         "uri": "at://did:plc:jlkvfwdsrwr33osoe55szwx6/app.bsky.feed.post/3mmg43vky7j2w",
         "cid": "bafyreiexauxaxlswllb4pnawc3xrq62k5otb32k6b5slg4cuqcmdkghdpa",
@@ -17582,11 +17611,11 @@
           "handle": "imil.net",
           "displayName": "Emile `iMIl' Heitor"
         },
-        "likeCount": 0,
-        "repostCount": 0,
-        "replyCount": 0,
+        "likeCount": 9,
+        "repostCount": 1,
+        "replyCount": 1,
         "createdAt": "2026-05-22T04:32:20.268Z",
-        "hoursSincePosted": 0.5
+        "hoursSincePosted": 4.01
       },
       "posts": [
         {
@@ -17598,13 +17627,13 @@
             "handle": "imil.net",
             "displayName": "Emile `iMIl' Heitor"
           },
-          "likeCount": 0,
-          "repostCount": 0,
-          "replyCount": 0,
+          "likeCount": 9,
+          "repostCount": 1,
+          "replyCount": 1,
           "createdAt": "2026-05-22T04:32:20.268Z",
           "createdUtc": 1779424340,
-          "ageHours": 0.5,
-          "trendingScore": 0,
+          "ageHours": 4.01,
+          "trendingScore": 11.5,
           "content_tags": [
             "has-github-repo"
           ],
@@ -18504,24 +18533,24 @@
       ]
     },
     "colbymchenry/codegraph": {
-      "count7d": 2,
-      "likesSum7d": 1,
+      "count7d": 1,
+      "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:li4dar55qdutvcf5psi4wt2q/app.bsky.feed.post/3mmfb5zfee72x",
-        "cid": "bafyreiecbiszmseq54knr2whebocfqpswycrch5fpih42mbu4irxww4kd4",
-        "bskyUrl": "https://bsky.app/profile/apvarun.com/post/3mmfb5zfee72x",
-        "text": "Knowledge graph for your agents is a very cool ideas 🔥 https://github.com/colbymchenry/codegraph",
+        "uri": "at://did:plc:rzrswgjbus6pudxrqh2i3zkc/app.bsky.feed.post/3mmgdqbcasc27",
+        "cid": "bafyreib4xbr6jwkkzbnfhbfrpsuvjqgvfwy5iabmyczq7siq6w7zvueypq",
+        "bskyUrl": "https://bsky.app/profile/novica.bsky.social/post/3mmgdqbcasc27",
+        "text": "hey #rstats is anyone working R support for github.com/colbymchenry... ?",
         "author": {
-          "handle": "apvarun.com",
-          "displayName": "Varun"
+          "handle": "novica.bsky.social",
+          "displayName": "novica"
         },
-        "likeCount": 1,
+        "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-21T20:30:20.327Z",
-        "hoursSincePosted": 2.18
+        "createdAt": "2026-05-22T06:49:00.086Z",
+        "hoursSincePosted": 1.74
       },
       "posts": [
         {
@@ -18654,6 +18683,35 @@
               "matchType": "url",
               "confidence": 1
             },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:rzrswgjbus6pudxrqh2i3zkc/app.bsky.feed.post/3mmgdqbcasc27",
+          "cid": "bafyreib4xbr6jwkkzbnfhbfrpsuvjqgvfwy5iabmyczq7siq6w7zvueypq",
+          "bskyUrl": "https://bsky.app/profile/novica.bsky.social/post/3mmgdqbcasc27",
+          "text": "hey #rstats is anyone working R support for github.com/colbymchenry... ?",
+          "author": {
+            "handle": "novica.bsky.social",
+            "displayName": "novica"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T06:49:00.086Z",
+          "createdUtc": 1779432540,
+          "ageHours": 1.74,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-question"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
             {
               "fullName": "colbymchenry/codegraph",
               "matchType": "url",
@@ -21159,25 +21217,53 @@
     },
     "can1357/oh-my-pi": {
       "count7d": 1,
-      "likesSum7d": 1,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepygfqxhv2",
-        "cid": "bafyreic6u6hiha6d5lcrn3p6hrs3k43uz2u7q4ac3upp3ytoydyewsi3ni",
-        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmepygfqxhv2",
-        "text": "8. https://github.com/ChromeDevTools/chrome-devtools-mcp - TypeScript, 132 stars today 9. https://github.com/rohitg00/ai-engineering-from-scratch - Python, 1318 stars today 10. https://github.com/teng-lin/notebooklm-py - Python, 182 stars today 11. https://github.com/can1357/oh-my-pi - […]",
+        "uri": "at://did:plc:4izdyxhcrjqdiwzbvd7epk7z/app.bsky.feed.post/3mmg65mbu3s2x",
+        "cid": "bafyreicitccpaz2xqbbign6fwwlvivmmwb6y6jpohqoytlzd4q2hvl6xoe",
+        "bskyUrl": "https://bsky.app/profile/adityamitra.bsky.social/post/3mmg65mbu3s2x",
+        "text": "tried out omp (github.com/can1357/oh-m...) now it is too much batteries included - and I like it if you compare opencode with omp, it is comparing flask with django #aitools #framework #opencode #ohmypi #opensource",
         "author": {
-          "handle": "ghtrend.newsmast.social.ap.brid.gy",
-          "displayName": "GitHub Trending"
+          "handle": "adityamitra.bsky.social",
+          "displayName": "Aditya Mitra"
         },
-        "likeCount": 1,
+        "likeCount": 2,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-21T15:22:16.000Z",
-        "hoursSincePosted": 3.9
+        "createdAt": "2026-05-22T05:09:05.362Z",
+        "hoursSincePosted": 3.4
       },
       "posts": [
+        {
+          "uri": "at://did:plc:4izdyxhcrjqdiwzbvd7epk7z/app.bsky.feed.post/3mmg65mbu3s2x",
+          "cid": "bafyreicitccpaz2xqbbign6fwwlvivmmwb6y6jpohqoytlzd4q2hvl6xoe",
+          "bskyUrl": "https://bsky.app/profile/adityamitra.bsky.social/post/3mmg65mbu3s2x",
+          "text": "tried out omp (github.com/can1357/oh-m...) now it is too much batteries included - and I like it if you compare opencode with omp, it is comparing flask with django #aitools #framework #opencode #ohmypi #opensource",
+          "author": {
+            "handle": "adityamitra.bsky.social",
+            "displayName": "Aditya Mitra"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T05:09:05.362Z",
+          "createdUtc": 1779426545,
+          "ageHours": 3.4,
+          "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "can1357/oh-my-pi",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepygfqxhv2",
           "cid": "bafyreic6u6hiha6d5lcrn3p6hrs3k43uz2u7q4ac3upp3ytoydyewsi3ni",
@@ -21480,9 +21566,9 @@
     },
     "charmbracelet/crush": {
       "count7d": 1,
-      "likesSum7d": 0,
-      "repostsSum7d": 0,
-      "repliesSum7d": 0,
+      "likesSum7d": 9,
+      "repostsSum7d": 1,
+      "repliesSum7d": 1,
       "topPost": {
         "uri": "at://did:plc:jlkvfwdsrwr33osoe55szwx6/app.bsky.feed.post/3mmg43vky7j2w",
         "cid": "bafyreiexauxaxlswllb4pnawc3xrq62k5otb32k6b5slg4cuqcmdkghdpa",
@@ -21492,11 +21578,11 @@
           "handle": "imil.net",
           "displayName": "Emile `iMIl' Heitor"
         },
-        "likeCount": 0,
-        "repostCount": 0,
-        "replyCount": 0,
+        "likeCount": 9,
+        "repostCount": 1,
+        "replyCount": 1,
         "createdAt": "2026-05-22T04:32:20.268Z",
-        "hoursSincePosted": 0.5
+        "hoursSincePosted": 4.01
       },
       "posts": [
         {
@@ -21508,13 +21594,13 @@
             "handle": "imil.net",
             "displayName": "Emile `iMIl' Heitor"
           },
-          "likeCount": 0,
-          "repostCount": 0,
-          "replyCount": 0,
+          "likeCount": 9,
+          "repostCount": 1,
+          "replyCount": 1,
           "createdAt": "2026-05-22T04:32:20.268Z",
           "createdUtc": 1779424340,
-          "ageHours": 0.5,
-          "trendingScore": 0,
+          "ageHours": 4.01,
+          "trendingScore": 11.5,
           "content_tags": [
             "has-github-repo"
           ],
@@ -21535,26 +21621,54 @@
       ]
     },
     "eigenpal/docx-editor": {
-      "count7d": 3,
+      "count7d": 2,
       "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:kb4r5p4f4rzz7li6lbjcwraz/app.bsky.feed.post/3mmfvk6ipcx2m",
-        "cid": "bafyreihbaaitoxsgfocp2muhnedwz2lsqz5phsspd74lemwyevxoxrc3ke",
-        "bskyUrl": "https://bsky.app/profile/betterhn50.e-work.xyz/post/3mmfvk6ipcx2m",
-        "text": "Show HN: Open-source .docx editor library for building document apps https://github.com/eigenpal/docx-editor (https://news.ycombinator.com/item?id=48228411)",
+        "uri": "at://did:plc:vevngu5t7a2zqvdftysxv26d/app.bsky.feed.post/3mmgb3m2k422a",
+        "cid": "bafyreierq7cw4f4yvupc5n6vz2zkosex4ofpqjwex7dux7sr77w5oljy7i",
+        "bskyUrl": "https://bsky.app/profile/ytroncal.bsky.social/post/3mmgb3m2k422a",
+        "text": "Open-source WYSIWYG .docx editor for React and Vue with canonical OOXML, tracked changes, and real-time collaboration. github.com/eigenpal/doc...",
         "author": {
-          "handle": "betterhn50.e-work.xyz",
-          "displayName": "Hacker News 50"
+          "handle": "ytroncal.bsky.social",
+          "displayName": "ytroncal"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-22T02:35:02.588Z",
-        "hoursSincePosted": 2.1
+        "createdAt": "2026-05-22T06:01:39.241Z",
+        "hoursSincePosted": 2.52
       },
       "posts": [
+        {
+          "uri": "at://did:plc:vevngu5t7a2zqvdftysxv26d/app.bsky.feed.post/3mmgb3m2k422a",
+          "cid": "bafyreierq7cw4f4yvupc5n6vz2zkosex4ofpqjwex7dux7sr77w5oljy7i",
+          "bskyUrl": "https://bsky.app/profile/ytroncal.bsky.social/post/3mmgb3m2k422a",
+          "text": "Open-source WYSIWYG .docx editor for React and Vue with canonical OOXML, tracked changes, and real-time collaboration. github.com/eigenpal/doc...",
+          "author": {
+            "handle": "ytroncal.bsky.social",
+            "displayName": "ytroncal"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T06:01:39.241Z",
+          "createdUtc": 1779429699,
+          "ageHours": 2.52,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "eigenpal/docx-editor",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:kb4r5p4f4rzz7li6lbjcwraz/app.bsky.feed.post/3mmfvk6ipcx2m",
           "cid": "bafyreihbaaitoxsgfocp2muhnedwz2lsqz5phsspd74lemwyevxoxrc3ke",
@@ -21569,7 +21683,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T02:35:02.588Z",
           "createdUtc": 1779417302,
-          "ageHours": 2.1,
+          "ageHours": 5.97,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -21643,7 +21757,7 @@
     },
     "Tenobrus/graphglyph": {
       "count7d": 1,
-      "likesSum7d": 22,
+      "likesSum7d": 27,
       "repostsSum7d": 1,
       "repliesSum7d": 2,
       "topPost": {
@@ -21655,11 +21769,11 @@
           "handle": "void.comind.network",
           "displayName": "Void"
         },
-        "likeCount": 22,
+        "likeCount": 27,
         "repostCount": 1,
         "replyCount": 2,
         "createdAt": "2026-05-22T01:56:34.125Z",
-        "hoursSincePosted": 2.75
+        "hoursSincePosted": 6.61
       },
       "posts": [
         {
@@ -21671,13 +21785,13 @@
             "handle": "void.comind.network",
             "displayName": "Void"
           },
-          "likeCount": 22,
+          "likeCount": 27,
           "repostCount": 1,
           "replyCount": 2,
           "createdAt": "2026-05-22T01:56:34.125Z",
           "createdUtc": 1779414994,
-          "ageHours": 2.75,
-          "trendingScore": 25,
+          "ageHours": 6.61,
+          "trendingScore": 30,
           "content_tags": [
             "has-github-repo"
           ],
@@ -21787,6 +21901,210 @@
           "linkedRepos": [
             {
               "fullName": "cclank/cell-architecture-studio",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "vasu-devs/JustHireMe": {
+      "count7d": 1,
+      "likesSum7d": 4,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmgazbbh3z2u",
+        "cid": "bafyreibo4o27w26qan45em5iewkfiuttuodbi3w4hrirdmnxsywmjain7q",
+        "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmgazbbh3z2u",
+        "text": "JustHireMe : un workbench local-first pour scraper des offres d'emploi, scorer sa compatibilité et générer des candidatures personnalisées — CV, lettre de motivation, messages d'approche. Open source, aucune donnée envoyée en dehors de votre machine. https://github.com/vasu-devs/JustHireMe",
+        "author": {
+          "handle": "camilleroux.com",
+          "displayName": "Camille Roux"
+        },
+        "likeCount": 4,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T08:00:20+02:00",
+        "hoursSincePosted": 2.55
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmgazbbh3z2u",
+          "cid": "bafyreibo4o27w26qan45em5iewkfiuttuodbi3w4hrirdmnxsywmjain7q",
+          "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmgazbbh3z2u",
+          "text": "JustHireMe : un workbench local-first pour scraper des offres d'emploi, scorer sa compatibilité et générer des candidatures personnalisées — CV, lettre de motivation, messages d'approche. Open source, aucune donnée envoyée en dehors de votre machine. https://github.com/vasu-devs/JustHireMe",
+          "author": {
+            "handle": "camilleroux.com",
+            "displayName": "Camille Roux"
+          },
+          "likeCount": 4,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T08:00:20+02:00",
+          "createdUtc": 1779429620,
+          "ageHours": 2.55,
+          "trendingScore": 4,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "vasu-devs/JustHireMe",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "pguso/rag-from-scratch": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmgaop4zkm2o",
+        "cid": "bafyreihihhjttmfx6vrh7f33s47by3a47yyzl63vfmxbdwabzh26r4p3oi",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmgaop4zkm2o",
+        "text": "https://github.com/pguso/rag-from-scratch",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T05:54:25Z",
+        "hoursSincePosted": 2.64
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmgaop4zkm2o",
+          "cid": "bafyreihihhjttmfx6vrh7f33s47by3a47yyzl63vfmxbdwabzh26r4p3oi",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmgaop4zkm2o",
+          "text": "https://github.com/pguso/rag-from-scratch",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T05:54:25Z",
+          "createdUtc": 1779429265,
+          "ageHours": 2.64,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "pguso/rag-from-scratch",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "Arindam200/awesome-ai-apps": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:7ufpvhrwwlhszrym3c5pahny/app.bsky.feed.post/3mmg5o36p462v",
+        "cid": "bafyreib2fnjgbicimxx2fupnhuo72ypvtp3h4xxu6q4s5gikid2supt2ge",
+        "bskyUrl": "https://bsky.app/profile/astrodevil1.bsky.social/post/3mmg5o36p462v",
+        "text": "Project repo → github.com/Arindam200/... more about Data Lab → nebius.com/blog/posts/...",
+        "author": {
+          "handle": "astrodevil1.bsky.social",
+          "displayName": "Mr. Ånand"
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T05:00:24.024518Z",
+        "hoursSincePosted": 3.55
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:7ufpvhrwwlhszrym3c5pahny/app.bsky.feed.post/3mmg5o36p462v",
+          "cid": "bafyreib2fnjgbicimxx2fupnhuo72ypvtp3h4xxu6q4s5gikid2supt2ge",
+          "bskyUrl": "https://bsky.app/profile/astrodevil1.bsky.social/post/3mmg5o36p462v",
+          "text": "Project repo → github.com/Arindam200/... more about Data Lab → nebius.com/blog/posts/...",
+          "author": {
+            "handle": "astrodevil1.bsky.social",
+            "displayName": "Mr. Ånand"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T05:00:24.024518Z",
+          "createdUtc": 1779426024,
+          "ageHours": 3.55,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Arindam200/awesome-ai-apps",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "alonsovm44/tc-lang": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:egoop22szzob7mszd3pfgdww/app.bsky.feed.post/3mmg53ht56b2d",
+        "cid": "bafyreic6zzhyhi6noy6pha6gpd45ps5a7wdp6rel5rx6qsy3v7u757rgie",
+        "bskyUrl": "https://bsky.app/profile/betterhn20.e-work.xyz/post/3mmg53ht56b2d",
+        "text": "Show HN: Tight C, a systems language with 10 keywords https://github.com/alonsovm44/tc-lang/ (https://news.ycombinator.com/item?id=48231674)",
+        "author": {
+          "handle": "betterhn20.e-work.xyz",
+          "displayName": "Hacker News 20"
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T04:49:59.138Z",
+        "hoursSincePosted": 3.72
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:egoop22szzob7mszd3pfgdww/app.bsky.feed.post/3mmg53ht56b2d",
+          "cid": "bafyreic6zzhyhi6noy6pha6gpd45ps5a7wdp6rel5rx6qsy3v7u757rgie",
+          "bskyUrl": "https://bsky.app/profile/betterhn20.e-work.xyz/post/3mmg53ht56b2d",
+          "text": "Show HN: Tight C, a systems language with 10 keywords https://github.com/alonsovm44/tc-lang/ (https://news.ycombinator.com/item?id=48231674)",
+          "author": {
+            "handle": "betterhn20.e-work.xyz",
+            "displayName": "Hacker News 20"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T04:49:59.138Z",
+          "createdUtc": 1779425399,
+          "ageHours": 3.72,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "alonsovm44/tc-lang",
               "matchType": "url",
               "confidence": 1
             }
@@ -24232,25 +24550,54 @@
     },
     "chenglou--pretext": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
       "repliesSum7d": 1,
       "topPost": {
-        "uri": "at://did:plc:eq7w4z5l7t7zug24tkhollrt/app.bsky.feed.post/3mlc44fdnp62n",
-        "cid": "bafyreiezjupw4lnib2fzb2xco2splsvrddjuavdexkfp32nffciwfjc2ue",
-        "bskyUrl": "https://bsky.app/profile/kevindangoor.com/post/3mlc44fdnp62n",
-        "text": "Cheng Lou's pretext is an impressive frontend engineering feat. His thread is a great tour of what precise text measurement in the browser makes possible. github.com/chenglou/... x.com/_chenglou/stat...",
+        "uri": "at://did:plc:allu5vs3gnm2wm7jzf4rad3r/app.bsky.feed.post/3mmgbbwh53c22",
+        "cid": "bafyreiciwwkek37dblm6ohzlig4amwciw2briqf3nd5yxggbkpwjscmcwi",
+        "bskyUrl": "https://bsky.app/profile/isolyth.dev/post/3mmgbbwh53c22",
+        "text": "What if you added github.com/chenglou/pre...",
         "author": {
-          "handle": "kevindangoor.com",
-          "displayName": "Kevin Dangoor"
+          "handle": "isolyth.dev",
+          "displayName": "Eris"
         },
-        "likeCount": 0,
+        "likeCount": 2,
         "repostCount": 0,
         "replyCount": 1,
-        "createdAt": "2026-05-07T20:56:45.000Z",
-        "hoursSincePosted": 1.59
+        "createdAt": "2026-05-22T06:05:11.466Z",
+        "hoursSincePosted": 2.47
       },
       "posts": [
+        {
+          "uri": "at://did:plc:allu5vs3gnm2wm7jzf4rad3r/app.bsky.feed.post/3mmgbbwh53c22",
+          "cid": "bafyreiciwwkek37dblm6ohzlig4amwciw2briqf3nd5yxggbkpwjscmcwi",
+          "bskyUrl": "https://bsky.app/profile/isolyth.dev/post/3mmgbbwh53c22",
+          "text": "What if you added github.com/chenglou/pre...",
+          "author": {
+            "handle": "isolyth.dev",
+            "displayName": "Eris"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T06:05:11.466Z",
+          "createdUtc": 1779429911,
+          "ageHours": 2.47,
+          "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo",
+            "is-question"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "chenglou/pretext",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:eq7w4z5l7t7zug24tkhollrt/app.bsky.feed.post/3mlc44fdnp62n",
           "cid": "bafyreiezjupw4lnib2fzb2xco2splsvrddjuavdexkfp32nffciwfjc2ue",
@@ -35502,7 +35849,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-22T02:15:14.454Z",
-        "hoursSincePosted": 2.43
+        "hoursSincePosted": 6.3
       },
       "posts": [
         {
@@ -35552,7 +35899,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T02:15:14.454Z",
           "createdUtc": 1779416114,
-          "ageHours": 2.43,
+          "ageHours": 6.3,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
@@ -38871,7 +39218,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-22T02:15:29.716Z",
-        "hoursSincePosted": 2.43
+        "hoursSincePosted": 6.29
       },
       "posts": [
         {
@@ -38926,7 +39273,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T02:15:29.716Z",
           "createdUtc": 1779416129,
-          "ageHours": 2.43,
+          "ageHours": 6.29,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
@@ -39361,9 +39708,9 @@
     },
     "sipeed--picoclaw": {
       "count7d": 1,
-      "likesSum7d": 0,
-      "repostsSum7d": 0,
-      "repliesSum7d": 0,
+      "likesSum7d": 9,
+      "repostsSum7d": 1,
+      "repliesSum7d": 1,
       "topPost": {
         "uri": "at://did:plc:jlkvfwdsrwr33osoe55szwx6/app.bsky.feed.post/3mmg43vky7j2w",
         "cid": "bafyreiexauxaxlswllb4pnawc3xrq62k5otb32k6b5slg4cuqcmdkghdpa",
@@ -39373,11 +39720,11 @@
           "handle": "imil.net",
           "displayName": "Emile `iMIl' Heitor"
         },
-        "likeCount": 0,
-        "repostCount": 0,
-        "replyCount": 0,
+        "likeCount": 9,
+        "repostCount": 1,
+        "replyCount": 1,
         "createdAt": "2026-05-22T04:32:20.268Z",
-        "hoursSincePosted": 0.5
+        "hoursSincePosted": 4.01
       },
       "posts": [
         {
@@ -39389,13 +39736,13 @@
             "handle": "imil.net",
             "displayName": "Emile `iMIl' Heitor"
           },
-          "likeCount": 0,
-          "repostCount": 0,
-          "replyCount": 0,
+          "likeCount": 9,
+          "repostCount": 1,
+          "replyCount": 1,
           "createdAt": "2026-05-22T04:32:20.268Z",
           "createdUtc": 1779424340,
-          "ageHours": 0.5,
-          "trendingScore": 0,
+          "ageHours": 4.01,
+          "trendingScore": 11.5,
           "content_tags": [
             "has-github-repo"
           ],
@@ -40295,24 +40642,24 @@
       ]
     },
     "colbymchenry--codegraph": {
-      "count7d": 2,
-      "likesSum7d": 1,
+      "count7d": 1,
+      "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:li4dar55qdutvcf5psi4wt2q/app.bsky.feed.post/3mmfb5zfee72x",
-        "cid": "bafyreiecbiszmseq54knr2whebocfqpswycrch5fpih42mbu4irxww4kd4",
-        "bskyUrl": "https://bsky.app/profile/apvarun.com/post/3mmfb5zfee72x",
-        "text": "Knowledge graph for your agents is a very cool ideas 🔥 https://github.com/colbymchenry/codegraph",
+        "uri": "at://did:plc:rzrswgjbus6pudxrqh2i3zkc/app.bsky.feed.post/3mmgdqbcasc27",
+        "cid": "bafyreib4xbr6jwkkzbnfhbfrpsuvjqgvfwy5iabmyczq7siq6w7zvueypq",
+        "bskyUrl": "https://bsky.app/profile/novica.bsky.social/post/3mmgdqbcasc27",
+        "text": "hey #rstats is anyone working R support for github.com/colbymchenry... ?",
         "author": {
-          "handle": "apvarun.com",
-          "displayName": "Varun"
+          "handle": "novica.bsky.social",
+          "displayName": "novica"
         },
-        "likeCount": 1,
+        "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-21T20:30:20.327Z",
-        "hoursSincePosted": 2.18
+        "createdAt": "2026-05-22T06:49:00.086Z",
+        "hoursSincePosted": 1.74
       },
       "posts": [
         {
@@ -40445,6 +40792,35 @@
               "matchType": "url",
               "confidence": 1
             },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:rzrswgjbus6pudxrqh2i3zkc/app.bsky.feed.post/3mmgdqbcasc27",
+          "cid": "bafyreib4xbr6jwkkzbnfhbfrpsuvjqgvfwy5iabmyczq7siq6w7zvueypq",
+          "bskyUrl": "https://bsky.app/profile/novica.bsky.social/post/3mmgdqbcasc27",
+          "text": "hey #rstats is anyone working R support for github.com/colbymchenry... ?",
+          "author": {
+            "handle": "novica.bsky.social",
+            "displayName": "novica"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T06:49:00.086Z",
+          "createdUtc": 1779432540,
+          "ageHours": 1.74,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-question"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
             {
               "fullName": "colbymchenry/codegraph",
               "matchType": "url",
@@ -42950,25 +43326,53 @@
     },
     "can1357--oh-my-pi": {
       "count7d": 1,
-      "likesSum7d": 1,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepygfqxhv2",
-        "cid": "bafyreic6u6hiha6d5lcrn3p6hrs3k43uz2u7q4ac3upp3ytoydyewsi3ni",
-        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmepygfqxhv2",
-        "text": "8. https://github.com/ChromeDevTools/chrome-devtools-mcp - TypeScript, 132 stars today 9. https://github.com/rohitg00/ai-engineering-from-scratch - Python, 1318 stars today 10. https://github.com/teng-lin/notebooklm-py - Python, 182 stars today 11. https://github.com/can1357/oh-my-pi - […]",
+        "uri": "at://did:plc:4izdyxhcrjqdiwzbvd7epk7z/app.bsky.feed.post/3mmg65mbu3s2x",
+        "cid": "bafyreicitccpaz2xqbbign6fwwlvivmmwb6y6jpohqoytlzd4q2hvl6xoe",
+        "bskyUrl": "https://bsky.app/profile/adityamitra.bsky.social/post/3mmg65mbu3s2x",
+        "text": "tried out omp (github.com/can1357/oh-m...) now it is too much batteries included - and I like it if you compare opencode with omp, it is comparing flask with django #aitools #framework #opencode #ohmypi #opensource",
         "author": {
-          "handle": "ghtrend.newsmast.social.ap.brid.gy",
-          "displayName": "GitHub Trending"
+          "handle": "adityamitra.bsky.social",
+          "displayName": "Aditya Mitra"
         },
-        "likeCount": 1,
+        "likeCount": 2,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-21T15:22:16.000Z",
-        "hoursSincePosted": 3.9
+        "createdAt": "2026-05-22T05:09:05.362Z",
+        "hoursSincePosted": 3.4
       },
       "posts": [
+        {
+          "uri": "at://did:plc:4izdyxhcrjqdiwzbvd7epk7z/app.bsky.feed.post/3mmg65mbu3s2x",
+          "cid": "bafyreicitccpaz2xqbbign6fwwlvivmmwb6y6jpohqoytlzd4q2hvl6xoe",
+          "bskyUrl": "https://bsky.app/profile/adityamitra.bsky.social/post/3mmg65mbu3s2x",
+          "text": "tried out omp (github.com/can1357/oh-m...) now it is too much batteries included - and I like it if you compare opencode with omp, it is comparing flask with django #aitools #framework #opencode #ohmypi #opensource",
+          "author": {
+            "handle": "adityamitra.bsky.social",
+            "displayName": "Aditya Mitra"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T05:09:05.362Z",
+          "createdUtc": 1779426545,
+          "ageHours": 3.4,
+          "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "can1357/oh-my-pi",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepygfqxhv2",
           "cid": "bafyreic6u6hiha6d5lcrn3p6hrs3k43uz2u7q4ac3upp3ytoydyewsi3ni",
@@ -43271,9 +43675,9 @@
     },
     "charmbracelet--crush": {
       "count7d": 1,
-      "likesSum7d": 0,
-      "repostsSum7d": 0,
-      "repliesSum7d": 0,
+      "likesSum7d": 9,
+      "repostsSum7d": 1,
+      "repliesSum7d": 1,
       "topPost": {
         "uri": "at://did:plc:jlkvfwdsrwr33osoe55szwx6/app.bsky.feed.post/3mmg43vky7j2w",
         "cid": "bafyreiexauxaxlswllb4pnawc3xrq62k5otb32k6b5slg4cuqcmdkghdpa",
@@ -43283,11 +43687,11 @@
           "handle": "imil.net",
           "displayName": "Emile `iMIl' Heitor"
         },
-        "likeCount": 0,
-        "repostCount": 0,
-        "replyCount": 0,
+        "likeCount": 9,
+        "repostCount": 1,
+        "replyCount": 1,
         "createdAt": "2026-05-22T04:32:20.268Z",
-        "hoursSincePosted": 0.5
+        "hoursSincePosted": 4.01
       },
       "posts": [
         {
@@ -43299,13 +43703,13 @@
             "handle": "imil.net",
             "displayName": "Emile `iMIl' Heitor"
           },
-          "likeCount": 0,
-          "repostCount": 0,
-          "replyCount": 0,
+          "likeCount": 9,
+          "repostCount": 1,
+          "replyCount": 1,
           "createdAt": "2026-05-22T04:32:20.268Z",
           "createdUtc": 1779424340,
-          "ageHours": 0.5,
-          "trendingScore": 0,
+          "ageHours": 4.01,
+          "trendingScore": 11.5,
           "content_tags": [
             "has-github-repo"
           ],
@@ -43326,26 +43730,54 @@
       ]
     },
     "eigenpal--docx-editor": {
-      "count7d": 3,
+      "count7d": 2,
       "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:kb4r5p4f4rzz7li6lbjcwraz/app.bsky.feed.post/3mmfvk6ipcx2m",
-        "cid": "bafyreihbaaitoxsgfocp2muhnedwz2lsqz5phsspd74lemwyevxoxrc3ke",
-        "bskyUrl": "https://bsky.app/profile/betterhn50.e-work.xyz/post/3mmfvk6ipcx2m",
-        "text": "Show HN: Open-source .docx editor library for building document apps https://github.com/eigenpal/docx-editor (https://news.ycombinator.com/item?id=48228411)",
+        "uri": "at://did:plc:vevngu5t7a2zqvdftysxv26d/app.bsky.feed.post/3mmgb3m2k422a",
+        "cid": "bafyreierq7cw4f4yvupc5n6vz2zkosex4ofpqjwex7dux7sr77w5oljy7i",
+        "bskyUrl": "https://bsky.app/profile/ytroncal.bsky.social/post/3mmgb3m2k422a",
+        "text": "Open-source WYSIWYG .docx editor for React and Vue with canonical OOXML, tracked changes, and real-time collaboration. github.com/eigenpal/doc...",
         "author": {
-          "handle": "betterhn50.e-work.xyz",
-          "displayName": "Hacker News 50"
+          "handle": "ytroncal.bsky.social",
+          "displayName": "ytroncal"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-22T02:35:02.588Z",
-        "hoursSincePosted": 2.1
+        "createdAt": "2026-05-22T06:01:39.241Z",
+        "hoursSincePosted": 2.52
       },
       "posts": [
+        {
+          "uri": "at://did:plc:vevngu5t7a2zqvdftysxv26d/app.bsky.feed.post/3mmgb3m2k422a",
+          "cid": "bafyreierq7cw4f4yvupc5n6vz2zkosex4ofpqjwex7dux7sr77w5oljy7i",
+          "bskyUrl": "https://bsky.app/profile/ytroncal.bsky.social/post/3mmgb3m2k422a",
+          "text": "Open-source WYSIWYG .docx editor for React and Vue with canonical OOXML, tracked changes, and real-time collaboration. github.com/eigenpal/doc...",
+          "author": {
+            "handle": "ytroncal.bsky.social",
+            "displayName": "ytroncal"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T06:01:39.241Z",
+          "createdUtc": 1779429699,
+          "ageHours": 2.52,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "eigenpal/docx-editor",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:kb4r5p4f4rzz7li6lbjcwraz/app.bsky.feed.post/3mmfvk6ipcx2m",
           "cid": "bafyreihbaaitoxsgfocp2muhnedwz2lsqz5phsspd74lemwyevxoxrc3ke",
@@ -43360,7 +43792,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T02:35:02.588Z",
           "createdUtc": 1779417302,
-          "ageHours": 2.1,
+          "ageHours": 5.97,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -43434,7 +43866,7 @@
     },
     "tenobrus--graphglyph": {
       "count7d": 1,
-      "likesSum7d": 22,
+      "likesSum7d": 27,
       "repostsSum7d": 1,
       "repliesSum7d": 2,
       "topPost": {
@@ -43446,11 +43878,11 @@
           "handle": "void.comind.network",
           "displayName": "Void"
         },
-        "likeCount": 22,
+        "likeCount": 27,
         "repostCount": 1,
         "replyCount": 2,
         "createdAt": "2026-05-22T01:56:34.125Z",
-        "hoursSincePosted": 2.75
+        "hoursSincePosted": 6.61
       },
       "posts": [
         {
@@ -43462,13 +43894,13 @@
             "handle": "void.comind.network",
             "displayName": "Void"
           },
-          "likeCount": 22,
+          "likeCount": 27,
           "repostCount": 1,
           "replyCount": 2,
           "createdAt": "2026-05-22T01:56:34.125Z",
           "createdUtc": 1779414994,
-          "ageHours": 2.75,
-          "trendingScore": 25,
+          "ageHours": 6.61,
+          "trendingScore": 30,
           "content_tags": [
             "has-github-repo"
           ],
@@ -43584,31 +44016,260 @@
           ]
         }
       ]
+    },
+    "vasu-devs--justhireme": {
+      "count7d": 1,
+      "likesSum7d": 4,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmgazbbh3z2u",
+        "cid": "bafyreibo4o27w26qan45em5iewkfiuttuodbi3w4hrirdmnxsywmjain7q",
+        "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmgazbbh3z2u",
+        "text": "JustHireMe : un workbench local-first pour scraper des offres d'emploi, scorer sa compatibilité et générer des candidatures personnalisées — CV, lettre de motivation, messages d'approche. Open source, aucune donnée envoyée en dehors de votre machine. https://github.com/vasu-devs/JustHireMe",
+        "author": {
+          "handle": "camilleroux.com",
+          "displayName": "Camille Roux"
+        },
+        "likeCount": 4,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T08:00:20+02:00",
+        "hoursSincePosted": 2.55
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmgazbbh3z2u",
+          "cid": "bafyreibo4o27w26qan45em5iewkfiuttuodbi3w4hrirdmnxsywmjain7q",
+          "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmgazbbh3z2u",
+          "text": "JustHireMe : un workbench local-first pour scraper des offres d'emploi, scorer sa compatibilité et générer des candidatures personnalisées — CV, lettre de motivation, messages d'approche. Open source, aucune donnée envoyée en dehors de votre machine. https://github.com/vasu-devs/JustHireMe",
+          "author": {
+            "handle": "camilleroux.com",
+            "displayName": "Camille Roux"
+          },
+          "likeCount": 4,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T08:00:20+02:00",
+          "createdUtc": 1779429620,
+          "ageHours": 2.55,
+          "trendingScore": 4,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "vasu-devs/JustHireMe",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "pguso--rag-from-scratch": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmgaop4zkm2o",
+        "cid": "bafyreihihhjttmfx6vrh7f33s47by3a47yyzl63vfmxbdwabzh26r4p3oi",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmgaop4zkm2o",
+        "text": "https://github.com/pguso/rag-from-scratch",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T05:54:25Z",
+        "hoursSincePosted": 2.64
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mmgaop4zkm2o",
+          "cid": "bafyreihihhjttmfx6vrh7f33s47by3a47yyzl63vfmxbdwabzh26r4p3oi",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mmgaop4zkm2o",
+          "text": "https://github.com/pguso/rag-from-scratch",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T05:54:25Z",
+          "createdUtc": 1779429265,
+          "ageHours": 2.64,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "pguso/rag-from-scratch",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "arindam200--awesome-ai-apps": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:7ufpvhrwwlhszrym3c5pahny/app.bsky.feed.post/3mmg5o36p462v",
+        "cid": "bafyreib2fnjgbicimxx2fupnhuo72ypvtp3h4xxu6q4s5gikid2supt2ge",
+        "bskyUrl": "https://bsky.app/profile/astrodevil1.bsky.social/post/3mmg5o36p462v",
+        "text": "Project repo → github.com/Arindam200/... more about Data Lab → nebius.com/blog/posts/...",
+        "author": {
+          "handle": "astrodevil1.bsky.social",
+          "displayName": "Mr. Ånand"
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T05:00:24.024518Z",
+        "hoursSincePosted": 3.55
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:7ufpvhrwwlhszrym3c5pahny/app.bsky.feed.post/3mmg5o36p462v",
+          "cid": "bafyreib2fnjgbicimxx2fupnhuo72ypvtp3h4xxu6q4s5gikid2supt2ge",
+          "bskyUrl": "https://bsky.app/profile/astrodevil1.bsky.social/post/3mmg5o36p462v",
+          "text": "Project repo → github.com/Arindam200/... more about Data Lab → nebius.com/blog/posts/...",
+          "author": {
+            "handle": "astrodevil1.bsky.social",
+            "displayName": "Mr. Ånand"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T05:00:24.024518Z",
+          "createdUtc": 1779426024,
+          "ageHours": 3.55,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Arindam200/awesome-ai-apps",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "alonsovm44--tc-lang": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:egoop22szzob7mszd3pfgdww/app.bsky.feed.post/3mmg53ht56b2d",
+        "cid": "bafyreic6zzhyhi6noy6pha6gpd45ps5a7wdp6rel5rx6qsy3v7u757rgie",
+        "bskyUrl": "https://bsky.app/profile/betterhn20.e-work.xyz/post/3mmg53ht56b2d",
+        "text": "Show HN: Tight C, a systems language with 10 keywords https://github.com/alonsovm44/tc-lang/ (https://news.ycombinator.com/item?id=48231674)",
+        "author": {
+          "handle": "betterhn20.e-work.xyz",
+          "displayName": "Hacker News 20"
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T04:49:59.138Z",
+        "hoursSincePosted": 3.72
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:egoop22szzob7mszd3pfgdww/app.bsky.feed.post/3mmg53ht56b2d",
+          "cid": "bafyreic6zzhyhi6noy6pha6gpd45ps5a7wdp6rel5rx6qsy3v7u757rgie",
+          "bskyUrl": "https://bsky.app/profile/betterhn20.e-work.xyz/post/3mmg53ht56b2d",
+          "text": "Show HN: Tight C, a systems language with 10 keywords https://github.com/alonsovm44/tc-lang/ (https://news.ycombinator.com/item?id=48231674)",
+          "author": {
+            "handle": "betterhn20.e-work.xyz",
+            "displayName": "Hacker News 20"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T04:49:59.138Z",
+          "createdUtc": 1779425399,
+          "ageHours": 3.72,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "alonsovm44/tc-lang",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
     }
   },
   "leaderboard": [
     {
       "fullName": "Tenobrus/graphglyph",
       "count7d": 1,
-      "likesSum7d": 22
-    },
-    {
-      "fullName": "VRSEN/OpenSwarm",
-      "count7d": 1,
-      "likesSum7d": 3
-    },
-    {
-      "fullName": "eigenpal/docx-editor",
-      "count7d": 3,
-      "likesSum7d": 0
-    },
-    {
-      "fullName": "cclank/cell-architecture-studio",
-      "count7d": 1,
-      "likesSum7d": 0
+      "likesSum7d": 27
     },
     {
       "fullName": "charmbracelet/crush",
+      "count7d": 1,
+      "likesSum7d": 9
+    },
+    {
+      "fullName": "sipeed/picoclaw",
+      "count7d": 1,
+      "likesSum7d": 9
+    },
+    {
+      "fullName": "vasu-devs/JustHireMe",
+      "count7d": 1,
+      "likesSum7d": 4
+    },
+    {
+      "fullName": "can1357/oh-my-pi",
+      "count7d": 1,
+      "likesSum7d": 2
+    },
+    {
+      "fullName": "chenglou/pretext",
+      "count7d": 1,
+      "likesSum7d": 2
+    },
+    {
+      "fullName": "eigenpal/docx-editor",
+      "count7d": 2,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "alonsovm44/tc-lang",
+      "count7d": 1,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "Arindam200/awesome-ai-apps",
+      "count7d": 1,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "colbymchenry/codegraph",
       "count7d": 1,
       "likesSum7d": 0
     },
@@ -43618,7 +44279,7 @@
       "likesSum7d": 0
     },
     {
-      "fullName": "sipeed/picoclaw",
+      "fullName": "pguso/rag-from-scratch",
       "count7d": 1,
       "likesSum7d": 0
     },

--- a/data/bluesky-trending.json
+++ b/data/bluesky-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T04:41:16.359Z",
+  "fetchedAt": "2026-05-22T08:33:06.267Z",
   "discoveryVersion": "2026-04-21",
   "keywords": [
     "AI agents",
@@ -17,11 +17,11 @@
     "LLMs": 60,
     "Coding agents": 120,
     "MCP": 59,
-    "RAG and retrieval": 30,
-    "Workflow and automation": 120,
-    "Context, prompts, memory": 90,
-    "AI skills": 90,
-    "Open source AI": 29
+    "RAG and retrieval": 29,
+    "Workflow and automation": 0,
+    "Context, prompts, memory": 0,
+    "AI skills": 0,
+    "Open source AI": 0
   },
   "queries": [
     "lang:en \"ai agent\"",
@@ -60,18 +60,7 @@
     "lang:en cline": 30,
     "lang:en \"mcp server\"": 30,
     "lang:en \"model context protocol\"": 29,
-    "lang:en rag": 30,
-    "lang:en workflow": 30,
-    "lang:en automation": 30,
-    "lang:en cli": 30,
-    "lang:en devtools": 30,
-    "lang:en \"context engineering\"": 30,
-    "lang:en \"prompt engineering\"": 30,
-    "lang:en \"agent memory\"": 30,
-    "lang:en \"claude skill\"": 30,
-    "lang:en \"claude skills\"": 30,
-    "lang:en \"ai skills\"": 30,
-    "lang:en \"open source ai\"": 29
+    "lang:en rag": 29
   },
   "queryFamilies": [
     {
@@ -152,7 +141,7 @@
       ]
     }
   ],
-  "scannedPosts": 669,
+  "scannedPosts": 354,
   "posts": [
     {
       "uri": "at://did:plc:oijtzlibd7mlf56jbfohssdz/app.bsky.feed.post/3ml46o7m5rs2b",
@@ -211,13 +200,13 @@
         "handle": "tressiemcphd.bsky.social",
         "displayName": "Tressie McMillan Cottom"
       },
-      "likeCount": 2665,
+      "likeCount": 2666,
       "repostCount": 365,
       "replyCount": 67,
       "createdAt": "2026-05-19T11:46:20.996Z",
       "createdUtc": 1779191180,
-      "ageHours": 64.92,
-      "trendingScore": 3428.5,
+      "ageHours": 68.78,
+      "trendingScore": 3429.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -379,13 +368,13 @@
         "handle": "coreyryung.bsky.social",
         "displayName": "Corey Rayburn Yung"
       },
-      "likeCount": 1351,
+      "likeCount": 1352,
       "repostCount": 307,
       "replyCount": 19,
       "createdAt": "2026-05-18T21:40:34.041Z",
       "createdUtc": 1779140434,
-      "ageHours": 79.01,
-      "trendingScore": 1974.5,
+      "ageHours": 82.88,
+      "trendingScore": 1975.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -578,6 +567,30 @@
       "createdUtc": 1779172596,
       "ageHours": 65.66,
       "trendingScore": 955,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
+      "uri": "at://did:plc:2zcfjzyocp6kapg6jc4eacok/app.bsky.feed.post/3mmfr5iz67c24",
+      "cid": "bafyreigoq74ncuffy6zxa5a2nttdf3otdfx7fynp4gv3fb2tdeowjhhafe",
+      "bskyUrl": "https://bsky.app/profile/andrew.heiss.phd/post/3mmfr5iz67c24",
+      "text": "Finally switched to DuckDuckGo and it’s nice to not have LLM summaries anymore",
+      "author": {
+        "handle": "andrew.heiss.phd",
+        "displayName": "Andrew Heiss"
+      },
+      "likeCount": 763,
+      "repostCount": 75,
+      "replyCount": 47,
+      "createdAt": "2026-05-22T01:16:23.287Z",
+      "createdUtc": 1779412583,
+      "ageHours": 7.28,
+      "trendingScore": 936.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -888,7 +901,7 @@
       "replyCount": 18,
       "createdAt": "2026-05-18T14:35:54.513Z",
       "createdUtc": 1779114954,
-      "ageHours": 86.09,
+      "ageHours": 89.95,
       "trendingScore": 669,
       "content_tags": [],
       "value_score": 0,
@@ -1032,7 +1045,7 @@
       "replyCount": 13,
       "createdAt": "2026-05-17T16:42:21.014Z",
       "createdUtc": 1779036141,
-      "ageHours": 107.98,
+      "ageHours": 111.85,
       "trendingScore": 579.5,
       "content_tags": [
         "is-question"
@@ -1119,30 +1132,6 @@
       "matchedTopicLabel": "Workflow and automation"
     },
     {
-      "uri": "at://did:plc:pzgvqg4ihnaihkrpmxqz5pu6/app.bsky.feed.post/3mmdqz3oyxk2p",
-      "cid": "bafyreihj445n3hjzsrp2t2shrubrpbof2pvxtebjziaendmqf4pfrawcta",
-      "bskyUrl": "https://bsky.app/profile/bell.bz/post/3mmdqz3oyxk2p",
-      "text": "Google I/O summary - shipping an LLM to your Chrome whether you want it or not - destroying search once and for all - pervert glasses 👍",
-      "author": {
-        "handle": "bell.bz",
-        "displayName": "Andy Bell"
-      },
-      "likeCount": 389,
-      "repostCount": 80,
-      "replyCount": 10,
-      "createdAt": "2026-05-21T06:08:35.631Z",
-      "createdUtc": 1779343715,
-      "ageHours": 22.54,
-      "trendingScore": 554,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
-    },
-    {
       "uri": "at://did:plc:ddvus7otnqtlh7fdooxm6qat/app.bsky.feed.post/3mmdbpwcjoc2v",
       "cid": "bafyreicz323vmb6ctk6h5sqniz2zxjedoc6v3hlzuylr6noryom3wo5lb4",
       "bskyUrl": "https://bsky.app/profile/maxkennerly.bsky.social/post/3mmdbpwcjoc2v",
@@ -1151,13 +1140,13 @@
         "handle": "maxkennerly.bsky.social",
         "displayName": "Max Kennerly"
       },
-      "likeCount": 462,
-      "repostCount": 45,
+      "likeCount": 468,
+      "repostCount": 46,
       "replyCount": 1,
       "createdAt": "2026-05-21T01:34:58.982Z",
       "createdUtc": 1779327298,
-      "ageHours": 27.11,
-      "trendingScore": 552.5,
+      "ageHours": 30.97,
+      "trendingScore": 560.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1165,6 +1154,30 @@
       "matchedQuery": "lang:en cursor",
       "matchedTopicId": "coding-agents",
       "matchedTopicLabel": "Coding agents"
+    },
+    {
+      "uri": "at://did:plc:pzgvqg4ihnaihkrpmxqz5pu6/app.bsky.feed.post/3mmdqz3oyxk2p",
+      "cid": "bafyreihj445n3hjzsrp2t2shrubrpbof2pvxtebjziaendmqf4pfrawcta",
+      "bskyUrl": "https://bsky.app/profile/bell.bz/post/3mmdqz3oyxk2p",
+      "text": "Google I/O summary - shipping an LLM to your Chrome whether you want it or not - destroying search once and for all - pervert glasses 👍",
+      "author": {
+        "handle": "bell.bz",
+        "displayName": "Andy Bell"
+      },
+      "likeCount": 391,
+      "repostCount": 80,
+      "replyCount": 10,
+      "createdAt": "2026-05-21T06:08:35.631Z",
+      "createdUtc": 1779343715,
+      "ageHours": 26.41,
+      "trendingScore": 556,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
     },
     {
       "uri": "at://did:plc:mivey63nzylfflvmmjoqcf6u/app.bsky.feed.post/3mm3e52ypys2j",
@@ -1180,7 +1193,7 @@
       "replyCount": 39,
       "createdAt": "2026-05-17T21:56:52.568Z",
       "createdUtc": 1779055012,
-      "ageHours": 102.74,
+      "ageHours": 106.6,
       "trendingScore": 550.5,
       "content_tags": [],
       "value_score": 0,
@@ -1239,30 +1252,6 @@
       "matchedTopicLabel": "LLMs"
     },
     {
-      "uri": "at://did:plc:2zcfjzyocp6kapg6jc4eacok/app.bsky.feed.post/3mmfr5iz67c24",
-      "cid": "bafyreigoq74ncuffy6zxa5a2nttdf3otdfx7fynp4gv3fb2tdeowjhhafe",
-      "bskyUrl": "https://bsky.app/profile/andrew.heiss.phd/post/3mmfr5iz67c24",
-      "text": "Finally switched to DuckDuckGo and it’s nice to not have LLM summaries anymore",
-      "author": {
-        "handle": "andrew.heiss.phd",
-        "displayName": "Andrew Heiss"
-      },
-      "likeCount": 433,
-      "repostCount": 43,
-      "replyCount": 28,
-      "createdAt": "2026-05-22T01:16:23.287Z",
-      "createdUtc": 1779412583,
-      "ageHours": 3.41,
-      "trendingScore": 533,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
-    },
-    {
       "uri": "at://did:plc:ladocdaw6idrxzuldk527nsq/app.bsky.feed.post/3mlhnqyuth22u",
       "cid": "bafyreib7xrh363hlbnxxlbfpjoijjt44kjaji5km7wfskxma7ccdmro44u",
       "bskyUrl": "https://bsky.app/profile/alleycatsleet.bsky.social/post/3mlhnqyuth22u",
@@ -1300,7 +1289,7 @@
       "replyCount": 7,
       "createdAt": "2026-05-19T18:44:40.122Z",
       "createdUtc": 1779216280,
-      "ageHours": 42.8,
+      "ageHours": 61.81,
       "trendingScore": 519.5,
       "content_tags": [],
       "value_score": 0,


### PR DESCRIPTION
Automated data refresh from `Refresh Bluesky signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26277273641

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.