### PR TITLE
chore(data): refresh awesome-skills index 2026-05-23T07:11:34Z

### DIFF
--- a/data/_meta/awesome-skills.json
+++ b/data/_meta/awesome-skills.json
@@ -1,8 +1,8 @@
 {
   "source": "awesome-skills",
   "reason": "ok",
-  "ts": "2026-05-22T07:57:06.567Z",
+  "ts": "2026-05-23T07:11:34.230Z",
   "count": 1,
-  "durationMs": 3784,
+  "durationMs": 3595,
   "extra": {}
 }

--- a/data/awesome-skills.json
+++ b/data/awesome-skills.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T07:57:02.785Z",
+  "fetchedAt": "2026-05-23T07:11:30.637Z",
   "source": "awesome-skills aggregate",
   "lists": [
     "sickn33/antigravity-awesome-skills",


### PR DESCRIPTION
Automated data refresh from `Refresh awesome-skills index`.

- Files changed: 3
- Run: https://github.com/0motionguy/starscreener/actions/runs/26326573073

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.