### PR TITLE
chore(data): refresh huggingface signals 2026-05-22T20:13:20Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-22T15:25:37.335Z",
+  "ts": "2026-05-22T20:13:20.616Z",
   "count": 1,
-  "durationMs": 7479,
+  "durationMs": 7163,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T15:25:29.857Z",
+  "fetchedAt": "2026-05-22T20:13:13.455Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -40,8 +40,8 @@
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/Lance",
       "downloads": 1001,
-      "likes": 620,
-      "trendingScore": 605,
+      "likes": 635,
+      "trendingScore": 614,
       "pipelineTag": "any-to-any",
       "libraryName": "Lance",
       "tags": [
@@ -60,7 +60,7 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-20T12:40:00.000Z"
+      "lastModified": "2026-05-22T16:55:56.000Z"
     },
     {
       "rank": 3,
@@ -259,8 +259,8 @@
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
       "downloads": 564,
-      "likes": 262,
-      "trendingScore": 254,
+      "likes": 268,
+      "trendingScore": 260,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -304,8 +304,8 @@
       "author": "NemoStation",
       "url": "https://huggingface.co/NemoStation/Marlin-2B",
       "downloads": 4002,
-      "likes": 241,
-      "trendingScore": 235,
+      "likes": 248,
+      "trendingScore": 241,
       "pipelineTag": "video-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -339,8 +339,8 @@
       "author": "sapientinc",
       "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
       "downloads": 72470,
-      "likes": 233,
-      "trendingScore": 231,
+      "likes": 239,
+      "trendingScore": 237,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -539,12 +539,57 @@
     },
     {
       "rank": 20,
+      "id": "tencent/Hy-MT2-30B-A3B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
+      "downloads": 224,
+      "likes": 181,
+      "trendingScore": 171,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hy_v3",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T07:43:51.000Z",
+      "lastModified": "2026-05-22T05:15:55.000Z"
+    },
+    {
+      "rank": 21,
       "id": "CohereLabs/command-a-plus-05-2026-w4a4",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
       "downloads": 2127,
-      "likes": 167,
-      "trendingScore": 164,
+      "likes": 170,
+      "trendingScore": 167,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -583,7 +628,7 @@
       "lastModified": "2026-05-22T14:39:44.000Z"
     },
     {
-      "rank": 21,
+      "rank": 22,
       "id": "froggeric/Qwen-Fixed-Chat-Templates",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
@@ -611,13 +656,13 @@
       "lastModified": "2026-05-16T13:44:07.000Z"
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "downloads": 28599,
-      "likes": 157,
-      "trendingScore": 155,
+      "likes": 159,
+      "trendingScore": 157,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -654,7 +699,7 @@
       "lastModified": "2026-05-19T23:41:58.000Z"
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -683,7 +728,7 @@
       "lastModified": "2026-04-28T07:01:37.000Z"
     },
     {
-      "rank": 24,
+      "rank": 25,
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/TencentARC/Pixal3D",
@@ -702,7 +747,7 @@
       "lastModified": "2026-05-12T23:37:47.000Z"
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "Qwen/Qwen3.6-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
@@ -725,51 +770,6 @@
       ],
       "createdAt": "2026-04-21T07:50:43.000Z",
       "lastModified": "2026-04-24T02:39:16.000Z"
-    },
-    {
-      "rank": 26,
-      "id": "tencent/Hy-MT2-30B-A3B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
-      "downloads": 224,
-      "likes": 140,
-      "trendingScore": 133,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hy_v3",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T07:43:51.000Z",
-      "lastModified": "2026-05-22T05:15:55.000Z"
     },
     {
       "rank": 27,
@@ -967,40 +967,12 @@
     },
     {
       "rank": 33,
-      "id": "sensenova/SenseNova-U1-8B-MoT",
-      "author": "sensenova",
-      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
-      "downloads": 2947,
-      "likes": 191,
-      "trendingScore": 103,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "neo_chat",
-        "feature-extraction",
-        "multimodal",
-        "text-to-image",
-        "image-to-text",
-        "image-editing",
-        "interleaved-generation",
-        "custom_code",
-        "any-to-any",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T04:43:54.000Z",
-      "lastModified": "2026-05-07T08:00:27.000Z"
-    },
-    {
-      "rank": 34,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
       "downloads": 11950,
-      "likes": 102,
-      "trendingScore": 101,
+      "likes": 105,
+      "trendingScore": 104,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1037,6 +1009,34 @@
       ],
       "createdAt": "2026-05-11T12:31:04.000Z",
       "lastModified": "2026-05-22T14:40:13.000Z"
+    },
+    {
+      "rank": 34,
+      "id": "sensenova/SenseNova-U1-8B-MoT",
+      "author": "sensenova",
+      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
+      "downloads": 2947,
+      "likes": 191,
+      "trendingScore": 103,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "neo_chat",
+        "feature-extraction",
+        "multimodal",
+        "text-to-image",
+        "image-to-text",
+        "image-editing",
+        "interleaved-generation",
+        "custom_code",
+        "any-to-any",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T04:43:54.000Z",
+      "lastModified": "2026-05-07T08:00:27.000Z"
     },
     {
       "rank": 35,
@@ -1496,6 +1496,31 @@
     },
     {
       "rank": 51,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 80,
+      "trendingScore": 80,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
+    },
+    {
+      "rank": 52,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1524,7 +1549,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 52,
+      "rank": 53,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -1550,7 +1575,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 53,
+      "rank": 54,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -1577,31 +1602,6 @@
       ],
       "createdAt": "2026-04-16T04:31:31.000Z",
       "lastModified": "2026-04-20T12:42:25.000Z"
-    },
-    {
-      "rank": 54,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 78,
-      "trendingScore": 78,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
     },
     {
       "rank": 55,
@@ -1736,6 +1736,43 @@
     },
     {
       "rank": 59,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 7576,
+      "likes": 73,
+      "trendingScore": 71,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 60,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -1758,7 +1795,7 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 60,
+      "rank": 61,
       "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
@@ -1790,7 +1827,7 @@
       "lastModified": "2026-05-14T17:07:52.000Z"
     },
     {
-      "rank": 61,
+      "rank": 62,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -1822,7 +1859,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 62,
+      "rank": 63,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -1845,43 +1882,6 @@
       ],
       "createdAt": "2026-05-12T02:15:21.000Z",
       "lastModified": "2026-05-12T14:25:54.000Z"
-    },
-    {
-      "rank": 63,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 7576,
-      "likes": 68,
-      "trendingScore": 66,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "image-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
       "rank": 64,
@@ -1930,133 +1930,12 @@
     },
     {
       "rank": 65,
-      "id": "moonshotai/Kimi-K2.6",
-      "author": "moonshotai",
-      "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
-      "downloads": 1696084,
-      "likes": 1274,
-      "trendingScore": 63,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "kimi_k25",
-        "feature-extraction",
-        "compressed-tensors",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "arxiv:2602.02276",
-        "license:other",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T04:23:36.000Z",
-      "lastModified": "2026-05-12T03:12:21.000Z"
-    },
-    {
-      "rank": 66,
-      "id": "joyfox/LTX2.3-ICEdit-Insight",
-      "author": "joyfox",
-      "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
-      "downloads": 5768,
-      "likes": 79,
-      "trendingScore": 62,
-      "pipelineTag": "video-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "video-editing",
-        "video-restoration",
-        "ltx-video",
-        "ltx-2-3",
-        "dit",
-        "ic-lora",
-        "watermark-removal",
-        "subtitle-removal",
-        "super-resolution",
-        "hd-enhancement",
-        "joyfox",
-        "video-to-video",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:finetune:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T10:09:22.000Z",
-      "lastModified": "2026-05-10T14:23:59.000Z"
-    },
-    {
-      "rank": 67,
-      "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 1061556,
-      "likes": 594,
-      "trendingScore": 61,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.6",
-        "moe",
-        "vision",
-        "multimodal",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "multilingual",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-17T00:15:26.000Z",
-      "lastModified": "2026-04-17T02:59:21.000Z"
-    },
-    {
-      "rank": 68,
-      "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-      "author": "Lightricks",
-      "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-      "downloads": 2414,
-      "likes": 64,
-      "trendingScore": 61,
-      "pipelineTag": "any-to-any",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "ltx-video",
-        "video-to-video",
-        "dubbing",
-        "lipdub",
-        "ic-lora",
-        "any-to-any",
-        "en",
-        "arxiv:2601.03233",
-        "arxiv:2601.22143",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:finetune:Lightricks/LTX-2.3",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T10:02:08.000Z",
-      "lastModified": "2026-05-12T11:38:27.000Z"
-    },
-    {
-      "rank": 69,
       "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "downloads": 21448,
-      "likes": 64,
-      "trendingScore": 61,
+      "likes": 68,
+      "trendingScore": 65,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -2092,6 +1971,127 @@
       ],
       "createdAt": "2026-05-18T05:48:32.000Z",
       "lastModified": "2026-05-19T23:43:59.000Z"
+    },
+    {
+      "rank": 66,
+      "id": "moonshotai/Kimi-K2.6",
+      "author": "moonshotai",
+      "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
+      "downloads": 1696084,
+      "likes": 1274,
+      "trendingScore": 63,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "kimi_k25",
+        "feature-extraction",
+        "compressed-tensors",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "arxiv:2602.02276",
+        "license:other",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T04:23:36.000Z",
+      "lastModified": "2026-05-12T03:12:21.000Z"
+    },
+    {
+      "rank": 67,
+      "id": "joyfox/LTX2.3-ICEdit-Insight",
+      "author": "joyfox",
+      "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
+      "downloads": 5768,
+      "likes": 79,
+      "trendingScore": 62,
+      "pipelineTag": "video-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "video-editing",
+        "video-restoration",
+        "ltx-video",
+        "ltx-2-3",
+        "dit",
+        "ic-lora",
+        "watermark-removal",
+        "subtitle-removal",
+        "super-resolution",
+        "hd-enhancement",
+        "joyfox",
+        "video-to-video",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:finetune:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T10:09:22.000Z",
+      "lastModified": "2026-05-10T14:23:59.000Z"
+    },
+    {
+      "rank": 68,
+      "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 1061556,
+      "likes": 594,
+      "trendingScore": 61,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.6",
+        "moe",
+        "vision",
+        "multimodal",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "multilingual",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-17T00:15:26.000Z",
+      "lastModified": "2026-04-17T02:59:21.000Z"
+    },
+    {
+      "rank": 69,
+      "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
+      "author": "Lightricks",
+      "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
+      "downloads": 2414,
+      "likes": 64,
+      "trendingScore": 61,
+      "pipelineTag": "any-to-any",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "ltx-video",
+        "video-to-video",
+        "dubbing",
+        "lipdub",
+        "ic-lora",
+        "any-to-any",
+        "en",
+        "arxiv:2601.03233",
+        "arxiv:2601.22143",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:finetune:Lightricks/LTX-2.3",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T10:02:08.000Z",
+      "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
       "rank": 70,
@@ -2202,6 +2202,32 @@
     },
     {
       "rank": 74,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 1992,
+      "likes": 58,
+      "trendingScore": 58,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 75,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -2224,7 +2250,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 75,
+      "rank": 76,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -2255,7 +2281,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 76,
+      "rank": 77,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -2283,32 +2309,6 @@
       ],
       "createdAt": "2026-04-27T13:37:38.000Z",
       "lastModified": "2026-05-07T04:23:16.000Z"
-    },
-    {
-      "rank": 77,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 1992,
-      "likes": 56,
-      "trendingScore": 56,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
       "rank": 78,
@@ -2401,6 +2401,34 @@
     },
     {
       "rank": 81,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 55,
+      "trendingScore": 54,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
+    },
+    {
+      "rank": 82,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -2427,7 +2455,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 82,
+      "rank": 83,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2460,7 +2488,7 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 83,
+      "rank": 84,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2505,7 +2533,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 84,
+      "rank": 85,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2530,34 +2558,6 @@
       ],
       "createdAt": "2026-04-29T17:33:22.000Z",
       "lastModified": "2026-05-13T18:41:56.000Z"
-    },
-    {
-      "rank": 85,
-      "id": "stabilityai/stable-audio-3-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
-      "downloads": 0,
-      "likes": 53,
-      "trendingScore": 52,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
     },
     {
       "rank": 86,
@@ -2626,8 +2626,8 @@
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 796434,
-      "likes": 609,
+      "downloads": 757475,
+      "likes": 639,
       "trendingScore": 49,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -3004,6 +3004,29 @@
     },
     {
       "rank": 102,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 116,
+      "likes": 42,
+      "trendingScore": 42,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
+    },
+    {
+      "rank": 103,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -3022,7 +3045,35 @@
       "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
+      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "downloads": 0,
+      "likes": 40,
+      "trendingScore": 39,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "audio-text-to-video",
+        "audio-image-text-to-video",
+        "audio-driven-video-continuation",
+        "transformers",
+        "avatar",
+        "video-generation",
+        "en",
+        "zh",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:05:55.000Z",
+      "lastModified": "2026-05-22T02:58:39.000Z"
+    },
+    {
+      "rank": 105,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -3049,7 +3100,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 104,
+      "rank": 106,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -3076,7 +3127,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 105,
+      "rank": 107,
       "id": "Alissonerdx/BFS-Best-Face-Swap",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
@@ -3109,7 +3160,7 @@
       "lastModified": "2026-03-08T12:54:54.000Z"
     },
     {
-      "rank": 106,
+      "rank": 108,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -3135,35 +3186,39 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 107,
-      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
-      "downloads": 0,
-      "likes": 37,
+      "rank": 109,
+      "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
+      "downloads": 63779,
+      "likes": 73,
       "trendingScore": 36,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
-        "onnx",
-        "safetensors",
-        "audio-text-to-video",
-        "audio-image-text-to-video",
-        "audio-driven-video-continuation",
         "transformers",
-        "avatar",
-        "video-generation",
-        "en",
-        "zh",
-        "license:mit",
-        "region:us"
+        "gguf",
+        "qwen3_5",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "mpoa",
+        "mtp",
+        "image-text-to-text",
+        "base_model:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
+        "base_model:quantized:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-21T09:05:55.000Z",
-      "lastModified": "2026-05-22T02:58:39.000Z"
+      "createdAt": "2026-05-06T22:05:38.000Z",
+      "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 108,
+      "rank": 110,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -3195,7 +3250,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 109,
+      "rank": 111,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -3218,7 +3273,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 110,
+      "rank": 112,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -3242,7 +3297,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 111,
+      "rank": 113,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
@@ -3271,39 +3326,7 @@
       "lastModified": "2026-05-20T14:30:55.000Z"
     },
     {
-      "rank": 112,
-      "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "downloads": 63779,
-      "likes": 70,
-      "trendingScore": 35,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3_5",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "mpoa",
-        "mtp",
-        "image-text-to-text",
-        "base_model:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
-        "base_model:quantized:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-06T22:05:38.000Z",
-      "lastModified": "2026-05-19T21:13:27.000Z"
-    },
-    {
-      "rank": 113,
+      "rank": 114,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
@@ -3335,12 +3358,12 @@
       "lastModified": "2026-05-21T21:34:50.000Z"
     },
     {
-      "rank": 114,
+      "rank": 115,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "downloads": 359608,
-      "likes": 645,
+      "likes": 648,
       "trendingScore": 35,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -3364,7 +3387,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 115,
+      "rank": 116,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -3388,7 +3411,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -3405,7 +3428,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -3429,7 +3452,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3455,7 +3478,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 119,
+      "rank": 120,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -3471,7 +3494,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 120,
+      "rank": 121,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -3498,7 +3521,53 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 121,
+      "rank": 122,
+      "id": "kohya-ss/Anima-LLLite",
+      "author": "kohya-ss",
+      "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
+      "downloads": 0,
+      "likes": 83,
+      "trendingScore": 34,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "base_model:circlestone-labs/Anima",
+        "base_model:adapter:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T12:32:06.000Z",
+      "lastModified": "2026-05-20T13:33:56.000Z"
+    },
+    {
+      "rank": 123,
+      "id": "stabilityai/stable-audio-3-small-music",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "downloads": 0,
+      "likes": 35,
+      "trendingScore": 34,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-music-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:33.000Z",
+      "lastModified": "2026-05-19T20:02:42.000Z"
+    },
+    {
+      "rank": 124,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -3543,7 +3612,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 122,
+      "rank": 125,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -3588,7 +3657,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 123,
+      "rank": 126,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -3632,7 +3701,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 124,
+      "rank": 127,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3672,7 +3741,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 125,
+      "rank": 128,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -3698,53 +3767,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 126,
-      "id": "kohya-ss/Anima-LLLite",
-      "author": "kohya-ss",
-      "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
-      "downloads": 0,
-      "likes": 81,
-      "trendingScore": 33,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "base_model:circlestone-labs/Anima",
-        "base_model:adapter:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T12:32:06.000Z",
-      "lastModified": "2026-05-20T13:33:56.000Z"
-    },
-    {
-      "rank": 127,
-      "id": "stabilityai/stable-audio-3-small-music",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
-      "downloads": 0,
-      "likes": 34,
-      "trendingScore": 33,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-music-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:33.000Z",
-      "lastModified": "2026-05-19T20:02:42.000Z"
-    },
-    {
-      "rank": 128,
+      "rank": 129,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -3788,7 +3811,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 129,
+      "rank": 130,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3813,7 +3836,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 130,
+      "rank": 131,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -3858,7 +3881,55 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 131,
+      "rank": 132,
+      "id": "HuggingFaceBio/Carbon-3B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
+      "downloads": 2993,
+      "likes": 34,
+      "trendingScore": 32,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T11:05:49.000Z",
+      "lastModified": "2026-05-20T13:39:48.000Z"
+    },
+    {
+      "rank": 133,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 1823,
+      "likes": 33,
+      "trendingScore": 32,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-22T05:15:52.000Z"
+    },
+    {
+      "rank": 134,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -3891,7 +3962,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 132,
+      "rank": 135,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -3915,7 +3986,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 133,
+      "rank": 136,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -3942,7 +4013,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 134,
+      "rank": 137,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -3984,7 +4055,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 135,
+      "rank": 138,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -4012,33 +4083,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 136,
-      "id": "HuggingFaceBio/Carbon-3B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 2993,
-      "likes": 33,
-      "trendingScore": 31,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T11:05:49.000Z",
-      "lastModified": "2026-05-20T13:39:48.000Z"
-    },
-    {
-      "rank": 137,
+      "rank": 139,
       "id": "ByteDance-Seed/Cola-DLM",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
@@ -4068,30 +4113,39 @@
       "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
-      "rank": 138,
-      "id": "microsoft/Lens-Turbo",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 116,
-      "likes": 31,
+      "rank": 140,
+      "id": "pyannote/speaker-diarization-3.1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
+      "downloads": 10263344,
+      "likes": 1922,
       "trendingScore": 31,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
       "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
         "license:mit",
-        "diffusers:LensPipeline",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
+      "createdAt": "2023-11-16T08:19:01.000Z",
+      "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 139,
+      "rank": 141,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4117,7 +4171,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 140,
+      "rank": 142,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4149,7 +4203,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 141,
+      "rank": 143,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4176,7 +4230,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 142,
+      "rank": 144,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -4210,7 +4264,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 143,
+      "rank": 145,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4232,182 +4286,13 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 144,
-      "id": "pyannote/speaker-diarization-3.1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 10263344,
-      "likes": 1919,
-      "trendingScore": 30,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-11-16T08:19:01.000Z",
-      "lastModified": "2024-05-10T19:43:23.000Z"
-    },
-    {
-      "rank": 145,
-      "id": "ibm-granite/granite-vision-4.1-4b",
-      "author": "ibm-granite",
-      "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
-      "downloads": 10243,
-      "likes": 67,
-      "trendingScore": 29,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "granite4_vision",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "arxiv:2603.27064",
-        "arxiv:2208.00385",
-        "arxiv:2502.09927",
-        "arxiv:2406.04334",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-16T13:58:07.000Z",
-      "lastModified": "2026-05-06T14:23:30.000Z"
-    },
-    {
       "rank": 146,
-      "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
-      "author": "Phr00t",
-      "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
-      "downloads": 0,
-      "likes": 2005,
-      "trendingScore": 29,
-      "pipelineTag": "text-to-image",
-      "libraryName": "comfyUI",
-      "tags": [
-        "comfyUI",
-        "qwen",
-        "qwen-edit",
-        "t2i",
-        "i2i",
-        "text-to-image",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:finetune:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-10-02T03:43:15.000Z",
-      "lastModified": "2026-02-03T02:10:35.000Z"
-    },
-    {
-      "rank": 147,
-      "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
-      "author": "Cseti",
-      "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
-      "downloads": 0,
-      "likes": 31,
-      "trendingScore": 29,
-      "pipelineTag": "video-to-video",
-      "libraryName": null,
-      "tags": [
-        "video-to-video",
-        "lora",
-        "ic-lora",
-        "style-transfer",
-        "ltx-video",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "region:us"
-      ],
-      "createdAt": "2026-05-05T10:21:33.000Z",
-      "lastModified": "2026-05-06T07:55:41.000Z"
-    },
-    {
-      "rank": 148,
-      "id": "oumoumad/ltx-2.3-dearchive-lora",
-      "author": "oumoumad",
-      "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
-      "downloads": 0,
-      "likes": 29,
-      "trendingScore": 29,
-      "pipelineTag": "video-to-video",
-      "libraryName": "peft",
-      "tags": [
-        "peft",
-        "lora",
-        "ic-lora",
-        "ltx-video",
-        "ltx-2.3",
-        "video-restoration",
-        "dearchive",
-        "video-to-video",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T22:56:25.000Z",
-      "lastModified": "2026-05-09T14:52:36.000Z"
-    },
-    {
-      "rank": 149,
-      "id": "Grio43/OppaiOracle",
-      "author": "Grio43",
-      "url": "https://huggingface.co/Grio43/OppaiOracle",
-      "downloads": 165,
-      "likes": 29,
-      "trendingScore": 29,
-      "pipelineTag": "image-classification",
-      "libraryName": null,
-      "tags": [
-        "onnx",
-        "safetensors",
-        "anime",
-        "anime-tagger",
-        "tagger",
-        "image-tagging",
-        "multi-label",
-        "multi-label-classification",
-        "vision-transformer",
-        "vit",
-        "illustration",
-        "danbooru",
-        "image-classification",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T01:03:31.000Z",
-      "lastModified": "2026-05-10T01:13:14.000Z"
-    },
-    {
-      "rank": 150,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
       "downloads": 5010593,
-      "likes": 5717,
-      "trendingScore": 29,
+      "likes": 5719,
+      "trendingScore": 30,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
       "tags": [
@@ -4446,7 +4331,194 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
+      "rank": 147,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 8345,
+      "likes": 30,
+      "trendingScore": 30,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
+      "rank": 148,
+      "id": "microsoft/Lens",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 133,
+      "likes": 33,
+      "trendingScore": 30,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
+    },
+    {
+      "rank": 149,
+      "id": "ibm-granite/granite-vision-4.1-4b",
+      "author": "ibm-granite",
+      "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
+      "downloads": 10243,
+      "likes": 67,
+      "trendingScore": 29,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "granite4_vision",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "arxiv:2603.27064",
+        "arxiv:2208.00385",
+        "arxiv:2502.09927",
+        "arxiv:2406.04334",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-16T13:58:07.000Z",
+      "lastModified": "2026-05-06T14:23:30.000Z"
+    },
+    {
+      "rank": 150,
+      "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
+      "author": "Phr00t",
+      "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
+      "downloads": 0,
+      "likes": 2005,
+      "trendingScore": 29,
+      "pipelineTag": "text-to-image",
+      "libraryName": "comfyUI",
+      "tags": [
+        "comfyUI",
+        "qwen",
+        "qwen-edit",
+        "t2i",
+        "i2i",
+        "text-to-image",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:finetune:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-10-02T03:43:15.000Z",
+      "lastModified": "2026-02-03T02:10:35.000Z"
+    },
+    {
       "rank": 151,
+      "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
+      "author": "Cseti",
+      "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
+      "downloads": 0,
+      "likes": 31,
+      "trendingScore": 29,
+      "pipelineTag": "video-to-video",
+      "libraryName": null,
+      "tags": [
+        "video-to-video",
+        "lora",
+        "ic-lora",
+        "style-transfer",
+        "ltx-video",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "region:us"
+      ],
+      "createdAt": "2026-05-05T10:21:33.000Z",
+      "lastModified": "2026-05-06T07:55:41.000Z"
+    },
+    {
+      "rank": 152,
+      "id": "oumoumad/ltx-2.3-dearchive-lora",
+      "author": "oumoumad",
+      "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
+      "downloads": 0,
+      "likes": 29,
+      "trendingScore": 29,
+      "pipelineTag": "video-to-video",
+      "libraryName": "peft",
+      "tags": [
+        "peft",
+        "lora",
+        "ic-lora",
+        "ltx-video",
+        "ltx-2.3",
+        "video-restoration",
+        "dearchive",
+        "video-to-video",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-07T22:56:25.000Z",
+      "lastModified": "2026-05-09T14:52:36.000Z"
+    },
+    {
+      "rank": 153,
+      "id": "Grio43/OppaiOracle",
+      "author": "Grio43",
+      "url": "https://huggingface.co/Grio43/OppaiOracle",
+      "downloads": 165,
+      "likes": 29,
+      "trendingScore": 29,
+      "pipelineTag": "image-classification",
+      "libraryName": null,
+      "tags": [
+        "onnx",
+        "safetensors",
+        "anime",
+        "anime-tagger",
+        "tagger",
+        "image-tagging",
+        "multi-label",
+        "multi-label-classification",
+        "vision-transformer",
+        "vit",
+        "illustration",
+        "danbooru",
+        "image-classification",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-09T01:03:31.000Z",
+      "lastModified": "2026-05-10T01:13:14.000Z"
+    },
+    {
+      "rank": 154,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -4475,7 +4547,49 @@
       "lastModified": "2026-05-16T06:48:11.000Z"
     },
     {
-      "rank": 152,
+      "rank": 155,
+      "id": "LatitudeGames/Equinox-31B",
+      "author": "LatitudeGames",
+      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
+      "downloads": 37,
+      "likes": 29,
+      "trendingScore": 29,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "gemma4",
+        "text adventure",
+        "roleplay",
+        "en",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:finetune:google/gemma-4-31B-it",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:45:53.000Z",
+      "lastModified": "2026-05-22T04:55:49.000Z"
+    },
+    {
+      "rank": 156,
+      "id": "zhen-nan/L2P",
+      "author": "zhen-nan",
+      "url": "https://huggingface.co/zhen-nan/L2P",
+      "downloads": 0,
+      "likes": 29,
+      "trendingScore": 29,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "arxiv:2605.12013",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-03T13:24:20.000Z",
+      "lastModified": "2026-05-22T07:53:35.000Z"
+    },
+    {
+      "rank": 157,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -4497,7 +4611,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 153,
+      "rank": 158,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -4534,7 +4648,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 154,
+      "rank": 159,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -4556,7 +4670,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 155,
+      "rank": 160,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -4589,7 +4703,7 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 156,
+      "rank": 161,
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
@@ -4617,7 +4731,7 @@
       "lastModified": "2026-05-19T21:32:32.000Z"
     },
     {
-      "rank": 157,
+      "rank": 162,
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
@@ -4662,7 +4776,34 @@
       "lastModified": "2026-05-22T14:40:30.000Z"
     },
     {
-      "rank": 158,
+      "rank": 163,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2719603,
+      "likes": 2031,
+      "trendingScore": 28,
+      "pipelineTag": "mask-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
+    },
+    {
+      "rank": 164,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -4702,7 +4843,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 159,
+      "rank": 165,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -4739,7 +4880,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 160,
+      "rank": 166,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -4782,7 +4923,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 161,
+      "rank": 167,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -4802,7 +4943,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 162,
+      "rank": 168,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -4827,7 +4968,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 163,
+      "rank": 169,
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
@@ -4852,56 +4993,103 @@
       "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 164,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 8345,
+      "rank": 170,
+      "id": "kjanh/KhanhTTS-OmniVoice",
+      "author": "kjanh",
+      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
+      "downloads": 3989,
+      "likes": 30,
+      "trendingScore": 27,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "omnivoice",
+        "text-to-speech",
+        "vi",
+        "en",
+        "arxiv:2604.00688",
+        "base_model:k2-fsa/OmniVoice",
+        "base_model:finetune:k2-fsa/OmniVoice",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T02:00:22.000Z",
+      "lastModified": "2026-05-16T04:32:12.000Z"
+    },
+    {
+      "rank": 171,
+      "id": "tencent/Hy-MT2-7B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
+      "downloads": 213,
       "likes": 27,
       "trendingScore": 27,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "safetensors",
+        "hunyuan_v1_dense",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
       ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
+      "createdAt": "2026-05-11T14:56:58.000Z",
+      "lastModified": "2026-05-22T05:16:06.000Z"
     },
     {
-      "rank": 165,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
-      "downloads": 1823,
-      "likes": 27,
+      "rank": 172,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 32,
       "trendingScore": 27,
-      "pipelineTag": null,
+      "pipelineTag": "automatic-speech-recognition",
       "libraryName": null,
       "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
       ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-22T05:15:52.000Z"
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-21T14:39:01.000Z"
     },
     {
-      "rank": 166,
+      "rank": 173,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -4946,7 +5134,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 167,
+      "rank": 174,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -4973,7 +5161,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 168,
+      "rank": 175,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -5018,7 +5206,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 169,
+      "rank": 176,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -5044,7 +5232,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 170,
+      "rank": 177,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -5066,7 +5254,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 171,
+      "rank": 178,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -5082,7 +5270,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 172,
+      "rank": 179,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -5118,7 +5306,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 173,
+      "rank": 180,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -5136,104 +5324,84 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 174,
-      "id": "kjanh/KhanhTTS-OmniVoice",
-      "author": "kjanh",
-      "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
-      "downloads": 3989,
-      "likes": 29,
+      "rank": 181,
+      "id": "sentence-transformers/all-MiniLM-L6-v2",
+      "author": "sentence-transformers",
+      "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
+      "downloads": 260087615,
+      "likes": 4819,
       "trendingScore": 26,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
       "tags": [
+        "sentence-transformers",
+        "pytorch",
+        "tf",
+        "rust",
+        "onnx",
         "safetensors",
-        "omnivoice",
-        "text-to-speech",
-        "vi",
+        "openvino",
+        "bert",
+        "feature-extraction",
+        "sentence-similarity",
+        "transformers",
         "en",
-        "arxiv:2604.00688",
-        "base_model:k2-fsa/OmniVoice",
-        "base_model:finetune:k2-fsa/OmniVoice",
-        "license:apache-2.0",
-        "region:us"
+        "dataset:s2orc",
+        "dataset:flax-sentence-embeddings/stackexchange_xml",
+        "dataset:ms_marco",
+        "dataset:gooaq",
+        "dataset:yahoo_answers_topics",
+        "dataset:code_search_net",
+        "dataset:search_qa",
+        "dataset:eli5",
+        "dataset:snli",
+        "dataset:multi_nli",
+        "dataset:wikihow",
+        "dataset:natural_questions",
+        "dataset:trivia_qa",
+        "dataset:embedding-data/sentence-compression",
+        "dataset:embedding-data/flickr30k-captions",
+        "dataset:embedding-data/altlex",
+        "dataset:embedding-data/simple-wiki",
+        "dataset:embedding-data/QQP"
       ],
-      "createdAt": "2026-05-16T02:00:22.000Z",
-      "lastModified": "2026-05-16T04:32:12.000Z"
+      "createdAt": "2022-03-02T23:29:05.000Z",
+      "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 175,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2719603,
-      "likes": 2029,
+      "rank": 182,
+      "id": "BAAI/bge-m3",
+      "author": "BAAI",
+      "url": "https://huggingface.co/BAAI/bge-m3",
+      "downloads": 28332931,
+      "likes": 3030,
       "trendingScore": 26,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
+      "pipelineTag": "sentence-similarity",
+      "libraryName": "sentence-transformers",
       "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
+        "sentence-transformers",
+        "pytorch",
+        "onnx",
+        "xlm-roberta",
         "feature-extraction",
-        "sam3",
-        "mask-generation",
-        "en",
-        "license:other",
+        "sentence-similarity",
+        "arxiv:2402.03216",
+        "arxiv:2004.04906",
+        "arxiv:2106.14807",
+        "arxiv:2107.05720",
+        "arxiv:2004.12832",
+        "license:mit",
         "eval-results",
+        "text-embeddings-inference",
         "endpoints_compatible",
         "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
+      "createdAt": "2024-01-27T17:07:29.000Z",
+      "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 176,
-      "id": "tencent/Hy-MT2-7B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
-      "downloads": 213,
-      "likes": 26,
-      "trendingScore": 26,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hunyuan_v1_dense",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T14:56:58.000Z",
-      "lastModified": "2026-05-22T05:16:06.000Z"
-    },
-    {
-      "rank": 177,
+      "rank": 183,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -5271,7 +5439,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 178,
+      "rank": 184,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -5289,7 +5457,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 179,
+      "rank": 185,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -5315,7 +5483,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 180,
+      "rank": 186,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -5335,7 +5503,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 181,
+      "rank": 187,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -5362,7 +5530,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 182,
+      "rank": 188,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -5388,7 +5556,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 183,
+      "rank": 189,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -5414,7 +5582,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 184,
+      "rank": 190,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -5451,7 +5619,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 185,
+      "rank": 191,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -5467,7 +5635,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 186,
+      "rank": 192,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -5490,7 +5658,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 187,
+      "rank": 193,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -5532,7 +5700,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 188,
+      "rank": 194,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -5571,84 +5739,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 189,
-      "id": "sentence-transformers/all-MiniLM-L6-v2",
-      "author": "sentence-transformers",
-      "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
-      "downloads": 260087615,
-      "likes": 4818,
-      "trendingScore": 25,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "pytorch",
-        "tf",
-        "rust",
-        "onnx",
-        "safetensors",
-        "openvino",
-        "bert",
-        "feature-extraction",
-        "sentence-similarity",
-        "transformers",
-        "en",
-        "dataset:s2orc",
-        "dataset:flax-sentence-embeddings/stackexchange_xml",
-        "dataset:ms_marco",
-        "dataset:gooaq",
-        "dataset:yahoo_answers_topics",
-        "dataset:code_search_net",
-        "dataset:search_qa",
-        "dataset:eli5",
-        "dataset:snli",
-        "dataset:multi_nli",
-        "dataset:wikihow",
-        "dataset:natural_questions",
-        "dataset:trivia_qa",
-        "dataset:embedding-data/sentence-compression",
-        "dataset:embedding-data/flickr30k-captions",
-        "dataset:embedding-data/altlex",
-        "dataset:embedding-data/simple-wiki",
-        "dataset:embedding-data/QQP"
-      ],
-      "createdAt": "2022-03-02T23:29:05.000Z",
-      "lastModified": "2025-03-06T13:37:44.000Z"
-    },
-    {
-      "rank": 190,
-      "id": "BAAI/bge-m3",
-      "author": "BAAI",
-      "url": "https://huggingface.co/BAAI/bge-m3",
-      "downloads": 28332931,
-      "likes": 3029,
-      "trendingScore": 25,
-      "pipelineTag": "sentence-similarity",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "pytorch",
-        "onnx",
-        "xlm-roberta",
-        "feature-extraction",
-        "sentence-similarity",
-        "arxiv:2402.03216",
-        "arxiv:2004.04906",
-        "arxiv:2106.14807",
-        "arxiv:2107.05720",
-        "arxiv:2004.12832",
-        "license:mit",
-        "eval-results",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-01-27T17:07:29.000Z",
-      "lastModified": "2024-07-03T14:50:10.000Z"
-    },
-    {
-      "rank": 191,
+      "rank": 195,
       "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
       "author": "fal",
       "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
@@ -5680,33 +5771,76 @@
       "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
-      "rank": 192,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "rank": 196,
+      "id": "stabilityai/stable-audio-3-small-sfx",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
       "downloads": 0,
-      "likes": 30,
+      "likes": 25,
       "trendingScore": 25,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
       "tags": [
+        "stable-audio-3",
         "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
+        "audio-generation",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
         "en",
-        "zh",
-        "arxiv:2605.19833",
-        "license:apache-2.0",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-sfx-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-21T14:39:01.000Z"
+      "createdAt": "2026-05-17T01:51:16.000Z",
+      "lastModified": "2026-05-19T20:02:45.000Z"
     },
     {
-      "rank": 193,
+      "rank": 197,
+      "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
+      "downloads": 4,
+      "likes": 26,
+      "trendingScore": 25,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T10:48:10.000Z",
+      "lastModified": "2026-05-22T16:20:09.000Z"
+    },
+    {
+      "rank": 198,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -5738,7 +5872,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 194,
+      "rank": 199,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -5762,7 +5896,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 195,
+      "rank": 200,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -5789,7 +5923,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 196,
+      "rank": 201,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -5814,7 +5948,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 197,
+      "rank": 202,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -5850,7 +5984,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 198,
+      "rank": 203,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -5866,7 +6000,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 199,
+      "rank": 204,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -5887,284 +6021,13 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 200,
-      "id": "stabilityai/stable-audio-3-small-sfx",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
-      "downloads": 0,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-sfx-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:16.000Z",
-      "lastModified": "2026-05-19T20:02:45.000Z"
-    },
-    {
-      "rank": 201,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 133,
-      "likes": 27,
-      "trendingScore": 24,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
-    },
-    {
-      "rank": 202,
-      "id": "Qwen/Qwen3.6-27B-FP8",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
-      "downloads": 3087118,
-      "likes": 196,
-      "trendingScore": 23,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "fp8",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2026-04-21T07:51:33.000Z",
-      "lastModified": "2026-04-24T02:39:18.000Z"
-    },
-    {
-      "rank": 203,
-      "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-      "downloads": 166640,
-      "likes": 649,
-      "trendingScore": 23,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen3",
-        "qwen",
-        "text-generation",
-        "arxiv:2505.09388",
-        "base_model:Qwen/Qwen3-Coder-30B-A3B-Instruct",
-        "base_model:quantized:Qwen/Qwen3-Coder-30B-A3B-Instruct",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2025-07-31T10:27:38.000Z",
-      "lastModified": "2026-01-30T06:29:38.000Z"
-    },
-    {
-      "rank": 204,
-      "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
-      "author": "vrgamedevgirl84",
-      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
-      "downloads": 0,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T23:58:14.000Z",
-      "lastModified": "2026-05-09T03:08:46.000Z"
-    },
-    {
       "rank": 205,
-      "id": "Abiray/Sulphur-2-base-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
-      "downloads": 42952,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": "text-to-video",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "quantized",
-        "text-to-video",
-        "base_model:SulphurAI/Sulphur-2-base",
-        "base_model:quantized:SulphurAI/Sulphur-2-base",
-        "region:us"
-      ],
-      "createdAt": "2026-05-10T15:01:12.000Z",
-      "lastModified": "2026-05-12T04:19:47.000Z"
-    },
-    {
-      "rank": 206,
-      "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-      "downloads": 1518342,
-      "likes": 1490,
-      "trendingScore": 23,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_tts",
-        "text-to-speech",
-        "arxiv:2601.15621",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-21T08:56:49.000Z",
-      "lastModified": "2026-01-29T08:00:54.000Z"
-    },
-    {
-      "rank": 207,
-      "id": "microsoft/TRELLIS.2-4B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
-      "downloads": 0,
-      "likes": 869,
-      "trendingScore": 23,
-      "pipelineTag": "image-to-3d",
-      "libraryName": "trellis2",
-      "tags": [
-        "trellis2",
-        "image-to-3d",
-        "en",
-        "arxiv:2512.14692",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2025-12-01T02:25:40.000Z",
-      "lastModified": "2025-12-27T13:21:56.000Z"
-    },
-    {
-      "rank": 208,
-      "id": "nvidia/Kimi-K2.6-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
-      "downloads": 56882,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "kimi_k25",
-        "nvidia",
-        "ModelOpt",
-        "Kimi-K2.6",
-        "quantized",
-        "FP4",
-        "fp4",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "base_model:moonshotai/Kimi-K2.6",
-        "base_model:quantized:moonshotai/Kimi-K2.6",
-        "license:other",
-        "modelopt",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T04:37:55.000Z",
-      "lastModified": "2026-05-15T17:40:07.000Z"
-    },
-    {
-      "rank": 209,
-      "id": "oron1208/OOO_Anima",
-      "author": "oron1208",
-      "url": "https://huggingface.co/oron1208/OOO_Anima",
-      "downloads": 0,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "text-to-image",
-        "image-generation",
-        "anime",
-        "illustration",
-        "anima",
-        "safetensors",
-        "ja",
-        "en",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T09:41:37.000Z",
-      "lastModified": "2026-05-21T15:24:20.000Z"
-    },
-    {
-      "rank": 210,
-      "id": "HuggingFaceBio/Carbon-500M",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
-      "downloads": 1243,
-      "likes": 26,
-      "trendingScore": 23,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "speculative-decoding",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T16:09:33.000Z",
-      "lastModified": "2026-05-20T13:40:43.000Z"
-    },
-    {
-      "rank": 211,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
       "downloads": 398,
-      "likes": 27,
-      "trendingScore": 23,
+      "likes": 28,
+      "trendingScore": 24,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -6203,7 +6066,228 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
+      "rank": 206,
+      "id": "Qwen/Qwen3.6-27B-FP8",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
+      "downloads": 3087118,
+      "likes": 196,
+      "trendingScore": 23,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "fp8",
+        "region:us",
+        "deploy:azure"
+      ],
+      "createdAt": "2026-04-21T07:51:33.000Z",
+      "lastModified": "2026-04-24T02:39:18.000Z"
+    },
+    {
+      "rank": 207,
+      "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+      "downloads": 166640,
+      "likes": 649,
+      "trendingScore": 23,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen3",
+        "qwen",
+        "text-generation",
+        "arxiv:2505.09388",
+        "base_model:Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "base_model:quantized:Qwen/Qwen3-Coder-30B-A3B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2025-07-31T10:27:38.000Z",
+      "lastModified": "2026-01-30T06:29:38.000Z"
+    },
+    {
+      "rank": 208,
+      "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
+      "author": "vrgamedevgirl84",
+      "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
+      "downloads": 0,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T23:58:14.000Z",
+      "lastModified": "2026-05-09T03:08:46.000Z"
+    },
+    {
+      "rank": 209,
+      "id": "Abiray/Sulphur-2-base-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
+      "downloads": 42952,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "text-to-video",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "quantized",
+        "text-to-video",
+        "base_model:SulphurAI/Sulphur-2-base",
+        "base_model:quantized:SulphurAI/Sulphur-2-base",
+        "region:us"
+      ],
+      "createdAt": "2026-05-10T15:01:12.000Z",
+      "lastModified": "2026-05-12T04:19:47.000Z"
+    },
+    {
+      "rank": 210,
+      "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "downloads": 1518342,
+      "likes": 1490,
+      "trendingScore": 23,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_tts",
+        "text-to-speech",
+        "arxiv:2601.15621",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-01-21T08:56:49.000Z",
+      "lastModified": "2026-01-29T08:00:54.000Z"
+    },
+    {
+      "rank": 211,
+      "id": "microsoft/TRELLIS.2-4B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
+      "downloads": 0,
+      "likes": 869,
+      "trendingScore": 23,
+      "pipelineTag": "image-to-3d",
+      "libraryName": "trellis2",
+      "tags": [
+        "trellis2",
+        "image-to-3d",
+        "en",
+        "arxiv:2512.14692",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-12-01T02:25:40.000Z",
+      "lastModified": "2025-12-27T13:21:56.000Z"
+    },
+    {
       "rank": 212,
+      "id": "nvidia/Kimi-K2.6-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
+      "downloads": 56882,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "kimi_k25",
+        "nvidia",
+        "ModelOpt",
+        "Kimi-K2.6",
+        "quantized",
+        "FP4",
+        "fp4",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "base_model:moonshotai/Kimi-K2.6",
+        "base_model:quantized:moonshotai/Kimi-K2.6",
+        "license:other",
+        "modelopt",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T04:37:55.000Z",
+      "lastModified": "2026-05-15T17:40:07.000Z"
+    },
+    {
+      "rank": 213,
+      "id": "oron1208/OOO_Anima",
+      "author": "oron1208",
+      "url": "https://huggingface.co/oron1208/OOO_Anima",
+      "downloads": 0,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "text-to-image",
+        "image-generation",
+        "anime",
+        "illustration",
+        "anima",
+        "safetensors",
+        "ja",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T09:41:37.000Z",
+      "lastModified": "2026-05-21T15:24:20.000Z"
+    },
+    {
+      "rank": 214,
+      "id": "HuggingFaceBio/Carbon-500M",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
+      "downloads": 1243,
+      "likes": 26,
+      "trendingScore": 23,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "speculative-decoding",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T16:09:33.000Z",
+      "lastModified": "2026-05-20T13:40:43.000Z"
+    },
+    {
+      "rank": 215,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6234,31 +6318,7 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 213,
-      "id": "LatitudeGames/Equinox-31B",
-      "author": "LatitudeGames",
-      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
-      "downloads": 37,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gemma4",
-        "text adventure",
-        "roleplay",
-        "en",
-        "base_model:google/gemma-4-31B-it",
-        "base_model:finetune:google/gemma-4-31B-it",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:45:53.000Z",
-      "lastModified": "2026-05-22T04:55:49.000Z"
-    },
-    {
-      "rank": 214,
+      "rank": 216,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6289,7 +6349,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 215,
+      "rank": 217,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6318,7 +6378,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 216,
+      "rank": 218,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6363,7 +6423,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 217,
+      "rank": 219,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6390,7 +6450,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 218,
+      "rank": 220,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -6416,7 +6476,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 219,
+      "rank": 221,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -6440,7 +6500,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 220,
+      "rank": 222,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -6478,7 +6538,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 221,
+      "rank": 223,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -6495,7 +6555,57 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 222,
+      "rank": 224,
+      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
+      "downloads": 28239,
+      "likes": 22,
+      "trendingScore": 22,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.5-122B-A10B",
+        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-15T19:03:18.000Z",
+      "lastModified": "2026-05-18T03:29:50.000Z"
+    },
+    {
+      "rank": 225,
+      "id": "facebook/sam3.1",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3.1",
+      "downloads": 301519,
+      "likes": 282,
+      "trendingScore": 22,
+      "pipelineTag": "mask-generation",
+      "libraryName": "checkpoint",
+      "tags": [
+        "checkpoint",
+        "sam3_video",
+        "sam3.1",
+        "mask-generation",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T01:25:54.000Z",
+      "lastModified": "2026-03-27T17:40:55.000Z"
+    },
+    {
+      "rank": 226,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -6540,7 +6650,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 223,
+      "rank": 227,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -6568,7 +6678,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 224,
+      "rank": 228,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -6604,7 +6714,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 225,
+      "rank": 229,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -6631,35 +6741,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 226,
-      "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
-      "downloads": 28239,
-      "likes": 21,
-      "trendingScore": 21,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.5-122B-A10B",
-        "base_model:quantized:Qwen/Qwen3.5-122B-A10B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-15T19:03:18.000Z",
-      "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 227,
+      "rank": 230,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -6687,7 +6769,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 228,
+      "rank": 231,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -6720,7 +6802,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 229,
+      "rank": 232,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -6745,7 +6827,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 230,
+      "rank": 233,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -6782,7 +6864,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 231,
+      "rank": 234,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -6825,7 +6907,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 232,
+      "rank": 235,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -6849,7 +6931,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 233,
+      "rank": 236,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -6873,7 +6955,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 234,
+      "rank": 237,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -6905,7 +6987,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 235,
+      "rank": 238,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -6934,7 +7016,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 236,
+      "rank": 239,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -6965,7 +7047,7 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 237,
+      "rank": 240,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -6983,7 +7065,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 238,
+      "rank": 241,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -7028,7 +7110,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 239,
+      "rank": 242,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -7051,7 +7133,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 240,
+      "rank": 243,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7096,7 +7178,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 241,
+      "rank": 244,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -7125,7 +7207,29 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 242,
+      "rank": 245,
+      "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
+      "downloads": 833,
+      "likes": 20,
+      "trendingScore": 20,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T09:26:32.000Z",
+      "lastModified": "2026-05-22T05:15:40.000Z"
+    },
+    {
+      "rank": 246,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -7170,7 +7274,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 243,
+      "rank": 247,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -7203,7 +7307,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 244,
+      "rank": 248,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -7225,7 +7329,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 245,
+      "rank": 249,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -7252,7 +7356,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 246,
+      "rank": 250,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -7268,7 +7372,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 247,
+      "rank": 251,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7285,7 +7389,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 248,
+      "rank": 252,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -7308,7 +7412,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 249,
+      "rank": 253,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -7333,7 +7437,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 250,
+      "rank": 254,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -7369,7 +7473,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 251,
+      "rank": 255,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -7398,7 +7502,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 252,
+      "rank": 256,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -7428,7 +7532,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 253,
+      "rank": 257,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -7473,7 +7577,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 254,
+      "rank": 258,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -7500,7 +7604,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 255,
+      "rank": 259,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -7526,7 +7630,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 256,
+      "rank": 260,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -7554,7 +7658,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 257,
+      "rank": 261,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -7583,29 +7687,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 258,
-      "id": "facebook/sam3.1",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 301519,
-      "likes": 278,
-      "trendingScore": 19,
-      "pipelineTag": "mask-generation",
-      "libraryName": "checkpoint",
-      "tags": [
-        "checkpoint",
-        "sam3_video",
-        "sam3.1",
-        "mask-generation",
-        "en",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T01:25:54.000Z",
-      "lastModified": "2026-03-27T17:40:55.000Z"
-    },
-    {
-      "rank": 259,
+      "rank": 262,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -7629,7 +7711,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 260,
+      "rank": 263,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -7654,29 +7736,36 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 261,
-      "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "downloads": 833,
-      "likes": 19,
+      "rank": 264,
+      "id": "stabilityai/stable-diffusion-xl-base-1.0",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "downloads": 1915891,
+      "likes": 7742,
       "trendingScore": 19,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "text-to-image",
+        "stable-diffusion",
+        "arxiv:2307.01952",
+        "arxiv:2211.01324",
+        "arxiv:2108.01073",
+        "arxiv:2112.10752",
+        "license:openrail++",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "diffusers:StableDiffusionXLPipeline",
+        "deploy:azure",
+        "region:us"
       ],
-      "createdAt": "2026-05-20T09:26:32.000Z",
-      "lastModified": "2026-05-22T05:15:40.000Z"
+      "createdAt": "2023-07-25T13:25:51.000Z",
+      "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 262,
+      "rank": 265,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -7698,7 +7787,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 263,
+      "rank": 266,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -7732,7 +7821,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 264,
+      "rank": 267,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -7756,7 +7845,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 265,
+      "rank": 268,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7782,7 +7871,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 266,
+      "rank": 269,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -7804,7 +7893,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 267,
+      "rank": 270,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -7833,7 +7922,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 268,
+      "rank": 271,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -7865,7 +7954,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 269,
+      "rank": 272,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -7883,7 +7972,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 270,
+      "rank": 273,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -7912,7 +8001,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 271,
+      "rank": 274,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7939,7 +8028,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 272,
+      "rank": 275,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -7957,36 +8046,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 273,
-      "id": "stabilityai/stable-diffusion-xl-base-1.0",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
-      "downloads": 1926286,
-      "likes": 7738,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "onnx",
-        "safetensors",
-        "text-to-image",
-        "stable-diffusion",
-        "arxiv:2307.01952",
-        "arxiv:2211.01324",
-        "arxiv:2108.01073",
-        "arxiv:2112.10752",
-        "license:openrail++",
-        "endpoints_compatible",
-        "diffusers:StableDiffusionXLPipeline",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2023-07-25T13:25:51.000Z",
-      "lastModified": "2023-10-30T16:03:47.000Z"
-    },
-    {
-      "rank": 274,
+      "rank": 276,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -8031,7 +8091,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 275,
+      "rank": 277,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -8060,7 +8120,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 276,
+      "rank": 278,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -8089,7 +8149,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 277,
+      "rank": 279,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -8121,7 +8181,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 278,
+      "rank": 280,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -8151,7 +8211,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 279,
+      "rank": 281,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -8172,7 +8232,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 280,
+      "rank": 282,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -8217,7 +8277,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 281,
+      "rank": 283,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -8246,7 +8306,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 282,
+      "rank": 284,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -8274,7 +8334,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 283,
+      "rank": 285,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -8299,7 +8359,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 284,
+      "rank": 286,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -8322,7 +8382,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 285,
+      "rank": 287,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -8349,7 +8409,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 286,
+      "rank": 288,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -8375,7 +8435,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 287,
+      "rank": 289,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -8404,7 +8464,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 288,
+      "rank": 290,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
@@ -8430,7 +8490,29 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 289,
+      "rank": 291,
+      "id": "tencent/Hy-MT2-7B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
+      "downloads": 4373,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-7B",
+        "base_model:quantized:tencent/Hy-MT2-7B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:31.000Z",
+      "lastModified": "2026-05-22T05:16:12.000Z"
+    },
+    {
+      "rank": 292,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -8455,7 +8537,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 290,
+      "rank": 293,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -8490,7 +8572,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 291,
+      "rank": 294,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -8535,7 +8617,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 292,
+      "rank": 295,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -8562,7 +8644,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 293,
+      "rank": 296,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -8591,7 +8673,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 294,
+      "rank": 297,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -8614,7 +8696,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 295,
+      "rank": 298,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -8658,7 +8740,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 296,
+      "rank": 299,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -8703,7 +8785,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 297,
+      "rank": 300,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -8721,7 +8803,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 298,
+      "rank": 301,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -8766,7 +8848,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 299,
+      "rank": 302,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -8804,7 +8886,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 300,
+      "rank": 303,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -8824,7 +8906,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 301,
+      "rank": 304,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -8857,7 +8939,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 302,
+      "rank": 305,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -8887,7 +8969,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 303,
+      "rank": 306,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -8919,7 +9001,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 304,
+      "rank": 307,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -8944,7 +9026,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 305,
+      "rank": 308,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -8967,7 +9049,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 306,
+      "rank": 309,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -8991,7 +9073,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 307,
+      "rank": 310,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9021,7 +9103,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 308,
+      "rank": 311,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -9045,7 +9127,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 309,
+      "rank": 312,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
@@ -9071,29 +9153,85 @@
       "lastModified": "2026-05-19T18:52:45.000Z"
     },
     {
-      "rank": 310,
-      "id": "tencent/Hy-MT2-7B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 4373,
+      "rank": 313,
+      "id": "pyannote/speaker-diarization-community-1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
+      "downloads": 2912607,
+      "likes": 394,
+      "trendingScore": 16,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2104.03603",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "arxiv:2110.07058",
+        "license:cc-by-4.0",
+        "region:us"
+      ],
+      "createdAt": "2025-04-15T21:31:35.000Z",
+      "lastModified": "2025-09-29T08:43:24.000Z"
+    },
+    {
+      "rank": 314,
+      "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "downloads": 0,
       "likes": 16,
       "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
+        "transformers",
         "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-7B",
-        "base_model:quantized:tencent/Hy-MT2-7B",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "devops",
+        "math",
+        "science",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-20T06:21:31.000Z",
-      "lastModified": "2026-05-22T05:16:12.000Z"
+      "createdAt": "2026-05-21T06:37:47.000Z",
+      "lastModified": "2026-05-22T16:14:46.000Z"
     },
     {
-      "rank": 311,
+      "rank": 315,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -9120,7 +9258,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 312,
+      "rank": 316,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -9165,7 +9303,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 313,
+      "rank": 317,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -9195,7 +9333,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 314,
+      "rank": 318,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -9225,7 +9363,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 315,
+      "rank": 319,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -9270,7 +9408,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 316,
+      "rank": 320,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -9305,7 +9443,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 317,
+      "rank": 321,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9333,7 +9471,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 318,
+      "rank": 322,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -9362,7 +9500,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 319,
+      "rank": 323,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -9387,7 +9525,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 320,
+      "rank": 324,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -9415,7 +9553,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 321,
+      "rank": 325,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -9443,7 +9581,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 322,
+      "rank": 326,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -9474,7 +9612,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 323,
+      "rank": 327,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -9519,7 +9657,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 324,
+      "rank": 328,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -9551,7 +9689,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 325,
+      "rank": 329,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -9578,7 +9716,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 326,
+      "rank": 330,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -9601,40 +9739,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 327,
-      "id": "pyannote/speaker-diarization-community-1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
-      "downloads": 2912607,
-      "likes": 392,
-      "trendingScore": 15,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2104.03603",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "arxiv:2110.07058",
-        "license:cc-by-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-04-15T21:31:35.000Z",
-      "lastModified": "2025-09-29T08:43:24.000Z"
-    },
-    {
-      "rank": 328,
+      "rank": 331,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -9661,7 +9766,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 329,
+      "rank": 332,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9680,7 +9785,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 330,
+      "rank": 333,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -9703,7 +9808,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 331,
+      "rank": 334,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -9729,7 +9834,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 332,
+      "rank": 335,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -9759,7 +9864,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 333,
+      "rank": 336,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -9786,7 +9891,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 334,
+      "rank": 337,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -9817,7 +9922,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 335,
+      "rank": 338,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -9845,7 +9950,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -9877,7 +9982,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 337,
+      "rank": 340,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -9909,7 +10014,7 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 338,
+      "rank": 341,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -9935,7 +10040,7 @@
       "lastModified": "2026-05-19T18:52:44.000Z"
     },
     {
-      "rank": 339,
+      "rank": 342,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -9961,7 +10066,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 340,
+      "rank": 343,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -9985,7 +10090,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 341,
+      "rank": 344,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -10012,7 +10117,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 342,
+      "rank": 345,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -10040,7 +10145,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 343,
+      "rank": 346,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -10059,7 +10164,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 344,
+      "rank": 347,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -10091,7 +10196,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 345,
+      "rank": 348,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -10120,7 +10225,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 346,
+      "rank": 349,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -10147,7 +10252,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 347,
+      "rank": 350,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -10173,7 +10278,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 348,
+      "rank": 351,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -10204,7 +10309,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 349,
+      "rank": 352,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -10232,7 +10337,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 350,
+      "rank": 353,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -10255,7 +10360,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 351,
+      "rank": 354,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -10289,7 +10394,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 352,
+      "rank": 355,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -10315,7 +10420,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 353,
+      "rank": 356,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -10357,7 +10462,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 354,
+      "rank": 357,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -10395,7 +10500,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 355,
+      "rank": 358,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -10414,7 +10519,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 356,
+      "rank": 359,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -10434,7 +10539,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 357,
+      "rank": 360,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -10461,7 +10566,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 358,
+      "rank": 361,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -10487,7 +10592,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 359,
+      "rank": 362,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -10512,7 +10617,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 360,
+      "rank": 363,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -10541,7 +10646,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 361,
+      "rank": 364,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -10586,7 +10691,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 362,
+      "rank": 365,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -10613,12 +10718,12 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 363,
+      "rank": 366,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
-      "downloads": 29549,
-      "likes": 65,
+      "downloads": 30054,
+      "likes": 67,
       "trendingScore": 14,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -10658,7 +10763,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 364,
+      "rank": 367,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -10687,7 +10792,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 365,
+      "rank": 368,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -10732,7 +10837,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 366,
+      "rank": 369,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -10761,7 +10866,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 367,
+      "rank": 370,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -10788,7 +10893,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 368,
+      "rank": 371,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -10815,7 +10920,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 369,
+      "rank": 372,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -10846,7 +10951,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 370,
+      "rank": 373,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -10870,7 +10975,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 371,
+      "rank": 374,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -10915,7 +11020,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 372,
+      "rank": 375,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -10942,7 +11047,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 373,
+      "rank": 376,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -10978,7 +11083,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 374,
+      "rank": 377,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -11009,7 +11114,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 375,
+      "rank": 378,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -11040,7 +11145,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 376,
+      "rank": 379,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -11073,7 +11178,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 377,
+      "rank": 380,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -11102,7 +11207,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 378,
+      "rank": 381,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -11128,7 +11233,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 379,
+      "rank": 382,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -11158,7 +11263,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 380,
+      "rank": 383,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -11176,7 +11281,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 381,
+      "rank": 384,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -11207,7 +11312,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 382,
+      "rank": 385,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -11228,7 +11333,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 383,
+      "rank": 386,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -11248,7 +11353,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 384,
+      "rank": 387,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -11276,7 +11381,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 385,
+      "rank": 388,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -11303,12 +11408,12 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 386,
+      "rank": 389,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
-      "downloads": 6104860,
-      "likes": 1023,
+      "downloads": 6617167,
+      "likes": 1032,
       "trendingScore": 13,
       "pipelineTag": "feature-extraction",
       "libraryName": "sentence-transformers",
@@ -11333,7 +11438,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 387,
+      "rank": 390,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -11350,7 +11455,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 388,
+      "rank": 391,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -11377,7 +11482,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 389,
+      "rank": 392,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11408,7 +11513,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 390,
+      "rank": 393,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -11436,7 +11541,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 391,
+      "rank": 394,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -11461,7 +11566,47 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 392,
+      "rank": 395,
+      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "downloads": 14423,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "gemma4",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "creative writing",
+        "translation",
+        "visual novels",
+        "finetune",
+        "roleplay",
+        "rp",
+        "image-text-to-text",
+        "en",
+        "ja",
+        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T06:59:32.000Z",
+      "lastModified": "2026-05-18T20:11:08.000Z"
+    },
+    {
+      "rank": 396,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -11506,7 +11651,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 393,
+      "rank": 397,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -11533,7 +11678,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 394,
+      "rank": 398,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -11561,7 +11706,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 395,
+      "rank": 399,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -11594,7 +11739,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 396,
+      "rank": 400,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -11610,7 +11755,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 397,
+      "rank": 401,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -11633,7 +11778,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 398,
+      "rank": 402,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -11667,7 +11812,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 399,
+      "rank": 403,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -11687,7 +11832,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 400,
+      "rank": 404,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -11722,7 +11867,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 401,
+      "rank": 405,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -11752,7 +11897,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 402,
+      "rank": 406,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -11773,7 +11918,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 403,
+      "rank": 407,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -11802,7 +11947,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 404,
+      "rank": 408,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -11832,7 +11977,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 405,
+      "rank": 409,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -11860,7 +12005,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 406,
+      "rank": 410,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -11889,7 +12034,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 407,
+      "rank": 411,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -11921,7 +12066,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 408,
+      "rank": 412,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -11950,7 +12095,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 409,
+      "rank": 413,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -11985,7 +12130,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 410,
+      "rank": 414,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -12007,7 +12152,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 411,
+      "rank": 415,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -12045,7 +12190,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 412,
+      "rank": 416,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -12084,7 +12229,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 413,
+      "rank": 417,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -12121,7 +12266,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 414,
+      "rank": 418,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -12145,7 +12290,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 415,
+      "rank": 419,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -12163,7 +12308,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 416,
+      "rank": 420,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -12182,7 +12327,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 417,
+      "rank": 421,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -12210,7 +12355,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 418,
+      "rank": 422,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -12251,7 +12396,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 419,
+      "rank": 423,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -12273,7 +12418,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 420,
+      "rank": 424,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -12310,7 +12455,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 421,
+      "rank": 425,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -12340,7 +12485,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 422,
+      "rank": 426,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -12369,7 +12514,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 423,
+      "rank": 427,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -12397,47 +12542,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 424,
-      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "downloads": 14423,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "gemma4",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "creative writing",
-        "translation",
-        "visual novels",
-        "finetune",
-        "roleplay",
-        "rp",
-        "image-text-to-text",
-        "en",
-        "ja",
-        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T06:59:32.000Z",
-      "lastModified": "2026-05-18T20:11:08.000Z"
-    },
-    {
-      "rank": 425,
+      "rank": 428,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -12455,7 +12560,7 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -12498,7 +12603,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -12524,7 +12629,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12549,7 +12654,7 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -12590,7 +12695,59 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
+      "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
+      "downloads": 150400,
+      "likes": 482,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-image",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "unsloth",
+        "qwen",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2508.02324",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:quantized:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-20T02:31:59.000Z",
+      "lastModified": "2026-01-08T21:13:12.000Z"
+    },
+    {
+      "rank": 434,
+      "id": "openbmb/BitCPM4-CANN-8B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
+      "downloads": 57,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "minicpm",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T13:10:51.000Z",
+      "lastModified": "2026-05-22T10:05:30.000Z"
+    },
+    {
+      "rank": 435,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -12635,7 +12792,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 431,
+      "rank": 436,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -12677,7 +12834,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 432,
+      "rank": 437,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -12703,7 +12860,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 433,
+      "rank": 438,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -12728,7 +12885,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 434,
+      "rank": 439,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -12745,7 +12902,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 435,
+      "rank": 440,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -12773,7 +12930,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 436,
+      "rank": 441,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -12799,7 +12956,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 437,
+      "rank": 442,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -12826,7 +12983,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 438,
+      "rank": 443,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -12854,7 +13011,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 439,
+      "rank": 444,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -12887,7 +13044,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 440,
+      "rank": 445,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -12921,7 +13078,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 441,
+      "rank": 446,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -12950,7 +13107,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 442,
+      "rank": 447,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -12979,7 +13136,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 443,
+      "rank": 448,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -13012,7 +13169,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 444,
+      "rank": 449,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -13039,7 +13196,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 445,
+      "rank": 450,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -13069,7 +13226,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 446,
+      "rank": 451,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -13092,7 +13249,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 447,
+      "rank": 452,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -13118,7 +13275,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 448,
+      "rank": 453,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -13142,7 +13299,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 449,
+      "rank": 454,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -13169,7 +13326,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 450,
+      "rank": 455,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -13199,7 +13356,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 451,
+      "rank": 456,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -13233,7 +13390,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 452,
+      "rank": 457,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -13249,7 +13406,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 453,
+      "rank": 458,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -13280,7 +13437,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 454,
+      "rank": 459,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -13302,7 +13459,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 455,
+      "rank": 460,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -13322,7 +13479,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 456,
+      "rank": 461,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -13344,7 +13501,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 457,
+      "rank": 462,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -13373,7 +13530,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 458,
+      "rank": 463,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -13398,7 +13555,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 459,
+      "rank": 464,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -13423,7 +13580,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 460,
+      "rank": 465,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -13458,7 +13615,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 461,
+      "rank": 466,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -13482,7 +13639,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 462,
+      "rank": 467,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -13513,34 +13670,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 463,
-      "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
-      "downloads": 150400,
-      "likes": 481,
-      "trendingScore": 11,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "unsloth",
-        "qwen",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:quantized:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-20T02:31:59.000Z",
-      "lastModified": "2026-01-08T21:13:12.000Z"
-    },
-    {
-      "rank": 464,
+      "rank": 468,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -13566,7 +13696,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 465,
+      "rank": 469,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -13596,7 +13726,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 466,
+      "rank": 470,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -13622,7 +13752,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 467,
+      "rank": 471,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -13667,7 +13797,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 468,
+      "rank": 472,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -13694,7 +13824,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 469,
+      "rank": 473,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -13720,7 +13850,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 470,
+      "rank": 474,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -13753,7 +13883,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 471,
+      "rank": 475,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -13782,12 +13912,12 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 472,
+      "rank": 476,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
-      "downloads": 1929428,
-      "likes": 283,
+      "downloads": 1945756,
+      "likes": 284,
       "trendingScore": 11,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -13809,7 +13939,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 473,
+      "rank": 477,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -13854,7 +13984,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 474,
+      "rank": 478,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -13880,7 +14010,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 475,
+      "rank": 479,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -13906,7 +14036,7 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 476,
+      "rank": 480,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -13939,7 +14069,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 477,
+      "rank": 481,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -13968,7 +14098,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 478,
+      "rank": 482,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -13993,12 +14123,12 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 479,
+      "rank": 483,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
       "downloads": 8034700,
-      "likes": 1419,
+      "likes": 1420,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -14031,25 +14161,34 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 480,
-      "id": "zhen-nan/L2P",
-      "author": "zhen-nan",
-      "url": "https://huggingface.co/zhen-nan/L2P",
-      "downloads": 0,
+      "rank": 484,
+      "id": "LatitudeGames/Equinox-31B-GGUF",
+      "author": "LatitudeGames",
+      "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
+      "downloads": 1304,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "arxiv:2605.12013",
+        "gguf",
+        "gemma4",
+        "text adventure",
+        "roleplay",
+        "en",
+        "base_model:LatitudeGames/Equinox-31B",
+        "base_model:quantized:LatitudeGames/Equinox-31B",
         "license:apache-2.0",
-        "region:us"
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-03T13:24:20.000Z",
-      "lastModified": "2026-05-22T07:53:35.000Z"
+      "createdAt": "2026-05-20T07:57:51.000Z",
+      "lastModified": "2026-05-22T04:56:16.000Z"
     },
     {
-      "rank": 481,
+      "rank": 485,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -14078,7 +14217,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 482,
+      "rank": 486,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -14112,7 +14251,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 483,
+      "rank": 487,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -14157,7 +14296,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 484,
+      "rank": 488,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -14186,7 +14325,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 485,
+      "rank": 489,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -14211,7 +14350,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 486,
+      "rank": 490,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -14246,7 +14385,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 487,
+      "rank": 491,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -14273,7 +14412,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 488,
+      "rank": 492,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -14318,7 +14457,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 489,
+      "rank": 493,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -14340,7 +14479,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 490,
+      "rank": 494,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -14372,7 +14511,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 491,
+      "rank": 495,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -14397,7 +14536,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 492,
+      "rank": 496,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -14421,7 +14560,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 493,
+      "rank": 497,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -14449,7 +14588,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 494,
+      "rank": 498,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -14492,7 +14631,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 495,
+      "rank": 499,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -14516,7 +14655,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 496,
+      "rank": 500,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -14561,7 +14700,7 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 497,
+      "rank": 501,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -14590,7 +14729,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 498,
+      "rank": 502,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -14622,7 +14761,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 499,
+      "rank": 503,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -14646,7 +14785,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 500,
+      "rank": 504,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -14668,7 +14807,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 501,
+      "rank": 505,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -14693,7 +14832,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 502,
+      "rank": 506,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -14721,7 +14860,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 503,
+      "rank": 507,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -14745,7 +14884,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 504,
+      "rank": 508,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -14772,7 +14911,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 505,
+      "rank": 509,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -14797,7 +14936,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 506,
+      "rank": 510,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -14814,7 +14953,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 507,
+      "rank": 511,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -14838,7 +14977,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 508,
+      "rank": 512,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -14862,7 +15001,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 509,
+      "rank": 513,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -14895,7 +15034,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 510,
+      "rank": 514,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -14929,7 +15068,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 511,
+      "rank": 515,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -14951,7 +15090,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 512,
+      "rank": 516,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -14974,7 +15113,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 513,
+      "rank": 517,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -14994,7 +15133,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 514,
+      "rank": 518,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -15026,7 +15165,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 515,
+      "rank": 519,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -15065,7 +15204,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 516,
+      "rank": 520,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -15099,7 +15238,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 517,
+      "rank": 521,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -15123,7 +15262,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 518,
+      "rank": 522,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -15143,7 +15282,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 519,
+      "rank": 523,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -15172,7 +15311,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 520,
+      "rank": 524,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -15194,7 +15333,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 521,
+      "rank": 525,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -15226,7 +15365,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 522,
+      "rank": 526,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -15253,7 +15392,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 523,
+      "rank": 527,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -15297,7 +15436,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 524,
+      "rank": 528,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -15315,7 +15454,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 525,
+      "rank": 529,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -15354,7 +15493,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 526,
+      "rank": 530,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -15393,7 +15532,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 527,
+      "rank": 531,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -15427,7 +15566,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 528,
+      "rank": 532,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -15455,7 +15594,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 529,
+      "rank": 533,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -15477,7 +15616,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 530,
+      "rank": 534,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -15505,7 +15644,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 531,
+      "rank": 535,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -15523,7 +15662,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 532,
+      "rank": 536,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -15551,7 +15690,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 533,
+      "rank": 537,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -15582,7 +15721,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 534,
+      "rank": 538,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -15598,7 +15737,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 535,
+      "rank": 539,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -15625,7 +15764,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 536,
+      "rank": 540,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -15654,7 +15793,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 537,
+      "rank": 541,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -15682,7 +15821,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 538,
+      "rank": 542,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -15711,7 +15850,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 539,
+      "rank": 543,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -15732,7 +15871,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 540,
+      "rank": 544,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -15753,7 +15892,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 541,
+      "rank": 545,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
@@ -15780,7 +15919,7 @@
       "lastModified": "2026-05-21T02:10:38.000Z"
     },
     {
-      "rank": 542,
+      "rank": 546,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -15825,7 +15964,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 543,
+      "rank": 547,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -15854,7 +15993,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 544,
+      "rank": 548,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -15874,7 +16013,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 545,
+      "rank": 549,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -15906,7 +16045,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 546,
+      "rank": 550,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -15935,7 +16074,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 547,
+      "rank": 551,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -15973,7 +16112,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 548,
+      "rank": 552,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -16003,34 +16142,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 549,
-      "id": "LatitudeGames/Equinox-31B-GGUF",
-      "author": "LatitudeGames",
-      "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
-      "downloads": 1304,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "gemma4",
-        "text adventure",
-        "roleplay",
-        "en",
-        "base_model:LatitudeGames/Equinox-31B",
-        "base_model:quantized:LatitudeGames/Equinox-31B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T07:57:51.000Z",
-      "lastModified": "2026-05-22T04:56:16.000Z"
-    },
-    {
-      "rank": 550,
+      "rank": 553,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -16073,7 +16185,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 551,
+      "rank": 554,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -16102,32 +16214,104 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 552,
-      "id": "openbmb/BitCPM4-CANN-8B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
-      "downloads": 57,
+      "rank": 555,
+      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
+      "downloads": 6295,
       "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
+        "image-text-to-text",
+        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T16:01:21.000Z",
+      "lastModified": "2026-05-19T16:22:18.000Z"
+    },
+    {
+      "rank": 556,
+      "id": "tori29umai/QwenImageEdit2511_LoRA",
+      "author": "tori29umai",
+      "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
+      "downloads": 0,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "image-to-image",
+      "libraryName": null,
+      "tags": [
+        "lora",
+        "qwen-image-edit",
+        "image-to-image",
+        "ja",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit",
+        "base_model:adapter:Qwen/Qwen-Image-Edit",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T23:38:39.000Z",
+      "lastModified": "2026-05-16T08:11:00.000Z"
+    },
+    {
+      "rank": 557,
+      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "author": "dphn",
+      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "downloads": 13224,
+      "likes": 519,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "pytorch",
-        "minicpm",
+        "safetensors",
+        "mistral3",
+        "image-text-to-text",
         "text-generation",
         "conversational",
-        "custom_code",
-        "zh",
-        "en",
+        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
+        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
         "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2026-05-15T13:10:51.000Z",
-      "lastModified": "2026-05-22T10:05:30.000Z"
+      "createdAt": "2025-06-12T05:29:16.000Z",
+      "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 553,
+      "rank": 558,
+      "id": "netease-youdao/Confucius4",
+      "author": "netease-youdao",
+      "url": "https://huggingface.co/netease-youdao/Confucius4",
+      "downloads": 100,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T10:13:40.000Z",
+      "lastModified": "2026-05-20T08:42:10.000Z"
+    },
+    {
+      "rank": 559,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -16154,7 +16338,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 554,
+      "rank": 560,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -16180,7 +16364,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 555,
+      "rank": 561,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -16208,7 +16392,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 556,
+      "rank": 562,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -16234,7 +16418,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 557,
+      "rank": 563,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -16278,7 +16462,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 558,
+      "rank": 564,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -16318,7 +16502,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 559,
+      "rank": 565,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -16354,7 +16538,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 560,
+      "rank": 566,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -16398,7 +16582,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 561,
+      "rank": 567,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -16423,7 +16607,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 562,
+      "rank": 568,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -16468,7 +16652,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 563,
+      "rank": 569,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -16487,7 +16671,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 564,
+      "rank": 570,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -16512,7 +16696,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 565,
+      "rank": 571,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -16551,7 +16735,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 566,
+      "rank": 572,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -16568,7 +16752,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 567,
+      "rank": 573,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -16596,7 +16780,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 568,
+      "rank": 574,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -16625,7 +16809,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 569,
+      "rank": 575,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -16650,7 +16834,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 570,
+      "rank": 576,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -16685,7 +16869,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 571,
+      "rank": 577,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -16715,7 +16899,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 572,
+      "rank": 578,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -16751,7 +16935,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 573,
+      "rank": 579,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -16774,7 +16958,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 574,
+      "rank": 580,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -16791,7 +16975,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 575,
+      "rank": 581,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -16811,7 +16995,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 576,
+      "rank": 582,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -16838,7 +17022,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 577,
+      "rank": 583,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -16862,7 +17046,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 578,
+      "rank": 584,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -16884,7 +17068,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 579,
+      "rank": 585,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -16916,7 +17100,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 580,
+      "rank": 586,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -16944,7 +17128,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 581,
+      "rank": 587,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -16962,7 +17146,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 582,
+      "rank": 588,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -16987,7 +17171,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 583,
+      "rank": 589,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -17010,7 +17194,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 584,
+      "rank": 590,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -17028,7 +17212,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 585,
+      "rank": 591,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -17063,7 +17247,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 586,
+      "rank": 592,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -17091,7 +17275,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 587,
+      "rank": 593,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -17113,7 +17297,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 588,
+      "rank": 594,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -17140,7 +17324,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 589,
+      "rank": 595,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -17165,7 +17349,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 590,
+      "rank": 596,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -17199,7 +17383,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 591,
+      "rank": 597,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -17226,7 +17410,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 592,
+      "rank": 598,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -17253,7 +17437,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 593,
+      "rank": 599,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -17294,7 +17478,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 594,
+      "rank": 600,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -17324,7 +17508,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 595,
+      "rank": 601,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -17361,7 +17545,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 596,
+      "rank": 602,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -17393,7 +17577,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 597,
+      "rank": 603,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -17435,7 +17619,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 598,
+      "rank": 604,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -17465,7 +17649,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 599,
+      "rank": 605,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -17510,7 +17694,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 600,
+      "rank": 606,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -17537,7 +17721,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 601,
+      "rank": 607,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -17569,7 +17753,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 602,
+      "rank": 608,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -17603,7 +17787,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 603,
+      "rank": 609,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -17633,7 +17817,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 604,
+      "rank": 610,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -17658,12 +17842,12 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 605,
+      "rank": 611,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
       "downloads": 1536548,
-      "likes": 2792,
+      "likes": 2793,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -17685,7 +17869,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 606,
+      "rank": 612,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -17717,7 +17901,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 607,
+      "rank": 613,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -17762,7 +17946,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 608,
+      "rank": 614,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -17790,7 +17974,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 609,
+      "rank": 615,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -17829,7 +18013,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 610,
+      "rank": 616,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -17855,7 +18039,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 611,
+      "rank": 617,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -17884,7 +18068,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 612,
+      "rank": 618,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -17926,7 +18110,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 613,
+      "rank": 619,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -17954,7 +18138,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 614,
+      "rank": 620,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
@@ -17984,7 +18168,7 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 615,
+      "rank": 621,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -18019,59 +18203,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 616,
-      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
-      "downloads": 6295,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
-        "image-text-to-text",
-        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T16:01:21.000Z",
-      "lastModified": "2026-05-19T16:22:18.000Z"
-    },
-    {
-      "rank": 617,
-      "id": "tori29umai/QwenImageEdit2511_LoRA",
-      "author": "tori29umai",
-      "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
-      "downloads": 0,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
-      "tags": [
-        "lora",
-        "qwen-image-edit",
-        "image-to-image",
-        "ja",
-        "en",
-        "base_model:Qwen/Qwen-Image-Edit",
-        "base_model:adapter:Qwen/Qwen-Image-Edit",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T23:38:39.000Z",
-      "lastModified": "2026-05-16T08:11:00.000Z"
-    },
-    {
-      "rank": 618,
+      "rank": 622,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -18100,34 +18232,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 619,
-      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "author": "dphn",
-      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13224,
-      "likes": 518,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "mistral3",
-        "image-text-to-text",
-        "text-generation",
-        "conversational",
-        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
-        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-06-12T05:29:16.000Z",
-      "lastModified": "2026-04-24T13:52:18.000Z"
-    },
-    {
-      "rank": 620,
+      "rank": 623,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -18157,7 +18262,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 621,
+      "rank": 624,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -18187,25 +18292,88 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 622,
-      "id": "netease-youdao/Confucius4",
-      "author": "netease-youdao",
-      "url": "https://huggingface.co/netease-youdao/Confucius4",
-      "downloads": 100,
+      "rank": 625,
+      "id": "Qwen/Qwen3.5-35B-A3B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
+      "downloads": 3065015,
+      "likes": 1431,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.5-35B-A3B-Base",
+        "base_model:finetune:Qwen/Qwen3.5-35B-A3B-Base",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-02-24T09:39:25.000Z",
+      "lastModified": "2026-04-24T02:38:38.000Z"
+    },
+    {
+      "rank": 626,
+      "id": "Efficient-Large-Model/SANA-Video_2B_720p",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
+      "downloads": 67,
+      "likes": 24,
+      "trendingScore": 9,
+      "pipelineTag": "text-to-video",
+      "libraryName": "sana, sana-video",
+      "tags": [
+        "sana, sana-video",
+        "text-to-video",
+        "SANA-Video",
+        "720p_5s_pretrained_model",
+        "BF16",
+        "diffusion",
+        "LTX2-VAE",
+        "en",
+        "zh",
+        "arxiv:2509.24695",
+        "base_model:Efficient-Large-Model/SANA-Video_2B_720p",
+        "base_model:finetune:Efficient-Large-Model/SANA-Video_2B_720p",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-16T10:01:28.000Z",
+      "lastModified": "2026-03-16T13:38:42.000Z"
+    },
+    {
+      "rank": 627,
+      "id": "stabilityai/SAME-S",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/SAME-S",
+      "downloads": 0,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": null,
-      "libraryName": null,
+      "libraryName": "stable-audio-3",
       "tags": [
+        "stable-audio-3",
         "safetensors",
-        "qwen3_5",
+        "music",
+        "sound-effects",
+        "audio",
+        "autoencoder",
+        "en",
+        "arxiv:2605.18613",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-19T10:13:40.000Z",
-      "lastModified": "2026-05-20T08:42:10.000Z"
+      "createdAt": "2026-05-17T02:17:58.000Z",
+      "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 623,
+      "rank": 628,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -18232,7 +18400,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 624,
+      "rank": 629,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -18256,7 +18424,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 625,
+      "rank": 630,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -18276,34 +18444,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 626,
-      "id": "Qwen/Qwen3.5-35B-A3B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
-      "downloads": 3065015,
-      "likes": 1430,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.5-35B-A3B-Base",
-        "base_model:finetune:Qwen/Qwen3.5-35B-A3B-Base",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-02-24T09:39:25.000Z",
-      "lastModified": "2026-04-24T02:38:38.000Z"
-    },
-    {
-      "rank": 627,
+      "rank": 631,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -18322,7 +18463,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 628,
+      "rank": 632,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -18356,7 +18497,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 629,
+      "rank": 633,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -18388,7 +18529,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 630,
+      "rank": 634,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -18410,7 +18551,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 631,
+      "rank": 635,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -18455,7 +18596,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 632,
+      "rank": 636,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -18474,7 +18615,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 633,
+      "rank": 637,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -18508,7 +18649,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 634,
+      "rank": 638,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -18536,7 +18677,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 635,
+      "rank": 639,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -18564,7 +18705,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 636,
+      "rank": 640,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -18587,7 +18728,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 637,
+      "rank": 641,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -18614,7 +18755,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 638,
+      "rank": 642,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -18659,7 +18800,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 639,
+      "rank": 643,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -18695,7 +18836,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 640,
+      "rank": 644,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -18735,7 +18876,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 641,
+      "rank": 645,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -18764,7 +18905,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 642,
+      "rank": 646,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -18792,7 +18933,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 643,
+      "rank": 647,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -18811,7 +18952,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 644,
+      "rank": 648,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -18830,7 +18971,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 645,
+      "rank": 649,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -18862,7 +19003,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 646,
+      "rank": 650,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -18889,7 +19030,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 647,
+      "rank": 651,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -18911,7 +19052,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 648,
+      "rank": 652,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -18929,7 +19070,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 649,
+      "rank": 653,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -18958,7 +19099,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 650,
+      "rank": 654,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -18979,7 +19120,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 651,
+      "rank": 655,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -19007,7 +19148,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 652,
+      "rank": 656,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -19028,7 +19169,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 653,
+      "rank": 657,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -19064,7 +19205,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 654,
+      "rank": 658,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -19109,7 +19250,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 655,
+      "rank": 659,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -19135,7 +19276,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 656,
+      "rank": 660,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -19158,7 +19299,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 657,
+      "rank": 661,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -19183,7 +19324,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 658,
+      "rank": 662,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -19218,7 +19359,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 659,
+      "rank": 663,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -19263,7 +19404,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 660,
+      "rank": 664,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -19290,7 +19431,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 661,
+      "rank": 665,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -19319,7 +19460,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 662,
+      "rank": 666,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -19338,7 +19479,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 663,
+      "rank": 667,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -19359,7 +19500,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 664,
+      "rank": 668,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -19385,7 +19526,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 665,
+      "rank": 669,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -19411,7 +19552,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 666,
+      "rank": 670,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -19448,7 +19589,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 667,
+      "rank": 671,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -19493,7 +19634,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 668,
+      "rank": 672,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -19518,7 +19659,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 669,
+      "rank": 673,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -19535,7 +19676,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 670,
+      "rank": 674,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -19562,7 +19703,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 671,
+      "rank": 675,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -19580,7 +19721,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 672,
+      "rank": 676,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -19605,7 +19746,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 673,
+      "rank": 677,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -19637,7 +19778,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 674,
+      "rank": 678,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -19658,7 +19799,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 675,
+      "rank": 679,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -19677,7 +19818,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 676,
+      "rank": 680,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -19708,7 +19849,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 677,
+      "rank": 681,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -19731,7 +19872,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 678,
+      "rank": 682,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -19748,7 +19889,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 679,
+      "rank": 683,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -19776,7 +19917,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 680,
+      "rank": 684,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -19793,7 +19934,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 681,
+      "rank": 685,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -19829,7 +19970,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 682,
+      "rank": 686,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -19859,7 +20000,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 683,
+      "rank": 687,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -19882,7 +20023,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 684,
+      "rank": 688,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -19915,7 +20056,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 685,
+      "rank": 689,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -19946,7 +20087,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 686,
+      "rank": 690,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -19969,7 +20110,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 687,
+      "rank": 691,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -20002,7 +20143,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 688,
+      "rank": 692,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -20025,7 +20166,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 689,
+      "rank": 693,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -20055,7 +20196,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 690,
+      "rank": 694,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -20082,7 +20223,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 691,
+      "rank": 695,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -20111,7 +20252,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 692,
+      "rank": 696,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -20140,7 +20281,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 693,
+      "rank": 697,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -20176,7 +20317,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 694,
+      "rank": 698,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -20199,7 +20340,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 695,
+      "rank": 699,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -20224,7 +20365,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 696,
+      "rank": 700,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -20254,36 +20395,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 697,
-      "id": "Efficient-Large-Model/SANA-Video_2B_720p",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
-      "downloads": 67,
-      "likes": 23,
-      "trendingScore": 8,
-      "pipelineTag": "text-to-video",
-      "libraryName": "sana, sana-video",
-      "tags": [
-        "sana, sana-video",
-        "text-to-video",
-        "SANA-Video",
-        "720p_5s_pretrained_model",
-        "BF16",
-        "diffusion",
-        "LTX2-VAE",
-        "en",
-        "zh",
-        "arxiv:2509.24695",
-        "base_model:Efficient-Large-Model/SANA-Video_2B_720p",
-        "base_model:finetune:Efficient-Large-Model/SANA-Video_2B_720p",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-16T10:01:28.000Z",
-      "lastModified": "2026-03-16T13:38:42.000Z"
-    },
-    {
-      "rank": 698,
+      "rank": 701,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -20319,7 +20431,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 699,
+      "rank": 702,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -20356,7 +20468,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 700,
+      "rank": 703,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -20380,7 +20492,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 701,
+      "rank": 704,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -20407,7 +20519,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 702,
+      "rank": 705,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -20440,7 +20552,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 703,
+      "rank": 706,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -20485,7 +20597,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 704,
+      "rank": 707,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -20510,7 +20622,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 705,
+      "rank": 708,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -20535,7 +20647,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 706,
+      "rank": 709,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -20572,32 +20684,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 707,
-      "id": "stabilityai/SAME-S",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/SAME-S",
-      "downloads": 0,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "music",
-        "sound-effects",
-        "audio",
-        "autoencoder",
-        "en",
-        "arxiv:2605.18613",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T02:17:58.000Z",
-      "lastModified": "2026-05-19T20:11:16.000Z"
-    },
-    {
-      "rank": 708,
+      "rank": 710,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -20625,7 +20712,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 709,
+      "rank": 711,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -20664,7 +20751,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 710,
+      "rank": 712,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -20701,7 +20788,121 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 711,
+      "rank": 713,
+      "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
+      "author": "lightx2v",
+      "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
+      "downloads": 262599,
+      "likes": 446,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "diffusion-single-file",
+        "comfyui",
+        "distillation",
+        "LoRA",
+        "lora",
+        "Qwen-Image",
+        "Qwen-Image-Edit",
+        "image-to-image",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-22T06:03:41.000Z",
+      "lastModified": "2026-01-15T10:41:12.000Z"
+    },
+    {
+      "rank": 714,
+      "id": "xai-org/grok-1",
+      "author": "xai-org",
+      "url": "https://huggingface.co/xai-org/grok-1",
+      "downloads": 503,
+      "likes": 2410,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "grok",
+      "tags": [
+        "grok",
+        "grok-1",
+        "text-generation",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2024-03-17T05:47:21.000Z",
+      "lastModified": "2024-03-28T16:25:32.000Z"
+    },
+    {
+      "rank": 715,
+      "id": "allenai/OlmoEarth-v1_1-Base",
+      "author": "allenai",
+      "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
+      "downloads": 90,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T15:14:45.000Z",
+      "lastModified": "2026-05-15T15:53:18.000Z"
+    },
+    {
+      "rank": 716,
+      "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
+      "downloads": 14091,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-02-04T23:24:06.000Z",
+      "lastModified": "2026-05-22T18:03:52.000Z"
+    },
+    {
+      "rank": 717,
+      "id": "microsoft/Lens-Base",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Base",
+      "downloads": 71,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:08:02.000Z",
+      "lastModified": "2026-05-22T03:10:01.000Z"
+    },
+    {
+      "rank": 718,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -20727,7 +20928,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 712,
+      "rank": 719,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -20744,7 +20945,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 713,
+      "rank": 720,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -20772,7 +20973,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 714,
+      "rank": 721,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -20807,7 +21008,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 715,
+      "rank": 722,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -20832,7 +21033,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 716,
+      "rank": 723,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -20862,7 +21063,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 717,
+      "rank": 724,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -20891,7 +21092,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 718,
+      "rank": 725,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -20918,7 +21119,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 719,
+      "rank": 726,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -20944,7 +21145,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 720,
+      "rank": 727,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -20975,7 +21176,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 721,
+      "rank": 728,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -20993,7 +21194,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 722,
+      "rank": 729,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -21022,7 +21223,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 723,
+      "rank": 730,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -21045,7 +21246,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 724,
+      "rank": 731,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -21090,7 +21291,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 725,
+      "rank": 732,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -21116,7 +21317,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 726,
+      "rank": 733,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -21144,7 +21345,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 727,
+      "rank": 734,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -21182,7 +21383,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 728,
+      "rank": 735,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -21209,7 +21410,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 729,
+      "rank": 736,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -21235,7 +21436,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 730,
+      "rank": 737,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -21253,7 +21454,7 @@
       "lastModified": "2026-04-29T04:52:06.000Z"
     },
     {
-      "rank": 731,
+      "rank": 738,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -21279,7 +21480,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 732,
+      "rank": 739,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -21303,7 +21504,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 733,
+      "rank": 740,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -21344,7 +21545,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 734,
+      "rank": 741,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -21361,7 +21562,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 735,
+      "rank": 742,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -21394,7 +21595,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 736,
+      "rank": 743,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -21428,7 +21629,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 737,
+      "rank": 744,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -21467,7 +21668,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 738,
+      "rank": 745,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -21497,7 +21698,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 739,
+      "rank": 746,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -21533,7 +21734,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 740,
+      "rank": 747,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -21559,7 +21760,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 741,
+      "rank": 748,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -21595,7 +21796,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 742,
+      "rank": 749,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -21625,7 +21826,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 743,
+      "rank": 750,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -21663,7 +21864,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 744,
+      "rank": 751,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -21698,7 +21899,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 745,
+      "rank": 752,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -21723,7 +21924,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 746,
+      "rank": 753,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -21740,7 +21941,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 747,
+      "rank": 754,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -21782,7 +21983,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 748,
+      "rank": 755,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -21812,7 +22013,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 749,
+      "rank": 756,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -21837,7 +22038,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 750,
+      "rank": 757,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -21865,7 +22066,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 751,
+      "rank": 758,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -21882,7 +22083,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 752,
+      "rank": 759,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -21909,7 +22110,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 753,
+      "rank": 760,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -21952,7 +22153,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 754,
+      "rank": 761,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -21992,7 +22193,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 755,
+      "rank": 762,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -22016,7 +22217,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 756,
+      "rank": 763,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -22045,7 +22246,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 757,
+      "rank": 764,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -22071,7 +22272,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 758,
+      "rank": 765,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -22099,7 +22300,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 759,
+      "rank": 766,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -22138,7 +22339,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 760,
+      "rank": 767,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -22162,7 +22363,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 761,
+      "rank": 768,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -22190,7 +22391,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 762,
+      "rank": 769,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -22222,7 +22423,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 763,
+      "rank": 770,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -22252,7 +22453,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 764,
+      "rank": 771,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -22281,7 +22482,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 765,
+      "rank": 772,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -22314,7 +22515,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 766,
+      "rank": 773,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -22343,7 +22544,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 767,
+      "rank": 774,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -22363,36 +22564,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 768,
-      "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
-      "author": "lightx2v",
-      "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
-      "downloads": 262599,
-      "likes": 445,
-      "trendingScore": 7,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "diffusion-single-file",
-        "comfyui",
-        "distillation",
-        "LoRA",
-        "lora",
-        "Qwen-Image",
-        "Qwen-Image-Edit",
-        "image-to-image",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-22T06:03:41.000Z",
-      "lastModified": "2026-01-15T10:41:12.000Z"
-    },
-    {
-      "rank": 769,
+      "rank": 775,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -22416,7 +22588,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 770,
+      "rank": 776,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -22446,7 +22618,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 771,
+      "rank": 777,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -22476,7 +22648,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 772,
+      "rank": 778,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -22494,7 +22666,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 773,
+      "rank": 779,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -22511,7 +22683,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 774,
+      "rank": 780,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -22547,7 +22719,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 775,
+      "rank": 781,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -22578,7 +22750,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 776,
+      "rank": 782,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -22609,7 +22781,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 777,
+      "rank": 783,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -22642,7 +22814,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 778,
+      "rank": 784,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -22670,7 +22842,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 779,
+      "rank": 785,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -22695,7 +22867,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 780,
+      "rank": 786,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -22718,7 +22890,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 781,
+      "rank": 787,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -22746,7 +22918,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 782,
+      "rank": 788,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -22779,7 +22951,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 783,
+      "rank": 789,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -22809,7 +22981,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 784,
+      "rank": 790,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -22844,7 +23016,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 785,
+      "rank": 791,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -22876,7 +23048,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 786,
+      "rank": 792,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -22901,7 +23073,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 787,
+      "rank": 793,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -22924,7 +23096,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 788,
+      "rank": 794,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -22951,7 +23123,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 789,
+      "rank": 795,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -22974,7 +23146,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 790,
+      "rank": 796,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -23019,7 +23191,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 791,
+      "rank": 797,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -23051,7 +23223,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 792,
+      "rank": 798,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -23078,7 +23250,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 793,
+      "rank": 799,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -23104,7 +23276,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 794,
+      "rank": 800,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -23136,7 +23308,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 795,
+      "rank": 801,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -23165,7 +23337,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 796,
+      "rank": 802,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -23197,7 +23369,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 797,
+      "rank": 803,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -23227,7 +23399,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 798,
+      "rank": 804,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -23244,7 +23416,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 799,
+      "rank": 805,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -23264,7 +23436,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 800,
+      "rank": 806,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -23303,7 +23475,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 801,
+      "rank": 807,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -23341,7 +23513,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 802,
+      "rank": 808,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -23369,7 +23541,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 803,
+      "rank": 809,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -23414,7 +23586,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 804,
+      "rank": 810,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -23438,7 +23610,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 805,
+      "rank": 811,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -23468,7 +23640,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 806,
+      "rank": 812,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -23495,7 +23667,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 807,
+      "rank": 813,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -23521,7 +23693,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 808,
+      "rank": 814,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -23550,7 +23722,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 809,
+      "rank": 815,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -23568,27 +23740,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 810,
-      "id": "xai-org/grok-1",
-      "author": "xai-org",
-      "url": "https://huggingface.co/xai-org/grok-1",
-      "downloads": 503,
-      "likes": 2409,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "grok",
-      "tags": [
-        "grok",
-        "grok-1",
-        "text-generation",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2024-03-17T05:47:21.000Z",
-      "lastModified": "2024-03-28T16:25:32.000Z"
-    },
-    {
-      "rank": 811,
+      "rank": 816,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -23620,7 +23772,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 812,
+      "rank": 817,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -23647,23 +23799,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 813,
-      "id": "allenai/OlmoEarth-v1_1-Base",
-      "author": "allenai",
-      "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
-      "downloads": 90,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T15:14:45.000Z",
-      "lastModified": "2026-05-15T15:53:18.000Z"
-    },
-    {
-      "rank": 814,
+      "rank": 818,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -23681,7 +23817,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 815,
+      "rank": 819,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -23708,7 +23844,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 816,
+      "rank": 820,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -23732,7 +23868,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 817,
+      "rank": 821,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -23777,7 +23913,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 818,
+      "rank": 822,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -23808,7 +23944,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 819,
+      "rank": 823,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -23848,7 +23984,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 820,
+      "rank": 824,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -23873,7 +24009,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 821,
+      "rank": 825,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -23904,7 +24040,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 822,
+      "rank": 826,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -23938,7 +24074,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 823,
+      "rank": 827,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -23956,7 +24092,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 824,
+      "rank": 828,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -24001,7 +24137,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 825,
+      "rank": 829,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -24046,33 +24182,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 826,
-      "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
-      "downloads": 14091,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-02-04T23:24:06.000Z",
-      "lastModified": "2026-05-19T18:52:45.000Z"
-    },
-    {
-      "rank": 827,
+      "rank": 830,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -24097,7 +24207,7 @@
       "lastModified": "2026-05-22T04:33:05.000Z"
     },
     {
-      "rank": 828,
+      "rank": 831,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -24124,7 +24234,7 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 829,
+      "rank": 832,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
@@ -24157,7 +24267,7 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 830,
+      "rank": 833,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -24198,7 +24308,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 831,
+      "rank": 834,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -24225,7 +24335,213 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 832,
+      "rank": 835,
+      "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
+      "downloads": 12100,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:samuelcardillo/Carnice-Qwen3.6-MoE-35B-A3B",
+        "base_model:quantized:samuelcardillo/Carnice-Qwen3.6-MoE-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T09:12:50.000Z",
+      "lastModified": "2026-05-21T21:35:06.000Z"
+    },
+    {
+      "rank": 836,
+      "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
+      "author": "resect-ai",
+      "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
+      "downloads": 42,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "factual-grounding",
+        "fact-checking",
+        "conversational",
+        "en",
+        "base_model:Qwen/Qwen3-8B",
+        "base_model:finetune:Qwen/Qwen3-8B",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T17:58:06.000Z",
+      "lastModified": "2026-05-21T19:18:06.000Z"
+    },
+    {
+      "rank": 837,
+      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "downloads": 8504,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T11:53:48.000Z",
+      "lastModified": "2026-05-19T13:01:22.000Z"
+    },
+    {
+      "rank": 838,
+      "id": "meituan-longcat/LongCat-Video",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
+      "downloads": 1285,
+      "likes": 478,
+      "trendingScore": 7,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "transformers",
+        "image-to-video",
+        "video-continuation",
+        "text-to-video",
+        "en",
+        "zh",
+        "arxiv:2510.22200",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-10-24T16:04:08.000Z",
+      "lastModified": "2025-10-29T06:22:46.000Z"
+    },
+    {
+      "rank": 839,
+      "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
+      "downloads": 531,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T09:26:12.000Z",
+      "lastModified": "2026-05-22T05:15:45.000Z"
+    },
+    {
+      "rank": 840,
+      "id": "SupraLabs/Supra-50M-Base",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
+      "downloads": 40,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T05:00:44.000Z",
+      "lastModified": "2026-05-22T15:13:03.000Z"
+    },
+    {
+      "rank": 841,
+      "id": "sinimiini/HRM-Text-1B-GGUF",
+      "author": "sinimiini",
+      "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
+      "downloads": 468,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "bf16",
+        "q8_0",
+        "q6_k",
+        "q5_k_m",
+        "quantized",
+        "llama.cpp",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "text-generation",
+        "en",
+        "base_model:sapientinc/HRM-Text-1B",
+        "base_model:quantized:sapientinc/HRM-Text-1B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T07:34:13.000Z",
+      "lastModified": "2026-05-21T09:49:08.000Z"
+    },
+    {
+      "rank": 842,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -24253,7 +24569,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 833,
+      "rank": 843,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -24286,7 +24602,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 834,
+      "rank": 844,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -24315,7 +24631,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 835,
+      "rank": 845,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -24360,7 +24676,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 836,
+      "rank": 846,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -24389,7 +24705,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 837,
+      "rank": 847,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -24434,7 +24750,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 838,
+      "rank": 848,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -24478,7 +24794,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 839,
+      "rank": 849,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -24504,7 +24820,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 840,
+      "rank": 850,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -24530,7 +24846,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 841,
+      "rank": 851,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -24562,7 +24878,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 842,
+      "rank": 852,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -24585,7 +24901,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 843,
+      "rank": 853,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -24628,7 +24944,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 844,
+      "rank": 854,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -24673,7 +24989,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 845,
+      "rank": 855,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -24718,7 +25034,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 846,
+      "rank": 856,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -24745,7 +25061,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 847,
+      "rank": 857,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -24772,7 +25088,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 848,
+      "rank": 858,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -24797,7 +25113,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 849,
+      "rank": 859,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -24836,7 +25152,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 850,
+      "rank": 860,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -24861,7 +25177,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 851,
+      "rank": 861,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -24889,7 +25205,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 852,
+      "rank": 862,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -24914,7 +25230,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 853,
+      "rank": 863,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -24930,7 +25246,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 854,
+      "rank": 864,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -24957,7 +25273,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 855,
+      "rank": 865,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -24989,7 +25305,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 856,
+      "rank": 866,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -25019,7 +25335,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 857,
+      "rank": 867,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -25051,7 +25367,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 858,
+      "rank": 868,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -25079,7 +25395,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 859,
+      "rank": 869,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -25105,7 +25421,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 860,
+      "rank": 870,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -25130,7 +25446,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 861,
+      "rank": 871,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -25159,7 +25475,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 862,
+      "rank": 872,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -25201,7 +25517,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 863,
+      "rank": 873,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -25228,7 +25544,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 864,
+      "rank": 874,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -25273,7 +25589,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 865,
+      "rank": 875,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -25299,7 +25615,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 866,
+      "rank": 876,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -25319,7 +25635,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 867,
+      "rank": 877,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -25346,7 +25662,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 868,
+      "rank": 878,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -25388,7 +25704,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 869,
+      "rank": 879,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -25415,7 +25731,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 870,
+      "rank": 880,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -25449,7 +25765,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 871,
+      "rank": 881,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -25478,7 +25794,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 872,
+      "rank": 882,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -25505,7 +25821,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 873,
+      "rank": 883,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -25532,7 +25848,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 874,
+      "rank": 884,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -25559,7 +25875,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 875,
+      "rank": 885,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -25587,7 +25903,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 876,
+      "rank": 886,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -25610,7 +25926,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 877,
+      "rank": 887,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -25641,7 +25957,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 878,
+      "rank": 888,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -25686,7 +26002,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 879,
+      "rank": 889,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -25708,7 +26024,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 880,
+      "rank": 890,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -25734,12 +26050,12 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 881,
+      "rank": 891,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 35038,
-      "likes": 102,
+      "downloads": 37038,
+      "likes": 109,
       "trendingScore": 6,
       "pipelineTag": "image-to-video",
       "libraryName": "diffusers",
@@ -25760,7 +26076,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 882,
+      "rank": 892,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -25791,7 +26107,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 883,
+      "rank": 893,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -25814,7 +26130,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 884,
+      "rank": 894,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -25844,7 +26160,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 885,
+      "rank": 895,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -25876,7 +26192,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 886,
+      "rank": 896,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -25905,7 +26221,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 887,
+      "rank": 897,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -25937,7 +26253,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 888,
+      "rank": 898,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -25969,7 +26285,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 889,
+      "rank": 899,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -26000,7 +26316,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 890,
+      "rank": 900,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -26031,7 +26347,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 891,
+      "rank": 901,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -26054,7 +26370,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 892,
+      "rank": 902,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -26081,7 +26397,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 893,
+      "rank": 903,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -26126,7 +26442,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 894,
+      "rank": 904,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -26144,7 +26460,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 895,
+      "rank": 905,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -26167,7 +26483,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 896,
+      "rank": 906,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -26197,7 +26513,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 897,
+      "rank": 907,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -26236,7 +26552,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 898,
+      "rank": 908,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -26274,7 +26590,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 899,
+      "rank": 909,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -26319,7 +26635,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 900,
+      "rank": 910,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -26344,7 +26660,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 901,
+      "rank": 911,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -26378,7 +26694,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 902,
+      "rank": 912,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -26403,7 +26719,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 903,
+      "rank": 913,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -26436,7 +26752,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 904,
+      "rank": 914,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -26463,7 +26779,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 905,
+      "rank": 915,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -26493,7 +26809,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 906,
+      "rank": 916,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -26525,7 +26841,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 907,
+      "rank": 917,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -26558,7 +26874,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 908,
+      "rank": 918,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -26576,7 +26892,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 909,
+      "rank": 919,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -26599,7 +26915,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 910,
+      "rank": 920,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -26631,7 +26947,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 911,
+      "rank": 921,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -26676,7 +26992,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 912,
+      "rank": 922,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -26715,7 +27031,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 913,
+      "rank": 923,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -26742,7 +27058,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 914,
+      "rank": 924,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -26779,7 +27095,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 915,
+      "rank": 925,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -26815,7 +27131,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 916,
+      "rank": 926,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -26833,7 +27149,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 917,
+      "rank": 927,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -26872,7 +27188,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 918,
+      "rank": 928,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -26901,7 +27217,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 919,
+      "rank": 929,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -26928,7 +27244,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 920,
+      "rank": 930,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -26955,7 +27271,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 921,
+      "rank": 931,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -26985,7 +27301,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 922,
+      "rank": 932,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -27012,7 +27328,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 923,
+      "rank": 933,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -27043,7 +27359,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 924,
+      "rank": 934,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -27062,7 +27378,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 925,
+      "rank": 935,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -27089,7 +27405,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 926,
+      "rank": 936,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -27114,7 +27430,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 927,
+      "rank": 937,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -27144,7 +27460,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 928,
+      "rank": 938,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -27166,7 +27482,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 929,
+      "rank": 939,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -27187,7 +27503,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 930,
+      "rank": 940,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -27223,7 +27539,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 931,
+      "rank": 941,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -27246,7 +27562,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 932,
+      "rank": 942,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -27291,7 +27607,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 933,
+      "rank": 943,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -27313,7 +27629,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 934,
+      "rank": 944,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -27343,7 +27659,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 935,
+      "rank": 945,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -27368,7 +27684,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 936,
+      "rank": 946,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -27401,7 +27717,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 937,
+      "rank": 947,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -27424,7 +27740,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 938,
+      "rank": 948,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -27444,7 +27760,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 939,
+      "rank": 949,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -27489,7 +27805,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 940,
+      "rank": 950,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -27510,7 +27826,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 941,
+      "rank": 951,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -27543,7 +27859,7 @@
       "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 942,
+      "rank": 952,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -27571,7 +27887,7 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 943,
+      "rank": 953,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -27616,7 +27932,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 944,
+      "rank": 954,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -27641,7 +27957,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 945,
+      "rank": 955,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -27669,7 +27985,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 946,
+      "rank": 956,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
@@ -27700,7 +28016,7 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 947,
+      "rank": 957,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
@@ -27719,12 +28035,12 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 948,
+      "rank": 958,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
-      "downloads": 80667,
-      "likes": 225,
+      "downloads": 90168,
+      "likes": 229,
       "trendingScore": 6,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -27745,7 +28061,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 949,
+      "rank": 959,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -27772,7 +28088,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 950,
+      "rank": 960,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
@@ -27804,7 +28120,7 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 951,
+      "rank": 961,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -27822,7 +28138,7 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 952,
+      "rank": 962,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -27845,7 +28161,7 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 953,
+      "rank": 963,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
@@ -27872,7 +28188,7 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 954,
+      "rank": 964,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
@@ -27904,7 +28220,7 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 955,
+      "rank": 965,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
@@ -27922,7 +28238,7 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 956,
+      "rank": 966,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
@@ -27955,39 +28271,7 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 957,
-      "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 12100,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:samuelcardillo/Carnice-Qwen3.6-MoE-35B-A3B",
-        "base_model:quantized:samuelcardillo/Carnice-Qwen3.6-MoE-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T09:12:50.000Z",
-      "lastModified": "2026-05-21T21:35:06.000Z"
-    },
-    {
-      "rank": 958,
+      "rank": 967,
       "id": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
       "author": "Ttimofeyka",
       "url": "https://huggingface.co/Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
@@ -28012,7 +28296,7 @@
       "lastModified": "2024-02-10T11:41:00.000Z"
     },
     {
-      "rank": 959,
+      "rank": 968,
       "id": "HuggingFaceTB/SmolLM2-135M-Instruct",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct",
@@ -28043,7 +28327,7 @@
       "lastModified": "2025-09-22T20:43:15.000Z"
     },
     {
-      "rank": 960,
+      "rank": 969,
       "id": "mistralai/Ministral-3-8B-Instruct-2512-GGUF",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF",
@@ -28078,12 +28362,12 @@
       "lastModified": "2026-01-15T11:18:05.000Z"
     },
     {
-      "rank": 961,
+      "rank": 970,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
-      "downloads": 8365,
-      "likes": 543,
+      "downloads": 8349,
+      "likes": 544,
       "trendingScore": 6,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "nemo",
@@ -28123,7 +28407,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 962,
+      "rank": 971,
       "id": "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
       "author": "hampsonw",
       "url": "https://huggingface.co/hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
@@ -28149,7 +28433,7 @@
       "lastModified": "2026-05-14T19:42:51.000Z"
     },
     {
-      "rank": 963,
+      "rank": 972,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -28188,7 +28472,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 964,
+      "rank": 973,
       "id": "Qwen/QwQ-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/QwQ-32B",
@@ -28219,7 +28503,7 @@
       "lastModified": "2025-03-11T12:15:48.000Z"
     },
     {
-      "rank": 965,
+      "rank": 974,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -28247,7 +28531,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 966,
+      "rank": 975,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -28263,7 +28547,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 967,
+      "rank": 976,
       "id": "inclusionAI/ARGenSeg-8B",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/ARGenSeg-8B",
@@ -28283,7 +28567,7 @@
       "lastModified": "2026-05-15T02:36:20.000Z"
     },
     {
-      "rank": 968,
+      "rank": 977,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -28309,7 +28593,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 969,
+      "rank": 978,
       "id": "Wan-AI/Wan2.2-Animate-14B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B",
@@ -28333,7 +28617,7 @@
       "lastModified": "2025-11-05T10:15:40.000Z"
     },
     {
-      "rank": 970,
+      "rank": 979,
       "id": "dx8152/LTX2.3-Multifunctional",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/LTX2.3-Multifunctional",
@@ -28354,64 +28638,7 @@
       "lastModified": "2026-04-30T07:06:19.000Z"
     },
     {
-      "rank": 971,
-      "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
-      "author": "resect-ai",
-      "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
-      "downloads": 42,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "factual-grounding",
-        "fact-checking",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3-8B",
-        "base_model:finetune:Qwen/Qwen3-8B",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T17:58:06.000Z",
-      "lastModified": "2026-05-21T19:18:06.000Z"
-    },
-    {
-      "rank": 972,
-      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "downloads": 8504,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T11:53:48.000Z",
-      "lastModified": "2026-05-19T13:01:22.000Z"
-    },
-    {
-      "rank": 973,
+      "rank": 980,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -28429,7 +28656,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 974,
+      "rank": 981,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -28461,7 +28688,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 975,
+      "rank": 982,
       "id": "FINAL-Bench/Darwin-2B-Opus-LoRA",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-2B-Opus-LoRA",
@@ -28487,7 +28714,7 @@
       "lastModified": "2026-05-15T02:29:20.000Z"
     },
     {
-      "rank": 976,
+      "rank": 983,
       "id": "FINAL-Bench/Darwin-28B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Opus",
@@ -28532,7 +28759,7 @@
       "lastModified": "2026-05-15T02:27:32.000Z"
     },
     {
-      "rank": 977,
+      "rank": 984,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -28565,33 +28792,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 978,
-      "id": "meituan-longcat/LongCat-Video",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
-      "downloads": 1285,
-      "likes": 477,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "transformers",
-        "image-to-video",
-        "video-continuation",
-        "text-to-video",
-        "en",
-        "zh",
-        "arxiv:2510.22200",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2025-10-24T16:04:08.000Z",
-      "lastModified": "2025-10-29T06:22:46.000Z"
-    },
-    {
-      "rank": 979,
+      "rank": 985,
       "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
       "author": "Baraje",
       "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
@@ -28614,7 +28815,7 @@
       "lastModified": "2026-04-22T06:19:53.000Z"
     },
     {
-      "rank": 980,
+      "rank": 986,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
@@ -28649,7 +28850,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 981,
+      "rank": 987,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -28674,7 +28875,7 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 982,
+      "rank": 988,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
@@ -28694,7 +28895,7 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 983,
+      "rank": 989,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
@@ -28731,29 +28932,7 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 984,
-      "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
-      "downloads": 531,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T09:26:12.000Z",
-      "lastModified": "2026-05-22T05:15:45.000Z"
-    },
-    {
-      "rank": 985,
+      "rank": 990,
       "id": "google/gemma-2-2b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-2-2b-it",
@@ -28798,7 +28977,7 @@
       "lastModified": "2024-08-27T19:41:44.000Z"
     },
     {
-      "rank": 986,
+      "rank": 991,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
@@ -28820,7 +28999,7 @@
       "lastModified": "2026-05-22T05:16:00.000Z"
     },
     {
-      "rank": 987,
+      "rank": 992,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
@@ -28850,7 +29029,7 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 988,
+      "rank": 993,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
@@ -28876,7 +29055,7 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 989,
+      "rank": 994,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
@@ -28906,7 +29085,7 @@
       "lastModified": "2026-01-05T17:19:35.000Z"
     },
     {
-      "rank": 990,
+      "rank": 995,
       "id": "facebook/lagernvs_general_512",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/lagernvs_general_512",
@@ -28929,7 +29108,7 @@
       "lastModified": "2026-05-21T15:22:11.000Z"
     },
     {
-      "rank": 991,
+      "rank": 996,
       "id": "Emanon14/Nameless-Anima",
       "author": "Emanon14",
       "url": "https://huggingface.co/Emanon14/Nameless-Anima",
@@ -28949,30 +29128,7 @@
       "lastModified": "2026-05-17T04:01:50.000Z"
     },
     {
-      "rank": 992,
-      "id": "microsoft/Lens-Base",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Base",
-      "downloads": 71,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T06:08:02.000Z",
-      "lastModified": "2026-05-22T03:10:01.000Z"
-    },
-    {
-      "rank": 993,
+      "rank": 997,
       "id": "openbmb/BitCPM4-CANN-3B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-3B",
@@ -28998,244 +29154,93 @@
       "lastModified": "2026-05-22T10:04:55.000Z"
     },
     {
-      "rank": 994,
-      "id": "mistralai/Mistral-7B-v0.1",
-      "author": "mistralai",
-      "url": "https://huggingface.co/mistralai/Mistral-7B-v0.1",
-      "downloads": 994601,
-      "likes": 4084,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "safetensors",
-        "mistral",
-        "text-generation",
-        "pretrained",
-        "mistral-common",
-        "en",
-        "arxiv:2310.06825",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "region:us"
-      ],
-      "createdAt": "2023-09-20T13:03:50.000Z",
-      "lastModified": "2025-07-24T16:44:02.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct",
-      "downloads": 1171800,
-      "likes": 2016,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "code",
-        "codeqwen",
-        "chat",
-        "qwen",
-        "qwen-coder",
-        "conversational",
-        "en",
-        "arxiv:2409.12186",
-        "arxiv:2309.00071",
-        "arxiv:2407.10671",
-        "base_model:Qwen/Qwen2.5-Coder-32B",
-        "base_model:finetune:Qwen/Qwen2.5-Coder-32B",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-11-06T07:49:50.000Z",
-      "lastModified": "2025-01-12T02:02:22.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
-      "author": "DavidAU",
-      "url": "https://huggingface.co/DavidAU/Llama-3.2-8X4B-MOE-V2-Dark-Champion-Instruct-uncensored-abliterated-21B-GGUF",
-      "downloads": 9125,
-      "likes": 124,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "mixture of experts",
-        "moe",
-        "8x4B",
-        "8 experts",
-        "128k context",
-        "Llama 3.2 MOE",
-        "creative",
-        "creative writing",
-        "fiction writing",
-        "plot generation",
-        "sub-plot generation",
-        "story generation",
-        "scene continue",
-        "storytelling",
-        "fiction story",
-        "science fiction",
-        "romance",
-        "all genres",
-        "story",
-        "writing",
-        "vivid prosing",
-        "vivid writing",
-        "fiction",
-        "roleplaying",
-        "float32",
-        "swearing",
-        "rp",
-        "horror",
-        "mergekit"
-      ],
-      "createdAt": "2025-02-12T00:29:33.000Z",
-      "lastModified": "2026-04-28T07:33:29.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "google/gemma-3-27b-it",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-3-27b-it",
-      "downloads": 627363,
-      "likes": 1965,
-      "trendingScore": 5,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma3",
-        "image-text-to-text",
-        "conversational",
-        "arxiv:1905.07830",
-        "arxiv:1905.10044",
-        "arxiv:1911.11641",
-        "arxiv:1904.09728",
-        "arxiv:1705.03551",
-        "arxiv:1911.01547",
-        "arxiv:1907.10641",
-        "arxiv:1903.00161",
-        "arxiv:2009.03300",
-        "arxiv:2304.06364",
-        "arxiv:2103.03874",
-        "arxiv:2110.14168",
-        "arxiv:2311.12022",
-        "arxiv:2108.07732",
-        "arxiv:2107.03374",
-        "arxiv:2210.03057",
-        "arxiv:2106.03193",
-        "arxiv:1910.11856",
-        "arxiv:2502.12404",
-        "arxiv:2502.21228",
-        "arxiv:2404.16816",
-        "arxiv:2104.12756",
-        "arxiv:2311.16502",
-        "arxiv:2203.10244",
-        "arxiv:2404.12390"
-      ],
-      "createdAt": "2025-03-01T19:10:19.000Z",
-      "lastModified": "2025-03-21T20:29:02.000Z"
-    },
-    {
       "rank": 998,
-      "id": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
-      "downloads": 22975,
-      "likes": 93,
-      "trendingScore": 5,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
+      "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
+      "author": "canada-quant",
+      "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
+      "downloads": 7347,
+      "likes": 13,
+      "trendingScore": 6,
+      "pipelineTag": null,
+      "libraryName": "vllm",
       "tags": [
-        "gguf",
-        "liquid",
-        "lfm2.5",
-        "edge",
-        "llama.cpp",
-        "text-generation",
+        "vllm",
+        "safetensors",
+        "deepseek_v4",
+        "mixture-of-experts",
+        "moe",
+        "compressed-tensors",
+        "w4a16",
+        "gptq",
+        "fp8-block",
+        "deepseek",
+        "deepseek-v4",
         "en",
-        "ar",
         "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "base_model:LiquidAI/LFM2.5-1.2B-Thinking",
-        "base_model:quantized:LiquidAI/LFM2.5-1.2B-Thinking",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "base_model:deepseek-ai/DeepSeek-V4-Flash",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
+        "license:mit",
+        "region:us"
       ],
-      "createdAt": "2026-01-16T19:04:55.000Z",
-      "lastModified": "2026-04-06T18:53:24.000Z"
+      "createdAt": "2026-05-04T06:15:20.000Z",
+      "lastModified": "2026-05-21T20:52:08.000Z"
     },
     {
       "rank": 999,
-      "id": "HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3VL-8B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 30455,
-      "likes": 29,
-      "trendingScore": 5,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3",
-        "vision",
-        "multimodal",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-01-31T16:55:43.000Z",
-      "lastModified": "2026-04-05T19:01:08.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "jeremyhola/LORAs",
-      "author": "jeremyhola",
-      "url": "https://huggingface.co/jeremyhola/LORAs",
-      "downloads": 3828,
+      "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
+      "author": "circlestone-labs",
+      "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
+      "downloads": 0,
       "likes": 6,
-      "trendingScore": 5,
-      "pipelineTag": "text-to-image",
+      "trendingScore": 6,
+      "pipelineTag": null,
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
-        "gguf",
-        "text-to-image",
-        "lora",
-        "template:diffusion-lora",
-        "base_model:HuggingFaceH4/zephyr-7b-beta",
-        "base_model:adapter:HuggingFaceH4/zephyr-7b-beta",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "safetensors",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "region:us"
       ],
-      "createdAt": "2026-01-31T20:02:29.000Z",
-      "lastModified": "2026-05-06T20:09:03.000Z"
+      "createdAt": "2026-05-20T22:43:49.000Z",
+      "lastModified": "2026-05-20T22:46:36.000Z"
+    },
+    {
+      "rank": 1000,
+      "id": "SupraLabs/Supra-50M-Instruct",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
+      "downloads": 117,
+      "likes": 6,
+      "trendingScore": 6,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "dataset:yahma/alpaca-cleaned",
+        "base_model:SupraLabs/Supra-50M-Base",
+        "base_model:finetune:SupraLabs/Supra-50M-Base",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T12:06:17.000Z",
+      "lastModified": "2026-05-22T14:54:55.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26309664785

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.