### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-22T20:47:00Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-22T17:19:50.570Z",
+  "ts": "2026-05-22T20:47:00.223Z",
   "count": 1,
-  "durationMs": 15807,
+  "durationMs": 11496,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-22T17:19:47.756Z",
+  "lastFetchedAt": "2026-05-22T20:46:58.217Z",
   "windowDays": 7,
   "launches": [
     {
@@ -646,6 +646,59 @@
       "aiAdjacent": false
     },
     {
+      "id": "1144878",
+      "name": "TestSprite 3.0",
+      "tagline": "Let a fleet of parallel agents test your app in minutes",
+      "description": "TestSprite generates and runs end-to-end tests for your app, autonomously. For backend, we can now generate complex integration tests with dynamic variables, auto-cleanup, and Data Flow debugging. For frontend, we now send a fleet of parallel AI agents to explore your app first — clicking through every feature like real users, then feeding results into testing. We're the first to do this. 3.0 also adds auto-heal for UI drift, auto-auth for regression, and a CLI for Claude Code, Codex users.",
+      "url": "https://www.producthunt.com/products/testsprite?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/DP36SVO3Y3LMV7",
+      "votesCount": 335,
+      "commentsCount": 57,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/50434618-8b14-40d7-9958-db6ef9c84ccb.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1147569",
       "name": "LobeHub",
       "tagline": "Your Chief Agent Operator for multi-agent work",
@@ -977,59 +1030,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1144878",
-      "name": "TestSprite 3.0",
-      "tagline": "Let a fleet of parallel agents test your app in minutes",
-      "description": "TestSprite generates and runs end-to-end tests for your app, autonomously. For backend, we can now generate complex integration tests with dynamic variables, auto-cleanup, and Data Flow debugging. For frontend, we now send a fleet of parallel AI agents to explore your app first — clicking through every feature like real users, then feeding results into testing. We're the first to do this. 3.0 also adds auto-heal for UI drift, auto-auth for regression, and a CLI for Claude Code, Codex users.",
-      "url": "https://www.producthunt.com/products/testsprite?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DP36SVO3Y3LMV7",
-      "votesCount": 294,
-      "commentsCount": 56,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/50434618-8b14-40d7-9958-db6ef9c84ccb.png?auto=format",
-      "topics": [
-        "developer-tools",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "942860",
       "name": "SUN-to-Spotify ",
       "tagline": "Generate audio with SUN and send it to your Spotify library",
@@ -1260,6 +1260,42 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
+    },
+    {
+      "id": "1152537",
+      "name": "Cleo",
+      "tagline": "The AI PM that runs your team",
+      "description": "Cleo is the AI product manager for founders and lean teams. It lives in Telegram and Slack - learns your tone, knows your team, and runs the PM work (standups, follow-ups, decisions) while you ship the product. What's different: every fact Cleo learns is transparent - you see the source, the confidence, and can confirm or correct it. No black-box memory. Five trust levels, from observer to operator. Free in Telegram. 1 min setup",
+      "url": "https://www.producthunt.com/products/cleo-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/UEIFHO7XED74LR",
+      "votesCount": 280,
+      "commentsCount": 57,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/5edce491-25ca-4a4e-ac6b-0521e5c83e07.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence",
+        "alpha"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
     },
     {
       "id": "1150124",
@@ -1676,42 +1712,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1152537",
-      "name": "Cleo",
-      "tagline": "The AI PM that runs your team",
-      "description": "Cleo is the AI product manager for founders and lean teams. It lives in Telegram and Slack - learns your tone, knows your team, and runs the PM work (standups, follow-ups, decisions) while you ship the product. What's different: every fact Cleo learns is transparent - you see the source, the confidence, and can confirm or correct it. No black-box memory. Five trust levels, from observer to operator. Free in Telegram. 1 min setup",
-      "url": "https://www.producthunt.com/products/cleo-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/UEIFHO7XED74LR",
-      "votesCount": 246,
-      "commentsCount": 51,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/5edce491-25ca-4a4e-ac6b-0521e5c83e07.png?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence",
-        "alpha"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1151355",
       "name": "Google Antigravity 2.0",
       "tagline": "Orchestrate multi-agent workflows from a desktop app",
@@ -1728,6 +1728,36 @@
         "artificial-intelligence"
       ],
       "makers": [],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1129994",
+      "name": "General Compute",
+      "tagline": "AI models that run on an inference cloud optimized for speed",
+      "description": "GPUs are built for training, not inference. General Compute is an inference cloud running on ASICs — purpose-built alternatives to Nvidia silicon designed specifically for inference. We deliver 5x faster responses and higher per-user throughput for latency-sensitive workloads like coding and voice agents. Our OpenAI-compatible API means you swap your base URL, keep your existing workflows, and run real-time AI on infrastructure built for the job.",
+      "url": "https://www.producthunt.com/products/general-compute?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/NHQEMRTC6G4X2J",
+      "votesCount": 242,
+      "commentsCount": 29,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/e7ecdc30-d819-457b-bd2c-c51b32c0379b.png?auto=format",
+      "topics": [
+        "api-1",
+        "software-engineering",
+        "alpha"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,
@@ -2006,36 +2036,6 @@
       "aiAdjacent": false
     },
     {
-      "id": "1129994",
-      "name": "General Compute",
-      "tagline": "AI models that run on an inference cloud optimized for speed",
-      "description": "GPUs are built for training, not inference. General Compute is an inference cloud running on ASICs — purpose-built alternatives to Nvidia silicon designed specifically for inference. We deliver 5x faster responses and higher per-user throughput for latency-sensitive workloads like coding and voice agents. Our OpenAI-compatible API means you swap your base URL, keep your existing workflows, and run real-time AI on infrastructure built for the job.",
-      "url": "https://www.producthunt.com/products/general-compute?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/NHQEMRTC6G4X2J",
-      "votesCount": 214,
-      "commentsCount": 25,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/e7ecdc30-d819-457b-bd2c-c51b32c0379b.png?auto=format",
-      "topics": [
-        "api-1",
-        "software-engineering",
-        "alpha"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1137047",
       "name": "Theneo",
       "tagline": "The API management platform for humans and agents",
@@ -2276,6 +2276,34 @@
       "aiAdjacent": false
     },
     {
+      "id": "1152815",
+      "name": "WordPress 7.0",
+      "tagline": "Introducing AI tools, new admin experience & design controls",
+      "description": "WordPress 7.0 marks the start of a new era, laying the foundation for AI across the WordPress experience. Greeting you with a modern, more intuitive dashboard, 7.0 introduces enhanced customization and development tools that inspire creativity and tap into endless potential. Whether you’re a creator, business owner or developer – WordPress 7.0 let’s you create in a way that is uniquely your own.",
+      "url": "https://www.producthunt.com/products/wordpress-7-0?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/DR7XDHFH7F2IGM",
+      "votesCount": 198,
+      "commentsCount": 4,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/834157b6-01ba-4baa-9997-d039fee7d26b.png?auto=format",
+      "topics": [
+        "wordpress"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1141872",
       "name": "How AI-pilled are you?",
       "tagline": "Curious how AI-fluent your organization is?",
@@ -2288,42 +2316,6 @@
       "thumbnail": "https://ph-files.imgix.net/aabbacbc-1ad1-4f5f-ac42-58a53a116cd5.png?auto=format",
       "topics": [
         "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1137004",
-      "name": "ClawSecure",
-      "tagline": "The AI-Powered Antivirus for AI Agents",
-      "description": "ClawSecure is the AI-powered antivirus for AI agents. Pre-install scanning, real-time runtime monitoring, an in-agent Security Companion Agent, and a sub-200ms Verification API. Full 10/10 OWASP ASI coverage. 41% of top agents are dangerous. Free, no signup. clawsecure.ai",
-      "url": "https://www.producthunt.com/products/clawsecure?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/CBB34LD6UL5TT2",
-      "votesCount": 197,
-      "commentsCount": 18,
-      "createdAt": "2026-05-11T07:00:00Z",
-      "thumbnail": "https://ph-files.imgix.net/81d1c1f7-26d3-4b8e-8079-52b1e6322b03.png?auto=format",
-      "topics": [
-        "developer-tools",
-        "artificial-intelligence",
-        "pitch-singapore"
       ],
       "makers": [
         {


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26311092366

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.