### PR TITLE
chore(data): refresh lobsters signals 2026-05-22T12:41:58Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-22T05:45:43.524Z",
+  "ts": "2026-05-22T12:41:58.040Z",
   "count": 1,
-  "durationMs": 4237,
+  "durationMs": 3531,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-22T05:45:39.308Z",
+  "fetchedAt": "2026-05-22T12:41:54.531Z",
   "windowDays": 7,
-  "scannedStories": 76,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-22T05:45:39.308Z",
+  "fetchedAt": "2026-05-22T12:41:54.531Z",
   "windowHours": 72,
-  "scannedTotal": 76,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -741,6 +741,25 @@
       "linkedRepos": []
     },
     {
+      "shortId": "ptvaan",
+      "title": "Gnutella: A Protocol Outliving the World That Created It",
+      "url": "https://rickcarlino.com/notes/p2p/gnutella-explanation.html",
+      "commentsUrl": "https://lobste.rs/s/ptvaan/gnutella_protocol_outliving_world",
+      "by": "",
+      "score": 42,
+      "commentCount": 3,
+      "createdUtc": 1779417426,
+      "ageHours": 10.08,
+      "trendingScore": 1.0003428882961223,
+      "tags": [
+        "distributed",
+        "historical",
+        "networking"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "kxmdvj",
       "title": "In what way if any are you a tech minimalist while maintaining your job/love for tech?",
       "url": "",
@@ -876,26 +895,6 @@
         "practices",
         "rust",
         "zig"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "r6lw7v",
-      "title": "How to open calc.exe from S&Box",
-      "url": "https://slugcat.systems/post/26-05-21-how-to-open-calc-exe-from-sbox/",
-      "commentsUrl": "https://lobste.rs/s/r6lw7v/how_open_calc_exe_from_s_box",
-      "by": "",
-      "score": 10,
-      "commentCount": 0,
-      "createdUtc": 1779393659,
-      "ageHours": 2.848333333333333,
-      "trendingScore": 0.9367232368575993,
-      "tags": [
-        "debugging",
-        "dotnet",
-        "reversing",
-        "security"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26288306478

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.