### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-23T00:16:36Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-22T20:47:00.223Z",
+  "ts": "2026-05-23T00:16:36.545Z",
   "count": 1,
-  "durationMs": 11496,
+  "durationMs": 11986,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-22T20:46:58.217Z",
+  "lastFetchedAt": "2026-05-23T00:16:35.036Z",
   "windowDays": 7,
   "launches": [
     {
@@ -531,6 +531,59 @@
       "aiAdjacent": true
     },
     {
+      "id": "1144878",
+      "name": "TestSprite 3.0",
+      "tagline": "Let a fleet of parallel agents test your app in minutes",
+      "description": "TestSprite generates and runs end-to-end tests for your app, autonomously. For backend, we can now generate complex integration tests with dynamic variables, auto-cleanup, and Data Flow debugging. For frontend, we now send a fleet of parallel AI agents to explore your app first — clicking through every feature like real users, then feeding results into testing. We're the first to do this. 3.0 also adds auto-heal for UI drift, auto-auth for regression, and a CLI for Claude Code, Codex users.",
+      "url": "https://www.producthunt.com/products/testsprite?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/DP36SVO3Y3LMV7",
+      "votesCount": 357,
+      "commentsCount": 60,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/50434618-8b14-40d7-9958-db6ef9c84ccb.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1136902",
       "name": "OpenHuman",
       "tagline": "An open source AI harness built with the human in mind",
@@ -644,59 +697,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1144878",
-      "name": "TestSprite 3.0",
-      "tagline": "Let a fleet of parallel agents test your app in minutes",
-      "description": "TestSprite generates and runs end-to-end tests for your app, autonomously. For backend, we can now generate complex integration tests with dynamic variables, auto-cleanup, and Data Flow debugging. For frontend, we now send a fleet of parallel AI agents to explore your app first — clicking through every feature like real users, then feeding results into testing. We're the first to do this. 3.0 also adds auto-heal for UI drift, auto-auth for regression, and a CLI for Claude Code, Codex users.",
-      "url": "https://www.producthunt.com/products/testsprite?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DP36SVO3Y3LMV7",
-      "votesCount": 335,
-      "commentsCount": 57,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/50434618-8b14-40d7-9958-db6ef9c84ccb.png?auto=format",
-      "topics": [
-        "developer-tools",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     },
     {
       "id": "1147569",
@@ -1030,6 +1030,42 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152537",
+      "name": "Cleo",
+      "tagline": "The AI PM that runs your team",
+      "description": "Cleo is the AI product manager for founders and lean teams. It lives in Telegram and Slack - learns your tone, knows your team, and runs the PM work (standups, follow-ups, decisions) while you ship the product. What's different: every fact Cleo learns is transparent - you see the source, the confidence, and can confirm or correct it. No black-box memory. Five trust levels, from observer to operator. Free in Telegram. 1 min setup",
+      "url": "https://www.producthunt.com/products/cleo-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/UEIFHO7XED74LR",
+      "votesCount": 296,
+      "commentsCount": 62,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/5edce491-25ca-4a4e-ac6b-0521e5c83e07.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence",
+        "alpha"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "942860",
       "name": "SUN-to-Spotify ",
       "tagline": "Generate audio with SUN and send it to your Spotify library",
@@ -1260,42 +1296,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1152537",
-      "name": "Cleo",
-      "tagline": "The AI PM that runs your team",
-      "description": "Cleo is the AI product manager for founders and lean teams. It lives in Telegram and Slack - learns your tone, knows your team, and runs the PM work (standups, follow-ups, decisions) while you ship the product. What's different: every fact Cleo learns is transparent - you see the source, the confidence, and can confirm or correct it. No black-box memory. Five trust levels, from observer to operator. Free in Telegram. 1 min setup",
-      "url": "https://www.producthunt.com/products/cleo-4?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/UEIFHO7XED74LR",
-      "votesCount": 280,
-      "commentsCount": 57,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/5edce491-25ca-4a4e-ac6b-0521e5c83e07.png?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence",
-        "alpha"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     },
     {
       "id": "1150124",
@@ -1575,6 +1575,36 @@
       "aiAdjacent": true
     },
     {
+      "id": "1129994",
+      "name": "General Compute",
+      "tagline": "AI models that run on an inference cloud optimized for speed",
+      "description": "GPUs are built for training, not inference. General Compute is an inference cloud running on ASICs — purpose-built alternatives to Nvidia silicon designed specifically for inference. We deliver 5x faster responses and higher per-user throughput for latency-sensitive workloads like coding and voice agents. Our OpenAI-compatible API means you swap your base URL, keep your existing workflows, and run real-time AI on infrastructure built for the job.",
+      "url": "https://www.producthunt.com/products/general-compute?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/NHQEMRTC6G4X2J",
+      "votesCount": 260,
+      "commentsCount": 31,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/e7ecdc30-d819-457b-bd2c-c51b32c0379b.png?auto=format",
+      "topics": [
+        "api-1",
+        "software-engineering",
+        "alpha"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1141635",
       "name": "Ghost",
       "tagline": "Open-source, self-hosted game servers",
@@ -1728,36 +1758,6 @@
         "artificial-intelligence"
       ],
       "makers": [],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1129994",
-      "name": "General Compute",
-      "tagline": "AI models that run on an inference cloud optimized for speed",
-      "description": "GPUs are built for training, not inference. General Compute is an inference cloud running on ASICs — purpose-built alternatives to Nvidia silicon designed specifically for inference. We deliver 5x faster responses and higher per-user throughput for latency-sensitive workloads like coding and voice agents. Our OpenAI-compatible API means you swap your base URL, keep your existing workflows, and run real-time AI on infrastructure built for the job.",
-      "url": "https://www.producthunt.com/products/general-compute?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/NHQEMRTC6G4X2J",
-      "votesCount": 242,
-      "commentsCount": 29,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/e7ecdc30-d819-457b-bd2c-c51b32c0379b.png?auto=format",
-      "topics": [
-        "api-1",
-        "software-engineering",
-        "alpha"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,
@@ -2108,6 +2108,34 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152815",
+      "name": "WordPress 7.0",
+      "tagline": "Introducing AI tools, new admin experience & design controls",
+      "description": "WordPress 7.0 marks the start of a new era, laying the foundation for AI across the WordPress experience. Greeting you with a modern, more intuitive dashboard, 7.0 introduces enhanced customization and development tools that inspire creativity and tap into endless potential. Whether you’re a creator, business owner or developer – WordPress 7.0 let’s you create in a way that is uniquely your own.",
+      "url": "https://www.producthunt.com/products/wordpress-7-0?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/DR7XDHFH7F2IGM",
+      "votesCount": 208,
+      "commentsCount": 5,
+      "createdAt": "2026-05-22T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/834157b6-01ba-4baa-9997-d039fee7d26b.png?auto=format",
+      "topics": [
+        "wordpress"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1151120",
       "name": "Runtime",
       "tagline": "Sandboxed coding agents for everyone on your team",
@@ -2260,34 +2288,6 @@
         "developer-tools",
         "github",
         "security"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
-      "id": "1152815",
-      "name": "WordPress 7.0",
-      "tagline": "Introducing AI tools, new admin experience & design controls",
-      "description": "WordPress 7.0 marks the start of a new era, laying the foundation for AI across the WordPress experience. Greeting you with a modern, more intuitive dashboard, 7.0 introduces enhanced customization and development tools that inspire creativity and tap into endless potential. Whether you’re a creator, business owner or developer – WordPress 7.0 let’s you create in a way that is uniquely your own.",
-      "url": "https://www.producthunt.com/products/wordpress-7-0?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DR7XDHFH7F2IGM",
-      "votesCount": 198,
-      "commentsCount": 4,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/834157b6-01ba-4baa-9997-d039fee7d26b.png?auto=format",
-      "topics": [
-        "wordpress"
       ],
       "makers": [
         {


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26318074805

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.