### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-22T17:19:50Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-22T13:37:05.680Z",
+  "ts": "2026-05-22T17:19:50.570Z",
   "count": 1,
-  "durationMs": 12189,
+  "durationMs": 15807,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-22T13:37:03.481Z",
+  "lastFetchedAt": "2026-05-22T17:19:47.756Z",
   "windowDays": 7,
   "launches": [
     {
@@ -977,6 +977,59 @@
       "aiAdjacent": true
     },
     {
+      "id": "1144878",
+      "name": "TestSprite 3.0",
+      "tagline": "Let a fleet of parallel agents test your app in minutes",
+      "description": "TestSprite generates and runs end-to-end tests for your app, autonomously. For backend, we can now generate complex integration tests with dynamic variables, auto-cleanup, and Data Flow debugging. For frontend, we now send a fleet of parallel AI agents to explore your app first — clicking through every feature like real users, then feeding results into testing. We're the first to do this. 3.0 also adds auto-heal for UI drift, auto-auth for regression, and a CLI for Claude Code, Codex users.",
+      "url": "https://www.producthunt.com/products/testsprite?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/DP36SVO3Y3LMV7",
+      "votesCount": 294,
+      "commentsCount": 56,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/50434618-8b14-40d7-9958-db6ef9c84ccb.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "942860",
       "name": "SUN-to-Spotify ",
       "tagline": "Generate audio with SUN and send it to your Spotify library",
@@ -1623,6 +1676,42 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152537",
+      "name": "Cleo",
+      "tagline": "The AI PM that runs your team",
+      "description": "Cleo is the AI product manager for founders and lean teams. It lives in Telegram and Slack - learns your tone, knows your team, and runs the PM work (standups, follow-ups, decisions) while you ship the product. What's different: every fact Cleo learns is transparent - you see the source, the confidence, and can confirm or correct it. No black-box memory. Five trust levels, from observer to operator. Free in Telegram. 1 min setup",
+      "url": "https://www.producthunt.com/products/cleo-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/UEIFHO7XED74LR",
+      "votesCount": 246,
+      "commentsCount": 51,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/5edce491-25ca-4a4e-ac6b-0521e5c83e07.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence",
+        "alpha"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1151355",
       "name": "Google Antigravity 2.0",
       "tagline": "Orchestrate multi-agent workflows from a desktop app",
@@ -1917,46 +2006,22 @@
       "aiAdjacent": false
     },
     {
-      "id": "1144878",
-      "name": "TestSprite 3.0",
-      "tagline": "Let a fleet of parallel agents test your app in minutes.",
-      "description": "TestSprite generates and runs end-to-end tests for your app, autonomously. For backend, we can now generate complex integration tests with dynamic variables, auto-cleanup, and Data Flow debugging. For frontend, we now send a fleet of parallel AI agents to explore your app first — clicking through every feature like real users, then feeding results into testing. We're the first to do this. 3.0 also adds auto-heal for UI drift, auto-auth for regression, and a CLI for Claude Code, Codex users.",
-      "url": "https://www.producthunt.com/products/testsprite?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DP36SVO3Y3LMV7",
+      "id": "1129994",
+      "name": "General Compute",
+      "tagline": "AI models that run on an inference cloud optimized for speed",
+      "description": "GPUs are built for training, not inference. General Compute is an inference cloud running on ASICs — purpose-built alternatives to Nvidia silicon designed specifically for inference. We deliver 5x faster responses and higher per-user throughput for latency-sensitive workloads like coding and voice agents. Our OpenAI-compatible API means you swap your base URL, keep your existing workflows, and run real-time AI on infrastructure built for the job.",
+      "url": "https://www.producthunt.com/products/general-compute?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/NHQEMRTC6G4X2J",
       "votesCount": 214,
-      "commentsCount": 47,
+      "commentsCount": 25,
       "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/50434618-8b14-40d7-9958-db6ef9c84ccb.png?auto=format",
+      "thumbnail": "https://ph-files.imgix.net/e7ecdc30-d819-457b-bd2c-c51b32c0379b.png?auto=format",
       "topics": [
-        "developer-tools",
-        "artificial-intelligence",
+        "api-1",
+        "software-engineering",
         "alpha"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2259,73 +2324,6 @@
         "developer-tools",
         "artificial-intelligence",
         "pitch-singapore"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1144087",
-      "name": "Files SDK",
-      "tagline": "A unified storage SDK for object and blob backends",
-      "description": "A unified storage SDK for object and blob backends. One small, honest API. Web-standards I/O. An escape hatch when you need the native client.",
-      "url": "https://www.producthunt.com/products/files-sdk?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/WCFEM6ZQGND5C5",
-      "votesCount": 197,
-      "commentsCount": 4,
-      "createdAt": "2026-05-17T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/4daf6ed9-a271-4ca4-9214-5acc6344e89b.png?auto=format",
-      "topics": [
-        "open-source",
-        "developer-tools",
-        "github",
-        "sdk"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1142063",
-      "name": "Kuku: open source",
-      "tagline": "Your open-source, local second brain for every AI",
-      "description": "Kuku is back as an open-source, local-first second brain for the AI era. It keeps your knowledge in plain Markdown files, then turns your vault into reusable context: wikilinks, backlinks, graph, search, and AI-assisted edits with reviewable diffs. Unlike closed note apps or one-off AI chats, Kuku is built to make your memory portable across tools, models, and self-hosted setups.",
-      "url": "https://www.producthunt.com/products/kuku?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/S4FEM3RNRHIADW",
-      "votesCount": 192,
-      "commentsCount": 15,
-      "createdAt": "2026-05-08T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/46548dee-2685-46c1-b34b-a64b4a00b42e.gif?auto=format",
-      "topics": [
-        "text-editors",
-        "saas",
-        "yc-application"
       ],
       "makers": [
         {


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26301886966

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.