### PR TITLE
fix(ci): unstick 3 zero-pass workflows (huggingface-avatars exclude + warmup artifact glob)

### DIFF
--- a/.github/workflows/cron-warmup.yml
+++ b/.github/workflows/cron-warmup.yml
@@ -67,7 +67,16 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: warmup-probes-${{ strategy.job-index }}
-          path: .perf/probe*.json
+          # upload-artifact@v7 has been intermittently failing to resolve
+          # `path: .perf/probe*.json` on this self-hosted runner ("No files
+          # were found with the provided path") even when the previous step
+          # writes + cats the file successfully. Uploading the whole
+          # directory bypasses the glob expansion path entirely. Each matrix
+          # job only writes one probe file so the artifact stays single-file.
+          # `if-no-files-found: error` makes a future regression loud at
+          # upload time instead of silently breaking the summarize job.
+          path: .perf/
+          if-no-files-found: error
           retention-days: 14
 
   summarize:

--- a/scripts/audit-freshness.mjs
+++ b/scripts/audit-freshness.mjs
@@ -53,6 +53,16 @@ const REQUIRED_SOURCES = new Set([
   "trending",
 ]);
 
+// Files under data/_meta/ that are NOT scraped-source freshness sidecars
+// and must be skipped by the audit. These are cache/lookup files imported
+// by app code that happen to live in data/_meta/ for historical reasons.
+//   - huggingface-avatars.json: HF org/user -> CDN avatar URL map, statically
+//     imported by src/lib/logos.ts. Has no producer in the cron fleet and
+//     no ts/writtenAt field, so it tripped the gate every run as "missing ts".
+const IGNORED_SOURCES = new Set([
+  "huggingface-avatars",
+]);
+
 // Default budget for any source not in DEFAULT_BUDGETS_MS. Generous so
 // adding a new collector doesn't immediately fail the gate before its
 // cadence stabilizes.
@@ -124,6 +134,7 @@ async function main() {
 
   for (const file of metaFiles) {
     const source = file.replace(/\.json$/, "");
+    if (IGNORED_SOURCES.has(source)) continue;
     seen.add(source);
     const meta = await loadMeta(file);
     if (meta?.__error) {

--- a/scripts/check-source-health.mjs
+++ b/scripts/check-source-health.mjs
@@ -55,6 +55,16 @@ const STALENESS_HOURS = {
 };
 const DEFAULT_STALENESS_HOURS = 24;
 
+// Files under data/_meta/ that are NOT scraped-source freshness sidecars
+// and must be skipped by the watcher. These are cache/lookup files imported
+// by app code that happen to live in data/_meta/ for historical reasons.
+//   - huggingface-avatars.json: HF org/user -> CDN avatar URL map, statically
+//     imported by src/lib/logos.ts. Has no producer and no `reason` / `ts`
+//     fields, so it always tripped the watcher as a FAIL ("undefined").
+const IGNORED_SOURCES = new Set([
+  "huggingface-avatars",
+]);
+
 function fmtAge(hours) {
   if (!Number.isFinite(hours)) return "?";
   if (hours < 1) return `${Math.round(hours * 60)}m`;
@@ -79,6 +89,7 @@ async function main() {
   const reports = [];
   for (const file of entries.filter((f) => f.endsWith(".json"))) {
     const source = file.replace(/\.json$/, "");
+    if (IGNORED_SOURCES.has(source)) continue;
     const path = resolve(META_DIR, file);
 
     let meta;


### PR DESCRIPTION
## Summary

Audits the 5 zero-pass workflows flagged in [MIRKO-PUNCH-LIST-2026-05-22.md](https://github.com/0motionguy/starscreener) (P1 row \"6 zero-pass workflows in starscreener\"). 3 are fixable in-repo, 2 are upstream/Mirko-side.

**Fixed in this PR:**
- **Source health watch** + **Audit - source freshness** — both treated `data/_meta/huggingface-avatars.json` (an avatar lookup map statically imported by `src/lib/logos.ts`, NOT a scraped source) as a hard FAIL because it has no `ts` / `reason` field. Added an `IGNORED_SOURCES` denylist to both `scripts/audit-freshness.mjs` and `scripts/check-source-health.mjs`.
- **Warm Vercel routes** — all 25 matrix `warmup` jobs were emitting `\"No files were found with the provided path: .perf/probe*.json\"` despite the previous step's `cat` printing the JSON, so the `summarize` job downloaded zero artifacts and exited 1. Switched the upload path from the `.perf/probe*.json` glob to the `.perf/` directory and added `if-no-files-found: error` to make future regressions loud.

**NOT fixed (out of scope / Mirko-side):**
- **Uptime monitor (every 5 minutes)** — `agnt-api-railway` upstream returns 500 (real upstream outage, not a workflow bug — job is correctly red and the alert is functioning as designed). See workflow YAML's positive-control comment.
- **Cron - pipeline ingest** — backend returns HTTP 524 from CF tunnel on `/api/pipeline/ingest` (real backend timeout, not a workflow bug — needs backend perf work). The workflow already has the 2-phase split + 330s `--max-time` headroom, so the fix has to land in `apps/web/src/api/pipeline/ingest`.

**Mirko-side punchlist items uncovered:**
After this PR ships, the Source health watch + Audit workflows will still fail on 3 genuinely-stale collectors:
- `funding-news` — 4.5d stale (collector likely broken, was last green 2026-05-18)
- `npm` — 7.4d stale (collector likely broken, was last green 2026-05-15)
- `twitter` — 18.3d stale, `empty_results` — Apify `apidojo~tweet-scraper` is the documented post-2026 single point of failure (see `audit-freshness.mjs` docstring + project memory note about cookie-based providers being dead)

These need separate investigation (deferred per `MIRKO-PUNCH-LIST-2026-05-22.md` \"Trendingrepo signal gaps (deferred — needs new scanner code or upstream investigation)\" row in §P2). After this PR the workflows continue failing on REAL signals instead of phantom noise.

## Verified locally

\`\`\`
$ node scripts/audit-freshness.mjs
FAIL — 3 violation(s):
  - funding-news: STALE — age=4.5d budget=1.0d
  - npm: STALE — age=7.4d budget=1.0d
  - twitter: STALE — age=18.3d budget=12.0h

$ node scripts/check-source-health.mjs
[health-watch] 3 source(s) unhealthy of 19 checked. Failing workflow.
\`\`\`

Before this PR: 4 unhealthy of 20 (the 4th being phantom `huggingface-avatars`).

## Test plan

- [ ] Wait for next scheduled fire of \"Source health watch\" (`*/30 * * * *`) — still fails (correctly) on funding-news + npm + twitter, no longer mentions `huggingface-avatars`.
- [ ] Wait for next scheduled fire of \"Audit - source freshness\" (hourly on `:00`) — same, but with the freshness-budget output table.
- [ ] Wait for next scheduled fire of \"Warm Vercel routes\" (every 5 min in 08-21 UTC) — all 25 warmup jobs green + summarize job downloads + merges 25 artifacts + uploads `cron-warmup-summary` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)