### PR TITLE
chore(data): refresh bluesky signals 2026-05-22T15:22:20Z

### DIFF
--- a/data/_meta/bluesky.json
+++ b/data/_meta/bluesky.json
@@ -1,8 +1,8 @@
 {
   "source": "bluesky",
   "reason": "ok",
-  "ts": "2026-05-22T12:01:18.117Z",
+  "ts": "2026-05-22T15:22:19.974Z",
   "count": 1,
-  "durationMs": 11455,
+  "durationMs": 12021,
   "extra": {}
 }

--- a/data/bluesky-mentions.json
+++ b/data/bluesky-mentions.json
@@ -1,9 +1,9 @@
 {
-  "fetchedAt": "2026-05-22T12:01:07.073Z",
+  "fetchedAt": "2026-05-22T15:22:08.194Z",
   "windowDays": 7,
-  "scannedPosts": 99,
+  "scannedPosts": 199,
   "searchQuery": "github.com",
-  "pagesFetched": 1,
+  "pagesFetched": 2,
   "mentions": {
     "antirez/ds4": {
       "count7d": 2,
@@ -830,25 +830,53 @@
     },
     "jj-vcs/jj": {
       "count7d": 1,
-      "likesSum7d": 1,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:ogwattsr55qdrjmtbovoa7za/app.bsky.feed.post/3mm7uuw5i7c2a",
-        "cid": "bafyreifzkejm2ft7safxafybmv5qxukih2sa2oph7xd7ldloqmjkhdlrmm",
-        "bskyUrl": "https://bsky.app/profile/botmatrix.myatproto.social/post/3mm7uuw5i7c2a",
-        "text": "tolerate it's much better than what was, the ux is terrible, the area needs innovation imo friends are looking at github.com/jj-vcs/jj",
+        "uri": "at://did:plc:fodyg35g25joa5rpplt4y43g/app.bsky.feed.post/3mmh3jfqdw22b",
+        "cid": "bafyreiefonqsfdo4izks7vkesimf26jzxp3jgigfo7xi7gfal6k54w63q4",
+        "bskyUrl": "https://bsky.app/profile/adolfont.github.io/post/3mmh3jfqdw22b",
+        "text": "github.com/jj-vcs/jj",
         "author": {
-          "handle": "botmatrix.myatproto.social",
-          "displayName": "eric shamow"
+          "handle": "adolfont.github.io",
+          "displayName": "Adolfo Neto"
         },
-        "likeCount": 1,
+        "likeCount": 2,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T17:07:11.609Z",
-        "hoursSincePosted": 3.76
+        "createdAt": "2026-05-22T13:54:39.664Z",
+        "hoursSincePosted": 1.46
       },
       "posts": [
+        {
+          "uri": "at://did:plc:fodyg35g25joa5rpplt4y43g/app.bsky.feed.post/3mmh3jfqdw22b",
+          "cid": "bafyreiefonqsfdo4izks7vkesimf26jzxp3jgigfo7xi7gfal6k54w63q4",
+          "bskyUrl": "https://bsky.app/profile/adolfont.github.io/post/3mmh3jfqdw22b",
+          "text": "github.com/jj-vcs/jj",
+          "author": {
+            "handle": "adolfont.github.io",
+            "displayName": "Adolfo Neto"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T13:54:39.664Z",
+          "createdUtc": 1779458079,
+          "ageHours": 1.46,
+          "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "jj-vcs/jj",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:ogwattsr55qdrjmtbovoa7za/app.bsky.feed.post/3mm7uuw5i7c2a",
           "cid": "bafyreifzkejm2ft7safxafybmv5qxukih2sa2oph7xd7ldloqmjkhdlrmm",
@@ -10058,24 +10086,24 @@
       ]
     },
     "rtk-ai/rtk": {
-      "count7d": 2,
-      "likesSum7d": 2,
+      "count7d": 1,
+      "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:fxbgd54fjpcthdcvcnu4gogy/app.bsky.feed.post/3mm7pks5mtk2f",
-        "cid": "bafyreiffbtuiujopzg5ssmrftxjuuezsdlanel4po63emmnk7adqce65by",
-        "bskyUrl": "https://bsky.app/profile/clofresh.bsky.social/post/3mm7pks5mtk2f",
-        "text": "There’s such an exciting opportunity to optimize token usage for local LLMs. Some other exciting token optimizations: * MTP for Qwen 3.6 and Gemma 4 (blog.google/innovation-a...) * RTK (github.com/rtk-ai/rtk) * cymbal (github.com/1broseidon/c...) * pi agent harness (minimal system prompt)",
+        "uri": "at://did:plc:jfc47fjoy4wr4wtax256z6ke/app.bsky.feed.post/3mmgxaqgr4s2o",
+        "cid": "bafyreig5yzq56yukpnlkiexgtx4nmujxdu3kjwg2zlmd7jhhu2sfulam2a",
+        "bskyUrl": "https://bsky.app/profile/yyano.bsky.social/post/3mmgxaqgr4s2o",
+        "text": "rtk-ai/rtk: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies github.com/rtk-ai/rtk おためしで動かしてる。かなり圧縮できていいかんじ。",
         "author": {
-          "handle": "clofresh.bsky.social",
-          "displayName": "C"
+          "handle": "yyano.bsky.social",
+          "displayName": "yyano"
         },
-        "likeCount": 1,
+        "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T15:32:03.166Z",
-        "hoursSincePosted": 3.76
+        "createdAt": "2026-05-22T12:38:13.928Z",
+        "hoursSincePosted": 2.73
       },
       "posts": [
         {
@@ -10168,6 +10196,34 @@
             },
             {
               "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:jfc47fjoy4wr4wtax256z6ke/app.bsky.feed.post/3mmgxaqgr4s2o",
+          "cid": "bafyreig5yzq56yukpnlkiexgtx4nmujxdu3kjwg2zlmd7jhhu2sfulam2a",
+          "bskyUrl": "https://bsky.app/profile/yyano.bsky.social/post/3mmgxaqgr4s2o",
+          "text": "rtk-ai/rtk: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies github.com/rtk-ai/rtk おためしで動かしてる。かなり圧縮できていいかんじ。",
+          "author": {
+            "handle": "yyano.bsky.social",
+            "displayName": "yyano"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T12:38:13.928Z",
+          "createdUtc": 1779453493,
+          "ageHours": 2.73,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "rtk-ai/rtk",
               "matchType": "url",
               "confidence": 1
             }
@@ -16060,25 +16116,63 @@
     },
     "ruvnet/RuView": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 1,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:mdocvky3thypleu26gbyjgex/app.bsky.feed.post/3mmerhmr54k2m",
-        "cid": "bafyreigmp4a36w3bo2d6sze25n3ufoa77qsr46gcv6oqnafnpygt2xwtgu",
-        "bskyUrl": "https://bsky.app/profile/flavio58.bsky.social/post/3mmerhmr54k2m",
-        "text": "github.com/ruvnet/RuView",
+        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+        "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
         "author": {
-          "handle": "flavio58.bsky.social",
-          "displayName": "Flavio58"
+          "handle": "ghtrend.newsmast.social.ap.brid.gy",
+          "displayName": "GitHub Trending"
         },
-        "likeCount": 0,
+        "likeCount": 1,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-21T15:49:23.015Z",
-        "hoursSincePosted": 3.45
+        "createdAt": "2026-05-22T14:36:20.000Z",
+        "hoursSincePosted": 0.76
       },
       "posts": [
+        {
+          "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+          "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+          "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+          "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
+          "author": {
+            "handle": "ghtrend.newsmast.social.ap.brid.gy",
+            "displayName": "GitHub Trending"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T14:36:20.000Z",
+          "createdUtc": 1779460580,
+          "ageHours": 0.76,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-plugins-official",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "ruvnet/RuView",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mm32vhnkxd2x",
           "cid": "bafyreidguwrfwuh7wnzxrglu4o6qa7ml2p7yhxzykonbm2w6tleixx3nhu",
@@ -16501,26 +16595,54 @@
       ]
     },
     "MinishLab/semble": {
-      "count7d": 2,
-      "likesSum7d": 0,
+      "count7d": 1,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
-      "repliesSum7d": 0,
+      "repliesSum7d": 1,
       "topPost": {
-        "uri": "at://did:plc:2pbcv2hgynjwwxnpu633n23w/app.bsky.feed.post/3mm7dq2la5s2u",
-        "cid": "bafyreiflwuay2ukzid5ik7s25njnfuqv7oo7mu22nixtcw4zxajx5zhafe",
-        "bskyUrl": "https://bsky.app/profile/jordbastin.bsky.social/post/3mm7dq2la5s2u",
-        "text": "Le vrai goulet d’étranglement des agents de code : trouver le bon contexte sans brûler toute la fenêtre. Semble promet une recherche de code pensée pour agents, avec beaucoup moins de tokens que grep + read. github.com/MinishLab/s...",
+        "uri": "at://did:plc:hosvhu6ascflszx7dab7ayyo/app.bsky.feed.post/3mmh4kxye5c2b",
+        "cid": "bafyreig7wwcjqiiyyvx6u2xlztbh6yxbfwvdrvxgpxapbu5nezvjpeq5zi",
+        "bskyUrl": "https://bsky.app/profile/francistm.bsky.social/post/3mmh4kxye5c2b",
+        "text": "Shipped ken v0.4.0 — pure-Go port of MinishLab/semble (hybrid code search for AI agents). Drop-in MCP replacement, no Python, single static binary. go install + ken download-model and you're running. github.com/townsendmeri...",
         "author": {
-          "handle": "jordbastin.bsky.social",
-          "displayName": "Jordan Bastin 🇫🇷"
+          "handle": "francistm.bsky.social"
         },
-        "likeCount": 0,
+        "likeCount": 2,
         "repostCount": 0,
-        "replyCount": 0,
-        "createdAt": "2026-05-19T12:00:14.710092Z",
-        "hoursSincePosted": 0.5
+        "replyCount": 1,
+        "createdAt": "2026-05-22T14:13:26.096Z",
+        "hoursSincePosted": 1.15
       },
       "posts": [
+        {
+          "uri": "at://did:plc:hosvhu6ascflszx7dab7ayyo/app.bsky.feed.post/3mmh4kxye5c2b",
+          "cid": "bafyreig7wwcjqiiyyvx6u2xlztbh6yxbfwvdrvxgpxapbu5nezvjpeq5zi",
+          "bskyUrl": "https://bsky.app/profile/francistm.bsky.social/post/3mmh4kxye5c2b",
+          "text": "Shipped ken v0.4.0 — pure-Go port of MinishLab/semble (hybrid code search for AI agents). Drop-in MCP replacement, no Python, single static binary. go install + ken download-model and you're running. github.com/townsendmeri...",
+          "author": {
+            "handle": "francistm.bsky.social"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T14:13:26.096Z",
+          "createdUtc": 1779459206,
+          "ageHours": 1.15,
+          "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo",
+            "has-agent",
+            "is-announcement"
+          ],
+          "value_score": 3,
+          "linkedRepos": [
+            {
+              "fullName": "MinishLab/semble",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:35ik6jgzsfh66jv5xrvcq6ke/app.bsky.feed.post/3mm6gp7ymf22y",
           "cid": "bafyreib2wm4mcsvigyu2wrxvlf3lk3wbhzcc3ep3cere3u74c6rvyp6cum",
@@ -17868,24 +17990,24 @@
       ]
     },
     "strukto-ai/mirage": {
-      "count7d": 1,
-      "likesSum7d": 2,
+      "count7d": 2,
+      "likesSum7d": 1,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:hm6svfyijdeb3yzv6pzsdtxr/app.bsky.feed.post/3mm6gfvi6pz2a",
-        "cid": "bafyreieupi3pbnbsipyn2tdg7idozrwb5ppkmajknwa4ppmjfe2prbfhmi",
-        "bskyUrl": "https://bsky.app/profile/pythonhub.dev/post/3mm6gfvi6pz2a",
-        "text": "Mirage A Unified Virtual Filesystem For AI Agents. https://github.com/strukto-ai/mirage",
+        "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmh3tczprl2l",
+        "cid": "bafyreigh6byjtu6dcxz7ppymqszogjwydtvtsjdxgth4ykmphgxqwvjp6q",
+        "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmh3tczprl2l",
+        "text": "Mirage : un système de fichiers virtuel unifié pour les agents IA. S3, Google Drive, Slack, GitHub, Redis… montés côte à côte sous une même arborescence, manipulables avec des commandes bash classiques. https://github.com/strukto-ai/mirage",
         "author": {
-          "handle": "pythonhub.dev",
-          "displayName": "Python Hub"
+          "handle": "camilleroux.com",
+          "displayName": "Camille Roux"
         },
-        "likeCount": 2,
+        "likeCount": 1,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T03:15:35.344616+00:00",
-        "hoursSincePosted": 5.39
+        "createdAt": "2026-05-22T16:00:12+02:00",
+        "hoursSincePosted": 1.37
       },
       "posts": [
         {
@@ -17904,6 +18026,63 @@
           "createdUtc": 1779160535,
           "ageHours": 5.39,
           "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo",
+            "has-agent"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "strukto-ai/mirage",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmh3tczprl2l",
+          "cid": "bafyreigh6byjtu6dcxz7ppymqszogjwydtvtsjdxgth4ykmphgxqwvjp6q",
+          "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmh3tczprl2l",
+          "text": "Mirage : un système de fichiers virtuel unifié pour les agents IA. S3, Google Drive, Slack, GitHub, Redis… montés côte à côte sous une même arborescence, manipulables avec des commandes bash classiques. https://github.com/strukto-ai/mirage",
+          "author": {
+            "handle": "camilleroux.com",
+            "displayName": "Camille Roux"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T16:00:12+02:00",
+          "createdUtc": 1779458412,
+          "ageHours": 1.37,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "strukto-ai/mirage",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:yklisov533zvvd4a3ejpktzq/app.bsky.feed.post/3mmgyalqz6b2u",
+          "cid": "bafyreid5blos5e6oadxmeg6ou5xaylyteypd25vqt3aetrugfovdpyfsou",
+          "bskyUrl": "https://bsky.app/profile/spinscale.bsky.social/post/3mmgyalqz6b2u",
+          "text": "mirate - a unified virtual filesystem for AI agents So, instead of tools, the current trend is to convert everything to a structure that can be searched with local filesystem tools, that agents already have local access to. Need to think about the implications of this... github.com/strukto-ai/m...",
+          "author": {
+            "handle": "spinscale.bsky.social",
+            "displayName": "Alexander Reelsen"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T12:56:01.594Z",
+          "createdUtc": 1779454561,
+          "ageHours": 2.44,
+          "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
             "has-agent"
@@ -18562,25 +18741,63 @@
     },
     "colbymchenry/codegraph": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 1,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:rzrswgjbus6pudxrqh2i3zkc/app.bsky.feed.post/3mmgdqbcasc27",
-        "cid": "bafyreib4xbr6jwkkzbnfhbfrpsuvjqgvfwy5iabmyczq7siq6w7zvueypq",
-        "bskyUrl": "https://bsky.app/profile/novica.bsky.social/post/3mmgdqbcasc27",
-        "text": "hey #rstats is anyone working R support for github.com/colbymchenry... ?",
+        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+        "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
         "author": {
-          "handle": "novica.bsky.social",
-          "displayName": "novica"
+          "handle": "ghtrend.newsmast.social.ap.brid.gy",
+          "displayName": "GitHub Trending"
         },
-        "likeCount": 0,
+        "likeCount": 1,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-22T06:49:00.086Z",
-        "hoursSincePosted": 1.74
+        "createdAt": "2026-05-22T14:36:20.000Z",
+        "hoursSincePosted": 0.76
       },
       "posts": [
+        {
+          "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+          "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+          "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+          "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
+          "author": {
+            "handle": "ghtrend.newsmast.social.ap.brid.gy",
+            "displayName": "GitHub Trending"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T14:36:20.000Z",
+          "createdUtc": 1779460580,
+          "ageHours": 0.76,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-plugins-official",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "ruvnet/RuView",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:li4dar55qdutvcf5psi4wt2q/app.bsky.feed.post/3mmfb5zfee72x",
           "cid": "bafyreiecbiszmseq54knr2whebocfqpswycrch5fpih42mbu4irxww4kd4",
@@ -19517,23 +19734,61 @@
       "count7d": 1,
       "likesSum7d": 1,
       "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepxav6dnq2",
-        "cid": "bafyreibsukq6dv5ydkzhpvcx6pvxxnaw6wxtg7xyzpkqavaqgv3fut7k4y",
-        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmepxav6dnq2",
-        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 891 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 4222 stars today 3. https://github.com/multica-ai/andrej-karpathy-skills - 2590 stars today 4 […]",
+        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+        "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
         "author": {
           "handle": "ghtrend.newsmast.social.ap.brid.gy",
           "displayName": "GitHub Trending"
         },
         "likeCount": 1,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-21T15:22:16.000Z",
-        "hoursSincePosted": 3.9
+        "replyCount": 0,
+        "createdAt": "2026-05-22T14:36:20.000Z",
+        "hoursSincePosted": 0.76
       },
       "posts": [
+        {
+          "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+          "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+          "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+          "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
+          "author": {
+            "handle": "ghtrend.newsmast.social.ap.brid.gy",
+            "displayName": "GitHub Trending"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T14:36:20.000Z",
+          "createdUtc": 1779460580,
+          "ageHours": 0.76,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-plugins-official",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "ruvnet/RuView",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepxav6dnq2",
           "cid": "bafyreibsukq6dv5ydkzhpvcx6pvxxnaw6wxtg7xyzpkqavaqgv3fut7k4y",
@@ -23097,25 +23352,53 @@
     },
     "jj-vcs--jj": {
       "count7d": 1,
-      "likesSum7d": 1,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:ogwattsr55qdrjmtbovoa7za/app.bsky.feed.post/3mm7uuw5i7c2a",
-        "cid": "bafyreifzkejm2ft7safxafybmv5qxukih2sa2oph7xd7ldloqmjkhdlrmm",
-        "bskyUrl": "https://bsky.app/profile/botmatrix.myatproto.social/post/3mm7uuw5i7c2a",
-        "text": "tolerate it's much better than what was, the ux is terrible, the area needs innovation imo friends are looking at github.com/jj-vcs/jj",
+        "uri": "at://did:plc:fodyg35g25joa5rpplt4y43g/app.bsky.feed.post/3mmh3jfqdw22b",
+        "cid": "bafyreiefonqsfdo4izks7vkesimf26jzxp3jgigfo7xi7gfal6k54w63q4",
+        "bskyUrl": "https://bsky.app/profile/adolfont.github.io/post/3mmh3jfqdw22b",
+        "text": "github.com/jj-vcs/jj",
         "author": {
-          "handle": "botmatrix.myatproto.social",
-          "displayName": "eric shamow"
+          "handle": "adolfont.github.io",
+          "displayName": "Adolfo Neto"
         },
-        "likeCount": 1,
+        "likeCount": 2,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T17:07:11.609Z",
-        "hoursSincePosted": 3.76
+        "createdAt": "2026-05-22T13:54:39.664Z",
+        "hoursSincePosted": 1.46
       },
       "posts": [
+        {
+          "uri": "at://did:plc:fodyg35g25joa5rpplt4y43g/app.bsky.feed.post/3mmh3jfqdw22b",
+          "cid": "bafyreiefonqsfdo4izks7vkesimf26jzxp3jgigfo7xi7gfal6k54w63q4",
+          "bskyUrl": "https://bsky.app/profile/adolfont.github.io/post/3mmh3jfqdw22b",
+          "text": "github.com/jj-vcs/jj",
+          "author": {
+            "handle": "adolfont.github.io",
+            "displayName": "Adolfo Neto"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T13:54:39.664Z",
+          "createdUtc": 1779458079,
+          "ageHours": 1.46,
+          "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "jj-vcs/jj",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:ogwattsr55qdrjmtbovoa7za/app.bsky.feed.post/3mm7uuw5i7c2a",
           "cid": "bafyreifzkejm2ft7safxafybmv5qxukih2sa2oph7xd7ldloqmjkhdlrmm",
@@ -32325,24 +32608,24 @@
       ]
     },
     "rtk-ai--rtk": {
-      "count7d": 2,
-      "likesSum7d": 2,
+      "count7d": 1,
+      "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:fxbgd54fjpcthdcvcnu4gogy/app.bsky.feed.post/3mm7pks5mtk2f",
-        "cid": "bafyreiffbtuiujopzg5ssmrftxjuuezsdlanel4po63emmnk7adqce65by",
-        "bskyUrl": "https://bsky.app/profile/clofresh.bsky.social/post/3mm7pks5mtk2f",
-        "text": "There’s such an exciting opportunity to optimize token usage for local LLMs. Some other exciting token optimizations: * MTP for Qwen 3.6 and Gemma 4 (blog.google/innovation-a...) * RTK (github.com/rtk-ai/rtk) * cymbal (github.com/1broseidon/c...) * pi agent harness (minimal system prompt)",
+        "uri": "at://did:plc:jfc47fjoy4wr4wtax256z6ke/app.bsky.feed.post/3mmgxaqgr4s2o",
+        "cid": "bafyreig5yzq56yukpnlkiexgtx4nmujxdu3kjwg2zlmd7jhhu2sfulam2a",
+        "bskyUrl": "https://bsky.app/profile/yyano.bsky.social/post/3mmgxaqgr4s2o",
+        "text": "rtk-ai/rtk: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies github.com/rtk-ai/rtk おためしで動かしてる。かなり圧縮できていいかんじ。",
         "author": {
-          "handle": "clofresh.bsky.social",
-          "displayName": "C"
+          "handle": "yyano.bsky.social",
+          "displayName": "yyano"
         },
-        "likeCount": 1,
+        "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T15:32:03.166Z",
-        "hoursSincePosted": 3.76
+        "createdAt": "2026-05-22T12:38:13.928Z",
+        "hoursSincePosted": 2.73
       },
       "posts": [
         {
@@ -32435,6 +32718,34 @@
             },
             {
               "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:jfc47fjoy4wr4wtax256z6ke/app.bsky.feed.post/3mmgxaqgr4s2o",
+          "cid": "bafyreig5yzq56yukpnlkiexgtx4nmujxdu3kjwg2zlmd7jhhu2sfulam2a",
+          "bskyUrl": "https://bsky.app/profile/yyano.bsky.social/post/3mmgxaqgr4s2o",
+          "text": "rtk-ai/rtk: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies github.com/rtk-ai/rtk おためしで動かしてる。かなり圧縮できていいかんじ。",
+          "author": {
+            "handle": "yyano.bsky.social",
+            "displayName": "yyano"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T12:38:13.928Z",
+          "createdUtc": 1779453493,
+          "ageHours": 2.73,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "rtk-ai/rtk",
               "matchType": "url",
               "confidence": 1
             }
@@ -38327,25 +38638,63 @@
     },
     "ruvnet--ruview": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 1,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:mdocvky3thypleu26gbyjgex/app.bsky.feed.post/3mmerhmr54k2m",
-        "cid": "bafyreigmp4a36w3bo2d6sze25n3ufoa77qsr46gcv6oqnafnpygt2xwtgu",
-        "bskyUrl": "https://bsky.app/profile/flavio58.bsky.social/post/3mmerhmr54k2m",
-        "text": "github.com/ruvnet/RuView",
+        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+        "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
         "author": {
-          "handle": "flavio58.bsky.social",
-          "displayName": "Flavio58"
+          "handle": "ghtrend.newsmast.social.ap.brid.gy",
+          "displayName": "GitHub Trending"
         },
-        "likeCount": 0,
+        "likeCount": 1,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-21T15:49:23.015Z",
-        "hoursSincePosted": 3.45
+        "createdAt": "2026-05-22T14:36:20.000Z",
+        "hoursSincePosted": 0.76
       },
       "posts": [
+        {
+          "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+          "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+          "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+          "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
+          "author": {
+            "handle": "ghtrend.newsmast.social.ap.brid.gy",
+            "displayName": "GitHub Trending"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T14:36:20.000Z",
+          "createdUtc": 1779460580,
+          "ageHours": 0.76,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-plugins-official",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "ruvnet/RuView",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mm32vhnkxd2x",
           "cid": "bafyreidguwrfwuh7wnzxrglu4o6qa7ml2p7yhxzykonbm2w6tleixx3nhu",
@@ -38768,26 +39117,54 @@
       ]
     },
     "minishlab--semble": {
-      "count7d": 2,
-      "likesSum7d": 0,
+      "count7d": 1,
+      "likesSum7d": 2,
       "repostsSum7d": 0,
-      "repliesSum7d": 0,
+      "repliesSum7d": 1,
       "topPost": {
-        "uri": "at://did:plc:2pbcv2hgynjwwxnpu633n23w/app.bsky.feed.post/3mm7dq2la5s2u",
-        "cid": "bafyreiflwuay2ukzid5ik7s25njnfuqv7oo7mu22nixtcw4zxajx5zhafe",
-        "bskyUrl": "https://bsky.app/profile/jordbastin.bsky.social/post/3mm7dq2la5s2u",
-        "text": "Le vrai goulet d’étranglement des agents de code : trouver le bon contexte sans brûler toute la fenêtre. Semble promet une recherche de code pensée pour agents, avec beaucoup moins de tokens que grep + read. github.com/MinishLab/s...",
+        "uri": "at://did:plc:hosvhu6ascflszx7dab7ayyo/app.bsky.feed.post/3mmh4kxye5c2b",
+        "cid": "bafyreig7wwcjqiiyyvx6u2xlztbh6yxbfwvdrvxgpxapbu5nezvjpeq5zi",
+        "bskyUrl": "https://bsky.app/profile/francistm.bsky.social/post/3mmh4kxye5c2b",
+        "text": "Shipped ken v0.4.0 — pure-Go port of MinishLab/semble (hybrid code search for AI agents). Drop-in MCP replacement, no Python, single static binary. go install + ken download-model and you're running. github.com/townsendmeri...",
         "author": {
-          "handle": "jordbastin.bsky.social",
-          "displayName": "Jordan Bastin 🇫🇷"
+          "handle": "francistm.bsky.social"
         },
-        "likeCount": 0,
+        "likeCount": 2,
         "repostCount": 0,
-        "replyCount": 0,
-        "createdAt": "2026-05-19T12:00:14.710092Z",
-        "hoursSincePosted": 0.5
+        "replyCount": 1,
+        "createdAt": "2026-05-22T14:13:26.096Z",
+        "hoursSincePosted": 1.15
       },
       "posts": [
+        {
+          "uri": "at://did:plc:hosvhu6ascflszx7dab7ayyo/app.bsky.feed.post/3mmh4kxye5c2b",
+          "cid": "bafyreig7wwcjqiiyyvx6u2xlztbh6yxbfwvdrvxgpxapbu5nezvjpeq5zi",
+          "bskyUrl": "https://bsky.app/profile/francistm.bsky.social/post/3mmh4kxye5c2b",
+          "text": "Shipped ken v0.4.0 — pure-Go port of MinishLab/semble (hybrid code search for AI agents). Drop-in MCP replacement, no Python, single static binary. go install + ken download-model and you're running. github.com/townsendmeri...",
+          "author": {
+            "handle": "francistm.bsky.social"
+          },
+          "likeCount": 2,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T14:13:26.096Z",
+          "createdUtc": 1779459206,
+          "ageHours": 1.15,
+          "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo",
+            "has-agent",
+            "is-announcement"
+          ],
+          "value_score": 3,
+          "linkedRepos": [
+            {
+              "fullName": "MinishLab/semble",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:35ik6jgzsfh66jv5xrvcq6ke/app.bsky.feed.post/3mm6gp7ymf22y",
           "cid": "bafyreib2wm4mcsvigyu2wrxvlf3lk3wbhzcc3ep3cere3u74c6rvyp6cum",
@@ -40135,24 +40512,24 @@
       ]
     },
     "strukto-ai--mirage": {
-      "count7d": 1,
-      "likesSum7d": 2,
+      "count7d": 2,
+      "likesSum7d": 1,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:hm6svfyijdeb3yzv6pzsdtxr/app.bsky.feed.post/3mm6gfvi6pz2a",
-        "cid": "bafyreieupi3pbnbsipyn2tdg7idozrwb5ppkmajknwa4ppmjfe2prbfhmi",
-        "bskyUrl": "https://bsky.app/profile/pythonhub.dev/post/3mm6gfvi6pz2a",
-        "text": "Mirage A Unified Virtual Filesystem For AI Agents. https://github.com/strukto-ai/mirage",
+        "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmh3tczprl2l",
+        "cid": "bafyreigh6byjtu6dcxz7ppymqszogjwydtvtsjdxgth4ykmphgxqwvjp6q",
+        "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmh3tczprl2l",
+        "text": "Mirage : un système de fichiers virtuel unifié pour les agents IA. S3, Google Drive, Slack, GitHub, Redis… montés côte à côte sous une même arborescence, manipulables avec des commandes bash classiques. https://github.com/strukto-ai/mirage",
         "author": {
-          "handle": "pythonhub.dev",
-          "displayName": "Python Hub"
+          "handle": "camilleroux.com",
+          "displayName": "Camille Roux"
         },
-        "likeCount": 2,
+        "likeCount": 1,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-19T03:15:35.344616+00:00",
-        "hoursSincePosted": 5.39
+        "createdAt": "2026-05-22T16:00:12+02:00",
+        "hoursSincePosted": 1.37
       },
       "posts": [
         {
@@ -40171,6 +40548,63 @@
           "createdUtc": 1779160535,
           "ageHours": 5.39,
           "trendingScore": 2,
+          "content_tags": [
+            "has-github-repo",
+            "has-agent"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "strukto-ai/mirage",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:5aumv6xsxxacaerhrubj322g/app.bsky.feed.post/3mmh3tczprl2l",
+          "cid": "bafyreigh6byjtu6dcxz7ppymqszogjwydtvtsjdxgth4ykmphgxqwvjp6q",
+          "bskyUrl": "https://bsky.app/profile/camilleroux.com/post/3mmh3tczprl2l",
+          "text": "Mirage : un système de fichiers virtuel unifié pour les agents IA. S3, Google Drive, Slack, GitHub, Redis… montés côte à côte sous une même arborescence, manipulables avec des commandes bash classiques. https://github.com/strukto-ai/mirage",
+          "author": {
+            "handle": "camilleroux.com",
+            "displayName": "Camille Roux"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T16:00:12+02:00",
+          "createdUtc": 1779458412,
+          "ageHours": 1.37,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "strukto-ai/mirage",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:yklisov533zvvd4a3ejpktzq/app.bsky.feed.post/3mmgyalqz6b2u",
+          "cid": "bafyreid5blos5e6oadxmeg6ou5xaylyteypd25vqt3aetrugfovdpyfsou",
+          "bskyUrl": "https://bsky.app/profile/spinscale.bsky.social/post/3mmgyalqz6b2u",
+          "text": "mirate - a unified virtual filesystem for AI agents So, instead of tools, the current trend is to convert everything to a structure that can be searched with local filesystem tools, that agents already have local access to. Need to think about the implications of this... github.com/strukto-ai/m...",
+          "author": {
+            "handle": "spinscale.bsky.social",
+            "displayName": "Alexander Reelsen"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T12:56:01.594Z",
+          "createdUtc": 1779454561,
+          "ageHours": 2.44,
+          "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
             "has-agent"
@@ -40829,25 +41263,63 @@
     },
     "colbymchenry--codegraph": {
       "count7d": 1,
-      "likesSum7d": 0,
+      "likesSum7d": 1,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:rzrswgjbus6pudxrqh2i3zkc/app.bsky.feed.post/3mmgdqbcasc27",
-        "cid": "bafyreib4xbr6jwkkzbnfhbfrpsuvjqgvfwy5iabmyczq7siq6w7zvueypq",
-        "bskyUrl": "https://bsky.app/profile/novica.bsky.social/post/3mmgdqbcasc27",
-        "text": "hey #rstats is anyone working R support for github.com/colbymchenry... ?",
+        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+        "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
         "author": {
-          "handle": "novica.bsky.social",
-          "displayName": "novica"
+          "handle": "ghtrend.newsmast.social.ap.brid.gy",
+          "displayName": "GitHub Trending"
         },
-        "likeCount": 0,
+        "likeCount": 1,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-22T06:49:00.086Z",
-        "hoursSincePosted": 1.74
+        "createdAt": "2026-05-22T14:36:20.000Z",
+        "hoursSincePosted": 0.76
       },
       "posts": [
+        {
+          "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+          "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+          "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+          "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
+          "author": {
+            "handle": "ghtrend.newsmast.social.ap.brid.gy",
+            "displayName": "GitHub Trending"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T14:36:20.000Z",
+          "createdUtc": 1779460580,
+          "ageHours": 0.76,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-plugins-official",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "ruvnet/RuView",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:li4dar55qdutvcf5psi4wt2q/app.bsky.feed.post/3mmfb5zfee72x",
           "cid": "bafyreiecbiszmseq54knr2whebocfqpswycrch5fpih42mbu4irxww4kd4",
@@ -41784,23 +42256,61 @@
       "count7d": 1,
       "likesSum7d": 1,
       "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepxav6dnq2",
-        "cid": "bafyreibsukq6dv5ydkzhpvcx6pvxxnaw6wxtg7xyzpkqavaqgv3fut7k4y",
-        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmepxav6dnq2",
-        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 891 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 4222 stars today 3. https://github.com/multica-ai/andrej-karpathy-skills - 2590 stars today 4 […]",
+        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+        "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+        "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
         "author": {
           "handle": "ghtrend.newsmast.social.ap.brid.gy",
           "displayName": "GitHub Trending"
         },
         "likeCount": 1,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-21T15:22:16.000Z",
-        "hoursSincePosted": 3.9
+        "replyCount": 0,
+        "createdAt": "2026-05-22T14:36:20.000Z",
+        "hoursSincePosted": 0.76
       },
       "posts": [
+        {
+          "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmh5tydeu2t2",
+          "cid": "bafyreiey5s6pwgwylojzwm3trbphrmou6cwbe4o4iuuq5rpdtx6cf74k4i",
+          "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmh5tydeu2t2",
+          "text": "📈 Today's GitHub Trending: 1. https://github.com/anthropics/claude-plugins-official - Python, 2556 stars today 2. https://github.com/colbymchenry/codegraph - TypeScript, 3688 stars today 3. https://github.com/ruvnet/RuView - Rust, 1269 stars today 4 […]",
+          "author": {
+            "handle": "ghtrend.newsmast.social.ap.brid.gy",
+            "displayName": "GitHub Trending"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T14:36:20.000Z",
+          "createdUtc": 1779460580,
+          "ageHours": 0.76,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-plugins-official",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "colbymchenry/codegraph",
+              "matchType": "url",
+              "confidence": 1
+            },
+            {
+              "fullName": "ruvnet/RuView",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmepxav6dnq2",
           "cid": "bafyreibsukq6dv5ydkzhpvcx6pvxxnaw6wxtg7xyzpkqavaqgv3fut7k4y",
@@ -44540,22 +45050,37 @@
   },
   "leaderboard": [
     {
-      "fullName": "freestylefly/awesome-gpt-image-2",
+      "fullName": "jj-vcs/jj",
       "count7d": 1,
-      "likesSum7d": 0
+      "likesSum7d": 2
     },
     {
-      "fullName": "HeyPuter/puter",
+      "fullName": "MinishLab/semble",
       "count7d": 1,
-      "likesSum7d": 0
+      "likesSum7d": 2
     },
     {
-      "fullName": "modem-dev/hunk",
-      "count7d": 1,
-      "likesSum7d": 0
+      "fullName": "strukto-ai/mirage",
+      "count7d": 2,
+      "likesSum7d": 1
     },
     {
-      "fullName": "wiltodelta/remove-ai-watermarks",
+      "fullName": "anthropics/claude-plugins-official",
+      "count7d": 1,
+      "likesSum7d": 1
+    },
+    {
+      "fullName": "colbymchenry/codegraph",
+      "count7d": 1,
+      "likesSum7d": 1
+    },
+    {
+      "fullName": "ruvnet/RuView",
+      "count7d": 1,
+      "likesSum7d": 1
+    },
+    {
+      "fullName": "rtk-ai/rtk",
       "count7d": 1,
       "likesSum7d": 0
     }

--- a/data/bluesky-trending.json
+++ b/data/bluesky-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T12:01:07.073Z",
+  "fetchedAt": "2026-05-22T15:22:08.194Z",
   "discoveryVersion": "2026-04-21",
   "keywords": [
     "AI agents",
@@ -152,7 +152,7 @@
       ]
     }
   ],
-  "scannedPosts": 667,
+  "scannedPosts": 664,
   "posts": [
     {
       "uri": "at://did:plc:oijtzlibd7mlf56jbfohssdz/app.bsky.feed.post/3ml46o7m5rs2b",
@@ -211,13 +211,13 @@
         "handle": "tressiemcphd.bsky.social",
         "displayName": "Tressie McMillan Cottom"
       },
-      "likeCount": 2666,
+      "likeCount": 2667,
       "repostCount": 365,
-      "replyCount": 67,
+      "replyCount": 66,
       "createdAt": "2026-05-19T11:46:20.996Z",
       "createdUtc": 1779191180,
-      "ageHours": 72.25,
-      "trendingScore": 3429.5,
+      "ageHours": 75.6,
+      "trendingScore": 3430,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -384,8 +384,32 @@
       "replyCount": 19,
       "createdAt": "2026-05-18T21:40:34.041Z",
       "createdUtc": 1779140434,
-      "ageHours": 86.34,
+      "ageHours": 89.69,
       "trendingScore": 1975.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
+      "uri": "at://did:plc:2zcfjzyocp6kapg6jc4eacok/app.bsky.feed.post/3mmfr5iz67c24",
+      "cid": "bafyreigoq74ncuffy6zxa5a2nttdf3otdfx7fynp4gv3fb2tdeowjhhafe",
+      "bskyUrl": "https://bsky.app/profile/andrew.heiss.phd/post/3mmfr5iz67c24",
+      "text": "Finally switched to DuckDuckGo and it’s nice to not have LLM summaries anymore",
+      "author": {
+        "handle": "andrew.heiss.phd",
+        "displayName": "Andrew Heiss"
+      },
+      "likeCount": 1398,
+      "repostCount": 139,
+      "replyCount": 87,
+      "createdAt": "2026-05-22T01:16:23.287Z",
+      "createdUtc": 1779412583,
+      "ageHours": 14.1,
+      "trendingScore": 1719.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -467,30 +491,6 @@
       "matchedTopicLabel": "LLMs"
     },
     {
-      "uri": "at://did:plc:2zcfjzyocp6kapg6jc4eacok/app.bsky.feed.post/3mmfr5iz67c24",
-      "cid": "bafyreigoq74ncuffy6zxa5a2nttdf3otdfx7fynp4gv3fb2tdeowjhhafe",
-      "bskyUrl": "https://bsky.app/profile/andrew.heiss.phd/post/3mmfr5iz67c24",
-      "text": "Finally switched to DuckDuckGo and it’s nice to not have LLM summaries anymore",
-      "author": {
-        "handle": "andrew.heiss.phd",
-        "displayName": "Andrew Heiss"
-      },
-      "likeCount": 988,
-      "repostCount": 98,
-      "replyCount": 63,
-      "createdAt": "2026-05-22T01:16:23.287Z",
-      "createdUtc": 1779412583,
-      "ageHours": 10.75,
-      "trendingScore": 1215.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
-    },
-    {
       "uri": "at://did:plc:n4765ftlk5sxhgd5low6rqbd/app.bsky.feed.post/3mlkbmsmpnk2m",
       "cid": "bafyreibvrps7rnqvjanbcg7sjw6x7icfkeu3jbaqwraledfe3knalalwfe",
       "bskyUrl": "https://bsky.app/profile/unormal.bsky.social/post/3mlkbmsmpnk2m",
@@ -523,13 +523,13 @@
         "handle": "michaelwhelan.bsky.social",
         "displayName": "Michael Whelan"
       },
-      "likeCount": 913,
-      "repostCount": 140,
+      "likeCount": 915,
+      "repostCount": 141,
       "replyCount": 29,
       "createdAt": "2026-05-21T00:02:07.549Z",
       "createdUtc": 1779321727,
-      "ageHours": 35.98,
-      "trendingScore": 1207.5,
+      "ageHours": 39.33,
+      "trendingScore": 1211.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -635,6 +635,30 @@
       "matchedTopicLabel": "Workflow and automation"
     },
     {
+      "uri": "at://did:plc:m4fvxlyv4gqpugzszzp4cjxf/app.bsky.feed.post/3mmcdok6rmk2m",
+      "cid": "bafyreiadpptrfoxwuxwqk6gkof6hohq4ybdyal7mordhrzuzeeci6i53im",
+      "bskyUrl": "https://bsky.app/profile/alexhanna.bsky.social/post/3mmcdok6rmk2m",
+      "text": "Today @dairinstitute.bsky.social is releasing the Luddite Lab Resource Hub. The hub hosts case studies, resources, and political education for unions, labor organizations, and workers who want to fight “AI” and automation at work. labor.dair-institute.org",
+      "author": {
+        "handle": "alexhanna.bsky.social",
+        "displayName": "Alex Hanna"
+      },
+      "likeCount": 398,
+      "repostCount": 238,
+      "replyCount": 3,
+      "createdAt": "2026-05-20T16:37:23.343Z",
+      "createdUtc": 1779295043,
+      "ageHours": 46.75,
+      "trendingScore": 875.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en automation",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:lqanhftsrp5dqwaivexrskwj/app.bsky.feed.post/3mlngjn7aws2q",
       "cid": "bafyreidmbzgkucuukvtwjex6mu4f3dlenfjngcm6v3saex75cnett5ci54",
       "bskyUrl": "https://bsky.app/profile/radiator9987.bsky.social/post/3mlngjn7aws2q",
@@ -681,30 +705,6 @@
       "matchedQuery": "lang:en \"claude code\"",
       "matchedTopicId": "coding-agents",
       "matchedTopicLabel": "Coding agents"
-    },
-    {
-      "uri": "at://did:plc:m4fvxlyv4gqpugzszzp4cjxf/app.bsky.feed.post/3mmcdok6rmk2m",
-      "cid": "bafyreiadpptrfoxwuxwqk6gkof6hohq4ybdyal7mordhrzuzeeci6i53im",
-      "bskyUrl": "https://bsky.app/profile/alexhanna.bsky.social/post/3mmcdok6rmk2m",
-      "text": "Today @dairinstitute.bsky.social is releasing the Luddite Lab Resource Hub. The hub hosts case studies, resources, and political education for unions, labor organizations, and workers who want to fight “AI” and automation at work. labor.dair-institute.org",
-      "author": {
-        "handle": "alexhanna.bsky.social",
-        "displayName": "Alex Hanna"
-      },
-      "likeCount": 380,
-      "repostCount": 227,
-      "replyCount": 3,
-      "createdAt": "2026-05-20T16:37:23.343Z",
-      "createdUtc": 1779295043,
-      "ageHours": 43.4,
-      "trendingScore": 835.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "Workflow and automation",
-      "matchedQuery": "lang:en automation",
-      "matchedTopicId": "workflow",
-      "matchedTopicLabel": "Workflow and automation"
     },
     {
       "uri": "at://did:plc:xbnsfdtxoothg654ujxe3p25/app.bsky.feed.post/3mm2ue7mtg22l",
@@ -888,7 +888,7 @@
       "replyCount": 2,
       "createdAt": "2026-04-21T03:38:29.785Z",
       "createdUtc": 1776742709,
-      "ageHours": 752.38,
+      "ageHours": 755.73,
       "trendingScore": 689,
       "content_tags": [],
       "value_score": 0,
@@ -907,13 +907,13 @@
         "handle": "webdevs.firefox.com",
         "displayName": "Firefox for Web Developers"
       },
-      "likeCount": 410,
+      "likeCount": 412,
       "repostCount": 125,
       "replyCount": 18,
       "createdAt": "2026-05-18T14:35:54.513Z",
       "createdUtc": 1779114954,
-      "ageHours": 93.42,
-      "trendingScore": 669,
+      "ageHours": 96.77,
+      "trendingScore": 671,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -971,6 +971,30 @@
       "matchedTopicLabel": "LLMs"
     },
     {
+      "uri": "at://did:plc:unkqxy3fxjckrxrqstopn3qb/app.bsky.feed.post/3mm2ywogrec2q",
+      "cid": "bafyreifhlvm3kjszlsq74toeu6zbga6tnju4ffwq5rndahvb2y2eux64mm",
+      "bskyUrl": "https://bsky.app/profile/robdenbleyker.com/post/3mm2ywogrec2q",
+      "text": "my grandfather used to roll hotdogs at the gas station before automation replaced him",
+      "author": {
+        "handle": "robdenbleyker.com",
+        "displayName": "Rob DenBleyker"
+      },
+      "likeCount": 545,
+      "repostCount": 34,
+      "replyCount": 9,
+      "createdAt": "2026-05-17T18:36:26.909Z",
+      "createdUtc": 1779042986,
+      "ageHours": 116.76,
+      "trendingScore": 617.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en automation",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:sefgphqp2xqwh2hawaixykwz/app.bsky.feed.post/3ml77wjrngc2l",
       "cid": "bafyreien37eqx6cd3ufq46x6tidd7xru4tdaiannwdcwmwlu5bswh45mby",
       "bskyUrl": "https://bsky.app/profile/esqueer.net/post/3ml77wjrngc2l",
@@ -1019,6 +1043,30 @@
       "matchedTopicLabel": "LLMs"
     },
     {
+      "uri": "at://did:plc:kzsnqhdb3styakbudv3xtq4p/app.bsky.feed.post/3mmg37qoxdk2j",
+      "cid": "bafyreifr4cvj5bzrsdrcsz65v37uktt5j5bikgjzyis43sfd6xujfkedxe",
+      "bskyUrl": "https://bsky.app/profile/mosheroperandi.bsky.social/post/3mmg37qoxdk2j",
+      "text": "Everyone says they want Fully Automated Luxury Gay Space Communism until they learn the Communism will be endless amounts of charts, the Space stuff will be done mostly by robots, the Full Automation will come from AI, and the Gay part will also involve AI making up for the top shortage.",
+      "author": {
+        "handle": "mosheroperandi.bsky.social",
+        "displayName": "Keith"
+      },
+      "likeCount": 465,
+      "repostCount": 64,
+      "replyCount": 14,
+      "createdAt": "2026-05-22T04:16:35.871Z",
+      "createdUtc": 1779423395,
+      "ageHours": 11.09,
+      "trendingScore": 600,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en automation",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:qgz7jtmlddfn3dikhimzlqu5/app.bsky.feed.post/3mkzt5ssyq22g",
       "cid": "bafyreichr25egk35zmdrmzqt2vyru62bpozsburrr3k34mplciwd2c5yta",
       "bskyUrl": "https://bsky.app/profile/kattenbarge.bsky.social/post/3mkzt5ssyq22g",
@@ -1032,7 +1080,7 @@
       "replyCount": 9,
       "createdAt": "2026-05-04T13:55:12.568Z",
       "createdUtc": 1777902912,
-      "ageHours": 430.1,
+      "ageHours": 433.45,
       "trendingScore": 581.5,
       "content_tags": [],
       "value_score": 0,
@@ -1056,7 +1104,7 @@
       "replyCount": 13,
       "createdAt": "2026-05-17T16:42:21.014Z",
       "createdUtc": 1779036141,
-      "ageHours": 115.31,
+      "ageHours": 118.66,
       "trendingScore": 580.5,
       "content_tags": [
         "is-question"
@@ -1077,13 +1125,13 @@
         "handle": "bell.bz",
         "displayName": "Andy Bell"
       },
-      "likeCount": 399,
+      "likeCount": 403,
       "repostCount": 81,
       "replyCount": 10,
       "createdAt": "2026-05-21T06:08:35.631Z",
       "createdUtc": 1779343715,
-      "ageHours": 29.88,
-      "trendingScore": 566,
+      "ageHours": 33.23,
+      "trendingScore": 570,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1143,30 +1191,6 @@
       "matchedTopicLabel": "RAG and retrieval"
     },
     {
-      "uri": "at://did:plc:unkqxy3fxjckrxrqstopn3qb/app.bsky.feed.post/3mm2ywogrec2q",
-      "cid": "bafyreifhlvm3kjszlsq74toeu6zbga6tnju4ffwq5rndahvb2y2eux64mm",
-      "bskyUrl": "https://bsky.app/profile/robdenbleyker.com/post/3mm2ywogrec2q",
-      "text": "my grandfather used to roll hotdogs at the gas station before automation replaced him",
-      "author": {
-        "handle": "robdenbleyker.com",
-        "displayName": "Rob DenBleyker"
-      },
-      "likeCount": 503,
-      "repostCount": 28,
-      "replyCount": 9,
-      "createdAt": "2026-05-17T18:36:26.909Z",
-      "createdUtc": 1779042986,
-      "ageHours": 113.41,
-      "trendingScore": 563.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "Workflow and automation",
-      "matchedQuery": "lang:en automation",
-      "matchedTopicId": "workflow",
-      "matchedTopicLabel": "Workflow and automation"
-    },
-    {
       "uri": "at://did:plc:ddvus7otnqtlh7fdooxm6qat/app.bsky.feed.post/3mmdbpwcjoc2v",
       "cid": "bafyreicz323vmb6ctk6h5sqniz2zxjedoc6v3hlzuylr6noryom3wo5lb4",
       "bskyUrl": "https://bsky.app/profile/maxkennerly.bsky.social/post/3mmdbpwcjoc2v",
@@ -1175,13 +1199,13 @@
         "handle": "maxkennerly.bsky.social",
         "displayName": "Max Kennerly"
       },
-      "likeCount": 470,
+      "likeCount": 471,
       "repostCount": 46,
       "replyCount": 1,
       "createdAt": "2026-05-21T01:34:58.982Z",
       "createdUtc": 1779327298,
-      "ageHours": 34.44,
-      "trendingScore": 562.5,
+      "ageHours": 37.79,
+      "trendingScore": 563.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1204,7 +1228,7 @@
       "replyCount": 39,
       "createdAt": "2026-05-17T21:56:52.568Z",
       "createdUtc": 1779055012,
-      "ageHours": 110.07,
+      "ageHours": 113.42,
       "trendingScore": 550.5,
       "content_tags": [],
       "value_score": 0,
@@ -1300,7 +1324,7 @@
       "replyCount": 7,
       "createdAt": "2026-05-19T18:44:40.122Z",
       "createdUtc": 1779216280,
-      "ageHours": 65.27,
+      "ageHours": 68.62,
       "trendingScore": 519.5,
       "content_tags": [],
       "value_score": 0,
@@ -1333,30 +1357,6 @@
       "matchedQuery": "lang:en llm",
       "matchedTopicId": "llms",
       "matchedTopicLabel": "LLMs"
-    },
-    {
-      "uri": "at://did:plc:o7xt7svg2xtjbb4e2xqahqqc/app.bsky.feed.post/3mlqm5atg3c2v",
-      "cid": "bafyreiclzmkvihbuaudow3xuu6ykl5l76yovpwvyns2ngrxbrsr53qfykm",
-      "bskyUrl": "https://bsky.app/profile/spavel.bsky.social/post/3mlqm5atg3c2v",
-      "text": "I hear a lot of \"we have to design for the agentic web\" from people who have so far failed to design for even the regular web",
-      "author": {
-        "handle": "spavel.bsky.social",
-        "displayName": "Pavel"
-      },
-      "likeCount": 376,
-      "repostCount": 66,
-      "replyCount": 8,
-      "createdAt": "2026-05-13T15:20:51.497Z",
-      "createdUtc": 1778685651,
-      "ageHours": 149.53,
-      "trendingScore": 512,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "AI agents",
-      "matchedQuery": "lang:en agentic",
-      "matchedTopicId": "agents",
-      "matchedTopicLabel": "AI agents"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh Bluesky signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26296299123

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.