### PR TITLE
chore(data): refresh huggingface space signals 2026-05-22T10:00:00Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-22T04:48:25.029Z",
+  "ts": "2026-05-22T10:00:00.277Z",
   "count": 1,
-  "durationMs": 6352,
+  "durationMs": 4259,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T04:48:18.679Z",
+  "fetchedAt": "2026-05-22T09:59:56.021Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -131,7 +131,7 @@
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
-      "likes": 102,
+      "likes": 112,
       "trendingScore": 85,
       "sdk": "gradio",
       "tags": [
@@ -247,8 +247,8 @@
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 68,
-      "trendingScore": 66,
+      "likes": 70,
+      "trendingScore": 68,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -624,7 +624,7 @@
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 29,
+      "likes": 32,
       "trendingScore": 26,
       "sdk": "gradio",
       "tags": [
@@ -723,6 +723,22 @@
     },
     {
       "rank": 44,
+      "id": "stabilityai/stable-audio-3",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
+      "likes": 23,
+      "trendingScore": 23,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T15:54:00.000Z",
+      "lastModified": "2026-05-21T20:34:31.000Z",
+      "models": []
+    },
+    {
+      "rank": 45,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -738,7 +754,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
@@ -758,7 +774,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -774,7 +790,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "Overworld/waypoint-1-5",
       "author": "Overworld",
       "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
@@ -790,7 +806,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "carlofkl/DreamLite",
       "author": "carlofkl",
       "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
@@ -810,7 +826,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "huggingface/physics-intern",
       "author": "huggingface",
       "url": "https://huggingface.co/spaces/huggingface/physics-intern",
@@ -824,22 +840,6 @@
       ],
       "createdAt": "2026-04-09T06:56:52.000Z",
       "lastModified": "2026-05-12T14:59:53.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
-      "author": "BoobyBoobs",
-      "url": "https://huggingface.co/spaces/BoobyBoobs/Flux_Lustly_AI_Uncensored_NSFW_V1",
-      "likes": 181,
-      "trendingScore": 20,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-10-10T19:23:32.000Z",
-      "lastModified": "2025-01-24T23:37:17.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26281212451

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.