### PR TITLE
chore(data): refresh lobsters signals 2026-05-22T16:04:56Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-22T12:41:58.040Z",
+  "ts": "2026-05-22T16:04:56.515Z",
   "count": 1,
-  "durationMs": 3531,
+  "durationMs": 4596,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T12:41:54.531Z",
+  "fetchedAt": "2026-05-22T16:04:51.939Z",
   "windowDays": 7,
   "scannedStories": 77,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T12:41:54.531Z",
+  "fetchedAt": "2026-05-22T16:04:51.939Z",
   "windowHours": 72,
   "scannedTotal": 77,
   "stories": [
@@ -447,6 +447,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "1acyon",
+      "title": "A Forth-inspired language for writing websites",
+      "url": "https://robida.net/entries/2026/05/21/a-forth-inspired-language-for-writing-websites",
+      "commentsUrl": "https://lobste.rs/s/1acyon/forth_inspired_language_for_writing",
+      "by": "",
+      "score": 20,
+      "commentCount": 4,
+      "createdUtc": 1779450466,
+      "ageHours": 4.284722222222222,
+      "trendingScore": 1.269406930280126,
+      "tags": [
+        "concatenative",
+        "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "ynxkj6",
       "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
       "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
@@ -876,25 +894,6 @@
       "trendingScore": 0.9406308156098016,
       "tags": [
         "browsers"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "9hiu10",
-      "title": "Bun's problem may be developing in the open",
-      "url": "https://00f.net/2026/05/17/developping-in-the-open/",
-      "commentsUrl": "https://lobste.rs/s/9hiu10/bun_s_problem_may_be_developing_open",
-      "by": "",
-      "score": 11,
-      "commentCount": 8,
-      "createdUtc": 1779035867,
-      "ageHours": 3.1533333333333333,
-      "trendingScore": 0.9402867858319629,
-      "tags": [
-        "practices",
-        "rust",
-        "zig"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26298413116

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.