### PR TITLE
chore(data): promote unknown mentions 2026-05-23T07:17:18Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-22T07:59:56.143Z",
-  "totalUnknownMentions": 234462,
-  "distinctRepos": 21538,
+  "generatedAt": "2026-05-23T07:17:18.404Z",
+  "totalUnknownMentions": 246245,
+  "distinctRepos": 22467,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
       "fullName": "oven-sh/bun",
-      "totalCount": 173,
+      "totalCount": 185,
       "sourceCount": 5,
       "sources": [
         "bluesky",
@@ -17,11 +17,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 89,
+      "totalCount": 94,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -31,11 +31,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
     },
     {
       "fullName": "trycua/cua",
-      "totalCount": 38,
+      "totalCount": 39,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -45,11 +45,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
     },
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 198,
+      "totalCount": 211,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -58,11 +58,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "vercel/next.js",
-      "totalCount": 168,
+      "totalCount": 170,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -71,7 +71,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "lastSeenAt": "2026-05-22T12:15:42.728Z"
     },
     {
       "fullName": "hmbown/deepseek-tui",
@@ -88,7 +88,7 @@
     },
     {
       "fullName": "vitejs/vite",
-      "totalCount": 95,
+      "totalCount": 98,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -97,11 +97,11 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+      "lastSeenAt": "2026-05-22T19:51:38.224Z"
     },
     {
       "fullName": "facebook/react",
-      "totalCount": 89,
+      "totalCount": 93,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -110,7 +110,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
     },
     {
       "fullName": "antirez/ds4",
@@ -153,7 +153,7 @@
     },
     {
       "fullName": "microsoft/vscode",
-      "totalCount": 170,
+      "totalCount": 180,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -161,7 +161,7 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "onyks-os/transparenttorproxy",
@@ -200,6 +200,18 @@
       "lastSeenAt": "2026-05-20T09:58:14.460Z"
     },
     {
+      "fullName": "naver/lispe",
+      "totalCount": 111,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+    },
+    {
       "fullName": "minishlab/semble",
       "totalCount": 111,
       "sourceCount": 3,
@@ -224,18 +236,6 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
-      "fullName": "naver/lispe",
-      "totalCount": 103,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
-    },
-    {
       "fullName": "scosman/cursed_browser",
       "totalCount": 103,
       "sourceCount": 3,
@@ -258,6 +258,30 @@
       ],
       "firstSeenAt": "2026-05-07T17:19:14.533Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "higangssh/homebutler",
+      "totalCount": 100,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+    },
+    {
+      "fullName": "andyyyy64/whichllm",
+      "totalCount": 100,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T10:12:27.167Z",
+      "lastSeenAt": "2026-05-23T06:46:01.193Z"
     },
     {
       "fullName": "reviewstage/stage-cli",
@@ -308,18 +332,6 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 95,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
-    },
-    {
       "fullName": "nvlabs/cuda-oxide",
       "totalCount": 93,
       "sourceCount": 3,
@@ -330,18 +342,6 @@
       ],
       "firstSeenAt": "2026-05-07T21:45:14.561Z",
       "lastSeenAt": "2026-05-11T00:07:14.314Z"
-    },
-    {
-      "fullName": "andyyyy64/whichllm",
-      "totalCount": 92,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-15T10:12:27.167Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "bring-shrubbery/ml-sharp-web",
@@ -368,6 +368,30 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
+      "fullName": "snyk/agent-scan",
+      "totalCount": 90,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T18:13:43.732Z",
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+    },
+    {
+      "fullName": "sifter-ai/sifter",
+      "totalCount": 89,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+    },
+    {
       "fullName": "shadcn-ui/ui",
       "totalCount": 89,
       "sourceCount": 3,
@@ -380,44 +404,8 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "sifter-ai/sifter",
-      "totalCount": 88,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
-    },
-    {
-      "fullName": "snyk/agent-scan",
-      "totalCount": 86,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T18:13:43.732Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
-    },
-    {
-      "fullName": "run-llama/llama_index",
-      "totalCount": 86,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-21T19:58:00.756Z"
-    },
-    {
       "fullName": "fsnotify/fsnotify",
-      "totalCount": 84,
+      "totalCount": 88,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -425,7 +413,31 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+    },
+    {
+      "fullName": "run-llama/llama_index",
+      "totalCount": 88,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-22T18:04:56.157Z"
+    },
+    {
+      "fullName": "tanstack/router",
+      "totalCount": 85,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-02T04:02:25.023Z",
+      "lastSeenAt": "2026-05-22T19:51:38.224Z"
     },
     {
       "fullName": "torrix-ai/install",
@@ -440,18 +452,6 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
-      "fullName": "tanstack/router",
-      "totalCount": 84,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T04:02:25.023Z",
-      "lastSeenAt": "2026-05-20T03:46:01.433Z"
-    },
-    {
       "fullName": "waybarrios/opencode-power-pack",
       "totalCount": 81,
       "sourceCount": 3,
@@ -464,8 +464,20 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
+      "fullName": "h4ckf0r0day/obscura",
+      "totalCount": 78,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+    },
+    {
       "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 76,
+      "totalCount": 77,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -473,11 +485,35 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+    },
+    {
+      "fullName": "jnuyens/modulejail",
+      "totalCount": 73,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+    },
+    {
+      "fullName": "ollama/ollama",
+      "totalCount": 72,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
     },
     {
       "fullName": "n8n-io/n8n",
-      "totalCount": 67,
+      "totalCount": 71,
       "sourceCount": 3,
       "sources": [
         "devto",
@@ -485,7 +521,31 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+    },
+    {
+      "fullName": "statewright/statewright",
+      "totalCount": 67,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T17:04:51.325Z",
+      "lastSeenAt": "2026-05-22T18:04:56.157Z"
+    },
+    {
+      "fullName": "v12-security/pocs",
+      "totalCount": 67,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-22T17:36:35.165Z"
     },
     {
       "fullName": "codecrafters-io/build-your-own-x",
@@ -500,30 +560,6 @@
       "lastSeenAt": "2026-05-20T22:44:07.574Z"
     },
     {
-      "fullName": "ollama/ollama",
-      "totalCount": 66,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
-    },
-    {
-      "fullName": "statewright/statewright",
-      "totalCount": 66,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T17:04:51.325Z",
-      "lastSeenAt": "2026-05-21T19:58:00.756Z"
-    },
-    {
       "fullName": "sambigeara/pollen",
       "totalCount": 66,
       "sourceCount": 3,
@@ -536,28 +572,16 @@
       "lastSeenAt": "2026-05-10T12:05:20.661Z"
     },
     {
-      "fullName": "jnuyens/modulejail",
-      "totalCount": 65,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
-    },
-    {
-      "fullName": "v12-security/pocs",
+      "fullName": "rust-lang/rust",
       "totalCount": 64,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-23T01:34:24.128Z"
     },
     {
       "fullName": "vercel/ai",
@@ -620,6 +644,30 @@
       "lastSeenAt": "2026-05-07T12:21:38.823Z"
     },
     {
+      "fullName": "vllm-project/vllm",
+      "totalCount": 62,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T19:21:26.285Z",
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+    },
+    {
+      "fullName": "localsend/localsend",
+      "totalCount": 62,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-22T15:22:19.973Z"
+    },
+    {
       "fullName": "navid-m/flightsim",
       "totalCount": 62,
       "sourceCount": 3,
@@ -642,18 +690,6 @@
       ],
       "firstSeenAt": "2026-05-11T21:52:07.915Z",
       "lastSeenAt": "2026-05-21T05:20:28.559Z"
-    },
-    {
-      "fullName": "localsend/localsend",
-      "totalCount": 61,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-20T12:04:16.253Z"
     },
     {
       "fullName": "redis/redis",
@@ -680,30 +716,6 @@
       "lastSeenAt": "2026-05-19T12:20:48.337Z"
     },
     {
-      "fullName": "rust-lang/rust",
-      "totalCount": 57,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
-    },
-    {
-      "fullName": "vllm-project/vllm",
-      "totalCount": 57,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
-    },
-    {
       "fullName": "uw-syfi/vibe-serve",
       "totalCount": 56,
       "sourceCount": 3,
@@ -714,6 +726,30 @@
       ],
       "firstSeenAt": "2026-05-08T16:57:07.580Z",
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
+    },
+    {
+      "fullName": "junegunn/fzf",
+      "totalCount": 55,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+    },
+    {
+      "fullName": "open-webui/open-webui",
+      "totalCount": 54,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T04:53:38.982Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "minio/minio",
@@ -728,16 +764,16 @@
       "lastSeenAt": "2026-05-09T08:04:55.501Z"
     },
     {
-      "fullName": "junegunn/fzf",
+      "fullName": "igorganapolsky/thumbgate",
       "totalCount": 51,
       "sourceCount": 3,
       "sources": [
+        "awesome-skills",
         "bluesky",
-        "devto",
-        "twitter"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
     },
     {
       "fullName": "cline/cline",
@@ -750,18 +786,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
-    },
-    {
-      "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 50,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -824,6 +848,30 @@
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
     },
     {
+      "fullName": "0xmassi/webclaw",
+      "totalCount": 46,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+    },
+    {
+      "fullName": "iliaal/fastchart",
+      "totalCount": 46,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-22T19:51:38.224Z"
+    },
+    {
       "fullName": "nooga/let-go",
       "totalCount": 46,
       "sourceCount": 3,
@@ -836,28 +884,28 @@
       "lastSeenAt": "2026-05-11T01:25:31.639Z"
     },
     {
-      "fullName": "0xmassi/webclaw",
+      "fullName": "zed-industries/zed",
       "totalCount": 45,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
-        "devto",
-        "reddit"
+        "bluesky",
+        "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
     },
     {
-      "fullName": "open-webui/open-webui",
+      "fullName": "anishathalye/ai-agent-security-lecture",
       "totalCount": 45,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "hackernews",
-        "reddit"
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-07T04:53:38.982Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "firstSeenAt": "2026-05-18T16:34:28.470Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
@@ -882,30 +930,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
-    },
-    {
-      "fullName": "zed-industries/zed",
-      "totalCount": 44,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
-    },
-    {
-      "fullName": "iliaal/fastchart",
-      "totalCount": 44,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-21T19:16:46.402Z"
     },
     {
       "fullName": "simdjson/simdjson",
@@ -933,7 +957,7 @@
     },
     {
       "fullName": "awslabs/mcp",
-      "totalCount": 37,
+      "totalCount": 38,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -941,10 +965,22 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
     },
     {
-      "fullName": "anishathalye/ai-agent-security-lecture",
+      "fullName": "yt-dlp/yt-dlp",
+      "totalCount": 38,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-08T11:47:27.264Z",
+      "lastSeenAt": "2026-05-23T06:46:01.193Z"
+    },
+    {
+      "fullName": "sander110419/lightroom-cc-on-linux",
       "totalCount": 37,
       "sourceCount": 3,
       "sources": [
@@ -952,8 +988,8 @@
         "hackernews",
         "lobsters"
       ],
-      "firstSeenAt": "2026-05-18T16:34:28.470Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "firstSeenAt": "2026-05-18T12:48:24.691Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "tabularisdb/tabularis",
@@ -980,20 +1016,8 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "sander110419/lightroom-cc-on-linux",
-      "totalCount": 29,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-18T12:48:24.691Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
-    },
-    {
       "fullName": "xataio/deltax",
-      "totalCount": 27,
+      "totalCount": 35,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -1001,7 +1025,43 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-19T19:17:55.212Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+    },
+    {
+      "fullName": "nrwl/nx-console",
+      "totalCount": 34,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-18T20:04:30.386Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+    },
+    {
+      "fullName": "pydantic/pydantic-ai",
+      "totalCount": 28,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+    },
+    {
+      "fullName": "nodejs/node",
+      "totalCount": 27,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T03:48:07.888Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -1016,7 +1076,7 @@
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
     },
     {
-      "fullName": "pydantic/pydantic-ai",
+      "fullName": "anthropics/claude-cookbooks",
       "totalCount": 25,
       "sourceCount": 3,
       "sources": [
@@ -1025,11 +1085,11 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
     },
     {
-      "fullName": "anthropics/claude-cookbooks",
-      "totalCount": 24,
+      "fullName": "duriantaco/skylos",
+      "totalCount": 19,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -1037,19 +1097,7 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
-    },
-    {
-      "fullName": "nodejs/node",
-      "totalCount": 19,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T03:48:07.888Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -1064,18 +1112,6 @@
       "lastSeenAt": "2026-05-17T21:12:09.791Z"
     },
     {
-      "fullName": "duriantaco/skylos",
-      "totalCount": 18,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
-    },
-    {
       "fullName": "skyhook-io/radar",
       "totalCount": 18,
       "sourceCount": 3,
@@ -1086,6 +1122,42 @@
       ],
       "firstSeenAt": "2026-05-03T09:05:56.174Z",
       "lastSeenAt": "2026-05-04T00:13:30.621Z"
+    },
+    {
+      "fullName": "reduxjs/react-redux",
+      "totalCount": 16,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-22T19:51:38.224Z"
+    },
+    {
+      "fullName": "superset-sh/superset",
+      "totalCount": 12,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T08:09:15.267Z",
+      "lastSeenAt": "2026-05-22T22:22:35.106Z"
+    },
+    {
+      "fullName": "brethofai/brethof-mind",
+      "totalCount": 10,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-22T17:36:35.165Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "simstudioai/sim",
@@ -1101,14 +1173,25 @@
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 171,
+      "totalCount": 179,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-22T07:57:06.565Z"
+      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+    },
+    {
+      "fullName": "jigjoy-ai/mozaik",
+      "totalCount": 139,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
     },
     {
       "fullName": "wojtczyk/trust",
@@ -1122,15 +1205,15 @@
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
-      "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 135,
+      "fullName": "raiyanyahya/how-to-train-your-gpt",
+      "totalCount": 130,
       "sourceCount": 2,
       "sources": [
-        "devto",
+        "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "nexu-io/open-design",
@@ -1142,17 +1225,6 @@
       ],
       "firstSeenAt": "2026-05-02T13:50:45.195Z",
       "lastSeenAt": "2026-05-11T19:17:39.871Z"
-    },
-    {
-      "fullName": "raiyanyahya/how-to-train-your-gpt",
-      "totalCount": 122,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
     },
     {
       "fullName": "warwickwood-cell/gengeo-agent-registry",
@@ -1221,6 +1293,17 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 109,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-23T06:46:01.193Z"
+    },
+    {
       "fullName": "jossephus/chuchu",
       "totalCount": 109,
       "sourceCount": 2,
@@ -1230,6 +1313,17 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-16T00:18:32.194Z"
+    },
+    {
+      "fullName": "harnexa/nexa-gauge",
+      "totalCount": 106,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T01:29:16.934Z",
+      "lastSeenAt": "2026-05-23T01:34:24.128Z"
     },
     {
       "fullName": "orhun/ratty",
@@ -1252,17 +1346,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
-    },
-    {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 104,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-22T04:41:30.451Z"
     },
     {
       "fullName": "facebookresearch/tuna-2",
@@ -1298,15 +1381,15 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
-      "fullName": "harnexa/nexa-gauge",
-      "totalCount": 99,
+      "fullName": "yamafaktory/hypergraphz",
+      "totalCount": 98,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-09T01:29:16.934Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "firstSeenAt": "2026-05-03T21:12:41.505Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "mekickdemons-creator/mnemara",
@@ -1364,17 +1447,6 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
-      "fullName": "yamafaktory/hypergraphz",
-      "totalCount": 90,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T21:12:41.505Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
-    },
-    {
       "fullName": "gfernandf/agent-skills",
       "totalCount": 89,
       "sourceCount": 2,
@@ -1419,6 +1491,39 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
+      "fullName": "chojs23/concord",
+      "totalCount": 88,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+    },
+    {
+      "fullName": "kiamehr5/kmri",
+      "totalCount": 87,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-03T10:34:44.583Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+    },
+    {
+      "fullName": "scottgl9/skelm",
+      "totalCount": 87,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-22T19:51:38.224Z"
+    },
+    {
       "fullName": "cubiczan/consensus-hardening-protocol",
       "totalCount": 87,
       "sourceCount": 2,
@@ -1441,15 +1546,26 @@
       "lastSeenAt": "2026-05-21T09:46:35.015Z"
     },
     {
-      "fullName": "scottgl9/skelm",
-      "totalCount": 84,
+      "fullName": "enmanuelmag/heimdall-mcp",
+      "totalCount": 85,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+    },
+    {
+      "fullName": "eleutherai/lm-evaluation-harness",
+      "totalCount": 85,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-22T19:51:38.224Z"
     },
     {
       "fullName": "v4bel/dirtyfrag",
@@ -1529,17 +1645,6 @@
       "lastSeenAt": "2026-05-09T18:44:58.134Z"
     },
     {
-      "fullName": "eleutherai/lm-evaluation-harness",
-      "totalCount": 82,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T14:30:15.363Z",
-      "lastSeenAt": "2026-05-21T09:46:35.015Z"
-    },
-    {
       "fullName": "dmarshaltu/coord",
       "totalCount": 82,
       "sourceCount": 2,
@@ -1549,17 +1654,6 @@
       ],
       "firstSeenAt": "2026-05-08T15:06:30.276Z",
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
-    },
-    {
-      "fullName": "enmanuelmag/heimdall-mcp",
-      "totalCount": 81,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-22T03:52:51.448Z"
     },
     {
       "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
@@ -1584,15 +1678,15 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "chojs23/concord",
+      "fullName": "comfyanonymous/comfyui",
       "totalCount": 80,
       "sourceCount": 2,
       "sources": [
         "bluesky",
-        "hackernews"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-22T05:57:42.221Z"
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-23T06:46:01.193Z"
     },
     {
       "fullName": "tsirysndr/rockbox-zig",
@@ -1648,17 +1742,6 @@
       ],
       "firstSeenAt": "2026-05-07T04:53:38.982Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "kiamehr5/kmri",
-      "totalCount": 79,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T10:34:44.583Z",
-      "lastSeenAt": "2026-05-10T10:08:57.038Z"
     },
     {
       "fullName": "dventimisupabase/pg_flight_recorder",
@@ -1749,6 +1832,17 @@
       "lastSeenAt": "2026-05-11T11:39:37.103Z"
     },
     {
+      "fullName": "yaelwrites/big-ass-data-broker-opt-out-list",
+      "totalCount": 76,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T12:21:38.823Z",
+      "lastSeenAt": "2026-05-22T23:20:30.127Z"
+    },
+    {
       "fullName": "datadog/java-reggie",
       "totalCount": 76,
       "sourceCount": 2,
@@ -1769,17 +1863,6 @@
       ],
       "firstSeenAt": "2026-05-03T04:20:52.369Z",
       "lastSeenAt": "2026-05-10T16:09:01.639Z"
-    },
-    {
-      "fullName": "h4ckf0r0day/obscura",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-21T22:41:39.489Z"
     },
     {
       "fullName": "davesimoes/crustai",
@@ -1826,6 +1909,28 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
+      "fullName": "npm/cli",
+      "totalCount": 74,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-23T06:46:01.193Z"
+    },
+    {
+      "fullName": "phel-lang/phel-lang",
+      "totalCount": 74,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T21:05:05.911Z",
+      "lastSeenAt": "2026-05-22T08:33:16.412Z"
+    },
+    {
       "fullName": "pyinfra-dev/pyinfra",
       "totalCount": 74,
       "sourceCount": 2,
@@ -1856,17 +1961,6 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "yaelwrites/big-ass-data-broker-opt-out-list",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T12:21:38.823Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
@@ -1903,17 +1997,6 @@
       "lastSeenAt": "2026-05-09T15:42:37.217Z"
     },
     {
-      "fullName": "phel-lang/phel-lang",
-      "totalCount": 73,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T21:05:05.911Z",
-      "lastSeenAt": "2026-05-22T04:41:30.451Z"
-    },
-    {
       "fullName": "heyputer/puter",
       "totalCount": 73,
       "sourceCount": 2,
@@ -1936,15 +2019,15 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
-      "fullName": "comfyanonymous/comfyui",
+      "fullName": "tanrikuluozlem/burn",
       "totalCount": 72,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
-        "devto"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-22T04:41:30.451Z"
+      "firstSeenAt": "2026-05-07T08:44:17.194Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "pion/rtwatch",
@@ -2112,6 +2195,17 @@
       "lastSeenAt": "2026-05-12T19:09:34.978Z"
     },
     {
+      "fullName": "zakirullin/files.md",
+      "totalCount": 70,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+    },
+    {
       "fullName": "webstonehq/tuxedo",
       "totalCount": 70,
       "sourceCount": 2,
@@ -2220,94 +2314,6 @@
       ],
       "firstSeenAt": "2026-05-01T15:17:55.542Z",
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
-    },
-    {
-      "fullName": "pnpm/pacquet",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-04T11:06:19.016Z"
-    },
-    {
-      "fullName": "valhalla/valhalla",
-      "totalCount": 68,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T20:50:24.350Z",
-      "lastSeenAt": "2026-05-19T19:17:55.212Z"
-    },
-    {
-      "fullName": "derekpascarella/universaldreamcastpatcher",
-      "totalCount": 68,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-18T00:10:02.617Z"
-    },
-    {
-      "fullName": "codeabra/iai-mcp",
-      "totalCount": 68,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-07T07:39:41.798Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "shouvik12/trooper",
-      "totalCount": 68,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-13T08:53:46.257Z"
-    },
-    {
-      "fullName": "bh3r1th/llm-evidence-gated-generation",
-      "totalCount": 68,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-07T19:50:24.370Z"
-    },
-    {
-      "fullName": "npm/cli",
-      "totalCount": 67,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-22T04:41:30.451Z"
-    },
-    {
-      "fullName": "trimooo/react-ai-stream",
-      "totalCount": 67,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-10T00:05:03.835Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26326695701

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.