### PR TITLE
chore(data): refresh huggingface signals 2026-05-22T15:25:37Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-22T09:52:06.768Z",
+  "ts": "2026-05-22T15:25:37.335Z",
   "count": 1,
-  "durationMs": 6882,
+  "durationMs": 7479,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T09:51:59.887Z",
+  "fetchedAt": "2026-05-22T15:25:29.857Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -40,8 +40,8 @@
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/Lance",
       "downloads": 1001,
-      "likes": 605,
-      "trendingScore": 593,
+      "likes": 620,
+      "trendingScore": 605,
       "pipelineTag": "any-to-any",
       "libraryName": "Lance",
       "tags": [
@@ -259,8 +259,8 @@
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
       "downloads": 564,
-      "likes": 257,
-      "trendingScore": 249,
+      "likes": 262,
+      "trendingScore": 254,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -300,40 +300,12 @@
     },
     {
       "rank": 11,
-      "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 296380,
-      "likes": 255,
-      "trendingScore": 229,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-11T12:57:12.000Z",
-      "lastModified": "2026-05-18T03:25:15.000Z"
-    },
-    {
-      "rank": 12,
       "id": "NemoStation/Marlin-2B",
       "author": "NemoStation",
       "url": "https://huggingface.co/NemoStation/Marlin-2B",
       "downloads": 4002,
-      "likes": 228,
-      "trendingScore": 222,
+      "likes": 241,
+      "trendingScore": 235,
       "pipelineTag": "video-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -362,13 +334,13 @@
       "lastModified": "2026-05-20T07:54:57.000Z"
     },
     {
-      "rank": 13,
+      "rank": 12,
       "id": "sapientinc/HRM-Text-1B",
       "author": "sapientinc",
       "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
       "downloads": 72470,
-      "likes": 221,
-      "trendingScore": 219,
+      "likes": 233,
+      "trendingScore": 231,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -390,6 +362,34 @@
       ],
       "createdAt": "2026-05-17T15:13:02.000Z",
       "lastModified": "2026-05-21T05:57:38.000Z"
+    },
+    {
+      "rank": 13,
+      "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 296380,
+      "likes": 255,
+      "trendingScore": 229,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-11T12:57:12.000Z",
+      "lastModified": "2026-05-18T03:25:15.000Z"
     },
     {
       "rank": 14,
@@ -539,40 +539,12 @@
     },
     {
       "rank": 20,
-      "id": "froggeric/Qwen-Fixed-Chat-Templates",
-      "author": "froggeric",
-      "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
-      "downloads": 0,
-      "likes": 358,
-      "trendingScore": 161,
-      "pipelineTag": null,
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "jinja",
-        "chat-template",
-        "qwen",
-        "qwen3.5",
-        "qwen3.6",
-        "lm-studio",
-        "llama.cpp",
-        "vllm",
-        "tool-calling",
-        "thinking",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T15:28:14.000Z",
-      "lastModified": "2026-05-16T13:44:07.000Z"
-    },
-    {
-      "rank": 21,
       "id": "CohereLabs/command-a-plus-05-2026-w4a4",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
       "downloads": 2127,
-      "likes": 159,
-      "trendingScore": 156,
+      "likes": 167,
+      "trendingScore": 164,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -608,7 +580,35 @@
         "ja"
       ],
       "createdAt": "2026-05-18T04:51:16.000Z",
-      "lastModified": "2026-05-21T17:11:48.000Z"
+      "lastModified": "2026-05-22T14:39:44.000Z"
+    },
+    {
+      "rank": 21,
+      "id": "froggeric/Qwen-Fixed-Chat-Templates",
+      "author": "froggeric",
+      "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
+      "downloads": 0,
+      "likes": 358,
+      "trendingScore": 161,
+      "pipelineTag": null,
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "jinja",
+        "chat-template",
+        "qwen",
+        "qwen3.5",
+        "qwen3.6",
+        "lm-studio",
+        "llama.cpp",
+        "vllm",
+        "tool-calling",
+        "thinking",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T15:28:14.000Z",
+      "lastModified": "2026-05-16T13:44:07.000Z"
     },
     {
       "rank": 22,
@@ -616,8 +616,8 @@
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "downloads": 28599,
-      "likes": 154,
-      "trendingScore": 152,
+      "likes": 157,
+      "trendingScore": 155,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -728,6 +728,51 @@
     },
     {
       "rank": 26,
+      "id": "tencent/Hy-MT2-30B-A3B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
+      "downloads": 224,
+      "likes": 140,
+      "trendingScore": 133,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hy_v3",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T07:43:51.000Z",
+      "lastModified": "2026-05-22T05:15:55.000Z"
+    },
+    {
+      "rank": 27,
       "id": "mistralai/Mistral-Medium-3.5-128B",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B",
@@ -772,7 +817,7 @@
       "lastModified": "2026-05-04T14:16:22.000Z"
     },
     {
-      "rank": 27,
+      "rank": 28,
       "id": "Qwen/Qwen3.6-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
@@ -797,7 +842,7 @@
       "lastModified": "2026-04-24T02:53:42.000Z"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "google/gemma-4-26B-A4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-assistant",
@@ -820,7 +865,7 @@
       "lastModified": "2026-05-11T07:50:08.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -862,7 +907,7 @@
       "lastModified": "2026-05-07T02:39:32.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
@@ -895,7 +940,7 @@
       "lastModified": "2026-04-12T13:42:43.000Z"
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -921,7 +966,7 @@
       "lastModified": "2026-05-06T04:18:09.000Z"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "sensenova/SenseNova-U1-8B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
@@ -949,61 +994,13 @@
       "lastModified": "2026-05-07T08:00:27.000Z"
     },
     {
-      "rank": 33,
-      "id": "jackxinning/Leanly_AI",
-      "author": "jackxinning",
-      "url": "https://huggingface.co/jackxinning/Leanly_AI",
-      "downloads": 10822,
-      "likes": 111,
-      "trendingScore": 99,
-      "pipelineTag": "question-answering",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "medical",
-        "question-answering",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-16T10:43:03.000Z",
-      "lastModified": "2026-05-04T07:50:46.000Z"
-    },
-    {
       "rank": 34,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
-      "downloads": 3819,
-      "likes": 99,
-      "trendingScore": 99,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T13:09:29.000Z",
-      "lastModified": "2026-05-15T10:40:24.000Z"
-    },
-    {
-      "rank": 35,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
       "downloads": 11950,
-      "likes": 100,
-      "trendingScore": 99,
+      "likes": 102,
+      "trendingScore": 101,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1039,10 +1036,58 @@
         "ja"
       ],
       "createdAt": "2026-05-11T12:31:04.000Z",
-      "lastModified": "2026-05-21T17:11:25.000Z"
+      "lastModified": "2026-05-22T14:40:13.000Z"
+    },
+    {
+      "rank": 35,
+      "id": "jackxinning/Leanly_AI",
+      "author": "jackxinning",
+      "url": "https://huggingface.co/jackxinning/Leanly_AI",
+      "downloads": 10822,
+      "likes": 111,
+      "trendingScore": 99,
+      "pipelineTag": "question-answering",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "medical",
+        "question-answering",
+        "en",
+        "zh",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-16T10:43:03.000Z",
+      "lastModified": "2026-05-04T07:50:46.000Z"
     },
     {
       "rank": 36,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+      "downloads": 3819,
+      "likes": 99,
+      "trendingScore": 99,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T13:09:29.000Z",
+      "lastModified": "2026-05-15T10:40:24.000Z"
+    },
+    {
+      "rank": 37,
       "id": "google/gemma-4-31B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B-it",
@@ -1069,7 +1114,7 @@
       "lastModified": "2026-05-07T07:39:17.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "ScenemaAI/scenema-audio",
       "author": "ScenemaAI",
       "url": "https://huggingface.co/ScenemaAI/scenema-audio",
@@ -1108,7 +1153,7 @@
       "lastModified": "2026-05-14T03:19:58.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "microsoft/Fara-7B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Fara-7B",
@@ -1135,7 +1180,7 @@
       "lastModified": "2026-05-19T15:37:05.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -1164,7 +1209,7 @@
       "lastModified": "2026-05-05T12:57:20.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
@@ -1190,7 +1235,7 @@
       "lastModified": "2026-04-25T21:33:07.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "unsloth/Qwen3.6-27B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
@@ -1218,7 +1263,7 @@
       "lastModified": "2026-04-22T16:01:39.000Z"
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "Cactus-Compute/needle",
       "author": "Cactus-Compute",
       "url": "https://huggingface.co/Cactus-Compute/needle",
@@ -1243,7 +1288,7 @@
       "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "internlm/Intern-S2-Preview",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview",
@@ -1265,51 +1310,6 @@
       ],
       "createdAt": "2026-05-15T03:49:25.000Z",
       "lastModified": "2026-05-19T08:01:07.000Z"
-    },
-    {
-      "rank": 44,
-      "id": "tencent/Hy-MT2-30B-A3B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
-      "downloads": 224,
-      "likes": 94,
-      "trendingScore": 89,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hy_v3",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T07:43:51.000Z",
-      "lastModified": "2026-05-22T05:15:55.000Z"
     },
     {
       "rank": 45,
@@ -1848,6 +1848,43 @@
     },
     {
       "rank": 63,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 7576,
+      "likes": 68,
+      "trendingScore": 66,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 64,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1892,7 +1929,7 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 64,
+      "rank": 65,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -1917,43 +1954,6 @@
       ],
       "createdAt": "2026-04-14T04:23:36.000Z",
       "lastModified": "2026-05-12T03:12:21.000Z"
-    },
-    {
-      "rank": 65,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 7576,
-      "likes": 64,
-      "trendingScore": 63,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "image-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
       "rank": 66,
@@ -2055,8 +2055,8 @@
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "downloads": 21448,
-      "likes": 63,
-      "trendingScore": 60,
+      "likes": 64,
+      "trendingScore": 61,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -2286,6 +2286,32 @@
     },
     {
       "rank": 77,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 1992,
+      "likes": 56,
+      "trendingScore": 56,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 78,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2329,7 +2355,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 78,
+      "rank": 79,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -2347,7 +2373,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 79,
+      "rank": 80,
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
@@ -2372,32 +2398,6 @@
       ],
       "createdAt": "2026-05-12T20:19:24.000Z",
       "lastModified": "2026-05-14T02:37:15.000Z"
-    },
-    {
-      "rank": 80,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 1992,
-      "likes": 54,
-      "trendingScore": 54,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
       "rank": 81,
@@ -2533,6 +2533,34 @@
     },
     {
       "rank": 85,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 53,
+      "trendingScore": 52,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
+    },
+    {
+      "rank": 86,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2560,7 +2588,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2594,7 +2622,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2622,34 +2650,6 @@
       ],
       "createdAt": "2026-04-02T22:29:19.000Z",
       "lastModified": "2026-04-06T03:50:35.000Z"
-    },
-    {
-      "rank": 88,
-      "id": "stabilityai/stable-audio-3-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
-      "downloads": 0,
-      "likes": 49,
-      "trendingScore": 49,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
     },
     {
       "rank": 89,
@@ -3136,6 +3136,34 @@
     },
     {
       "rank": 107,
+      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "downloads": 0,
+      "likes": 37,
+      "trendingScore": 36,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "audio-text-to-video",
+        "audio-image-text-to-video",
+        "audio-driven-video-continuation",
+        "transformers",
+        "avatar",
+        "video-generation",
+        "en",
+        "zh",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:05:55.000Z",
+      "lastModified": "2026-05-22T02:58:39.000Z"
+    },
+    {
+      "rank": 108,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -3167,7 +3195,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 108,
+      "rank": 109,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -3190,7 +3218,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 109,
+      "rank": 110,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -3214,7 +3242,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 110,
+      "rank": 111,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
@@ -3243,7 +3271,7 @@
       "lastModified": "2026-05-20T14:30:55.000Z"
     },
     {
-      "rank": 111,
+      "rank": 112,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3275,7 +3303,7 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 112,
+      "rank": 113,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
@@ -3307,7 +3335,7 @@
       "lastModified": "2026-05-21T21:34:50.000Z"
     },
     {
-      "rank": 113,
+      "rank": 114,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -3336,7 +3364,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 114,
+      "rank": 115,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -3360,7 +3388,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 115,
+      "rank": 116,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -3377,7 +3405,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -3401,7 +3429,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3427,7 +3455,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -3443,7 +3471,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 119,
+      "rank": 120,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -3470,7 +3498,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 120,
+      "rank": 121,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -3515,7 +3543,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 121,
+      "rank": 122,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -3560,7 +3588,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 122,
+      "rank": 123,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -3604,7 +3632,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 123,
+      "rank": 124,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3644,7 +3672,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 124,
+      "rank": 125,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -3670,7 +3698,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 125,
+      "rank": 126,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -3689,7 +3717,34 @@
       "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 126,
+      "rank": 127,
+      "id": "stabilityai/stable-audio-3-small-music",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "downloads": 0,
+      "likes": 34,
+      "trendingScore": 33,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-music-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:33.000Z",
+      "lastModified": "2026-05-19T20:02:42.000Z"
+    },
+    {
+      "rank": 128,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -3733,7 +3788,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 127,
+      "rank": 129,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3758,7 +3813,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 128,
+      "rank": 130,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -3803,7 +3858,7 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 129,
+      "rank": 131,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -3836,7 +3891,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 130,
+      "rank": 132,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -3860,7 +3915,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 131,
+      "rank": 133,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -3887,7 +3942,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 132,
+      "rank": 134,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -3929,7 +3984,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 133,
+      "rank": 135,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -3957,7 +4012,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 134,
+      "rank": 136,
       "id": "HuggingFaceBio/Carbon-3B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
@@ -3983,7 +4038,7 @@
       "lastModified": "2026-05-20T13:39:48.000Z"
     },
     {
-      "rank": 135,
+      "rank": 137,
       "id": "ByteDance-Seed/Cola-DLM",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
@@ -4013,35 +4068,30 @@
       "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
-      "rank": 136,
-      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
-      "downloads": 0,
-      "likes": 32,
+      "rank": 138,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 116,
+      "likes": 31,
       "trendingScore": 31,
-      "pipelineTag": null,
+      "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
-        "onnx",
         "safetensors",
-        "audio-text-to-video",
-        "audio-image-text-to-video",
-        "audio-driven-video-continuation",
-        "transformers",
-        "avatar",
-        "video-generation",
+        "text-to-image",
         "en",
-        "zh",
+        "arxiv:2605.21573",
         "license:mit",
+        "diffusers:LensPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-21T09:05:55.000Z",
-      "lastModified": "2026-05-22T02:58:39.000Z"
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
     },
     {
-      "rank": 137,
+      "rank": 139,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4067,7 +4117,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 138,
+      "rank": 140,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4099,7 +4149,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 139,
+      "rank": 141,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4126,7 +4176,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 140,
+      "rank": 142,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -4160,7 +4210,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 141,
+      "rank": 143,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4182,34 +4232,39 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 142,
-      "id": "stabilityai/stable-audio-3-small-music",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
-      "downloads": 0,
-      "likes": 31,
+      "rank": 144,
+      "id": "pyannote/speaker-diarization-3.1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
+      "downloads": 10263344,
+      "likes": 1919,
       "trendingScore": 30,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
       "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-music-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
-        "license:other",
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "license:mit",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-17T01:51:33.000Z",
-      "lastModified": "2026-05-19T20:02:42.000Z"
+      "createdAt": "2023-11-16T08:19:01.000Z",
+      "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 143,
+      "rank": 145,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -4240,7 +4295,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 144,
+      "rank": 146,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -4265,7 +4320,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 145,
+      "rank": 147,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -4288,7 +4343,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 146,
+      "rank": 148,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -4315,7 +4370,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 147,
+      "rank": 149,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -4346,12 +4401,12 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 148,
+      "rank": 150,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
-      "downloads": 4942215,
-      "likes": 5712,
+      "downloads": 5010593,
+      "likes": 5717,
       "trendingScore": 29,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
@@ -4391,7 +4446,7 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 149,
+      "rank": 151,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -4420,7 +4475,7 @@
       "lastModified": "2026-05-16T06:48:11.000Z"
     },
     {
-      "rank": 150,
+      "rank": 152,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -4442,7 +4497,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 151,
+      "rank": 153,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -4479,7 +4534,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 152,
+      "rank": 154,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -4501,7 +4556,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 153,
+      "rank": 155,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -4534,12 +4589,12 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 154,
+      "rank": 156,
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "downloads": 1250,
-      "likes": 29,
+      "likes": 28,
       "trendingScore": 28,
       "pipelineTag": "text-generation",
       "libraryName": "gguf",
@@ -4562,7 +4617,7 @@
       "lastModified": "2026-05-19T21:32:32.000Z"
     },
     {
-      "rank": 155,
+      "rank": 157,
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
@@ -4604,10 +4659,10 @@
         "ja"
       ],
       "createdAt": "2026-05-18T04:50:57.000Z",
-      "lastModified": "2026-05-21T17:10:45.000Z"
+      "lastModified": "2026-05-22T14:40:30.000Z"
     },
     {
-      "rank": 156,
+      "rank": 158,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -4647,7 +4702,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 157,
+      "rank": 159,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -4684,7 +4739,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 158,
+      "rank": 160,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -4727,7 +4782,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 159,
+      "rank": 161,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -4747,7 +4802,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 160,
+      "rank": 162,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -4772,7 +4827,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 161,
+      "rank": 163,
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
@@ -4797,7 +4852,56 @@
       "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 162,
+      "rank": 164,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 8345,
+      "likes": 27,
+      "trendingScore": 27,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
+      "rank": 165,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 1823,
+      "likes": 27,
+      "trendingScore": 27,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-22T05:15:52.000Z"
+    },
+    {
+      "rank": 166,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -4842,7 +4946,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 163,
+      "rank": 167,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -4869,7 +4973,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 164,
+      "rank": 168,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -4914,7 +5018,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 165,
+      "rank": 169,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -4940,7 +5044,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 166,
+      "rank": 170,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -4962,7 +5066,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 167,
+      "rank": 171,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -4978,7 +5082,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 168,
+      "rank": 172,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -5014,7 +5118,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 169,
+      "rank": 173,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -5032,7 +5136,7 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 170,
+      "rank": 174,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -5057,34 +5161,79 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 171,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 8345,
-      "likes": 26,
+      "rank": 175,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2719603,
+      "likes": 2029,
       "trendingScore": 26,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": "mask-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "deploy:azure",
+        "region:us"
       ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 172,
+      "rank": 176,
+      "id": "tencent/Hy-MT2-7B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
+      "downloads": 213,
+      "likes": 26,
+      "trendingScore": 26,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hunyuan_v1_dense",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T14:56:58.000Z",
+      "lastModified": "2026-05-22T05:16:06.000Z"
+    },
+    {
+      "rank": 177,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -5122,7 +5271,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 173,
+      "rank": 178,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -5140,7 +5289,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 174,
+      "rank": 179,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -5166,7 +5315,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 175,
+      "rank": 180,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -5186,7 +5335,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 176,
+      "rank": 181,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -5213,7 +5362,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 177,
+      "rank": 182,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -5239,7 +5388,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 178,
+      "rank": 183,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -5265,7 +5414,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 179,
+      "rank": 184,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -5302,7 +5451,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 180,
+      "rank": 185,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -5318,7 +5467,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 181,
+      "rank": 186,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -5341,7 +5490,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 182,
+      "rank": 187,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -5383,7 +5532,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 183,
+      "rank": 188,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -5422,12 +5571,12 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 184,
+      "rank": 189,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
-      "downloads": 259912583,
-      "likes": 4816,
+      "downloads": 260087615,
+      "likes": 4818,
       "trendingScore": 25,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -5467,111 +5616,7 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 185,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2719603,
-      "likes": 2027,
-      "trendingScore": 25,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
-        "feature-extraction",
-        "sam3",
-        "mask-generation",
-        "en",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 186,
-      "id": "tencent/Hy-MT2-7B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
-      "downloads": 213,
-      "likes": 25,
-      "trendingScore": 25,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hunyuan_v1_dense",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T14:56:58.000Z",
-      "lastModified": "2026-05-22T05:16:06.000Z"
-    },
-    {
-      "rank": 187,
-      "id": "pyannote/speaker-diarization-3.1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 10263344,
-      "likes": 1912,
-      "trendingScore": 25,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-11-16T08:19:01.000Z",
-      "lastModified": "2024-05-10T19:43:23.000Z"
-    },
-    {
-      "rank": 188,
+      "rank": 190,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -5596,14 +5641,72 @@
         "eval-results",
         "text-embeddings-inference",
         "endpoints_compatible",
-        "region:us",
-        "deploy:azure"
+        "deploy:azure",
+        "region:us"
       ],
       "createdAt": "2024-01-27T17:07:29.000Z",
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 189,
+      "rank": 191,
+      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "author": "fal",
+      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "downloads": 46104,
+      "likes": 1328,
+      "trendingScore": 25,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "qwen",
+        "qwen-image-edit",
+        "qwen-image-edit-2511",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "camera-control",
+        "image-editing",
+        "image-to-image",
+        "gaussian-splatting",
+        "fal",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T17:01:15.000Z",
+      "lastModified": "2026-01-07T17:06:01.000Z"
+    },
+    {
+      "rank": 192,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 30,
+      "trendingScore": 25,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-21T14:39:01.000Z"
+    },
+    {
+      "rank": 193,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -5635,7 +5738,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 190,
+      "rank": 194,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -5659,7 +5762,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 191,
+      "rank": 195,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -5686,7 +5789,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 192,
+      "rank": 196,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -5711,7 +5814,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 193,
+      "rank": 197,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -5747,7 +5850,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 194,
+      "rank": 198,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -5763,7 +5866,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 195,
+      "rank": 199,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -5784,39 +5887,57 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 196,
-      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "author": "fal",
-      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "downloads": 46104,
-      "likes": 1326,
+      "rank": 200,
+      "id": "stabilityai/stable-audio-3-small-sfx",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
+      "downloads": 0,
+      "likes": 24,
       "trendingScore": 24,
-      "pipelineTag": "image-to-image",
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-sfx-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:16.000Z",
+      "lastModified": "2026-05-19T20:02:45.000Z"
+    },
+    {
+      "rank": 201,
+      "id": "microsoft/Lens",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 133,
+      "likes": 27,
+      "trendingScore": 24,
+      "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
-        "qwen",
-        "qwen-image-edit",
-        "qwen-image-edit-2511",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "camera-control",
-        "image-editing",
-        "image-to-image",
-        "gaussian-splatting",
-        "fal",
+        "safetensors",
+        "text-to-image",
         "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
         "region:us"
       ],
-      "createdAt": "2026-01-07T17:01:15.000Z",
-      "lastModified": "2026-01-07T17:06:01.000Z"
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
-      "rank": 197,
+      "rank": 202,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -5843,7 +5964,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 198,
+      "rank": 203,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -5872,7 +5993,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 199,
+      "rank": 204,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -5889,7 +6010,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 200,
+      "rank": 205,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -5910,7 +6031,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 201,
+      "rank": 206,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -5931,7 +6052,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 202,
+      "rank": 207,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -5952,7 +6073,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 203,
+      "rank": 208,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -5984,7 +6105,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 204,
+      "rank": 209,
       "id": "oron1208/OOO_Anima",
       "author": "oron1208",
       "url": "https://huggingface.co/oron1208/OOO_Anima",
@@ -6011,7 +6132,7 @@
       "lastModified": "2026-05-21T15:24:20.000Z"
     },
     {
-      "rank": 205,
+      "rank": 210,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
@@ -6037,7 +6158,7 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 206,
+      "rank": 211,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6082,34 +6203,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 207,
-      "id": "stabilityai/stable-audio-3-small-sfx",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
-      "downloads": 0,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-sfx-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:16.000Z",
-      "lastModified": "2026-05-19T20:02:45.000Z"
-    },
-    {
-      "rank": 208,
+      "rank": 212,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6140,55 +6234,31 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 209,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
-      "downloads": 1823,
+      "rank": 213,
+      "id": "LatitudeGames/Equinox-31B",
+      "author": "LatitudeGames",
+      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
+      "downloads": 37,
       "likes": 23,
       "trendingScore": 23,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-22T05:15:52.000Z"
-    },
-    {
-      "rank": 210,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
-      "downloads": 0,
-      "likes": 28,
-      "trendingScore": 23,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
         "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
+        "gemma4",
+        "text adventure",
+        "roleplay",
         "en",
-        "zh",
-        "arxiv:2605.19833",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:finetune:google/gemma-4-31B-it",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-21T14:39:01.000Z"
+      "createdAt": "2026-05-18T15:45:53.000Z",
+      "lastModified": "2026-05-22T04:55:49.000Z"
     },
     {
-      "rank": 211,
+      "rank": 214,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6219,7 +6289,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 212,
+      "rank": 215,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6248,7 +6318,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 213,
+      "rank": 216,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6293,7 +6363,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 214,
+      "rank": 217,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6320,7 +6390,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 215,
+      "rank": 218,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -6346,7 +6416,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 216,
+      "rank": 219,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -6370,7 +6440,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 217,
+      "rank": 220,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -6408,7 +6478,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 218,
+      "rank": 221,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -6425,31 +6495,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 219,
-      "id": "LatitudeGames/Equinox-31B",
-      "author": "LatitudeGames",
-      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
-      "downloads": 37,
-      "likes": 22,
-      "trendingScore": 22,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gemma4",
-        "text adventure",
-        "roleplay",
-        "en",
-        "base_model:google/gemma-4-31B-it",
-        "base_model:finetune:google/gemma-4-31B-it",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:45:53.000Z",
-      "lastModified": "2026-05-22T04:55:49.000Z"
-    },
-    {
-      "rank": 220,
+      "rank": 222,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -6494,7 +6540,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 221,
+      "rank": 223,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -6522,7 +6568,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 222,
+      "rank": 224,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -6558,7 +6604,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 223,
+      "rank": 225,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -6585,7 +6631,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 224,
+      "rank": 226,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -6613,7 +6659,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 225,
+      "rank": 227,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -6641,7 +6687,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 226,
+      "rank": 228,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -6674,7 +6720,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 227,
+      "rank": 229,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -6699,7 +6745,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 228,
+      "rank": 230,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -6736,7 +6782,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 229,
+      "rank": 231,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -6779,7 +6825,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 230,
+      "rank": 232,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -6803,7 +6849,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 231,
+      "rank": 233,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -6827,7 +6873,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 232,
+      "rank": 234,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -6859,7 +6905,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 233,
+      "rank": 235,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -6888,7 +6934,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 234,
+      "rank": 236,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -6919,7 +6965,7 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 235,
+      "rank": 237,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -6937,7 +6983,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 236,
+      "rank": 238,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -6982,7 +7028,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 237,
+      "rank": 239,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -7005,7 +7051,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 238,
+      "rank": 240,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7050,7 +7096,36 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 239,
+      "rank": 241,
+      "id": "openai/gpt-oss-20b",
+      "author": "openai",
+      "url": "https://huggingface.co/openai/gpt-oss-20b",
+      "downloads": 7969576,
+      "likes": 4631,
+      "trendingScore": 20,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gpt_oss",
+        "text-generation",
+        "vllm",
+        "conversational",
+        "arxiv:2508.10925",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "8-bit",
+        "mxfp4",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-08-04T22:33:29.000Z",
+      "lastModified": "2025-08-26T17:25:47.000Z"
+    },
+    {
+      "rank": 242,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -7095,7 +7170,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 240,
+      "rank": 243,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -7128,7 +7203,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 241,
+      "rank": 244,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -7150,7 +7225,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 242,
+      "rank": 245,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -7177,7 +7252,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 243,
+      "rank": 246,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -7193,7 +7268,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 244,
+      "rank": 247,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7210,7 +7285,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 245,
+      "rank": 248,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -7233,7 +7308,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 246,
+      "rank": 249,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -7258,7 +7333,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 247,
+      "rank": 250,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -7294,7 +7369,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 248,
+      "rank": 251,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -7323,7 +7398,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 249,
+      "rank": 252,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -7353,7 +7428,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 250,
+      "rank": 253,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -7398,7 +7473,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 251,
+      "rank": 254,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -7425,7 +7500,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 252,
+      "rank": 255,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -7451,7 +7526,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 253,
+      "rank": 256,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -7479,7 +7554,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 254,
+      "rank": 257,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -7508,7 +7583,100 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 255,
+      "rank": 258,
+      "id": "facebook/sam3.1",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3.1",
+      "downloads": 301519,
+      "likes": 278,
+      "trendingScore": 19,
+      "pipelineTag": "mask-generation",
+      "libraryName": "checkpoint",
+      "tags": [
+        "checkpoint",
+        "sam3_video",
+        "sam3.1",
+        "mask-generation",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T01:25:54.000Z",
+      "lastModified": "2026-03-27T17:40:55.000Z"
+    },
+    {
+      "rank": 259,
+      "id": "Alissonerdx/EditAnything",
+      "author": "Alissonerdx",
+      "url": "https://huggingface.co/Alissonerdx/EditAnything",
+      "downloads": 1945,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "video",
+        "video-editing",
+        "ltx-2.3",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-01T08:12:57.000Z",
+      "lastModified": "2026-05-18T17:56:08.000Z"
+    },
+    {
+      "rank": 260,
+      "id": "Efficient-Large-Model/LongLive-2.0-5B",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
+      "downloads": 0,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "text-to-video",
+        "multi-shot",
+        "video-generation",
+        "diffusion",
+        "long-video",
+        "longlive2",
+        "arxiv:2605.18739",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:10:14.000Z",
+      "lastModified": "2026-05-19T02:54:48.000Z"
+    },
+    {
+      "rank": 261,
+      "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
+      "downloads": 833,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T09:26:32.000Z",
+      "lastModified": "2026-05-22T05:15:40.000Z"
+    },
+    {
+      "rank": 262,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -7530,7 +7698,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 256,
+      "rank": 263,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -7564,7 +7732,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 257,
+      "rank": 264,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -7588,7 +7756,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 258,
+      "rank": 265,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7614,7 +7782,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 259,
+      "rank": 266,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -7636,7 +7804,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 260,
+      "rank": 267,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -7665,7 +7833,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 261,
+      "rank": 268,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -7697,58 +7865,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 262,
-      "id": "openai/gpt-oss-20b",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/gpt-oss-20b",
-      "downloads": 7969576,
-      "likes": 4629,
-      "trendingScore": 18,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gpt_oss",
-        "text-generation",
-        "vllm",
-        "conversational",
-        "arxiv:2508.10925",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "8-bit",
-        "mxfp4",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-08-04T22:33:29.000Z",
-      "lastModified": "2025-08-26T17:25:47.000Z"
-    },
-    {
-      "rank": 263,
-      "id": "facebook/sam3.1",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 294517,
-      "likes": 265,
-      "trendingScore": 18,
-      "pipelineTag": "mask-generation",
-      "libraryName": "checkpoint",
-      "tags": [
-        "checkpoint",
-        "sam3_video",
-        "sam3.1",
-        "mask-generation",
-        "en",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T01:25:54.000Z",
-      "lastModified": "2026-03-27T17:40:55.000Z"
-    },
-    {
-      "rank": 264,
+      "rank": 269,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -7766,7 +7883,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 265,
+      "rank": 270,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -7795,7 +7912,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 266,
+      "rank": 271,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7822,7 +7939,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 267,
+      "rank": 272,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -7840,31 +7957,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 268,
-      "id": "Alissonerdx/EditAnything",
-      "author": "Alissonerdx",
-      "url": "https://huggingface.co/Alissonerdx/EditAnything",
-      "downloads": 1945,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "video",
-        "video-editing",
-        "ltx-2.3",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-01T08:12:57.000Z",
-      "lastModified": "2026-05-18T17:56:08.000Z"
-    },
-    {
-      "rank": 269,
+      "rank": 273,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7893,32 +7986,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 270,
-      "id": "Efficient-Large-Model/LongLive-2.0-5B",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
-      "downloads": 0,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-video",
-      "libraryName": "wan2.2",
-      "tags": [
-        "wan2.2",
-        "text-to-video",
-        "multi-shot",
-        "video-generation",
-        "diffusion",
-        "long-video",
-        "longlive2",
-        "arxiv:2605.18739",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:10:14.000Z",
-      "lastModified": "2026-05-19T02:54:48.000Z"
-    },
-    {
-      "rank": 271,
+      "rank": 274,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -7963,7 +8031,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 272,
+      "rank": 275,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -7992,7 +8060,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 273,
+      "rank": 276,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -8021,7 +8089,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 274,
+      "rank": 277,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -8053,7 +8121,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 275,
+      "rank": 278,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -8083,7 +8151,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 276,
+      "rank": 279,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -8104,7 +8172,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 277,
+      "rank": 280,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -8149,7 +8217,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 278,
+      "rank": 281,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -8178,7 +8246,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 279,
+      "rank": 282,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -8206,7 +8274,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 280,
+      "rank": 283,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -8231,7 +8299,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 281,
+      "rank": 284,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -8254,7 +8322,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 282,
+      "rank": 285,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -8281,7 +8349,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 283,
+      "rank": 286,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -8307,7 +8375,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 284,
+      "rank": 287,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -8336,7 +8404,33 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 285,
+      "rank": 288,
+      "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
+      "downloads": 7438,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:47:29.000Z",
+      "lastModified": "2026-05-19T22:23:34.000Z"
+    },
+    {
+      "rank": 289,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -8361,7 +8455,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 286,
+      "rank": 290,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -8396,7 +8490,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 287,
+      "rank": 291,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -8441,7 +8535,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 288,
+      "rank": 292,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -8468,7 +8562,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 289,
+      "rank": 293,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -8497,7 +8591,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 290,
+      "rank": 294,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -8520,7 +8614,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 291,
+      "rank": 295,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -8564,7 +8658,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 292,
+      "rank": 296,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -8609,7 +8703,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 293,
+      "rank": 297,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -8627,7 +8721,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 294,
+      "rank": 298,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -8672,7 +8766,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 295,
+      "rank": 299,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -8710,7 +8804,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 296,
+      "rank": 300,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -8730,7 +8824,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 297,
+      "rank": 301,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -8763,7 +8857,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 298,
+      "rank": 302,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -8793,7 +8887,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 299,
+      "rank": 303,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -8825,7 +8919,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 300,
+      "rank": 304,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -8850,29 +8944,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 301,
-      "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "downloads": 833,
-      "likes": 16,
-      "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T09:26:32.000Z",
-      "lastModified": "2026-05-22T05:15:40.000Z"
-    },
-    {
-      "rank": 302,
+      "rank": 305,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -8895,7 +8967,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 303,
+      "rank": 306,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -8919,7 +8991,109 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 304,
+      "rank": 307,
+      "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
+      "downloads": 10241,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "dataset:zerofata/Instruct-Anime",
+        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
+        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
+        "base_model:llmfan46/G4-MeroMero-31B-uncensored-heretic",
+        "base_model:quantized:llmfan46/G4-MeroMero-31B-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T23:58:07.000Z",
+      "lastModified": "2026-05-16T21:47:09.000Z"
+    },
+    {
+      "rank": 308,
+      "id": "Qwen/Qwen-Image-Edit-2511",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
+      "downloads": 222219,
+      "likes": 1004,
+      "trendingScore": 16,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2508.02324",
+        "license:apache-2.0",
+        "diffusers:QwenImageEditPlusPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-12-17T05:55:58.000Z",
+      "lastModified": "2025-12-23T13:13:52.000Z"
+    },
+    {
+      "rank": 309,
+      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
+      "downloads": 19699,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T17:45:13.000Z",
+      "lastModified": "2026-05-19T18:52:45.000Z"
+    },
+    {
+      "rank": 310,
+      "id": "tencent/Hy-MT2-7B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
+      "downloads": 4373,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-7B",
+        "base_model:quantized:tencent/Hy-MT2-7B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:31.000Z",
+      "lastModified": "2026-05-22T05:16:12.000Z"
+    },
+    {
+      "rank": 311,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -8946,7 +9120,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 305,
+      "rank": 312,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -8991,7 +9165,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 306,
+      "rank": 313,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -9021,7 +9195,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 307,
+      "rank": 314,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -9051,7 +9225,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 308,
+      "rank": 315,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -9096,7 +9270,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 309,
+      "rank": 316,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -9131,7 +9305,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 310,
+      "rank": 317,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9159,7 +9333,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 311,
+      "rank": 318,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -9188,7 +9362,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 312,
+      "rank": 319,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -9213,7 +9387,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 313,
+      "rank": 320,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -9241,7 +9415,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 314,
+      "rank": 321,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -9269,7 +9443,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 315,
+      "rank": 322,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -9300,7 +9474,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 316,
+      "rank": 323,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -9345,7 +9519,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 317,
+      "rank": 324,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -9377,7 +9551,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 318,
+      "rank": 325,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -9404,7 +9578,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 319,
+      "rank": 326,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -9427,12 +9601,12 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 320,
+      "rank": 327,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
-      "downloads": 2886538,
-      "likes": 372,
+      "downloads": 2912607,
+      "likes": 392,
       "trendingScore": 15,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "pyannote-audio",
@@ -9460,7 +9634,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 321,
+      "rank": 328,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -9487,7 +9661,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 322,
+      "rank": 329,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9506,7 +9680,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 323,
+      "rank": 330,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -9529,7 +9703,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 324,
+      "rank": 331,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -9555,7 +9729,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 325,
+      "rank": 332,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -9585,7 +9759,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 326,
+      "rank": 333,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -9612,37 +9786,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 327,
-      "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
-      "downloads": 10241,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "dataset:zerofata/Instruct-Anime",
-        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
-        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
-        "base_model:llmfan46/G4-MeroMero-31B-uncensored-heretic",
-        "base_model:quantized:llmfan46/G4-MeroMero-31B-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T23:58:07.000Z",
-      "lastModified": "2026-05-16T21:47:09.000Z"
-    },
-    {
-      "rank": 328,
+      "rank": 334,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -9673,7 +9817,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 329,
+      "rank": 335,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -9701,57 +9845,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 330,
-      "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
-      "downloads": 7438,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T21:47:29.000Z",
-      "lastModified": "2026-05-19T22:23:34.000Z"
-    },
-    {
-      "rank": 331,
-      "id": "Qwen/Qwen-Image-Edit-2511",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
-      "downloads": 222219,
-      "likes": 1003,
-      "trendingScore": 15,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "license:apache-2.0",
-        "diffusers:QwenImageEditPlusPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-12-17T05:55:58.000Z",
-      "lastModified": "2025-12-23T13:13:52.000Z"
-    },
-    {
-      "rank": 332,
+      "rank": 336,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -9783,7 +9877,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 333,
+      "rank": 337,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -9815,7 +9909,7 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 334,
+      "rank": 338,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -9841,7 +9935,33 @@
       "lastModified": "2026-05-19T18:52:44.000Z"
     },
     {
-      "rank": 335,
+      "rank": 339,
+      "id": "stabilityai/stable-audio-3-medium-base",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
+      "downloads": 0,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:44:44.000Z",
+      "lastModified": "2026-05-19T20:02:40.000Z"
+    },
+    {
+      "rank": 340,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -9865,7 +9985,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 336,
+      "rank": 341,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -9892,7 +10012,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 337,
+      "rank": 342,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -9920,7 +10040,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 338,
+      "rank": 343,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -9939,7 +10059,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 339,
+      "rank": 344,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -9971,7 +10091,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 340,
+      "rank": 345,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -10000,7 +10120,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 341,
+      "rank": 346,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -10027,7 +10147,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 342,
+      "rank": 347,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -10053,7 +10173,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 343,
+      "rank": 348,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -10084,7 +10204,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 344,
+      "rank": 349,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -10112,12 +10232,12 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 345,
+      "rank": 350,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
-      "downloads": 1160660,
-      "likes": 277,
+      "downloads": 1195884,
+      "likes": 278,
       "trendingScore": 14,
       "pipelineTag": "any-to-any",
       "libraryName": "transformers",
@@ -10135,7 +10255,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 346,
+      "rank": 351,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -10169,7 +10289,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 347,
+      "rank": 352,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -10195,7 +10315,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 348,
+      "rank": 353,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -10237,7 +10357,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 349,
+      "rank": 354,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -10275,7 +10395,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 350,
+      "rank": 355,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -10294,7 +10414,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 351,
+      "rank": 356,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -10314,7 +10434,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 352,
+      "rank": 357,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -10341,7 +10461,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 353,
+      "rank": 358,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -10367,7 +10487,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 354,
+      "rank": 359,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -10392,7 +10512,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 355,
+      "rank": 360,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -10421,7 +10541,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 356,
+      "rank": 361,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -10466,7 +10586,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 357,
+      "rank": 362,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -10493,7 +10613,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 358,
+      "rank": 363,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10538,59 +10658,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 359,
-      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
-      "downloads": 19699,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T17:45:13.000Z",
-      "lastModified": "2026-05-19T18:52:45.000Z"
-    },
-    {
-      "rank": 360,
-      "id": "stabilityai/stable-audio-3-medium-base",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
-      "downloads": 0,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:44:44.000Z",
-      "lastModified": "2026-05-19T20:02:40.000Z"
-    },
-    {
-      "rank": 361,
+      "rank": 364,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -10619,7 +10687,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 362,
+      "rank": 365,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -10664,7 +10732,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 363,
+      "rank": 366,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -10693,7 +10761,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 364,
+      "rank": 367,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -10720,7 +10788,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 365,
+      "rank": 368,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -10747,7 +10815,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 366,
+      "rank": 369,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -10778,7 +10846,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 367,
+      "rank": 370,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -10802,7 +10870,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 368,
+      "rank": 371,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -10847,7 +10915,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 369,
+      "rank": 372,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -10874,7 +10942,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 370,
+      "rank": 373,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -10910,7 +10978,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 371,
+      "rank": 374,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -10941,7 +11009,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 372,
+      "rank": 375,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -10972,7 +11040,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 373,
+      "rank": 376,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -11005,7 +11073,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 374,
+      "rank": 377,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -11034,7 +11102,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 375,
+      "rank": 378,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -11060,7 +11128,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 376,
+      "rank": 379,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -11090,7 +11158,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 377,
+      "rank": 380,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -11108,7 +11176,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 378,
+      "rank": 381,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -11139,7 +11207,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 379,
+      "rank": 382,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -11160,7 +11228,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 380,
+      "rank": 383,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -11180,7 +11248,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 381,
+      "rank": 384,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -11208,7 +11276,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 382,
+      "rank": 385,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -11235,7 +11303,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 383,
+      "rank": 386,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -11265,7 +11333,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 384,
+      "rank": 387,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -11282,7 +11350,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 385,
+      "rank": 388,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -11309,7 +11377,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 386,
+      "rank": 389,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11340,7 +11408,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 387,
+      "rank": 390,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -11368,57 +11436,37 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 388,
-      "id": "tencent/Hy-MT2-7B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 4373,
-      "likes": 13,
+      "rank": 391,
+      "id": "unsloth/Qwen3.5-4B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
+      "downloads": 664906,
+      "likes": 259,
       "trendingScore": 13,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
+        "transformers",
         "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-7B",
-        "base_model:quantized:tencent/Hy-MT2-7B",
+        "unsloth",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:quantized:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-20T06:21:31.000Z",
-      "lastModified": "2026-05-22T05:16:12.000Z"
+      "createdAt": "2026-03-02T05:46:32.000Z",
+      "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 389,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 133,
-      "likes": 16,
-      "trendingScore": 13,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
-    },
-    {
-      "rank": 390,
+      "rank": 392,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
-      "downloads": 7637418,
-      "likes": 2997,
+      "downloads": 7570231,
+      "likes": 3024,
       "trendingScore": 12,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
@@ -11458,7 +11506,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 391,
+      "rank": 393,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -11485,7 +11533,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 392,
+      "rank": 394,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -11513,7 +11561,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 393,
+      "rank": 395,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -11546,7 +11594,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 394,
+      "rank": 396,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -11562,7 +11610,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 395,
+      "rank": 397,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -11585,7 +11633,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 396,
+      "rank": 398,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -11619,7 +11667,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 397,
+      "rank": 399,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -11639,7 +11687,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 398,
+      "rank": 400,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -11674,7 +11722,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 399,
+      "rank": 401,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -11704,7 +11752,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 400,
+      "rank": 402,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -11725,7 +11773,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 401,
+      "rank": 403,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -11754,7 +11802,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 402,
+      "rank": 404,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -11784,7 +11832,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 403,
+      "rank": 405,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -11812,7 +11860,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 404,
+      "rank": 406,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -11841,7 +11889,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 405,
+      "rank": 407,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -11873,7 +11921,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 406,
+      "rank": 408,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -11902,7 +11950,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 407,
+      "rank": 409,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -11937,7 +11985,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 408,
+      "rank": 410,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -11959,7 +12007,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 409,
+      "rank": 411,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -11997,7 +12045,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 410,
+      "rank": 412,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -12036,7 +12084,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 411,
+      "rank": 413,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -12073,7 +12121,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 412,
+      "rank": 414,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -12097,7 +12145,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 413,
+      "rank": 415,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -12115,7 +12163,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 414,
+      "rank": 416,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -12134,7 +12182,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 415,
+      "rank": 417,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -12162,7 +12210,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 416,
+      "rank": 418,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -12203,7 +12251,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 417,
+      "rank": 419,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -12225,7 +12273,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 418,
+      "rank": 420,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -12262,7 +12310,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 419,
+      "rank": 421,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -12292,7 +12340,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 420,
+      "rank": 422,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -12321,7 +12369,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 421,
+      "rank": 423,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -12349,7 +12397,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 422,
+      "rank": 424,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -12389,32 +12437,7 @@
       "lastModified": "2026-05-18T20:11:08.000Z"
     },
     {
-      "rank": 423,
-      "id": "unsloth/Qwen3.5-4B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
-      "downloads": 664906,
-      "likes": 258,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:quantized:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-02T05:46:32.000Z",
-      "lastModified": "2026-03-02T14:08:17.000Z"
-    },
-    {
-      "rank": 424,
+      "rank": 425,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -12432,7 +12455,7 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 425,
+      "rank": 426,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -12475,7 +12498,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 426,
+      "rank": 427,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -12501,7 +12524,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 427,
+      "rank": 428,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12526,7 +12549,48 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 428,
+      "rank": 429,
+      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
+      "author": "NousResearch",
+      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
+      "downloads": 220625,
+      "likes": 435,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "Llama-3",
+        "instruct",
+        "finetune",
+        "chatml",
+        "gpt4",
+        "synthetic data",
+        "distillation",
+        "function calling",
+        "json mode",
+        "axolotl",
+        "roleplaying",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2408.11857",
+        "base_model:meta-llama/Llama-3.1-8B",
+        "base_model:finetune:meta-llama/Llama-3.1-8B",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-07-28T06:00:57.000Z",
+      "lastModified": "2024-09-08T07:39:55.000Z"
+    },
+    {
+      "rank": 430,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -12571,7 +12635,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 429,
+      "rank": 431,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -12613,7 +12677,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 430,
+      "rank": 432,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -12639,7 +12703,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 431,
+      "rank": 433,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -12664,7 +12728,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 432,
+      "rank": 434,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -12681,7 +12745,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 433,
+      "rank": 435,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -12709,7 +12773,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 434,
+      "rank": 436,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -12735,7 +12799,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 435,
+      "rank": 437,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -12762,7 +12826,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 436,
+      "rank": 438,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -12790,7 +12854,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 437,
+      "rank": 439,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -12823,7 +12887,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 438,
+      "rank": 440,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -12857,7 +12921,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 439,
+      "rank": 441,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -12886,7 +12950,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 440,
+      "rank": 442,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -12915,7 +12979,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 441,
+      "rank": 443,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -12948,7 +13012,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 442,
+      "rank": 444,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -12975,7 +13039,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 443,
+      "rank": 445,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -13005,7 +13069,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 444,
+      "rank": 446,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -13028,7 +13092,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 445,
+      "rank": 447,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -13054,7 +13118,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 446,
+      "rank": 448,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -13078,7 +13142,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 447,
+      "rank": 449,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -13105,7 +13169,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 448,
+      "rank": 450,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -13135,7 +13199,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 449,
+      "rank": 451,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -13169,7 +13233,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 450,
+      "rank": 452,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -13185,7 +13249,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 451,
+      "rank": 453,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -13216,7 +13280,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 452,
+      "rank": 454,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -13238,7 +13302,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 453,
+      "rank": 455,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -13258,7 +13322,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 454,
+      "rank": 456,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -13280,7 +13344,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 455,
+      "rank": 457,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -13309,7 +13373,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 456,
+      "rank": 458,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -13334,7 +13398,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 457,
+      "rank": 459,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -13359,7 +13423,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 458,
+      "rank": 460,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -13394,7 +13458,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 459,
+      "rank": 461,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -13418,7 +13482,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 460,
+      "rank": 462,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -13449,12 +13513,12 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 461,
+      "rank": 463,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
-      "downloads": 148442,
-      "likes": 476,
+      "downloads": 150400,
+      "likes": 481,
       "trendingScore": 11,
       "pipelineTag": "image-to-image",
       "libraryName": null,
@@ -13476,7 +13540,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 462,
+      "rank": 464,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -13502,7 +13566,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 463,
+      "rank": 465,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -13532,7 +13596,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 464,
+      "rank": 466,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -13558,7 +13622,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 465,
+      "rank": 467,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -13603,7 +13667,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 466,
+      "rank": 468,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -13630,48 +13694,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 467,
-      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
-      "author": "NousResearch",
-      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 220625,
-      "likes": 434,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "Llama-3",
-        "instruct",
-        "finetune",
-        "chatml",
-        "gpt4",
-        "synthetic data",
-        "distillation",
-        "function calling",
-        "json mode",
-        "axolotl",
-        "roleplaying",
-        "chat",
-        "conversational",
-        "en",
-        "arxiv:2408.11857",
-        "base_model:meta-llama/Llama-3.1-8B",
-        "base_model:finetune:meta-llama/Llama-3.1-8B",
-        "license:llama3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-07-28T06:00:57.000Z",
-      "lastModified": "2024-09-08T07:39:55.000Z"
-    },
-    {
-      "rank": 468,
+      "rank": 469,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -13697,7 +13720,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 469,
+      "rank": 470,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -13730,7 +13753,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 470,
+      "rank": 471,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -13759,7 +13782,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 471,
+      "rank": 472,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -13786,7 +13809,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 472,
+      "rank": 473,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -13831,7 +13854,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 473,
+      "rank": 474,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -13857,7 +13880,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 474,
+      "rank": 475,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -13883,12 +13906,12 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 475,
+      "rank": 476,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
       "downloads": 17502119,
-      "likes": 3254,
+      "likes": 3255,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -13916,30 +13939,117 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 476,
-      "id": "microsoft/Lens-Turbo",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 116,
+      "rank": 477,
+      "id": "GestaltLabs/BusyBeaver-50M",
+      "author": "GestaltLabs",
+      "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
+      "downloads": 307,
       "likes": 11,
       "trendingScore": 11,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
+        "transformers",
         "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
+        "busybeaver_qdelta",
+        "text-generation",
+        "busybeaver",
+        "tool-calling",
+        "agent-policy",
+        "json",
+        "local-agents",
+        "qdelta",
+        "50m",
+        "license:other",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
+      "createdAt": "2026-05-18T14:18:11.000Z",
+      "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 477,
+      "rank": 478,
+      "id": "Wan-AI/Wan2.2-TI2V-5B",
+      "author": "Wan-AI",
+      "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
+      "downloads": 9252,
+      "likes": 605,
+      "trendingScore": 11,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "diffusers",
+        "safetensors",
+        "ti2v",
+        "text-to-video",
+        "en",
+        "zh",
+        "arxiv:2503.20314",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-07-18T09:35:44.000Z",
+      "lastModified": "2025-08-07T10:22:24.000Z"
+    },
+    {
+      "rank": 479,
+      "id": "meta-llama/Llama-3.2-1B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
+      "downloads": 8034700,
+      "likes": 1419,
+      "trendingScore": 11,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:12:47.000Z",
+      "lastModified": "2024-10-24T15:07:51.000Z"
+    },
+    {
+      "rank": 480,
+      "id": "zhen-nan/L2P",
+      "author": "zhen-nan",
+      "url": "https://huggingface.co/zhen-nan/L2P",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "arxiv:2605.12013",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-03T13:24:20.000Z",
+      "lastModified": "2026-05-22T07:53:35.000Z"
+    },
+    {
+      "rank": 481,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -13968,7 +14078,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 478,
+      "rank": 482,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -14002,7 +14112,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 479,
+      "rank": 483,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -14047,7 +14157,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 480,
+      "rank": 484,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -14076,7 +14186,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 481,
+      "rank": 485,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -14101,7 +14211,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 482,
+      "rank": 486,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -14136,7 +14246,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 483,
+      "rank": 487,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -14163,7 +14273,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 484,
+      "rank": 488,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -14208,7 +14318,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 485,
+      "rank": 489,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -14230,7 +14340,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 486,
+      "rank": 490,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -14262,7 +14372,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 487,
+      "rank": 491,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -14287,7 +14397,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 488,
+      "rank": 492,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -14311,7 +14421,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 489,
+      "rank": 493,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -14339,7 +14449,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 490,
+      "rank": 494,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -14382,7 +14492,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 491,
+      "rank": 495,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -14406,7 +14516,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 492,
+      "rank": 496,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -14451,7 +14561,7 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 493,
+      "rank": 497,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -14480,7 +14590,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 494,
+      "rank": 498,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -14512,7 +14622,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 495,
+      "rank": 499,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -14536,7 +14646,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 496,
+      "rank": 500,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -14558,7 +14668,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 497,
+      "rank": 501,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -14583,7 +14693,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 498,
+      "rank": 502,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -14611,7 +14721,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 499,
+      "rank": 503,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -14635,7 +14745,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 500,
+      "rank": 504,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -14662,7 +14772,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 501,
+      "rank": 505,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -14687,7 +14797,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 502,
+      "rank": 506,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -14704,7 +14814,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 503,
+      "rank": 507,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -14728,7 +14838,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 504,
+      "rank": 508,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -14752,7 +14862,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 505,
+      "rank": 509,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -14785,7 +14895,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 506,
+      "rank": 510,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -14819,7 +14929,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 507,
+      "rank": 511,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -14841,7 +14951,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 508,
+      "rank": 512,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -14864,7 +14974,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 509,
+      "rank": 513,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -14884,7 +14994,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 510,
+      "rank": 514,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -14916,7 +15026,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 511,
+      "rank": 515,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -14955,7 +15065,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 512,
+      "rank": 516,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -14989,7 +15099,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 513,
+      "rank": 517,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -15013,7 +15123,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 514,
+      "rank": 518,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -15033,7 +15143,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 515,
+      "rank": 519,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -15062,7 +15172,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 516,
+      "rank": 520,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -15084,7 +15194,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 517,
+      "rank": 521,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -15116,7 +15226,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 518,
+      "rank": 522,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -15143,7 +15253,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 519,
+      "rank": 523,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -15187,7 +15297,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 520,
+      "rank": 524,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -15205,7 +15315,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 521,
+      "rank": 525,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -15244,7 +15354,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 522,
+      "rank": 526,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -15283,7 +15393,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 523,
+      "rank": 527,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -15317,7 +15427,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 524,
+      "rank": 528,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -15345,7 +15455,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 525,
+      "rank": 529,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -15367,7 +15477,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 526,
+      "rank": 530,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -15395,7 +15505,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 527,
+      "rank": 531,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -15413,7 +15523,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 528,
+      "rank": 532,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -15441,12 +15551,12 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 529,
+      "rank": 533,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
-      "downloads": 4552869,
-      "likes": 1540,
+      "downloads": 4571094,
+      "likes": 1542,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -15472,7 +15582,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 530,
+      "rank": 534,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -15488,7 +15598,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 531,
+      "rank": 535,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -15515,7 +15625,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 532,
+      "rank": 536,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -15544,7 +15654,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 533,
+      "rank": 537,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -15572,7 +15682,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 534,
+      "rank": 538,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -15601,36 +15711,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 535,
-      "id": "GestaltLabs/BusyBeaver-50M",
-      "author": "GestaltLabs",
-      "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
-      "downloads": 307,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "busybeaver_qdelta",
-        "text-generation",
-        "busybeaver",
-        "tool-calling",
-        "agent-policy",
-        "json",
-        "local-agents",
-        "qdelta",
-        "50m",
-        "license:other",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T14:18:11.000Z",
-      "lastModified": "2026-05-19T00:07:41.000Z"
-    },
-    {
-      "rank": 536,
+      "rank": 539,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -15651,7 +15732,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 537,
+      "rank": 540,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -15672,70 +15753,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 538,
-      "id": "Wan-AI/Wan2.2-TI2V-5B",
-      "author": "Wan-AI",
-      "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
-      "downloads": 9252,
-      "likes": 603,
-      "trendingScore": 10,
-      "pipelineTag": "text-to-video",
-      "libraryName": "wan2.2",
-      "tags": [
-        "wan2.2",
-        "diffusers",
-        "safetensors",
-        "ti2v",
-        "text-to-video",
-        "en",
-        "zh",
-        "arxiv:2503.20314",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-07-18T09:35:44.000Z",
-      "lastModified": "2025-08-07T10:22:24.000Z"
-    },
-    {
-      "rank": 539,
-      "id": "meta-llama/Llama-3.2-1B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 8034700,
-      "likes": 1418,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:12:47.000Z",
-      "lastModified": "2024-10-24T15:07:51.000Z"
-    },
-    {
-      "rank": 540,
+      "rank": 541,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
@@ -15762,7 +15780,7 @@
       "lastModified": "2026-05-21T02:10:38.000Z"
     },
     {
-      "rank": 541,
+      "rank": 542,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -15807,7 +15825,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 542,
+      "rank": 543,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -15836,7 +15854,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 543,
+      "rank": 544,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -15856,7 +15874,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 544,
+      "rank": 545,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -15888,7 +15906,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 545,
+      "rank": 546,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -15917,7 +15935,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 546,
+      "rank": 547,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -15955,7 +15973,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 547,
+      "rank": 548,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -15985,7 +16003,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 548,
+      "rank": 549,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
@@ -16012,7 +16030,104 @@
       "lastModified": "2026-05-22T04:56:16.000Z"
     },
     {
-      "rank": 549,
+      "rank": 550,
+      "id": "NousResearch/Hermes-4.3-36B",
+      "author": "NousResearch",
+      "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
+      "downloads": 6439,
+      "likes": 209,
+      "trendingScore": 10,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "seed_oss",
+        "text-generation",
+        "Bytedance Seed",
+        "instruct",
+        "finetune",
+        "reasoning",
+        "hybrid-mode",
+        "chatml",
+        "function calling",
+        "tool use",
+        "json mode",
+        "structured outputs",
+        "atropos",
+        "dataforge",
+        "long context",
+        "roleplaying",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2508.18255",
+        "base_model:ByteDance-Seed/Seed-OSS-36B-Base",
+        "base_model:finetune:ByteDance-Seed/Seed-OSS-36B-Base",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-17T19:48:42.000Z",
+      "lastModified": "2025-12-06T15:04:17.000Z"
+    },
+    {
+      "rank": 551,
+      "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
+      "author": "aifeifei798",
+      "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
+      "downloads": 1038,
+      "likes": 32,
+      "trendingScore": 10,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "roleplay",
+        "llama3",
+        "sillytavern",
+        "idol",
+        "en",
+        "arxiv:2403.19522",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-07-21T23:20:43.000Z",
+      "lastModified": "2024-07-23T10:35:13.000Z"
+    },
+    {
+      "rank": 552,
+      "id": "openbmb/BitCPM4-CANN-8B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
+      "downloads": 57,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "minicpm",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T13:10:51.000Z",
+      "lastModified": "2026-05-22T10:05:30.000Z"
+    },
+    {
+      "rank": 553,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -16039,7 +16154,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 550,
+      "rank": 554,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -16065,7 +16180,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 551,
+      "rank": 555,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -16093,7 +16208,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 552,
+      "rank": 556,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -16119,7 +16234,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 553,
+      "rank": 557,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -16163,7 +16278,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 554,
+      "rank": 558,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -16203,7 +16318,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 555,
+      "rank": 559,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -16239,7 +16354,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 556,
+      "rank": 560,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -16283,7 +16398,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 557,
+      "rank": 561,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -16308,7 +16423,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 558,
+      "rank": 562,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -16353,7 +16468,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 559,
+      "rank": 563,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -16372,7 +16487,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 560,
+      "rank": 564,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -16397,7 +16512,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 561,
+      "rank": 565,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -16436,7 +16551,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 562,
+      "rank": 566,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -16453,7 +16568,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 563,
+      "rank": 567,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -16481,7 +16596,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 564,
+      "rank": 568,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -16510,7 +16625,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 565,
+      "rank": 569,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -16535,7 +16650,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 566,
+      "rank": 570,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -16570,7 +16685,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 567,
+      "rank": 571,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -16600,7 +16715,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 568,
+      "rank": 572,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -16636,7 +16751,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 569,
+      "rank": 573,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -16659,7 +16774,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 570,
+      "rank": 574,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -16676,7 +16791,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 571,
+      "rank": 575,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -16696,7 +16811,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 572,
+      "rank": 576,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -16723,7 +16838,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 573,
+      "rank": 577,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -16747,7 +16862,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 574,
+      "rank": 578,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -16769,7 +16884,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 575,
+      "rank": 579,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -16801,7 +16916,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 576,
+      "rank": 580,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -16829,7 +16944,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 577,
+      "rank": 581,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -16847,7 +16962,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 578,
+      "rank": 582,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -16872,7 +16987,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 579,
+      "rank": 583,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -16895,7 +17010,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 580,
+      "rank": 584,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -16913,7 +17028,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 581,
+      "rank": 585,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -16948,7 +17063,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 582,
+      "rank": 586,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -16976,7 +17091,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 583,
+      "rank": 587,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -16998,7 +17113,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 584,
+      "rank": 588,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -17025,7 +17140,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 585,
+      "rank": 589,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -17050,7 +17165,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 586,
+      "rank": 590,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -17084,7 +17199,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 587,
+      "rank": 591,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -17111,7 +17226,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 588,
+      "rank": 592,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -17138,7 +17253,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 589,
+      "rank": 593,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -17179,7 +17294,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 590,
+      "rank": 594,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -17209,7 +17324,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 591,
+      "rank": 595,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -17246,7 +17361,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 592,
+      "rank": 596,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -17278,7 +17393,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 593,
+      "rank": 597,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -17320,7 +17435,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 594,
+      "rank": 598,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -17350,7 +17465,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 595,
+      "rank": 599,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -17395,7 +17510,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 596,
+      "rank": 600,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -17422,7 +17537,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 597,
+      "rank": 601,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -17454,7 +17569,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 598,
+      "rank": 602,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -17488,7 +17603,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 599,
+      "rank": 603,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -17518,7 +17633,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 600,
+      "rank": 604,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -17543,7 +17658,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 601,
+      "rank": 605,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -17570,7 +17685,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 602,
+      "rank": 606,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -17602,7 +17717,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 603,
+      "rank": 607,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -17647,12 +17762,12 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 604,
+      "rank": 608,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
       "downloads": 3252554,
-      "likes": 3145,
+      "likes": 3146,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -17675,7 +17790,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 605,
+      "rank": 609,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -17714,7 +17829,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 606,
+      "rank": 610,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -17740,7 +17855,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 607,
+      "rank": 611,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -17769,7 +17884,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 608,
+      "rank": 612,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -17811,7 +17926,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 609,
+      "rank": 613,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -17839,7 +17954,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 610,
+      "rank": 614,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
@@ -17869,7 +17984,7 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 611,
+      "rank": 615,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -17904,7 +18019,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 612,
+      "rank": 616,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
@@ -17932,79 +18047,7 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 613,
-      "id": "NousResearch/Hermes-4.3-36B",
-      "author": "NousResearch",
-      "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
-      "downloads": 6439,
-      "likes": 207,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "seed_oss",
-        "text-generation",
-        "Bytedance Seed",
-        "instruct",
-        "finetune",
-        "reasoning",
-        "hybrid-mode",
-        "chatml",
-        "function calling",
-        "tool use",
-        "json mode",
-        "structured outputs",
-        "atropos",
-        "dataforge",
-        "long context",
-        "roleplaying",
-        "chat",
-        "conversational",
-        "en",
-        "arxiv:2508.18255",
-        "base_model:ByteDance-Seed/Seed-OSS-36B-Base",
-        "base_model:finetune:ByteDance-Seed/Seed-OSS-36B-Base",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-17T19:48:42.000Z",
-      "lastModified": "2025-12-06T15:04:17.000Z"
-    },
-    {
-      "rank": 614,
-      "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "author": "aifeifei798",
-      "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "downloads": 1038,
-      "likes": 31,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "roleplay",
-        "llama3",
-        "sillytavern",
-        "idol",
-        "en",
-        "arxiv:2403.19522",
-        "license:llama3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-07-21T23:20:43.000Z",
-      "lastModified": "2024-07-23T10:35:13.000Z"
-    },
-    {
-      "rank": 615,
+      "rank": 617,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -18028,7 +18071,141 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 616,
+      "rank": 618,
+      "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
+      "downloads": 411,
+      "likes": 10,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "gemma4",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "dataset:zerofata/Instruct-Anime",
+        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
+        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
+        "base_model:zerofata/G4-MeroMero-31B",
+        "base_model:finetune:zerofata/G4-MeroMero-31B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T22:29:00.000Z",
+      "lastModified": "2026-05-15T23:03:21.000Z"
+    },
+    {
+      "rank": 619,
+      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "author": "dphn",
+      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "downloads": 13224,
+      "likes": 518,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "mistral3",
+        "image-text-to-text",
+        "text-generation",
+        "conversational",
+        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
+        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-06-12T05:29:16.000Z",
+      "lastModified": "2026-04-24T13:52:18.000Z"
+    },
+    {
+      "rank": 620,
+      "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
+      "downloads": 19630,
+      "likes": 31,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3_5",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "image-text-to-text",
+        "base_model:llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2",
+        "base_model:quantized:llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-03-30T16:40:50.000Z",
+      "lastModified": "2026-03-30T22:38:36.000Z"
+    },
+    {
+      "rank": 621,
+      "id": "Qwen/Qwen3-VL-Embedding-8B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
+      "downloads": 1174838,
+      "likes": 413,
+      "trendingScore": 9,
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "transformers",
+        "multimodal embedding",
+        "qwen",
+        "embedding",
+        "sentence-similarity",
+        "arxiv:2601.04720",
+        "base_model:Qwen/Qwen3-VL-8B-Instruct",
+        "base_model:finetune:Qwen/Qwen3-VL-8B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T03:02:55.000Z",
+      "lastModified": "2026-04-16T08:55:18.000Z"
+    },
+    {
+      "rank": 622,
+      "id": "netease-youdao/Confucius4",
+      "author": "netease-youdao",
+      "url": "https://huggingface.co/netease-youdao/Confucius4",
+      "downloads": 100,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T10:13:40.000Z",
+      "lastModified": "2026-05-20T08:42:10.000Z"
+    },
+    {
+      "rank": 623,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -18055,7 +18232,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 617,
+      "rank": 624,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -18079,7 +18256,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 618,
+      "rank": 625,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -18099,7 +18276,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 619,
+      "rank": 626,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -18126,7 +18303,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 620,
+      "rank": 627,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -18145,7 +18322,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 621,
+      "rank": 628,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -18179,7 +18356,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 622,
+      "rank": 629,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -18211,7 +18388,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 623,
+      "rank": 630,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -18233,7 +18410,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 624,
+      "rank": 631,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -18278,7 +18455,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 625,
+      "rank": 632,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -18297,7 +18474,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 626,
+      "rank": 633,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -18331,7 +18508,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 627,
+      "rank": 634,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -18359,7 +18536,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 628,
+      "rank": 635,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -18387,7 +18564,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 629,
+      "rank": 636,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -18410,7 +18587,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 630,
+      "rank": 637,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -18437,7 +18614,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 631,
+      "rank": 638,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -18482,7 +18659,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 632,
+      "rank": 639,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -18518,7 +18695,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 633,
+      "rank": 640,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -18558,7 +18735,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 634,
+      "rank": 641,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -18587,7 +18764,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 635,
+      "rank": 642,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -18615,7 +18792,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 636,
+      "rank": 643,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -18634,7 +18811,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 637,
+      "rank": 644,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -18653,7 +18830,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 638,
+      "rank": 645,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -18685,7 +18862,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 639,
+      "rank": 646,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -18712,7 +18889,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 640,
+      "rank": 647,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -18734,7 +18911,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 641,
+      "rank": 648,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -18752,7 +18929,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 642,
+      "rank": 649,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -18781,7 +18958,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 643,
+      "rank": 650,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -18802,7 +18979,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 644,
+      "rank": 651,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -18830,7 +19007,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 645,
+      "rank": 652,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -18851,7 +19028,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 646,
+      "rank": 653,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -18887,7 +19064,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 647,
+      "rank": 654,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -18932,7 +19109,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 648,
+      "rank": 655,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -18958,7 +19135,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 649,
+      "rank": 656,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -18981,7 +19158,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 650,
+      "rank": 657,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -19006,7 +19183,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 651,
+      "rank": 658,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -19041,7 +19218,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 652,
+      "rank": 659,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -19086,7 +19263,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 653,
+      "rank": 660,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -19113,7 +19290,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 654,
+      "rank": 661,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -19142,7 +19319,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 655,
+      "rank": 662,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -19161,7 +19338,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 656,
+      "rank": 663,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -19182,7 +19359,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 657,
+      "rank": 664,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -19208,7 +19385,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 658,
+      "rank": 665,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -19234,7 +19411,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 659,
+      "rank": 666,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -19271,7 +19448,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 660,
+      "rank": 667,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -19316,7 +19493,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 661,
+      "rank": 668,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -19341,7 +19518,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 662,
+      "rank": 669,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -19358,7 +19535,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 663,
+      "rank": 670,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -19385,7 +19562,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 664,
+      "rank": 671,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -19403,7 +19580,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 665,
+      "rank": 672,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -19428,7 +19605,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 666,
+      "rank": 673,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -19460,7 +19637,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 667,
+      "rank": 674,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -19481,7 +19658,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 668,
+      "rank": 675,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -19500,7 +19677,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 669,
+      "rank": 676,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -19531,7 +19708,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 670,
+      "rank": 677,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -19554,7 +19731,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 671,
+      "rank": 678,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -19571,7 +19748,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 672,
+      "rank": 679,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -19599,7 +19776,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 673,
+      "rank": 680,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -19616,7 +19793,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 674,
+      "rank": 681,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -19652,7 +19829,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 675,
+      "rank": 682,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -19682,36 +19859,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 676,
-      "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
-      "downloads": 411,
-      "likes": 9,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gemma4",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "dataset:zerofata/Instruct-Anime",
-        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
-        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
-        "base_model:zerofata/G4-MeroMero-31B",
-        "base_model:finetune:zerofata/G4-MeroMero-31B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T22:29:00.000Z",
-      "lastModified": "2026-05-15T23:03:21.000Z"
-    },
-    {
-      "rank": 677,
+      "rank": 683,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -19734,7 +19882,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 678,
+      "rank": 684,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -19767,7 +19915,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 679,
+      "rank": 685,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -19798,7 +19946,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 680,
+      "rank": 686,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -19821,7 +19969,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 681,
+      "rank": 687,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -19854,7 +20002,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 682,
+      "rank": 688,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -19877,7 +20025,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 683,
+      "rank": 689,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -19907,7 +20055,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 684,
+      "rank": 690,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -19934,7 +20082,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 685,
+      "rank": 691,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -19963,7 +20111,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 686,
+      "rank": 692,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -19992,7 +20140,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 687,
+      "rank": 693,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -20028,7 +20176,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 688,
+      "rank": 694,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -20051,7 +20199,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 689,
+      "rank": 695,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -20076,34 +20224,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 690,
-      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "author": "dphn",
-      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13224,
-      "likes": 517,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "mistral3",
-        "image-text-to-text",
-        "text-generation",
-        "conversational",
-        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
-        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-06-12T05:29:16.000Z",
-      "lastModified": "2026-04-24T13:52:18.000Z"
-    },
-    {
-      "rank": 691,
+      "rank": 696,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -20133,7 +20254,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 692,
+      "rank": 697,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -20162,37 +20283,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 693,
-      "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
-      "downloads": 19630,
-      "likes": 30,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3_5",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "image-text-to-text",
-        "base_model:llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2",
-        "base_model:quantized:llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-30T16:40:50.000Z",
-      "lastModified": "2026-03-30T22:38:36.000Z"
-    },
-    {
-      "rank": 694,
+      "rank": 698,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -20228,7 +20319,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 695,
+      "rank": 699,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -20265,7 +20356,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 696,
+      "rank": 700,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -20289,7 +20380,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 697,
+      "rank": 701,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -20316,7 +20407,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 698,
+      "rank": 702,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -20349,7 +20440,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 699,
+      "rank": 703,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -20394,7 +20485,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 700,
+      "rank": 704,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -20419,7 +20510,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 701,
+      "rank": 705,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -20444,7 +20535,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 702,
+      "rank": 706,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -20481,7 +20572,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 703,
+      "rank": 707,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -20506,7 +20597,111 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 704,
+      "rank": 708,
+      "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
+      "downloads": 16071,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.5-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T14:30:19.000Z",
+      "lastModified": "2026-05-18T03:22:32.000Z"
+    },
+    {
+      "rank": 709,
+      "id": "meta-llama/Llama-3.3-70B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
+      "downloads": 972996,
+      "likes": 2773,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "de",
+        "arxiv:2204.05149",
+        "base_model:meta-llama/Llama-3.1-70B",
+        "base_model:finetune:meta-llama/Llama-3.1-70B",
+        "license:llama3.3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-11-26T16:08:47.000Z",
+      "lastModified": "2024-12-21T18:28:01.000Z"
+    },
+    {
+      "rank": 710,
+      "id": "meta-llama/Llama-3.2-1B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
+      "downloads": 1962065,
+      "likes": 2393,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:03:14.000Z",
+      "lastModified": "2024-10-24T15:08:03.000Z"
+    },
+    {
+      "rank": 711,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -20532,7 +20727,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 705,
+      "rank": 712,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -20549,7 +20744,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 706,
+      "rank": 713,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -20577,7 +20772,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 707,
+      "rank": 714,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -20612,7 +20807,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 708,
+      "rank": 715,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -20637,7 +20832,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 709,
+      "rank": 716,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -20667,7 +20862,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 710,
+      "rank": 717,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -20696,7 +20891,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 711,
+      "rank": 718,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -20723,7 +20918,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 712,
+      "rank": 719,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -20749,7 +20944,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 713,
+      "rank": 720,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -20780,7 +20975,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 714,
+      "rank": 721,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -20798,7 +20993,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 715,
+      "rank": 722,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -20827,7 +21022,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 716,
+      "rank": 723,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -20850,7 +21045,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 717,
+      "rank": 724,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -20895,7 +21090,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 718,
+      "rank": 725,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -20921,7 +21116,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 719,
+      "rank": 726,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -20949,7 +21144,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 720,
+      "rank": 727,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -20987,7 +21182,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 721,
+      "rank": 728,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -21014,7 +21209,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 722,
+      "rank": 729,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -21040,7 +21235,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 723,
+      "rank": 730,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -21058,7 +21253,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 724,
+      "rank": 731,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -21084,7 +21279,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 725,
+      "rank": 732,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -21108,7 +21303,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 726,
+      "rank": 733,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -21149,7 +21344,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 727,
+      "rank": 734,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -21166,7 +21361,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 728,
+      "rank": 735,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -21199,7 +21394,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 729,
+      "rank": 736,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -21233,7 +21428,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 730,
+      "rank": 737,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -21272,7 +21467,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 731,
+      "rank": 738,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -21302,7 +21497,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 732,
+      "rank": 739,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -21338,7 +21533,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 733,
+      "rank": 740,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -21364,7 +21559,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 734,
+      "rank": 741,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -21400,7 +21595,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 735,
+      "rank": 742,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -21430,7 +21625,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 736,
+      "rank": 743,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -21468,7 +21663,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 737,
+      "rank": 744,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -21503,7 +21698,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 738,
+      "rank": 745,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -21528,7 +21723,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 739,
+      "rank": 746,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -21545,7 +21740,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 740,
+      "rank": 747,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -21587,7 +21782,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 741,
+      "rank": 748,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -21617,7 +21812,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 742,
+      "rank": 749,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -21642,7 +21837,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 743,
+      "rank": 750,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -21670,7 +21865,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 744,
+      "rank": 751,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -21687,7 +21882,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 745,
+      "rank": 752,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -21714,7 +21909,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 746,
+      "rank": 753,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -21757,7 +21952,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 747,
+      "rank": 754,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -21797,7 +21992,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 748,
+      "rank": 755,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -21821,7 +22016,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 749,
+      "rank": 756,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -21850,7 +22045,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 750,
+      "rank": 757,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -21876,7 +22071,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 751,
+      "rank": 758,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -21904,7 +22099,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 752,
+      "rank": 759,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -21943,7 +22138,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 753,
+      "rank": 760,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -21967,7 +22162,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 754,
+      "rank": 761,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -21995,7 +22190,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 755,
+      "rank": 762,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -22027,7 +22222,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 756,
+      "rank": 763,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -22057,7 +22252,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 757,
+      "rank": 764,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -22086,7 +22281,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 758,
+      "rank": 765,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -22119,7 +22314,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 759,
+      "rank": 766,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -22148,7 +22343,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 760,
+      "rank": 767,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -22168,12 +22363,12 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 761,
+      "rank": 768,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
-      "downloads": 215469,
-      "likes": 436,
+      "downloads": 262599,
+      "likes": 445,
       "trendingScore": 7,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -22197,7 +22392,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 762,
+      "rank": 769,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -22221,7 +22416,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 763,
+      "rank": 770,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -22251,7 +22446,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 764,
+      "rank": 771,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -22281,7 +22476,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 765,
+      "rank": 772,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -22299,7 +22494,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 766,
+      "rank": 773,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -22316,7 +22511,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 767,
+      "rank": 774,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -22352,7 +22547,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 768,
+      "rank": 775,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -22383,7 +22578,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 769,
+      "rank": 776,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -22414,7 +22609,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 770,
+      "rank": 777,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -22447,7 +22642,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 771,
+      "rank": 778,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -22475,7 +22670,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 772,
+      "rank": 779,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -22500,7 +22695,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 773,
+      "rank": 780,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -22523,7 +22718,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 774,
+      "rank": 781,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -22551,7 +22746,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 775,
+      "rank": 782,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -22584,7 +22779,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 776,
+      "rank": 783,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -22614,7 +22809,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 777,
+      "rank": 784,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -22649,7 +22844,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 778,
+      "rank": 785,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -22681,7 +22876,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 779,
+      "rank": 786,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -22706,7 +22901,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 780,
+      "rank": 787,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -22729,7 +22924,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 781,
+      "rank": 788,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -22756,7 +22951,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 782,
+      "rank": 789,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -22779,7 +22974,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 783,
+      "rank": 790,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -22824,7 +23019,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 784,
+      "rank": 791,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -22856,7 +23051,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 785,
+      "rank": 792,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -22883,7 +23078,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 786,
+      "rank": 793,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -22909,7 +23104,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 787,
+      "rank": 794,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -22941,7 +23136,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 788,
+      "rank": 795,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -22970,7 +23165,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 789,
+      "rank": 796,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -23002,7 +23197,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 790,
+      "rank": 797,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -23032,7 +23227,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 791,
+      "rank": 798,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -23049,7 +23244,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 792,
+      "rank": 799,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -23069,7 +23264,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 793,
+      "rank": 800,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -23108,7 +23303,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 794,
+      "rank": 801,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -23146,7 +23341,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 795,
+      "rank": 802,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -23174,7 +23369,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 796,
+      "rank": 803,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -23219,12 +23414,12 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 797,
+      "rank": 804,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
-      "downloads": 65958,
-      "likes": 2391,
+      "downloads": 68788,
+      "likes": 2395,
       "trendingScore": 7,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -23243,7 +23438,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 798,
+      "rank": 805,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -23273,7 +23468,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 799,
+      "rank": 806,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -23300,7 +23495,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 800,
+      "rank": 807,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -23326,35 +23521,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 801,
-      "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
-      "downloads": 16071,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.5-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T14:30:19.000Z",
-      "lastModified": "2026-05-18T03:22:32.000Z"
-    },
-    {
-      "rank": 802,
+      "rank": 808,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -23383,7 +23550,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 803,
+      "rank": 809,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -23401,7 +23568,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 804,
+      "rank": 810,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -23421,7 +23588,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 805,
+      "rank": 811,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -23453,7 +23620,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 806,
+      "rank": 812,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -23480,7 +23647,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 807,
+      "rank": 813,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -23496,37 +23663,7 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 808,
-      "id": "Qwen/Qwen3-VL-Embedding-8B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
-      "downloads": 1174838,
-      "likes": 411,
-      "trendingScore": 7,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "transformers",
-        "multimodal embedding",
-        "qwen",
-        "embedding",
-        "sentence-similarity",
-        "arxiv:2601.04720",
-        "base_model:Qwen/Qwen3-VL-8B-Instruct",
-        "base_model:finetune:Qwen/Qwen3-VL-8B-Instruct",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-01-07T03:02:55.000Z",
-      "lastModified": "2026-04-16T08:55:18.000Z"
-    },
-    {
-      "rank": 809,
+      "rank": 814,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -23544,7 +23681,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 810,
+      "rank": 815,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -23571,7 +23708,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 811,
+      "rank": 816,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -23595,7 +23732,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 812,
+      "rank": 817,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -23640,7 +23777,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 813,
+      "rank": 818,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -23671,7 +23808,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 814,
+      "rank": 819,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -23711,7 +23848,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 815,
+      "rank": 820,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -23736,7 +23873,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 816,
+      "rank": 821,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -23767,7 +23904,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 817,
+      "rank": 822,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -23801,7 +23938,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 818,
+      "rank": 823,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -23819,7 +23956,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 819,
+      "rank": 824,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -23864,7 +24001,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 820,
+      "rank": 825,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -23909,7 +24046,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 821,
+      "rank": 826,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -23935,7 +24072,7 @@
       "lastModified": "2026-05-19T18:52:45.000Z"
     },
     {
-      "rank": 822,
+      "rank": 827,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -23960,7 +24097,7 @@
       "lastModified": "2026-05-22T04:33:05.000Z"
     },
     {
-      "rank": 823,
+      "rank": 828,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -23987,46 +24124,7 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 824,
-      "id": "meta-llama/Llama-3.3-70B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
-      "downloads": 972996,
-      "likes": 2772,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "de",
-        "arxiv:2204.05149",
-        "base_model:meta-llama/Llama-3.1-70B",
-        "base_model:finetune:meta-llama/Llama-3.1-70B",
-        "license:llama3.3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-11-26T16:08:47.000Z",
-      "lastModified": "2024-12-21T18:28:01.000Z"
-    },
-    {
-      "rank": 825,
+      "rank": 829,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
@@ -24059,25 +24157,75 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 826,
-      "id": "netease-youdao/Confucius4",
-      "author": "netease-youdao",
-      "url": "https://huggingface.co/netease-youdao/Confucius4",
-      "downloads": 100,
-      "likes": 7,
+      "rank": 830,
+      "id": "ModelsLab/omnivoice-singing",
+      "author": "ModelsLab",
+      "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
+      "downloads": 992,
+      "likes": 22,
       "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "text-to-speech",
+      "libraryName": "transformers",
       "tags": [
+        "transformers",
         "safetensors",
-        "qwen3_5",
+        "omnivoice",
+        "text-to-speech",
+        "tts",
+        "singing",
+        "emotion",
+        "expressive-tts",
+        "multilingual",
+        "voice-cloning",
+        "en",
+        "zh",
+        "ja",
+        "ko",
+        "es",
+        "fr",
+        "de",
+        "it",
+        "ru",
+        "hi",
+        "gu",
+        "base_model:k2-fsa/OmniVoice",
+        "base_model:finetune:k2-fsa/OmniVoice",
+        "license:apache-2.0",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-19T10:13:40.000Z",
-      "lastModified": "2026-05-20T08:42:10.000Z"
+      "createdAt": "2026-04-17T13:11:05.000Z",
+      "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 827,
+      "rank": 831,
+      "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
+      "downloads": 14024,
+      "likes": 9,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-0.8B",
+        "base_model:quantized:Qwen/Qwen3.5-0.8B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T11:24:44.000Z",
+      "lastModified": "2026-05-16T12:38:54.000Z"
+    },
+    {
+      "rank": 832,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -24105,7 +24253,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 828,
+      "rank": 833,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -24138,7 +24286,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 829,
+      "rank": 834,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -24167,7 +24315,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 830,
+      "rank": 835,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -24212,7 +24360,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 831,
+      "rank": 836,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -24241,7 +24389,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 832,
+      "rank": 837,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -24286,7 +24434,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 833,
+      "rank": 838,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -24330,7 +24478,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 834,
+      "rank": 839,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -24356,7 +24504,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 835,
+      "rank": 840,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -24382,7 +24530,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 836,
+      "rank": 841,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -24414,7 +24562,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 837,
+      "rank": 842,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -24437,7 +24585,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 838,
+      "rank": 843,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -24480,7 +24628,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 839,
+      "rank": 844,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -24525,7 +24673,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 840,
+      "rank": 845,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -24570,7 +24718,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 841,
+      "rank": 846,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -24597,7 +24745,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 842,
+      "rank": 847,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -24624,7 +24772,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 843,
+      "rank": 848,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -24649,7 +24797,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 844,
+      "rank": 849,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -24688,7 +24836,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 845,
+      "rank": 850,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -24713,7 +24861,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 846,
+      "rank": 851,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -24741,7 +24889,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 847,
+      "rank": 852,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -24766,7 +24914,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 848,
+      "rank": 853,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -24782,7 +24930,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 849,
+      "rank": 854,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -24809,7 +24957,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 850,
+      "rank": 855,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -24841,7 +24989,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 851,
+      "rank": 856,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -24871,7 +25019,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 852,
+      "rank": 857,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -24903,7 +25051,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 853,
+      "rank": 858,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -24931,7 +25079,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 854,
+      "rank": 859,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -24957,7 +25105,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 855,
+      "rank": 860,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -24982,7 +25130,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 856,
+      "rank": 861,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -25011,7 +25159,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 857,
+      "rank": 862,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -25053,7 +25201,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 858,
+      "rank": 863,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -25080,7 +25228,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 859,
+      "rank": 864,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -25125,7 +25273,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 860,
+      "rank": 865,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -25151,7 +25299,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 861,
+      "rank": 866,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -25171,7 +25319,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 862,
+      "rank": 867,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -25198,7 +25346,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 863,
+      "rank": 868,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -25240,7 +25388,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 864,
+      "rank": 869,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -25267,7 +25415,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 865,
+      "rank": 870,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -25301,7 +25449,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 866,
+      "rank": 871,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -25330,7 +25478,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 867,
+      "rank": 872,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -25357,7 +25505,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 868,
+      "rank": 873,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -25384,7 +25532,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 869,
+      "rank": 874,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -25411,7 +25559,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 870,
+      "rank": 875,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -25439,7 +25587,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 871,
+      "rank": 876,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -25462,7 +25610,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 872,
+      "rank": 877,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -25493,7 +25641,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 873,
+      "rank": 878,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -25538,7 +25686,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 874,
+      "rank": 879,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -25560,7 +25708,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 875,
+      "rank": 880,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -25586,7 +25734,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 876,
+      "rank": 881,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -25612,7 +25760,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 877,
+      "rank": 882,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -25643,7 +25791,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 878,
+      "rank": 883,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -25666,7 +25814,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 879,
+      "rank": 884,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -25696,7 +25844,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 880,
+      "rank": 885,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -25728,7 +25876,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 881,
+      "rank": 886,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -25757,7 +25905,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 882,
+      "rank": 887,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -25789,7 +25937,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 883,
+      "rank": 888,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -25821,7 +25969,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 884,
+      "rank": 889,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -25852,7 +26000,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 885,
+      "rank": 890,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -25883,7 +26031,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 886,
+      "rank": 891,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -25906,7 +26054,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 887,
+      "rank": 892,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -25933,7 +26081,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 888,
+      "rank": 893,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -25978,7 +26126,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 889,
+      "rank": 894,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -25996,7 +26144,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 890,
+      "rank": 895,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -26019,7 +26167,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 891,
+      "rank": 896,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -26049,7 +26197,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 892,
+      "rank": 897,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -26088,7 +26236,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 893,
+      "rank": 898,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -26126,7 +26274,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 894,
+      "rank": 899,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -26171,7 +26319,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 895,
+      "rank": 900,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -26196,7 +26344,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 896,
+      "rank": 901,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -26230,7 +26378,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 897,
+      "rank": 902,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -26255,7 +26403,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 898,
+      "rank": 903,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -26288,7 +26436,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 899,
+      "rank": 904,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -26315,7 +26463,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 900,
+      "rank": 905,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -26345,7 +26493,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 901,
+      "rank": 906,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -26377,7 +26525,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 902,
+      "rank": 907,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -26410,7 +26558,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 903,
+      "rank": 908,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -26428,7 +26576,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 904,
+      "rank": 909,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -26451,7 +26599,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 905,
+      "rank": 910,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -26483,7 +26631,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 906,
+      "rank": 911,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -26528,48 +26676,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 907,
-      "id": "ModelsLab/omnivoice-singing",
-      "author": "ModelsLab",
-      "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
-      "downloads": 992,
-      "likes": 21,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "omnivoice",
-        "text-to-speech",
-        "tts",
-        "singing",
-        "emotion",
-        "expressive-tts",
-        "multilingual",
-        "voice-cloning",
-        "en",
-        "zh",
-        "ja",
-        "ko",
-        "es",
-        "fr",
-        "de",
-        "it",
-        "ru",
-        "hi",
-        "gu",
-        "base_model:k2-fsa/OmniVoice",
-        "base_model:finetune:k2-fsa/OmniVoice",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T13:11:05.000Z",
-      "lastModified": "2026-04-17T13:12:21.000Z"
-    },
-    {
-      "rank": 908,
+      "rank": 912,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -26608,7 +26715,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 909,
+      "rank": 913,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -26635,7 +26742,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 910,
+      "rank": 914,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -26672,7 +26779,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 911,
+      "rank": 915,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -26708,7 +26815,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 912,
+      "rank": 916,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -26726,7 +26833,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 913,
+      "rank": 917,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -26765,7 +26872,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 914,
+      "rank": 918,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -26794,7 +26901,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 915,
+      "rank": 919,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -26821,7 +26928,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 916,
+      "rank": 920,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -26848,7 +26955,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 917,
+      "rank": 921,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -26878,7 +26985,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 918,
+      "rank": 922,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -26905,7 +27012,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 919,
+      "rank": 923,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -26936,7 +27043,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 920,
+      "rank": 924,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -26955,7 +27062,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 921,
+      "rank": 925,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -26982,7 +27089,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 922,
+      "rank": 926,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -27007,7 +27114,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 923,
+      "rank": 927,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -27037,7 +27144,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 924,
+      "rank": 928,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -27059,7 +27166,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 925,
+      "rank": 929,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -27080,7 +27187,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 926,
+      "rank": 930,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -27116,7 +27223,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 927,
+      "rank": 931,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -27139,7 +27246,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 928,
+      "rank": 932,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -27184,12 +27291,12 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 929,
+      "rank": 933,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
-      "downloads": 15362609,
-      "likes": 696,
+      "downloads": 15072960,
+      "likes": 702,
       "trendingScore": 6,
       "pipelineTag": null,
       "libraryName": "ultralytics",
@@ -27206,7 +27313,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 930,
+      "rank": 934,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -27236,7 +27343,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 931,
+      "rank": 935,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -27261,7 +27368,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 932,
+      "rank": 936,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -27294,7 +27401,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 933,
+      "rank": 937,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -27317,7 +27424,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 934,
+      "rank": 938,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -27337,7 +27444,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 935,
+      "rank": 939,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -27382,7 +27489,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 936,
+      "rank": 940,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -27403,7 +27510,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 937,
+      "rank": 941,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -27436,7 +27543,7 @@
       "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 938,
+      "rank": 942,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -27464,7 +27571,7 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 939,
+      "rank": 943,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -27509,7 +27616,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 940,
+      "rank": 944,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -27534,7 +27641,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 941,
+      "rank": 945,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -27562,32 +27669,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 942,
-      "id": "openbmb/BitCPM4-CANN-8B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "minicpm",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T13:10:51.000Z",
-      "lastModified": "2026-05-18T05:58:18.000Z"
-    },
-    {
-      "rank": 943,
+      "rank": 946,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
@@ -27618,7 +27700,7 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 944,
+      "rank": 947,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
@@ -27637,7 +27719,7 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 945,
+      "rank": 948,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -27663,12 +27745,12 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 946,
+      "rank": 949,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
-      "downloads": 2495855,
-      "likes": 407,
+      "downloads": 2338693,
+      "likes": 408,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -27690,7 +27772,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 947,
+      "rank": 950,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
@@ -27722,7 +27804,7 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 948,
+      "rank": 951,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -27740,7 +27822,7 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 949,
+      "rank": 952,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -27763,7 +27845,7 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 950,
+      "rank": 953,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
@@ -27790,7 +27872,7 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 951,
+      "rank": 954,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
@@ -27822,7 +27904,7 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 952,
+      "rank": 955,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
@@ -27840,7 +27922,7 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 953,
+      "rank": 956,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
@@ -27873,7 +27955,7 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 954,
+      "rank": 957,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -27905,34 +27987,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 955,
-      "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
-      "downloads": 11765,
-      "likes": 7,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-0.8B",
-        "base_model:quantized:Qwen/Qwen3.5-0.8B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T11:24:44.000Z",
-      "lastModified": "2026-05-16T12:38:54.000Z"
-    },
-    {
-      "rank": 956,
+      "rank": 958,
       "id": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
       "author": "Ttimofeyka",
       "url": "https://huggingface.co/Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
@@ -27957,7 +28012,7 @@
       "lastModified": "2024-02-10T11:41:00.000Z"
     },
     {
-      "rank": 957,
+      "rank": 959,
       "id": "HuggingFaceTB/SmolLM2-135M-Instruct",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct",
@@ -27988,7 +28043,7 @@
       "lastModified": "2025-09-22T20:43:15.000Z"
     },
     {
-      "rank": 958,
+      "rank": 960,
       "id": "mistralai/Ministral-3-8B-Instruct-2512-GGUF",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF",
@@ -28023,7 +28078,7 @@
       "lastModified": "2026-01-15T11:18:05.000Z"
     },
     {
-      "rank": 959,
+      "rank": 961,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -28068,12 +28123,12 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 960,
+      "rank": 962,
       "id": "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
       "author": "hampsonw",
       "url": "https://huggingface.co/hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
-      "downloads": 12680,
-      "likes": 14,
+      "downloads": 14361,
+      "likes": 15,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -28094,7 +28149,7 @@
       "lastModified": "2026-05-14T19:42:51.000Z"
     },
     {
-      "rank": 961,
+      "rank": 963,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -28133,7 +28188,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 962,
+      "rank": 964,
       "id": "Qwen/QwQ-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/QwQ-32B",
@@ -28164,12 +28219,12 @@
       "lastModified": "2025-03-11T12:15:48.000Z"
     },
     {
-      "rank": 963,
+      "rank": 965,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
       "downloads": 849189,
-      "likes": 1731,
+      "likes": 1730,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -28192,7 +28247,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 964,
+      "rank": 966,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -28208,7 +28263,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 965,
+      "rank": 967,
       "id": "inclusionAI/ARGenSeg-8B",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/ARGenSeg-8B",
@@ -28228,7 +28283,7 @@
       "lastModified": "2026-05-15T02:36:20.000Z"
     },
     {
-      "rank": 966,
+      "rank": 968,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -28254,7 +28309,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 967,
+      "rank": 969,
       "id": "Wan-AI/Wan2.2-Animate-14B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B",
@@ -28278,7 +28333,7 @@
       "lastModified": "2025-11-05T10:15:40.000Z"
     },
     {
-      "rank": 968,
+      "rank": 970,
       "id": "dx8152/LTX2.3-Multifunctional",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/LTX2.3-Multifunctional",
@@ -28299,7 +28354,7 @@
       "lastModified": "2026-04-30T07:06:19.000Z"
     },
     {
-      "rank": 969,
+      "rank": 971,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -28328,7 +28383,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 970,
+      "rank": 972,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
@@ -28356,7 +28411,7 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 971,
+      "rank": 973,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -28374,7 +28429,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 972,
+      "rank": 974,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -28406,7 +28461,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 973,
+      "rank": 975,
       "id": "FINAL-Bench/Darwin-2B-Opus-LoRA",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-2B-Opus-LoRA",
@@ -28432,7 +28487,7 @@
       "lastModified": "2026-05-15T02:29:20.000Z"
     },
     {
-      "rank": 974,
+      "rank": 976,
       "id": "FINAL-Bench/Darwin-28B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Opus",
@@ -28477,7 +28532,7 @@
       "lastModified": "2026-05-15T02:27:32.000Z"
     },
     {
-      "rank": 975,
+      "rank": 977,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -28510,44 +28565,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 976,
-      "id": "meta-llama/Llama-3.2-1B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
-      "downloads": 1962065,
-      "likes": 2391,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:03:14.000Z",
-      "lastModified": "2024-10-24T15:08:03.000Z"
-    },
-    {
-      "rank": 977,
+      "rank": 978,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
@@ -28573,7 +28591,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 978,
+      "rank": 979,
       "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
       "author": "Baraje",
       "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
@@ -28596,7 +28614,7 @@
       "lastModified": "2026-04-22T06:19:53.000Z"
     },
     {
-      "rank": 979,
+      "rank": 980,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
@@ -28631,7 +28649,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 980,
+      "rank": 981,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -28656,7 +28674,7 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 981,
+      "rank": 982,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
@@ -28676,7 +28694,7 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 982,
+      "rank": 983,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
@@ -28713,7 +28731,7 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 983,
+      "rank": 984,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -28735,7 +28753,7 @@
       "lastModified": "2026-05-22T05:15:45.000Z"
     },
     {
-      "rank": 984,
+      "rank": 985,
       "id": "google/gemma-2-2b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-2-2b-it",
@@ -28780,7 +28798,7 @@
       "lastModified": "2024-08-27T19:41:44.000Z"
     },
     {
-      "rank": 985,
+      "rank": 986,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
@@ -28802,7 +28820,185 @@
       "lastModified": "2026-05-22T05:16:00.000Z"
     },
     {
-      "rank": 986,
+      "rank": 987,
+      "id": "Qwen/Qwen2.5-3B-Instruct",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
+      "downloads": 10075457,
+      "likes": 463,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2407.10671",
+        "base_model:Qwen/Qwen2.5-3B",
+        "base_model:finetune:Qwen/Qwen2.5-3B",
+        "license:other",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-09-17T14:08:52.000Z",
+      "lastModified": "2024-09-25T12:33:00.000Z"
+    },
+    {
+      "rank": 988,
+      "id": "zemelee/qwen2.5-jailbreak",
+      "author": "zemelee",
+      "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
+      "downloads": 406,
+      "likes": 18,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "base_model:Qwen/Qwen2.5-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-05-08T06:14:45.000Z",
+      "lastModified": "2025-05-08T06:56:32.000Z"
+    },
+    {
+      "rank": 989,
+      "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
+      "author": "Fortytwo-Network",
+      "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
+      "downloads": 514,
+      "likes": 176,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "dataset:Fortytwo-Network/Strandset-Rust-v1",
+        "arxiv:2510.24801",
+        "arxiv:2409.08386",
+        "base_model:Qwen/Qwen2.5-Coder-14B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-Coder-14B-Instruct",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-09-29T06:09:17.000Z",
+      "lastModified": "2026-01-05T17:19:35.000Z"
+    },
+    {
+      "rank": 990,
+      "id": "facebook/lagernvs_general_512",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/lagernvs_general_512",
+      "downloads": 1884,
+      "likes": 25,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": "lagernvs",
+      "tags": [
+        "lagernvs",
+        "meta-ai",
+        "facebook",
+        "meta-pytorch",
+        "en",
+        "arxiv:2603.20176",
+        "license:fair-noncommercial-research-license",
+        "region:us"
+      ],
+      "createdAt": "2026-03-05T11:15:51.000Z",
+      "lastModified": "2026-05-21T15:22:11.000Z"
+    },
+    {
+      "rank": 991,
+      "id": "Emanon14/Nameless-Anima",
+      "author": "Emanon14",
+      "url": "https://huggingface.co/Emanon14/Nameless-Anima",
+      "downloads": 0,
+      "likes": 15,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "text-to-image",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T06:02:43.000Z",
+      "lastModified": "2026-05-17T04:01:50.000Z"
+    },
+    {
+      "rank": 992,
+      "id": "microsoft/Lens-Base",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Base",
+      "downloads": 71,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:08:02.000Z",
+      "lastModified": "2026-05-22T03:10:01.000Z"
+    },
+    {
+      "rank": 993,
+      "id": "openbmb/BitCPM4-CANN-3B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-3B",
+      "downloads": 37,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "llama",
+        "text-generation",
+        "conversational",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T13:10:02.000Z",
+      "lastModified": "2026-05-22T10:04:55.000Z"
+    },
+    {
+      "rank": 994,
       "id": "mistralai/Mistral-7B-v0.1",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
@@ -28829,7 +29025,7 @@
       "lastModified": "2025-07-24T16:44:02.000Z"
     },
     {
-      "rank": 987,
+      "rank": 995,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
@@ -28865,7 +29061,7 @@
       "lastModified": "2025-01-12T02:02:22.000Z"
     },
     {
-      "rank": 988,
+      "rank": 996,
       "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
@@ -28910,7 +29106,7 @@
       "lastModified": "2026-04-28T07:33:29.000Z"
     },
     {
-      "rank": 989,
+      "rank": 997,
       "id": "google/gemma-3-27b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-27b-it",
@@ -28955,7 +29151,7 @@
       "lastModified": "2025-03-21T20:29:02.000Z"
     },
     {
-      "rank": 990,
+      "rank": 998,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
@@ -28990,7 +29186,7 @@
       "lastModified": "2026-04-06T18:53:24.000Z"
     },
     {
-      "rank": 991,
+      "rank": 999,
       "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
@@ -29016,7 +29212,7 @@
       "lastModified": "2026-04-05T19:01:08.000Z"
     },
     {
-      "rank": 992,
+      "rank": 1000,
       "id": "jeremyhola/LORAs",
       "author": "jeremyhola",
       "url": "https://huggingface.co/jeremyhola/LORAs",
@@ -29040,212 +29236,6 @@
       ],
       "createdAt": "2026-01-31T20:02:29.000Z",
       "lastModified": "2026-05-06T20:09:03.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "TheDrummer/Skyfall-31B-v4.2",
-      "author": "TheDrummer",
-      "url": "https://huggingface.co/TheDrummer/Skyfall-31B-v4.2",
-      "downloads": 2364,
-      "likes": 47,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "mistral",
-        "base_model:mistralai/Magistral-Small-2509",
-        "base_model:finetune:mistralai/Magistral-Small-2509",
-        "region:us"
-      ],
-      "createdAt": "2026-02-13T06:15:09.000Z",
-      "lastModified": "2026-04-03T20:52:19.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "LiquidAI/LFM2-24B-A2B-GGUF",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B-GGUF",
-      "downloads": 25739,
-      "likes": 130,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "liquid",
-        "lfm2",
-        "edge",
-        "moe",
-        "llama.cpp",
-        "text-generation",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "pt",
-        "base_model:LiquidAI/LFM2-24B-A2B",
-        "base_model:quantized:LiquidAI/LFM2-24B-A2B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-02-17T12:53:20.000Z",
-      "lastModified": "2026-03-30T12:54:26.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "nvidia/GR00T-N1.7-3B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/GR00T-N1.7-3B",
-      "downloads": 17367,
-      "likes": 27,
-      "trendingScore": 5,
-      "pipelineTag": "robotics",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "Gr00tN1d7",
-        "robotics",
-        "arxiv:2503.14734",
-        "region:us"
-      ],
-      "createdAt": "2026-02-25T00:39:18.000Z",
-      "lastModified": "2026-04-23T19:09:30.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "Aratako/Irodori-TTS-500M",
-      "author": "Aratako",
-      "url": "https://huggingface.co/Aratako/Irodori-TTS-500M",
-      "downloads": 0,
-      "likes": 91,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "speech",
-        "voice",
-        "tts",
-        "text-to-speech",
-        "ja",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-02-25T14:13:53.000Z",
-      "lastModified": "2026-03-18T11:03:56.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "Qwen/Qwen3.5-0.8B-Base",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B-Base",
-      "downloads": 153938,
-      "likes": 75,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-02-28T23:57:45.000Z",
-      "lastModified": "2026-04-23T11:14:09.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "z-lab/Qwen3.5-9B-DFlash",
-      "author": "z-lab",
-      "url": "https://huggingface.co/z-lab/Qwen3.5-9B-DFlash",
-      "downloads": 11612,
-      "likes": 32,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "feature-extraction",
-        "dflash",
-        "speculative-decoding",
-        "block-diffusion",
-        "draft-model",
-        "efficiency",
-        "qwen",
-        "diffusion-language-model",
-        "text-generation",
-        "custom_code",
-        "arxiv:2602.06036",
-        "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-05T19:33:23.000Z",
-      "lastModified": "2026-04-07T14:29:47.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "Winnougan/Must_Have_Klein_9b_loras",
-      "author": "Winnougan",
-      "url": "https://huggingface.co/Winnougan/Must_Have_Klein_9b_loras",
-      "downloads": 0,
-      "likes": 19,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "lora",
-        "flux",
-        "klein-9b",
-        "text-to-image",
-        "comfyui",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-24T12:28:58.000Z",
-      "lastModified": "2026-03-26T22:03:08.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
-      "author": "TrevorJS",
-      "url": "https://huggingface.co/TrevorJS/gemma-4-26B-A4B-it-uncensored-GGUF",
-      "downloads": 81741,
-      "likes": 56,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "abliteration",
-        "uncensored",
-        "gemma-4",
-        "text-generation",
-        "en",
-        "base_model:TrevorJS/gemma-4-26B-A4B-it-uncensored",
-        "base_model:quantized:TrevorJS/gemma-4-26B-A4B-it-uncensored",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-04T15:40:43.000Z",
-      "lastModified": "2026-04-05T16:05:28.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26296464318

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.