### PR TITLE
chore(data): refresh bluesky signals 2026-05-22T23:20:30Z

### DIFF
--- a/data/_meta/bluesky.json
+++ b/data/_meta/bluesky.json
@@ -1,8 +1,8 @@
 {
   "source": "bluesky",
   "reason": "ok",
-  "ts": "2026-05-22T20:08:44.720Z",
+  "ts": "2026-05-22T23:20:30.128Z",
   "count": 1,
-  "durationMs": 15175,
+  "durationMs": 15885,
   "extra": {}
 }

--- a/data/bluesky-mentions.json
+++ b/data/bluesky-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T20:08:30.064Z",
+  "fetchedAt": "2026-05-22T23:20:14.822Z",
   "windowDays": 7,
   "scannedPosts": 300,
   "searchQuery": "github.com",
@@ -5548,10 +5548,10 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mleg6czxgc2n",
-        "cid": "bafyreihram5s2cfh7h5oldbf3gdqachnhaf6es5esvavi37kxc3lcsvemi",
-        "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mleg6czxgc2n",
-        "text": "junhoyeo / tokscale: 🛰️ A CLI tool for tracking token usage from OpenCode, Claude Code, 🦞OpenClaw (Clawdbot/Moltbot), Pi, Codex, Gemini, Cursor, AmpCode, Factory Droid, Kimi, and more! • 🏅Global Leaderboard + 2D/3D Contributions Graph ★2729 https://github.com/junhoyeo/tokscale",
+        "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmhu5pbhwo22",
+        "cid": "bafyreig4an737jqqxp6u43yyaixjsfgpilhnnnc3tzw3ww3n7h7ntx2qwy",
+        "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmhu5pbhwo22",
+        "text": "junhoyeo / tokscale: 🛰️ A CLI tool for tracking token usage from OpenCode, Claude Code, 🦞OpenClaw (Clawdbot/Moltbot), Pi, Codex, Gemini, Cursor, AmpCode, Factory Droid, Kimi, and more! • 🏅Global Leaderboard + 2D/3D Contributions Graph ★3128 https://github.com/junhoyeo/tokscale",
         "author": {
           "handle": "rusttrending.bsky.social",
           "displayName": "RustTrending"
@@ -5559,10 +5559,38 @@
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-08T19:02:07.929743Z",
-        "hoursSincePosted": 4.17
+        "createdAt": "2026-05-22T21:15:30.419168Z",
+        "hoursSincePosted": 2.08
       },
       "posts": [
+        {
+          "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmhu5pbhwo22",
+          "cid": "bafyreig4an737jqqxp6u43yyaixjsfgpilhnnnc3tzw3ww3n7h7ntx2qwy",
+          "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmhu5pbhwo22",
+          "text": "junhoyeo / tokscale: 🛰️ A CLI tool for tracking token usage from OpenCode, Claude Code, 🦞OpenClaw (Clawdbot/Moltbot), Pi, Codex, Gemini, Cursor, AmpCode, Factory Droid, Kimi, and more! • 🏅Global Leaderboard + 2D/3D Contributions Graph ★3128 https://github.com/junhoyeo/tokscale",
+          "author": {
+            "handle": "rusttrending.bsky.social",
+            "displayName": "RustTrending"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T21:15:30.419168Z",
+          "createdUtc": 1779484530,
+          "ageHours": 2.08,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "junhoyeo/tokscale",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mleg6czxgc2n",
           "cid": "bafyreihram5s2cfh7h5oldbf3gdqachnhaf6es5esvavi37kxc3lcsvemi",
@@ -12816,24 +12844,24 @@
       ]
     },
     "warpdotdev/warp": {
-      "count7d": 5,
-      "likesSum7d": 3,
+      "count7d": 7,
+      "likesSum7d": 7,
       "repostsSum7d": 0,
-      "repliesSum7d": 4,
+      "repliesSum7d": 6,
       "topPost": {
-        "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mlvsjknzmy2n",
-        "cid": "bafyreigtyqd3ne5nr6wzxdsj7dlchg57ayj3a42u6cisnpch7zrwwsfrum",
-        "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mlvsjknzmy2n",
-        "text": "David Engelmann is taking on log growth in a few places. His MCP and LSP PRs add size-based log rotation so verbose servers can’t grow logs without bound during long sessions. github.com/warpdotdev/... github.com/warpdotdev/...",
+        "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6nnho25",
+        "cid": "bafyreiett5mwty2i27yodr2bdpr64kjbnzgxk2udbngnf6wzp5bft4o5dm",
+        "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6nnho25",
+        "text": "If you’ve run into a bug that bugs you, come contribute. github.com/warpdotdev/... ⭐",
         "author": {
           "handle": "warp.dev",
           "displayName": "Warp"
         },
         "likeCount": 1,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-15T16:58:25.530778Z",
-        "hoursSincePosted": 3.63
+        "replyCount": 0,
+        "createdAt": "2026-05-22T23:09:51.696629Z",
+        "hoursSincePosted": 0.5
       },
       "posts": [
         {
@@ -12852,6 +12880,202 @@
           "createdUtc": 1778864302,
           "ageHours": 1.98,
           "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6nnho25",
+          "cid": "bafyreiett5mwty2i27yodr2bdpr64kjbnzgxk2udbngnf6wzp5bft4o5dm",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6nnho25",
+          "text": "If you’ve run into a bug that bugs you, come contribute. github.com/warpdotdev/... ⭐",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T23:09:51.696629Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6klbh26",
+          "cid": "bafyreiahjcanv467kkbzi6et2pokasvao4yx4ffcogmltdghlibcxblo4y",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6klbh26",
+          "text": "Wayne Hoover wired OSC 7 escape sequences into Warp’s tab state. Tabs can now update their working directory and git branch from shell-emitted OSC 7 data. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.599525Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6hgt52w",
+          "cid": "bafyreigddflqukjo2ggue6e5pnlep2m5n764nd7srjacjvhzbg77esgq4y",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6hgt52w",
+          "text": "David Danielsson (djdanielsson) added Podman exec/run support for warpify subshells. Warpify now reaches more container workflows, with PTY, bootstrap, and rc-file handling covered by tests. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.495632Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6e7bg2b",
+          "cid": "bafyreie4tybcdzvrhb7uunaclh3q7nt2fqrkijul5tezot6tbevmbsfl44",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6e7bg2b",
+          "text": "Max Hsu (maxmilian) fixed warpify rc file paths to use the target OS path separator. That makes shell bootstrap paths behave correctly across OS boundaries. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.384532Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6b3bd2b",
+          "cid": "bafyreibeojp2pzwwxfo7bdnlcsmtum74q5lvcdk5bqplkieoyf2xms3cky",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6b3bd2b",
+          "text": "Samarth Shridhar fixed a macOS restore bug that could bring Warp back as a 1px-wide window after green-tile. The fix floors persisted window dimensions so restore has sane bounds. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.287373Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k664ix2h",
+          "cid": "bafyreie72srkovwhlrbfykskd4s4mb55pfydybsynnewpducc6k2zob3jm",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k664ix2h",
+          "text": "dagmfactory fixed a split-pane UI bug where the terminal footer could overflow its column. Small layout fix, noticeable result: panes stay clipped where they should. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.192076Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k636s32b",
+          "cid": "bafyreihpo5huhrnyeynvh3fcummorbdyr4idhl3y3jsdsglmx22esb4fbu",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k636s32b",
+          "text": "Bobby Wang (BobbyWang0120) exposed terminal focus URL env vars. Scripts can now read the active terminal session UUID and focus URL from the environment, including WSL paths covered by the allowlist. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.080758Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
           "content_tags": [
             "has-github-repo"
           ],
@@ -14838,7 +15062,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-22T20:00:00.300Z",
-        "hoursSincePosted": 0.5
+        "hoursSincePosted": 3.34
       },
       "posts": [
         {
@@ -14855,7 +15079,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T20:00:00.300Z",
           "createdUtc": 1779480000,
-          "ageHours": 0.5,
+          "ageHours": 3.34,
           "trendingScore": 1,
           "content_tags": [
             "has-github-repo",
@@ -22942,6 +23166,55 @@
           ]
         }
       ]
+    },
+    "Mesh-LLM/mesh-llm": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 1,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:md2y5fbzsk7lyff5ahk4eiu7/app.bsky.feed.post/3mmhw6bqph223",
+        "cid": "bafyreiaw2eshew64m67yf4pqfn7cso37xvzsxapkqaaxjcsmwubbehuw7q",
+        "bskyUrl": "https://bsky.app/profile/wsmoak.bsky.social/post/3mmhw6bqph223",
+        "text": "Mesh LLM github.com/Mesh-LLM/mes...",
+        "author": {
+          "handle": "wsmoak.bsky.social"
+        },
+        "likeCount": 1,
+        "repostCount": 1,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T21:51:37.413Z",
+        "hoursSincePosted": 1.48
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:md2y5fbzsk7lyff5ahk4eiu7/app.bsky.feed.post/3mmhw6bqph223",
+          "cid": "bafyreiaw2eshew64m67yf4pqfn7cso37xvzsxapkqaaxjcsmwubbehuw7q",
+          "bskyUrl": "https://bsky.app/profile/wsmoak.bsky.social/post/3mmhw6bqph223",
+          "text": "Mesh LLM github.com/Mesh-LLM/mes...",
+          "author": {
+            "handle": "wsmoak.bsky.social"
+          },
+          "likeCount": 1,
+          "repostCount": 1,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T21:51:37.413Z",
+          "createdUtc": 1779486697,
+          "ageHours": 1.48,
+          "trendingScore": 3,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Mesh-LLM/mesh-llm",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
     }
   },
   "mentionsByRepoId": {
@@ -28488,10 +28761,10 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mleg6czxgc2n",
-        "cid": "bafyreihram5s2cfh7h5oldbf3gdqachnhaf6es5esvavi37kxc3lcsvemi",
-        "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mleg6czxgc2n",
-        "text": "junhoyeo / tokscale: 🛰️ A CLI tool for tracking token usage from OpenCode, Claude Code, 🦞OpenClaw (Clawdbot/Moltbot), Pi, Codex, Gemini, Cursor, AmpCode, Factory Droid, Kimi, and more! • 🏅Global Leaderboard + 2D/3D Contributions Graph ★2729 https://github.com/junhoyeo/tokscale",
+        "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmhu5pbhwo22",
+        "cid": "bafyreig4an737jqqxp6u43yyaixjsfgpilhnnnc3tzw3ww3n7h7ntx2qwy",
+        "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmhu5pbhwo22",
+        "text": "junhoyeo / tokscale: 🛰️ A CLI tool for tracking token usage from OpenCode, Claude Code, 🦞OpenClaw (Clawdbot/Moltbot), Pi, Codex, Gemini, Cursor, AmpCode, Factory Droid, Kimi, and more! • 🏅Global Leaderboard + 2D/3D Contributions Graph ★3128 https://github.com/junhoyeo/tokscale",
         "author": {
           "handle": "rusttrending.bsky.social",
           "displayName": "RustTrending"
@@ -28499,10 +28772,38 @@
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-08T19:02:07.929743Z",
-        "hoursSincePosted": 4.17
+        "createdAt": "2026-05-22T21:15:30.419168Z",
+        "hoursSincePosted": 2.08
       },
       "posts": [
+        {
+          "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmhu5pbhwo22",
+          "cid": "bafyreig4an737jqqxp6u43yyaixjsfgpilhnnnc3tzw3ww3n7h7ntx2qwy",
+          "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmhu5pbhwo22",
+          "text": "junhoyeo / tokscale: 🛰️ A CLI tool for tracking token usage from OpenCode, Claude Code, 🦞OpenClaw (Clawdbot/Moltbot), Pi, Codex, Gemini, Cursor, AmpCode, Factory Droid, Kimi, and more! • 🏅Global Leaderboard + 2D/3D Contributions Graph ★3128 https://github.com/junhoyeo/tokscale",
+          "author": {
+            "handle": "rusttrending.bsky.social",
+            "displayName": "RustTrending"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T21:15:30.419168Z",
+          "createdUtc": 1779484530,
+          "ageHours": 2.08,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "junhoyeo/tokscale",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mleg6czxgc2n",
           "cid": "bafyreihram5s2cfh7h5oldbf3gdqachnhaf6es5esvavi37kxc3lcsvemi",
@@ -35756,24 +36057,24 @@
       ]
     },
     "warpdotdev--warp": {
-      "count7d": 5,
-      "likesSum7d": 3,
+      "count7d": 7,
+      "likesSum7d": 7,
       "repostsSum7d": 0,
-      "repliesSum7d": 4,
+      "repliesSum7d": 6,
       "topPost": {
-        "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mlvsjknzmy2n",
-        "cid": "bafyreigtyqd3ne5nr6wzxdsj7dlchg57ayj3a42u6cisnpch7zrwwsfrum",
-        "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mlvsjknzmy2n",
-        "text": "David Engelmann is taking on log growth in a few places. His MCP and LSP PRs add size-based log rotation so verbose servers can’t grow logs without bound during long sessions. github.com/warpdotdev/... github.com/warpdotdev/...",
+        "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6nnho25",
+        "cid": "bafyreiett5mwty2i27yodr2bdpr64kjbnzgxk2udbngnf6wzp5bft4o5dm",
+        "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6nnho25",
+        "text": "If you’ve run into a bug that bugs you, come contribute. github.com/warpdotdev/... ⭐",
         "author": {
           "handle": "warp.dev",
           "displayName": "Warp"
         },
         "likeCount": 1,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-15T16:58:25.530778Z",
-        "hoursSincePosted": 3.63
+        "replyCount": 0,
+        "createdAt": "2026-05-22T23:09:51.696629Z",
+        "hoursSincePosted": 0.5
       },
       "posts": [
         {
@@ -35792,6 +36093,202 @@
           "createdUtc": 1778864302,
           "ageHours": 1.98,
           "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6nnho25",
+          "cid": "bafyreiett5mwty2i27yodr2bdpr64kjbnzgxk2udbngnf6wzp5bft4o5dm",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6nnho25",
+          "text": "If you’ve run into a bug that bugs you, come contribute. github.com/warpdotdev/... ⭐",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T23:09:51.696629Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6klbh26",
+          "cid": "bafyreiahjcanv467kkbzi6et2pokasvao4yx4ffcogmltdghlibcxblo4y",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6klbh26",
+          "text": "Wayne Hoover wired OSC 7 escape sequences into Warp’s tab state. Tabs can now update their working directory and git branch from shell-emitted OSC 7 data. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.599525Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6hgt52w",
+          "cid": "bafyreigddflqukjo2ggue6e5pnlep2m5n764nd7srjacjvhzbg77esgq4y",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6hgt52w",
+          "text": "David Danielsson (djdanielsson) added Podman exec/run support for warpify subshells. Warpify now reaches more container workflows, with PTY, bootstrap, and rc-file handling covered by tests. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.495632Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6e7bg2b",
+          "cid": "bafyreie4tybcdzvrhb7uunaclh3q7nt2fqrkijul5tezot6tbevmbsfl44",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6e7bg2b",
+          "text": "Max Hsu (maxmilian) fixed warpify rc file paths to use the target OS path separator. That makes shell bootstrap paths behave correctly across OS boundaries. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.384532Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k6b3bd2b",
+          "cid": "bafyreibeojp2pzwwxfo7bdnlcsmtum74q5lvcdk5bqplkieoyf2xms3cky",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k6b3bd2b",
+          "text": "Samarth Shridhar fixed a macOS restore bug that could bring Warp back as a 1px-wide window after green-tile. The fix floors persisted window dimensions so restore has sane bounds. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.287373Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k664ix2h",
+          "cid": "bafyreie72srkovwhlrbfykskd4s4mb55pfydybsynnewpducc6k2zob3jm",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k664ix2h",
+          "text": "dagmfactory fixed a split-pane UI bug where the terminal footer could overflow its column. Small layout fix, noticeable result: panes stay clipped where they should. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.192076Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "warpdotdev/warp",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z4lutgunglpmgcbawqnckkfm/app.bsky.feed.post/3mmi2k636s32b",
+          "cid": "bafyreihpo5huhrnyeynvh3fcummorbdyr4idhl3y3jsdsglmx22esb4fbu",
+          "bskyUrl": "https://bsky.app/profile/warp.dev/post/3mmi2k636s32b",
+          "text": "Bobby Wang (BobbyWang0120) exposed terminal focus URL env vars. Scripts can now read the active terminal session UUID and focus URL from the environment, including WSL paths covered by the allowlist. github.com/warpdotdev/...",
+          "author": {
+            "handle": "warp.dev",
+            "displayName": "Warp"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-22T23:09:51.080758Z",
+          "createdUtc": 1779491391,
+          "ageHours": 0.5,
+          "trendingScore": 1.5,
           "content_tags": [
             "has-github-repo"
           ],
@@ -37778,7 +38275,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-22T20:00:00.300Z",
-        "hoursSincePosted": 0.5
+        "hoursSincePosted": 3.34
       },
       "posts": [
         {
@@ -37795,7 +38292,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-22T20:00:00.300Z",
           "createdUtc": 1779480000,
-          "ageHours": 0.5,
+          "ageHours": 3.34,
           "trendingScore": 1,
           "content_tags": [
             "has-github-repo",
@@ -45882,21 +46379,65 @@
           ]
         }
       ]
+    },
+    "mesh-llm--mesh-llm": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 1,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:md2y5fbzsk7lyff5ahk4eiu7/app.bsky.feed.post/3mmhw6bqph223",
+        "cid": "bafyreiaw2eshew64m67yf4pqfn7cso37xvzsxapkqaaxjcsmwubbehuw7q",
+        "bskyUrl": "https://bsky.app/profile/wsmoak.bsky.social/post/3mmhw6bqph223",
+        "text": "Mesh LLM github.com/Mesh-LLM/mes...",
+        "author": {
+          "handle": "wsmoak.bsky.social"
+        },
+        "likeCount": 1,
+        "repostCount": 1,
+        "replyCount": 0,
+        "createdAt": "2026-05-22T21:51:37.413Z",
+        "hoursSincePosted": 1.48
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:md2y5fbzsk7lyff5ahk4eiu7/app.bsky.feed.post/3mmhw6bqph223",
+          "cid": "bafyreiaw2eshew64m67yf4pqfn7cso37xvzsxapkqaaxjcsmwubbehuw7q",
+          "bskyUrl": "https://bsky.app/profile/wsmoak.bsky.social/post/3mmhw6bqph223",
+          "text": "Mesh LLM github.com/Mesh-LLM/mes...",
+          "author": {
+            "handle": "wsmoak.bsky.social"
+          },
+          "likeCount": 1,
+          "repostCount": 1,
+          "replyCount": 0,
+          "createdAt": "2026-05-22T21:51:37.413Z",
+          "createdUtc": 1779486697,
+          "ageHours": 1.48,
+          "trendingScore": 3,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Mesh-LLM/mesh-llm",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
     }
   },
   "leaderboard": [
     {
-      "fullName": "anthropics/claude-code",
-      "count7d": 1,
-      "likesSum7d": 1
+      "fullName": "warpdotdev/warp",
+      "count7d": 7,
+      "likesSum7d": 7
     },
     {
-      "fullName": "colbymchenry/codegraph",
-      "count7d": 1,
-      "likesSum7d": 1
-    },
-    {
-      "fullName": "JuliusBrussee/caveman",
+      "fullName": "Mesh-LLM/mesh-llm",
       "count7d": 1,
       "likesSum7d": 1
     },
@@ -45906,12 +46447,7 @@
       "likesSum7d": 1
     },
     {
-      "fullName": "unprovable/ShadowCat",
-      "count7d": 2,
-      "likesSum7d": 0
-    },
-    {
-      "fullName": "Tenobrus/graphglyph",
+      "fullName": "junhoyeo/tokscale",
       "count7d": 1,
       "likesSum7d": 0
     }

--- a/data/bluesky-trending.json
+++ b/data/bluesky-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T20:08:30.064Z",
+  "fetchedAt": "2026-05-22T23:20:14.822Z",
   "discoveryVersion": "2026-04-21",
   "keywords": [
     "AI agents",
@@ -152,7 +152,7 @@
       ]
     }
   ],
-  "scannedPosts": 665,
+  "scannedPosts": 666,
   "posts": [
     {
       "uri": "at://did:plc:oijtzlibd7mlf56jbfohssdz/app.bsky.feed.post/3ml46o7m5rs2b",
@@ -216,7 +216,7 @@
       "replyCount": 66,
       "createdAt": "2026-05-19T11:46:20.996Z",
       "createdUtc": 1779191180,
-      "ageHours": 80.37,
+      "ageHours": 83.57,
       "trendingScore": 3431,
       "content_tags": [],
       "value_score": 0,
@@ -323,6 +323,30 @@
       "matchedTopicLabel": "LLMs"
     },
     {
+      "uri": "at://did:plc:2zcfjzyocp6kapg6jc4eacok/app.bsky.feed.post/3mmfr5iz67c24",
+      "cid": "bafyreigoq74ncuffy6zxa5a2nttdf3otdfx7fynp4gv3fb2tdeowjhhafe",
+      "bskyUrl": "https://bsky.app/profile/andrew.heiss.phd/post/3mmfr5iz67c24",
+      "text": "Finally switched to DuckDuckGo and it’s nice to not have LLM summaries anymore",
+      "author": {
+        "handle": "andrew.heiss.phd",
+        "displayName": "Andrew Heiss"
+      },
+      "likeCount": 1886,
+      "repostCount": 171,
+      "replyCount": 115,
+      "createdAt": "2026-05-22T01:16:23.287Z",
+      "createdUtc": 1779412583,
+      "ageHours": 22.06,
+      "trendingScore": 2285.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
       "uri": "at://did:plc:qnd2lqn52ernybdfonq4mc43/app.bsky.feed.post/3mluculejys2w",
       "cid": "bafyreicksi2jpuoxbi67iu54pudznpdqkph7i6fe4bh46n5mxlwlbrgjdm",
       "bskyUrl": "https://bsky.app/profile/cwarzel.bsky.social/post/3mluculejys2w",
@@ -345,30 +369,6 @@
       "matchedQuery": "lang:en \"ai agent\"",
       "matchedTopicId": "agents",
       "matchedTopicLabel": "AI agents"
-    },
-    {
-      "uri": "at://did:plc:2zcfjzyocp6kapg6jc4eacok/app.bsky.feed.post/3mmfr5iz67c24",
-      "cid": "bafyreigoq74ncuffy6zxa5a2nttdf3otdfx7fynp4gv3fb2tdeowjhhafe",
-      "bskyUrl": "https://bsky.app/profile/andrew.heiss.phd/post/3mmfr5iz67c24",
-      "text": "Finally switched to DuckDuckGo and it’s nice to not have LLM summaries anymore",
-      "author": {
-        "handle": "andrew.heiss.phd",
-        "displayName": "Andrew Heiss"
-      },
-      "likeCount": 1699,
-      "repostCount": 157,
-      "replyCount": 104,
-      "createdAt": "2026-05-22T01:16:23.287Z",
-      "createdUtc": 1779412583,
-      "ageHours": 18.87,
-      "trendingScore": 2065,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
     },
     {
       "uri": "at://did:plc:y77hmt4ost5n5cnwyvy7qyk7/app.bsky.feed.post/3mknfsgwcxs2g",
@@ -408,7 +408,7 @@
       "replyCount": 19,
       "createdAt": "2026-05-18T21:40:34.041Z",
       "createdUtc": 1779140434,
-      "ageHours": 94.47,
+      "ageHours": 97.66,
       "trendingScore": 1975.5,
       "content_tags": [],
       "value_score": 0,
@@ -467,6 +467,30 @@
       "matchedTopicLabel": "LLMs"
     },
     {
+      "uri": "at://did:plc:4ucd72agwuypyuzhxwh3qq3l/app.bsky.feed.post/3mmd4jsafdc2u",
+      "cid": "bafyreieawg5pca75uufqa4sipaef5mwdk56asw3tpjzohgjwm7ue7634jq",
+      "bskyUrl": "https://bsky.app/profile/michaelwhelan.bsky.social/post/3mmd4jsafdc2u",
+      "text": "\"A tribute to Michael Whelan\" ...who has told you unequivocally to stop using his name in prompts. 🙄😮‍💨",
+      "author": {
+        "handle": "michaelwhelan.bsky.social",
+        "displayName": "Michael Whelan"
+      },
+      "likeCount": 919,
+      "repostCount": 142,
+      "replyCount": 29,
+      "createdAt": "2026-05-21T00:02:07.549Z",
+      "createdUtc": 1779321727,
+      "ageHours": 47.3,
+      "trendingScore": 1217.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en workflow",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:z4llsx425l4htoylyyx6iam3/app.bsky.feed.post/3mlwgb5ao7k23",
       "cid": "bafyreibrfqpd7a5rxim6dpsksk7l5h7ddqx5t3tn6pqium6wchtpb7zbcy",
       "bskyUrl": "https://bsky.app/profile/antlervel.vet/post/3mlwgb5ao7k23",
@@ -489,30 +513,6 @@
       "matchedQuery": "lang:en llm",
       "matchedTopicId": "llms",
       "matchedTopicLabel": "LLMs"
-    },
-    {
-      "uri": "at://did:plc:4ucd72agwuypyuzhxwh3qq3l/app.bsky.feed.post/3mmd4jsafdc2u",
-      "cid": "bafyreieawg5pca75uufqa4sipaef5mwdk56asw3tpjzohgjwm7ue7634jq",
-      "bskyUrl": "https://bsky.app/profile/michaelwhelan.bsky.social/post/3mmd4jsafdc2u",
-      "text": "\"A tribute to Michael Whelan\" ...who has told you unequivocally to stop using his name in prompts. 🙄😮‍💨",
-      "author": {
-        "handle": "michaelwhelan.bsky.social",
-        "displayName": "Michael Whelan"
-      },
-      "likeCount": 918,
-      "repostCount": 142,
-      "replyCount": 29,
-      "createdAt": "2026-05-21T00:02:07.549Z",
-      "createdUtc": 1779321727,
-      "ageHours": 44.11,
-      "trendingScore": 1216.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "Workflow and automation",
-      "matchedQuery": "lang:en workflow",
-      "matchedTopicId": "workflow",
-      "matchedTopicLabel": "Workflow and automation"
     },
     {
       "uri": "at://did:plc:n4765ftlk5sxhgd5low6rqbd/app.bsky.feed.post/3mlkbmsmpnk2m",
@@ -595,13 +595,13 @@
         "handle": "alexhanna.bsky.social",
         "displayName": "Alex Hanna"
       },
-      "likeCount": 448,
-      "repostCount": 259,
+      "likeCount": 453,
+      "repostCount": 260,
       "replyCount": 5,
       "createdAt": "2026-05-20T16:37:23.343Z",
       "createdUtc": 1779295043,
-      "ageHours": 51.52,
-      "trendingScore": 968.5,
+      "ageHours": 54.71,
+      "trendingScore": 975.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -707,6 +707,30 @@
       "matchedTopicLabel": "Coding agents"
     },
     {
+      "uri": "at://did:plc:ybkylffhwhn2an2ic2lxh76k/app.bsky.feed.post/3mmh7ys4yjc23",
+      "cid": "bafyreierycreaexmhecqs6q5gqdgzffkklnh6ecz7zfyrnjgwjantsrpdq",
+      "bskyUrl": "https://bsky.app/profile/wolvendamien.bsky.social/post/3mmh7ys4yjc23",
+      "text": "Yeah, y'all: we told you it would. LLM based \"AI\" concatenates strings of next-most-likely tokens. It bullshits. It makes shit up. An inventory situation where the systems need to \"count\" & \"report\" doesn't *change* that fundamental architecture; so why are these people continually surprised by it??",
+      "author": {
+        "handle": "wolvendamien.bsky.social",
+        "displayName": "Dr. Damien P. Williams is under the vast indifference of heaven"
+      },
+      "likeCount": 502,
+      "repostCount": 155,
+      "replyCount": 22,
+      "createdAt": "2026-05-22T15:14:50.942Z",
+      "createdUtc": 1779462890,
+      "ageHours": 8.09,
+      "trendingScore": 823,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
       "uri": "at://did:plc:xbnsfdtxoothg654ujxe3p25/app.bsky.feed.post/3mm2ue7mtg22l",
       "cid": "bafyreiap7zpczdjbl7xtetjbjowwqdvhlfwqpmvxfr4y3iruccuw3aetde",
       "bskyUrl": "https://bsky.app/profile/stephenkb.bsky.social/post/3mm2ue7mtg22l",
@@ -722,30 +746,6 @@
       "createdUtc": 1779038072,
       "ageHours": 79.06,
       "trendingScore": 800.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
-    },
-    {
-      "uri": "at://did:plc:ybkylffhwhn2an2ic2lxh76k/app.bsky.feed.post/3mmh7ys4yjc23",
-      "cid": "bafyreierycreaexmhecqs6q5gqdgzffkklnh6ecz7zfyrnjgwjantsrpdq",
-      "bskyUrl": "https://bsky.app/profile/wolvendamien.bsky.social/post/3mmh7ys4yjc23",
-      "text": "Yeah, y'all: we told you it would. LLM based \"AI\" concatenates strings of next-most-likely tokens. It bullshits. It makes shit up. An inventory situation where the systems need to \"count\" & \"report\" doesn't *change* that fundamental architecture; so why are these people continually surprised by it??",
-      "author": {
-        "handle": "wolvendamien.bsky.social",
-        "displayName": "Dr. Damien P. Williams is under the vast indifference of heaven"
-      },
-      "likeCount": 474,
-      "repostCount": 150,
-      "replyCount": 20,
-      "createdAt": "2026-05-22T15:14:50.942Z",
-      "createdUtc": 1779462890,
-      "ageHours": 4.89,
-      "trendingScore": 784,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -912,7 +912,7 @@
       "replyCount": 2,
       "createdAt": "2026-04-21T03:38:29.785Z",
       "createdUtc": 1776742709,
-      "ageHours": 760.5,
+      "ageHours": 763.7,
       "trendingScore": 689,
       "content_tags": [],
       "value_score": 0,
@@ -923,6 +923,30 @@
       "matchedTopicLabel": "AI skills"
     },
     {
+      "uri": "at://did:plc:kzsnqhdb3styakbudv3xtq4p/app.bsky.feed.post/3mmg37qoxdk2j",
+      "cid": "bafyreifr4cvj5bzrsdrcsz65v37uktt5j5bikgjzyis43sfd6xujfkedxe",
+      "bskyUrl": "https://bsky.app/profile/mosheroperandi.bsky.social/post/3mmg37qoxdk2j",
+      "text": "Everyone says they want Fully Automated Luxury Gay Space Communism until they learn the Communism will be endless amounts of charts, the Space stuff will be done mostly by robots, the Full Automation will come from AI, and the Gay part will also involve AI making up for the top shortage.",
+      "author": {
+        "handle": "mosheroperandi.bsky.social",
+        "displayName": "Keith"
+      },
+      "likeCount": 517,
+      "repostCount": 75,
+      "replyCount": 15,
+      "createdAt": "2026-05-22T04:16:35.871Z",
+      "createdUtc": 1779423395,
+      "ageHours": 19.06,
+      "trendingScore": 674.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en automation",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:6jsvyhtxrkb4d2wrlwd2avmm/app.bsky.feed.post/3mm53xi3po22e",
       "cid": "bafyreigjhnzmg32njy327bndt3rkqgejsfgur2vwn2xuu23nse5ylfbi5m",
       "bskyUrl": "https://bsky.app/profile/webdevs.firefox.com/post/3mm53xi3po22e",
@@ -931,13 +955,13 @@
         "handle": "webdevs.firefox.com",
         "displayName": "Firefox for Web Developers"
       },
-      "likeCount": 412,
+      "likeCount": 413,
       "repostCount": 125,
       "replyCount": 18,
       "createdAt": "2026-05-18T14:35:54.513Z",
       "createdUtc": 1779114954,
-      "ageHours": 101.54,
-      "trendingScore": 671,
+      "ageHours": 104.74,
+      "trendingScore": 672,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -971,30 +995,6 @@
       "matchedTopicLabel": "LLMs"
     },
     {
-      "uri": "at://did:plc:kzsnqhdb3styakbudv3xtq4p/app.bsky.feed.post/3mmg37qoxdk2j",
-      "cid": "bafyreifr4cvj5bzrsdrcsz65v37uktt5j5bikgjzyis43sfd6xujfkedxe",
-      "bskyUrl": "https://bsky.app/profile/mosheroperandi.bsky.social/post/3mmg37qoxdk2j",
-      "text": "Everyone says they want Fully Automated Luxury Gay Space Communism until they learn the Communism will be endless amounts of charts, the Space stuff will be done mostly by robots, the Full Automation will come from AI, and the Gay part will also involve AI making up for the top shortage.",
-      "author": {
-        "handle": "mosheroperandi.bsky.social",
-        "displayName": "Keith"
-      },
-      "likeCount": 502,
-      "repostCount": 72,
-      "replyCount": 15,
-      "createdAt": "2026-05-22T04:16:35.871Z",
-      "createdUtc": 1779423395,
-      "ageHours": 15.87,
-      "trendingScore": 653.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "Workflow and automation",
-      "matchedQuery": "lang:en automation",
-      "matchedTopicId": "workflow",
-      "matchedTopicLabel": "Workflow and automation"
-    },
-    {
       "uri": "at://did:plc:unkqxy3fxjckrxrqstopn3qb/app.bsky.feed.post/3mm2ywogrec2q",
       "cid": "bafyreifhlvm3kjszlsq74toeu6zbga6tnju4ffwq5rndahvb2y2eux64mm",
       "bskyUrl": "https://bsky.app/profile/robdenbleyker.com/post/3mm2ywogrec2q",
@@ -1003,13 +1003,13 @@
         "handle": "robdenbleyker.com",
         "displayName": "Rob DenBleyker"
       },
-      "likeCount": 546,
+      "likeCount": 547,
       "repostCount": 36,
       "replyCount": 9,
       "createdAt": "2026-05-17T18:36:26.909Z",
       "createdUtc": 1779042986,
-      "ageHours": 121.53,
-      "trendingScore": 622.5,
+      "ageHours": 124.73,
+      "trendingScore": 623.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1104,7 +1104,7 @@
       "replyCount": 13,
       "createdAt": "2026-05-17T16:42:21.014Z",
       "createdUtc": 1779036141,
-      "ageHours": 123.44,
+      "ageHours": 126.63,
       "trendingScore": 581.5,
       "content_tags": [
         "is-question"
@@ -1130,7 +1130,7 @@
       "replyCount": 9,
       "createdAt": "2026-05-04T13:55:12.568Z",
       "createdUtc": 1777902912,
-      "ageHours": 438.22,
+      "ageHours": 441.42,
       "trendingScore": 581.5,
       "content_tags": [],
       "value_score": 0,
@@ -1149,13 +1149,13 @@
         "handle": "bell.bz",
         "displayName": "Andy Bell"
       },
-      "likeCount": 404,
+      "likeCount": 405,
       "repostCount": 82,
       "replyCount": 10,
       "createdAt": "2026-05-21T06:08:35.631Z",
       "createdUtc": 1779343715,
-      "ageHours": 38,
-      "trendingScore": 573,
+      "ageHours": 41.19,
+      "trendingScore": 574,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1178,7 +1178,7 @@
       "replyCount": 1,
       "createdAt": "2026-05-21T01:34:58.982Z",
       "createdUtc": 1779327298,
-      "ageHours": 42.56,
+      "ageHours": 45.75,
       "trendingScore": 565.5,
       "content_tags": [],
       "value_score": 0,
@@ -1252,8 +1252,32 @@
       "replyCount": 39,
       "createdAt": "2026-05-17T21:56:52.568Z",
       "createdUtc": 1779055012,
-      "ageHours": 118.19,
+      "ageHours": 121.39,
       "trendingScore": 551.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
+      "uri": "at://did:plc:2dv4enaklqwhdswno3iurehp/app.bsky.feed.post/3mmh2getuvk23",
+      "cid": "bafyreihjarr75wnqjz6v25qflw72viyd6jwtxz7tag3l2yuak2bjnuypeu",
+      "bskyUrl": "https://bsky.app/profile/oregonthedm.bsky.social/post/3mmh2getuvk23",
+      "text": "",
+      "author": {
+        "handle": "oregonthedm.bsky.social",
+        "displayName": "Oregon 🕎🎲"
+      },
+      "likeCount": 384,
+      "repostCount": 81,
+      "replyCount": 2,
+      "createdAt": "2026-05-22T13:35:04.324Z",
+      "createdUtc": 1779456904,
+      "ageHours": 9.75,
+      "trendingScore": 547,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -1333,30 +1357,6 @@
       "matchedQuery": "lang:en rag",
       "matchedTopicId": "retrieval",
       "matchedTopicLabel": "RAG and retrieval"
-    },
-    {
-      "uri": "at://did:plc:xciroqs5w2kazs6fc6ypcbh7/app.bsky.feed.post/3mma2d7pvpc27",
-      "cid": "bafyreibtxx2tlp6j3gebfir3j75pst44zke4epyi247gfr2isexp2slkwa",
-      "bskyUrl": "https://bsky.app/profile/timmarchman.bsky.social/post/3mma2d7pvpc27",
-      "text": "Okay but I don't *want* a conversational agentic experience, I really do want a list of links ranked for relevance by a basic algorithm, ideally 100 per page.",
-      "author": {
-        "handle": "timmarchman.bsky.social",
-        "displayName": "Tim Marchman"
-      },
-      "likeCount": 398,
-      "repostCount": 59,
-      "replyCount": 7,
-      "createdAt": "2026-05-19T18:44:40.122Z",
-      "createdUtc": 1779216280,
-      "ageHours": 73.4,
-      "trendingScore": 519.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "AI agents",
-      "matchedQuery": "lang:en agentic",
-      "matchedTopicId": "agents",
-      "matchedTopicLabel": "AI agents"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh Bluesky signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26316560749

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.