### PR TITLE
chore(data): refresh dev.to signals 2026-05-23T08:24:13Z

### DIFF
--- a/data/_meta/devto.json
+++ b/data/_meta/devto.json
@@ -1,8 +1,8 @@
 {
   "source": "devto",
   "reason": "ok",
-  "ts": "2026-05-23T03:28:28.889Z",
+  "ts": "2026-05-23T08:24:13.061Z",
   "count": 1,
-  "durationMs": 119502,
+  "durationMs": 86831,
   "extra": {}
 }

--- a/data/devto-mentions.json
+++ b/data/devto-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T03:26:29.419Z",
+  "fetchedAt": "2026-05-23T08:22:46.250Z",
   "discoveryVersion": "2026-04-21",
   "windowDays": 7,
   "scannedArticles": 1319,
@@ -179,7 +179,7 @@
   ],
   "sliceCounts": {
     "global-top-7d": 100,
-    "global-rising": 19,
+    "global-rising": 16,
     "global-fresh": 100,
     "tag-ai-top-7d": 100,
     "tag-artificialintelligence-top-7d": 0,
@@ -216,7 +216,7 @@
         "author": "om_shree_0709",
         "reactions": 47,
         "comments": 26,
-        "hoursSincePosted": 74.7,
+        "hoursSincePosted": 79.6,
         "readingTime": 5
       },
       "articles": [
@@ -240,7 +240,7 @@
             "ai",
             "mcp"
           ],
-          "trendingScore": 3.79,
+          "trendingScore": 3.55,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -268,7 +268,7 @@
             "mcp",
             "devchallenge"
           ],
-          "trendingScore": 1.67,
+          "trendingScore": 1.54,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -289,7 +289,7 @@
         "author": "lovestaco",
         "reactions": 31,
         "comments": 2,
-        "hoursSincePosted": 80.7,
+        "hoursSincePosted": 85.6,
         "readingTime": 6
       },
       "articles": [
@@ -313,7 +313,7 @@
             "javascript",
             "beginners"
           ],
-          "trendingScore": 0.69,
+          "trendingScore": 0.65,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -341,7 +341,7 @@
             "go",
             "beginners"
           ],
-          "trendingScore": 0.83,
+          "trendingScore": 0.76,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -352,9 +352,9 @@
       ]
     },
     "NousResearch/hermes-agent": {
-      "count7d": 17,
-      "reactionsSum7d": 401,
-      "commentsSum7d": 146,
+      "count7d": 15,
+      "reactionsSum7d": 375,
+      "commentsSum7d": 127,
       "topArticle": {
         "id": 3682129,
         "title": "I Gave Hermes Agent 5 Impossible Tasks",
@@ -362,7 +362,7 @@
         "author": "syedahmershah",
         "reactions": 270,
         "comments": 96,
-        "hoursSincePosted": 162.9,
+        "hoursSincePosted": 167.8,
         "readingTime": 9
       },
       "articles": [
@@ -386,7 +386,7 @@
             "agents",
             "git"
           ],
-          "trendingScore": 42.73,
+          "trendingScore": 41.47,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -414,40 +414,12 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.85,
+          "trendingScore": 2.69,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
               "location": "body"
             },
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3681236,
-          "title": "I Ran Hermes Agent on the Same Task for 7 Days. The Skill File on Day 7 Looked Nothing Like Day 1.",
-          "description": "This is a submission for the Hermes Agent Challenge      TL;DR: Hermes Agent is the only open-source...",
-          "url": "https://dev.to/sreejit_/i-ran-hermes-agent-on-the-same-task-for-7-days-the-skill-file-on-day-7-looked-nothing-like-day-1-2oa8",
-          "author": {
-            "username": "sreejit_",
-            "name": "Sreejit Pradhan",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3904430%2Fbd74576f-cef8-4620-a63e-8a001f1e9d6c.png"
-          },
-          "reactionsCount": 25,
-          "commentsCount": 19,
-          "readingTime": 12,
-          "publishedAt": "2026-05-16T04:05:21Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents",
-            "ai"
-          ],
-          "trendingScore": 0.61,
-          "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
               "location": "body"
@@ -474,7 +446,7 @@
             "agents",
             "ai"
           ],
-          "trendingScore": 0.33,
+          "trendingScore": 0.31,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -501,7 +473,7 @@
             "devchallenge",
             "agents"
           ],
-          "trendingScore": 0.19,
+          "trendingScore": 0.18,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -529,7 +501,7 @@
             "ai",
             "agents"
           ],
-          "trendingScore": 0.06,
+          "trendingScore": 0.05,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -702,34 +674,6 @@
             "nextjs"
           ],
           "trendingScore": 0.01,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3725240,
-          "title": "The 4 Levels of Hermes Agent Scaling Framework: From One Hermes Agent to a Fully Automated Team",
-          "description": "A practical framework for scaling from a single AI agent to a self-running team of specialists. Includes setup instructions, progression checkpoints, and the one mistake that ruins everything.",
-          "url": "https://dev.to/shilpamitra/the-4-levels-of-hermes-agent-scaling-framework-from-one-hermes-agent-to-a-fully-automated-team-2gdp",
-          "author": {
-            "username": "shilpamitra",
-            "name": "Shilpa Mitra",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3943639%2F687febe9-259f-4c1e-a2a0-798ce0d6cc2b.png"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-22T11:56:54Z",
-          "tags": [
-            "ai",
-            "opensource",
-            "automation",
-            "productivity"
-          ],
-          "trendingScore": 0,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -862,7 +806,7 @@
         "author": "tahosin",
         "reactions": 42,
         "comments": 26,
-        "hoursSincePosted": 86.2,
+        "hoursSincePosted": 91.2,
         "readingTime": 13
       },
       "articles": [
@@ -886,7 +830,7 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.85,
+          "trendingScore": 2.69,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -978,7 +922,7 @@
         "author": "thecodedaniel",
         "reactions": 10,
         "comments": 0,
-        "hoursSincePosted": 79.9,
+        "hoursSincePosted": 84.8,
         "readingTime": 5
       },
       "articles": [
@@ -1001,111 +945,10 @@
             "gemmachallenge",
             "gemma"
           ],
-          "trendingScore": 0.13,
+          "trendingScore": 0.12,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/LiteRT-LM",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "vectorize-io/hindsight": {
-      "count7d": 3,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3727361,
-        "title": "I built an agent to audit incidents, but it kept forgetting Tuesday by Wednesday.",
-        "url": "https://dev.to/karthik_s_599904b6f055c2c/i-built-an-agent-to-audit-incidents-but-it-kept-forgetting-tuesday-by-wednesday-149c",
-        "author": "karthik_s_599904b6f055c2c",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 10,
-        "readingTime": 3
-      },
-      "articles": [
-        {
-          "id": 3727361,
-          "title": "I built an agent to audit incidents, but it kept forgetting Tuesday by Wednesday.",
-          "description": "When you build an enterprise AI agent, the honeymoon phase lasts exactly until you push to...",
-          "url": "https://dev.to/karthik_s_599904b6f055c2c/i-built-an-agent-to-audit-incidents-but-it-kept-forgetting-tuesday-by-wednesday-149c",
-          "author": {
-            "username": "karthik_s_599904b6f055c2c",
-            "name": "Karthik S",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3944646%2F9bfc3b7c-06dd-448c-a6a5-e8291213fde1.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-22T17:26:24Z",
-          "tags": [
-            "ai",
-            "opensource",
-            "backend",
-            "javascript"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "vectorize-io/hindsight",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3702728,
-          "title": "The cheapest model call is the one you don't make",
-          "description": "I spent the better part of a week building an alert triage co-pilot, and the most useful thing it...",
-          "url": "https://dev.to/wnxd/the-cheapest-model-call-is-the-one-you-dont-make-36kb",
-          "author": {
-            "username": "wnxd",
-            "name": "Sidharth SP",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3940827%2F1587348a-88e1-461e-bd1c-83eb1f725d0d.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-19T17:32:54Z",
-          "tags": [
-            "ai",
-            "automation",
-            "devops",
-            "llm"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "vectorize-io/hindsight",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3695395,
-          "title": "CRMs store data. I built something that remembers context.",
-          "description": "The first question I get when I tell people we have no database is: \"What do you mean, no...",
-          "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
-          "author": {
-            "username": "sandhyagk",
-            "name": "Sandhya G K",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3938594%2F33c002a2-ec2d-4666-a42d-3abbabb292e7.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 1,
-          "readingTime": 6,
-          "publishedAt": "2026-05-18T18:56:33Z",
-          "tags": [
-            "ai",
-            "architecture",
-            "rag",
-            "showdev"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "vectorize-io/hindsight",
               "location": "body"
             }
           ]
@@ -1123,7 +966,7 @@
         "author": "numbpill3d",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 5.7,
+        "hoursSincePosted": 10.6,
         "readingTime": 7
       },
       "articles": [
@@ -1162,8 +1005,8 @@
       ]
     },
     "JuliusBrussee/caveman": {
-      "count7d": 2,
-      "reactionsSum7d": 11,
+      "count7d": 1,
+      "reactionsSum7d": 8,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3710524,
@@ -1172,7 +1015,7 @@
         "author": "bd_perez",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 59.4,
+        "hoursSincePosted": 64.3,
         "readingTime": 7
       },
       "articles": [
@@ -1196,134 +1039,10 @@
             "money",
             "models"
           ],
-          "trendingScore": 0.12,
+          "trendingScore": 0.11,
           "linkedRepos": [
             {
               "fullName": "JuliusBrussee/caveman",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3698382,
-          "title": "KiroGraph: from a personal side project to community-AI-driven tool",
-          "description": "This is the second part of my \"Build in Public with Kiro\" series. I'm an AWS Community Builder, and...",
-          "url": "https://dev.to/aws-builders/kirograph-from-a-personal-side-project-to-community-ai-driven-tool-395e",
-          "author": {
-            "username": "ddesio",
-            "name": "Davide De Sio",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1402618%2F7b0b959e-0a8c-43b6-ad1d-90ae70727bb6.png"
-          },
-          "reactionsCount": 3,
-          "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-20T07:37:28Z",
-          "tags": [
-            "kiro",
-            "ai",
-            "aws"
-          ],
-          "trendingScore": 0.02,
-          "linkedRepos": [
-            {
-              "fullName": "JuliusBrussee/caveman",
-              "location": "body"
-            },
-            {
-              "fullName": "rtk-ai/rtk",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "rtk-ai/rtk": {
-      "count7d": 1,
-      "reactionsSum7d": 3,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3698382,
-        "title": "KiroGraph: from a personal side project to community-AI-driven tool",
-        "url": "https://dev.to/aws-builders/kirograph-from-a-personal-side-project-to-community-ai-driven-tool-395e",
-        "author": "ddesio",
-        "reactions": 3,
-        "comments": 0,
-        "hoursSincePosted": 67.8,
-        "readingTime": 11
-      },
-      "articles": [
-        {
-          "id": 3698382,
-          "title": "KiroGraph: from a personal side project to community-AI-driven tool",
-          "description": "This is the second part of my \"Build in Public with Kiro\" series. I'm an AWS Community Builder, and...",
-          "url": "https://dev.to/aws-builders/kirograph-from-a-personal-side-project-to-community-ai-driven-tool-395e",
-          "author": {
-            "username": "ddesio",
-            "name": "Davide De Sio",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1402618%2F7b0b959e-0a8c-43b6-ad1d-90ae70727bb6.png"
-          },
-          "reactionsCount": 3,
-          "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-20T07:37:28Z",
-          "tags": [
-            "kiro",
-            "ai",
-            "aws"
-          ],
-          "trendingScore": 0.02,
-          "linkedRepos": [
-            {
-              "fullName": "JuliusBrussee/caveman",
-              "location": "body"
-            },
-            {
-              "fullName": "rtk-ai/rtk",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "multica-ai/multica": {
-      "count7d": 1,
-      "reactionsSum7d": 5,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3720461,
-        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-        "author": "arshtechpro",
-        "reactions": 5,
-        "comments": 1,
-        "hoursSincePosted": 29.3,
-        "readingTime": 4
-      },
-      "articles": [
-        {
-          "id": 3720461,
-          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
-          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-          "author": {
-            "username": "arshtechpro",
-            "name": "ArshTechPro",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
-          },
-          "reactionsCount": 5,
-          "commentsCount": 1,
-          "readingTime": 4,
-          "publishedAt": "2026-05-21T22:07:10Z",
-          "tags": [
-            "ai",
-            "agents",
-            "python",
-            "programming"
-          ],
-          "trendingScore": 0.13,
-          "linkedRepos": [
-            {
-              "fullName": "multica-ai/multica",
               "location": "body"
             }
           ]
@@ -1341,7 +1060,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 87.8,
+        "hoursSincePosted": 92.7,
         "readingTime": 5
       },
       "articles": [
@@ -1375,6 +1094,103 @@
         }
       ]
     },
+    "multica-ai/multica": {
+      "count7d": 1,
+      "reactionsSum7d": 5,
+      "commentsSum7d": 1,
+      "topArticle": {
+        "id": 3720461,
+        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
+        "author": "arshtechpro",
+        "reactions": 5,
+        "comments": 1,
+        "hoursSincePosted": 34.3,
+        "readingTime": 4
+      },
+      "articles": [
+        {
+          "id": 3720461,
+          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
+          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
+          "author": {
+            "username": "arshtechpro",
+            "name": "ArshTechPro",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
+          },
+          "reactionsCount": 5,
+          "commentsCount": 1,
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T22:07:10Z",
+          "tags": [
+            "ai",
+            "agents",
+            "python",
+            "programming"
+          ],
+          "trendingScore": 0.11,
+          "linkedRepos": [
+            {
+              "fullName": "multica-ai/multica",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "nextlevelbuilder/goclaw": {
+      "count7d": 1,
+      "reactionsSum7d": 5,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3691887,
+        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+        "author": "truongpx396",
+        "reactions": 5,
+        "comments": 0,
+        "hoursSincePosted": 120.2,
+        "readingTime": 16
+      },
+      "articles": [
+        {
+          "id": 3691887,
+          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
+          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+          "author": {
+            "username": "truongpx396",
+            "name": "Truong Phung",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
+          },
+          "reactionsCount": 5,
+          "commentsCount": 0,
+          "readingTime": 16,
+          "publishedAt": "2026-05-18T08:12:05Z",
+          "tags": [
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents"
+          ],
+          "trendingScore": 0.03,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            },
+            {
+              "fullName": "openclaw/openclaw",
+              "location": "body"
+            },
+            {
+              "fullName": "nextlevelbuilder/goclaw",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "anthropics/claude-code": {
       "count7d": 10,
       "reactionsSum7d": 3,
@@ -1386,7 +1202,7 @@
         "author": "crawleyprint_71",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 131.5,
+        "hoursSincePosted": 136.4,
         "readingTime": 11
       },
       "articles": [
@@ -1688,364 +1504,6 @@
         }
       ]
     },
-    "nextlevelbuilder/goclaw": {
-      "count7d": 1,
-      "reactionsSum7d": 5,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3691887,
-        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
-        "author": "truongpx396",
-        "reactions": 5,
-        "comments": 0,
-        "hoursSincePosted": 115.2,
-        "readingTime": 16
-      },
-      "articles": [
-        {
-          "id": 3691887,
-          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
-          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
-          "author": {
-            "username": "truongpx396",
-            "name": "Truong Phung",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
-          },
-          "reactionsCount": 5,
-          "commentsCount": 0,
-          "readingTime": 16,
-          "publishedAt": "2026-05-18T08:12:05Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
-          ],
-          "trendingScore": 0.03,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            },
-            {
-              "fullName": "openclaw/openclaw",
-              "location": "body"
-            },
-            {
-              "fullName": "nextlevelbuilder/goclaw",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "can1357/oh-my-pi": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3710799,
-        "title": "Secure Agents: Control Policies in the Harness",
-        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
-        "author": "epappas",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 58.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3710799,
-          "title": "Secure Agents: Control Policies in the Harness",
-          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
-          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
-          "author": {
-            "username": "epappas",
-            "name": "Evangelos Pappas",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-20T17:03:09Z",
-          "tags": [
-            "ai",
-            "agents",
-            "cybersecurity",
-            "devops"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "can1357/oh-my-pi",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "Fission-AI/OpenSpec": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3690020,
-        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
-        "author": "kenimo49",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 86.4,
-        "readingTime": 6
-      },
-      "articles": [
-        {
-          "id": 3690020,
-          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
-          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
-          "author": {
-            "username": "kenimo49",
-            "name": "Ken Imoto",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-19T13:00:01Z",
-          "tags": [
-            "claudecode",
-            "ai",
-            "spec",
-            "openapi"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Fission-AI/OpenSpec",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "openai/symphony": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3729039,
-        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-        "author": "judy_miranttie",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 2.4,
-        "readingTime": 14
-      },
-      "articles": [
-        {
-          "id": 3729039,
-          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
-          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-          "author": {
-            "username": "judy_miranttie",
-            "name": "Judy",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 14,
-          "publishedAt": "2026-05-23T01:00:08Z",
-          "tags": [
-            "multiagent",
-            "aiteam",
-            "aiautomation",
-            "claudecode"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "openai/symphony",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "anthropics/skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 139.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "mattpocock/skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 139.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "addyosmani/agent-skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 139.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "obra/superpowers": {
       "count7d": 3,
       "reactionsSum7d": 1,
@@ -2057,7 +1515,7 @@
         "author": "chen115y",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 50.5,
+        "hoursSincePosted": 55.4,
         "readingTime": 20
       },
       "articles": [
@@ -2163,6 +1621,312 @@
         }
       ]
     },
+    "can1357/oh-my-pi": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3710799,
+        "title": "Secure Agents: Control Policies in the Harness",
+        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+        "author": "epappas",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 63.3,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3710799,
+          "title": "Secure Agents: Control Policies in the Harness",
+          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
+          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+          "author": {
+            "username": "epappas",
+            "name": "Evangelos Pappas",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-20T17:03:09Z",
+          "tags": [
+            "ai",
+            "agents",
+            "cybersecurity",
+            "devops"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "can1357/oh-my-pi",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "Fission-AI/OpenSpec": {
+      "count7d": 1,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3690020,
+        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+        "author": "kenimo49",
+        "reactions": 1,
+        "comments": 0,
+        "hoursSincePosted": 91.4,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3690020,
+          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
+          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+          "author": {
+            "username": "kenimo49",
+            "name": "Ken Imoto",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 6,
+          "publishedAt": "2026-05-19T13:00:01Z",
+          "tags": [
+            "claudecode",
+            "ai",
+            "spec",
+            "openapi"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Fission-AI/OpenSpec",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "openai/symphony": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3729039,
+        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+        "author": "judy_miranttie",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 7.4,
+        "readingTime": 14
+      },
+      "articles": [
+        {
+          "id": 3729039,
+          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
+          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+          "author": {
+            "username": "judy_miranttie",
+            "name": "Judy",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 14,
+          "publishedAt": "2026-05-23T01:00:08Z",
+          "tags": [
+            "multiagent",
+            "aiteam",
+            "aiautomation",
+            "claudecode"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "openai/symphony",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "anthropics/skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 144.4,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "mattpocock/skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 144.4,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "addyosmani/agent-skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 144.4,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "openai/codex": {
       "count7d": 4,
       "reactionsSum7d": 1,
@@ -2174,7 +1938,7 @@
         "author": "skyguan92",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 118.4,
+        "hoursSincePosted": 123.4,
         "readingTime": 10
       },
       "articles": [
@@ -2307,7 +2071,7 @@
         "author": "ec1980",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 98.2,
+        "hoursSincePosted": 103.1,
         "readingTime": 5
       },
       "articles": [
@@ -2416,7 +2180,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 20.5,
+        "hoursSincePosted": 25.4,
         "readingTime": 10
       },
       "articles": [
@@ -2461,7 +2225,7 @@
         "author": "maicon_ribeiroesteves_32",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 88.4,
+        "hoursSincePosted": 93.3,
         "readingTime": 3
       },
       "articles": [
@@ -2506,7 +2270,7 @@
         "author": "yahya_bin_naveed",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 43,
+        "hoursSincePosted": 48,
         "readingTime": 12
       },
       "articles": [
@@ -2551,7 +2315,7 @@
         "author": "nickyeolk",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 61.5,
+        "hoursSincePosted": 66.4,
         "readingTime": 7
       },
       "articles": [
@@ -2596,7 +2360,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 142,
+        "hoursSincePosted": 146.9,
         "readingTime": 6
       },
       "articles": [
@@ -2649,7 +2413,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 142,
+        "hoursSincePosted": 146.9,
         "readingTime": 6
       },
       "articles": [
@@ -2702,7 +2466,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 20.4,
+        "hoursSincePosted": 25.4,
         "readingTime": 8
       },
       "articles": [
@@ -2747,7 +2511,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 49.6,
+        "hoursSincePosted": 54.5,
         "readingTime": 9
       },
       "articles": [
@@ -2792,7 +2556,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 73.4,
+        "hoursSincePosted": 78.4,
         "readingTime": 9
       },
       "articles": [
@@ -2837,7 +2601,7 @@
         "author": "wonderlab",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 120.7,
+        "hoursSincePosted": 125.6,
         "readingTime": 8
       },
       "articles": [
@@ -2882,7 +2646,7 @@
         "author": "max_quimby",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 119.5,
+        "hoursSincePosted": 124.5,
         "readingTime": 9
       },
       "articles": [
@@ -2931,7 +2695,7 @@
         "author": "andrew-ooo",
         "reactions": 0,
         "comments": 1,
-        "hoursSincePosted": 184.2,
+        "hoursSincePosted": 189.2,
         "readingTime": 11
       },
       "articles": [
@@ -2976,7 +2740,7 @@
         "author": "madhaviai",
         "reactions": 4,
         "comments": 6,
-        "hoursSincePosted": 108.4,
+        "hoursSincePosted": 113.3,
         "readingTime": 3
       },
       "articles": [
@@ -2999,7 +2763,7 @@
             "mcp",
             "llm"
           ],
-          "trendingScore": 0.04,
+          "trendingScore": 0.03,
           "linkedRepos": [
             {
               "fullName": "github/github-mcp-server",
@@ -3014,21 +2778,21 @@
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3718857,
-        "title": "Measuring AI Gateway Failover: 30 Days of Production Data",
-        "url": "https://dev.to/marcuswwchen/measuring-ai-gateway-failover-30-days-of-production-data-336k",
+        "id": 3722673,
+        "title": "Why Your LLM Eval Harness Is Lying to You (And How to Fix It)",
+        "url": "https://dev.to/marcuswwchen/why-your-llm-eval-harness-is-lying-to-you-and-how-to-fix-it-2dmb",
         "author": "marcuswwchen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 35.4,
-        "readingTime": 3
+        "hoursSincePosted": 25.8,
+        "readingTime": 4
       },
       "articles": [
         {
-          "id": 3718857,
-          "title": "Measuring AI Gateway Failover: 30 Days of Production Data",
-          "description": "TL;DR: We measured failover latency across three AI gateways (Bifrost, LiteLLM, Portkey) during 30...",
-          "url": "https://dev.to/marcuswwchen/measuring-ai-gateway-failover-30-days-of-production-data-336k",
+          "id": 3722673,
+          "title": "Why Your LLM Eval Harness Is Lying to You (And How to Fix It)",
+          "description": "TL;DR: Most eval harnesses I see in production are measuring the wrong thing. They report 87% pass...",
+          "url": "https://dev.to/marcuswwchen/why-your-llm-eval-harness-is-lying-to-you-and-how-to-fix-it-2dmb",
           "author": {
             "username": "marcuswwchen",
             "name": "Marcus Chen",
@@ -3036,69 +2800,13 @@
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-21T16:02:16Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-22T06:32:58Z",
           "tags": [
             "mlops",
             "llm",
-            "infrastructure",
+            "machinelearning",
             "devops"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3718494,
-          "title": "Routing diffusion inference traffic across three providers",
-          "description": "TL;DR: We route a mix of diffusion and LLM traffic across three providers from a single Go-based...",
-          "url": "https://dev.to/elise_moreau/routing-diffusion-inference-traffic-across-three-providers-51h3",
-          "author": {
-            "username": "elise_moreau",
-            "name": "Elise Moreau",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-21T14:52:31Z",
-          "tags": [
-            "machinelearning",
-            "llm",
-            "mlops",
-            "infrastructure"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3722306,
-          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
-          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
-          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
-          "author": {
-            "username": "elise_moreau",
-            "name": "Elise Moreau",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-22T05:37:23Z",
-          "tags": [
-            "machinelearning",
-            "llm",
-            "mlops",
-            "pytorch"
           ],
           "trendingScore": 0,
           "linkedRepos": [
@@ -3167,76 +2875,59 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "datawhalechina/hello-agents": {
-      "count7d": 2,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3728972,
-        "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-        "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
-        "author": "wonderlab",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 2.8,
-        "readingTime": 11
-      },
-      "articles": [
+        },
         {
-          "id": 3728972,
-          "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-          "description": "You Think Your Agent Is \"Thinking.\" It's Actually Just Predicting Tokens.   Here's a...",
-          "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
+          "id": 3718494,
+          "title": "Routing diffusion inference traffic across three providers",
+          "description": "TL;DR: We route a mix of diffusion and LLM traffic across three providers from a single Go-based...",
+          "url": "https://dev.to/elise_moreau/routing-diffusion-inference-traffic-across-three-providers-51h3",
           "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+            "username": "elise_moreau",
+            "name": "Elise Moreau",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-23T00:40:05Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T14:52:31Z",
           "tags": [
-            "agents",
+            "machinelearning",
             "llm",
-            "langchain",
-            "ai"
+            "mlops",
+            "infrastructure"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "datawhalechina/hello-agents",
+              "fullName": "maximhq/bifrost",
               "location": "body"
             }
           ]
         },
         {
-          "id": 3715025,
-          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
-          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
-          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+          "id": 3722306,
+          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
+          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
+          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
           "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+            "username": "elise_moreau",
+            "name": "Elise Moreau",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-21T07:43:56Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-22T05:37:23Z",
           "tags": [
-            "agents",
+            "machinelearning",
             "llm",
-            "ai",
-            "langchain"
+            "mlops",
+            "pytorch"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "datawhalechina/hello-agents",
+              "fullName": "maximhq/bifrost",
               "location": "body"
             }
           ]
@@ -3254,7 +2945,7 @@
         "author": "marcorinaldi_ai",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 34.6,
+        "hoursSincePosted": 39.5,
         "readingTime": 4
       },
       "articles": [
@@ -3303,7 +2994,7 @@
         "author": "anajsana95",
         "reactions": 4,
         "comments": 0,
-        "hoursSincePosted": 107.9,
+        "hoursSincePosted": 112.8,
         "readingTime": 5
       },
       "articles": [
@@ -3336,6 +3027,79 @@
         }
       ]
     },
+    "vectorize-io/hindsight": {
+      "count7d": 2,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 1,
+      "topArticle": {
+        "id": 3695395,
+        "title": "CRMs store data. I built something that remembers context.",
+        "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
+        "author": "sandhyagk",
+        "reactions": 0,
+        "comments": 1,
+        "hoursSincePosted": 109.4,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3695395,
+          "title": "CRMs store data. I built something that remembers context.",
+          "description": "The first question I get when I tell people we have no database is: \"What do you mean, no...",
+          "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
+          "author": {
+            "username": "sandhyagk",
+            "name": "Sandhya G K",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3938594%2F33c002a2-ec2d-4666-a42d-3abbabb292e7.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 1,
+          "readingTime": 6,
+          "publishedAt": "2026-05-18T18:56:33Z",
+          "tags": [
+            "ai",
+            "architecture",
+            "rag",
+            "showdev"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "vectorize-io/hindsight",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3702728,
+          "title": "The cheapest model call is the one you don't make",
+          "description": "I spent the better part of a week building an alert triage co-pilot, and the most useful thing it...",
+          "url": "https://dev.to/wnxd/the-cheapest-model-call-is-the-one-you-dont-make-36kb",
+          "author": {
+            "username": "wnxd",
+            "name": "Sidharth SP",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3940827%2F1587348a-88e1-461e-bd1c-83eb1f725d0d.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 6,
+          "publishedAt": "2026-05-19T17:32:54Z",
+          "tags": [
+            "ai",
+            "automation",
+            "devops",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "vectorize-io/hindsight",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "mcneel/RhinoMCP": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -3347,7 +3111,7 @@
         "author": "allelishi",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 84.9,
+        "hoursSincePosted": 89.9,
         "readingTime": 4
       },
       "articles": [
@@ -3392,7 +3156,7 @@
         "author": "selfagency",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 105.2,
+        "hoursSincePosted": 110.1,
         "readingTime": 7
       },
       "articles": [
@@ -3437,7 +3201,7 @@
         "author": "imper_7cde72b79d2529291ec",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 106.5,
+        "hoursSincePosted": 111.4,
         "readingTime": 2
       },
       "articles": [
@@ -3513,7 +3277,7 @@
         "author": "imper_7cde72b79d2529291ec",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 106,
+        "hoursSincePosted": 111,
         "readingTime": 2
       },
       "articles": [
@@ -3558,7 +3322,7 @@
         "author": "adityamitra",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 14.7,
+        "hoursSincePosted": 19.7,
         "readingTime": 4
       },
       "articles": [
@@ -3607,7 +3371,7 @@
         "author": "mir_mursalin_ankur",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 131.9,
+        "hoursSincePosted": 136.9,
         "readingTime": 53
       },
       "articles": [
@@ -3656,7 +3420,7 @@
         "author": "doramagic",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 133.2,
+        "hoursSincePosted": 138.2,
         "readingTime": 3
       },
       "articles": [
@@ -3701,7 +3465,7 @@
         "author": "jadysmgodoi",
         "reactions": 1,
         "comments": 1,
-        "hoursSincePosted": 37.5,
+        "hoursSincePosted": 42.5,
         "readingTime": 3
       },
       "articles": [
@@ -3746,7 +3510,7 @@
         "author": "mervindublin",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 43.1,
+        "hoursSincePosted": 48,
         "readingTime": 3
       },
       "articles": [
@@ -3780,6 +3544,51 @@
         }
       ]
     },
+    "datawhalechina/hello-agents": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3715025,
+        "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
+        "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+        "author": "wonderlab",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 48.6,
+        "readingTime": 9
+      },
+      "articles": [
+        {
+          "id": 3715025,
+          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
+          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
+          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-21T07:43:56Z",
+          "tags": [
+            "agents",
+            "llm",
+            "ai",
+            "langchain"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "datawhalechina/hello-agents",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "czlonkowski/n8n-mcp": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -3791,7 +3600,7 @@
         "author": "rentierdigital",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 157.8,
+        "hoursSincePosted": 162.7,
         "readingTime": 11
       },
       "articles": [
@@ -3825,51 +3634,6 @@
         }
       ]
     },
-    "henrygd/beszel": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3681158,
-        "title": "I Tested 7 Self-Hosted Monitoring Tools on a $3 VPS in 2026 (Here's the One I Kept)",
-        "url": "https://dev.to/vikasprogrammer/i-tested-7-self-hosted-monitoring-tools-on-a-3-vps-in-2026-heres-the-one-i-kept-aoa",
-        "author": "vikasprogrammer",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 167.8,
-        "readingTime": 5
-      },
-      "articles": [
-        {
-          "id": 3681158,
-          "title": "I Tested 7 Self-Hosted Monitoring Tools on a $3 VPS in 2026 (Here's the One I Kept)",
-          "description": "Beszel, Netdata, Grafana, Pulse, Glances, Prometheus, Dozzle - all running on the same 1 CPU / 2 GB box. Here's the full bench, costs, and the one I stopped uninstalling.",
-          "url": "https://dev.to/vikasprogrammer/i-tested-7-self-hosted-monitoring-tools-on-a-3-vps-in-2026-heres-the-one-i-kept-aoa",
-          "author": {
-            "username": "vikasprogrammer",
-            "name": "Vikas Singhal",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3786948%2Fb3e5ac8e-8727-4201-986a-9a04f6053231.png"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-16T03:38:40Z",
-          "tags": [
-            "monitoring",
-            "selfhosted",
-            "devops",
-            "opensource"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "henrygd/beszel",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "Tracer-Cloud/opensre": {
       "count7d": 1,
       "reactionsSum7d": 5,
@@ -3881,7 +3645,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 114.4,
+        "hoursSincePosted": 119.4,
         "readingTime": 3
       },
       "articles": [
@@ -3926,7 +3690,7 @@
         "author": "hectorvent",
         "reactions": 3,
         "comments": 0,
-        "hoursSincePosted": 152.9,
+        "hoursSincePosted": 157.8,
         "readingTime": 4
       },
       "articles": [
@@ -3973,7 +3737,7 @@
         "author": "om_shree_0709",
         "reactions": 47,
         "comments": 26,
-        "hoursSincePosted": 74.7,
+        "hoursSincePosted": 79.6,
         "readingTime": 5
       },
       "articles": [
@@ -3997,7 +3761,7 @@
             "ai",
             "mcp"
           ],
-          "trendingScore": 3.79,
+          "trendingScore": 3.55,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -4025,7 +3789,7 @@
             "mcp",
             "devchallenge"
           ],
-          "trendingScore": 1.67,
+          "trendingScore": 1.54,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -4046,7 +3810,7 @@
         "author": "lovestaco",
         "reactions": 31,
         "comments": 2,
-        "hoursSincePosted": 80.7,
+        "hoursSincePosted": 85.6,
         "readingTime": 6
       },
       "articles": [
@@ -4070,7 +3834,7 @@
             "javascript",
             "beginners"
           ],
-          "trendingScore": 0.69,
+          "trendingScore": 0.65,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -4098,7 +3862,7 @@
             "go",
             "beginners"
           ],
-          "trendingScore": 0.83,
+          "trendingScore": 0.76,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -4109,9 +3873,9 @@
       ]
     },
     "nousresearch--hermes-agent": {
-      "count7d": 17,
-      "reactionsSum7d": 401,
-      "commentsSum7d": 146,
+      "count7d": 15,
+      "reactionsSum7d": 375,
+      "commentsSum7d": 127,
       "topArticle": {
         "id": 3682129,
         "title": "I Gave Hermes Agent 5 Impossible Tasks",
@@ -4119,7 +3883,7 @@
         "author": "syedahmershah",
         "reactions": 270,
         "comments": 96,
-        "hoursSincePosted": 162.9,
+        "hoursSincePosted": 167.8,
         "readingTime": 9
       },
       "articles": [
@@ -4143,7 +3907,7 @@
             "agents",
             "git"
           ],
-          "trendingScore": 42.73,
+          "trendingScore": 41.47,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4171,40 +3935,12 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.85,
+          "trendingScore": 2.69,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
               "location": "body"
             },
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3681236,
-          "title": "I Ran Hermes Agent on the Same Task for 7 Days. The Skill File on Day 7 Looked Nothing Like Day 1.",
-          "description": "This is a submission for the Hermes Agent Challenge      TL;DR: Hermes Agent is the only open-source...",
-          "url": "https://dev.to/sreejit_/i-ran-hermes-agent-on-the-same-task-for-7-days-the-skill-file-on-day-7-looked-nothing-like-day-1-2oa8",
-          "author": {
-            "username": "sreejit_",
-            "name": "Sreejit Pradhan",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3904430%2Fbd74576f-cef8-4620-a63e-8a001f1e9d6c.png"
-          },
-          "reactionsCount": 25,
-          "commentsCount": 19,
-          "readingTime": 12,
-          "publishedAt": "2026-05-16T04:05:21Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents",
-            "ai"
-          ],
-          "trendingScore": 0.61,
-          "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
               "location": "body"
@@ -4231,7 +3967,7 @@
             "agents",
             "ai"
           ],
-          "trendingScore": 0.33,
+          "trendingScore": 0.31,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4258,7 +3994,7 @@
             "devchallenge",
             "agents"
           ],
-          "trendingScore": 0.19,
+          "trendingScore": 0.18,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4286,7 +4022,7 @@
             "ai",
             "agents"
           ],
-          "trendingScore": 0.06,
+          "trendingScore": 0.05,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4467,34 +4203,6 @@
           ]
         },
         {
-          "id": 3725240,
-          "title": "The 4 Levels of Hermes Agent Scaling Framework: From One Hermes Agent to a Fully Automated Team",
-          "description": "A practical framework for scaling from a single AI agent to a self-running team of specialists. Includes setup instructions, progression checkpoints, and the one mistake that ruins everything.",
-          "url": "https://dev.to/shilpamitra/the-4-levels-of-hermes-agent-scaling-framework-from-one-hermes-agent-to-a-fully-automated-team-2gdp",
-          "author": {
-            "username": "shilpamitra",
-            "name": "Shilpa Mitra",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3943639%2F687febe9-259f-4c1e-a2a0-798ce0d6cc2b.png"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-22T11:56:54Z",
-          "tags": [
-            "ai",
-            "opensource",
-            "automation",
-            "productivity"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
           "id": 3729077,
           "title": "One Soul, Any Model: Portable Memory for Open-Source Agents with .klickd",
           "description": "This is a submission for the Hermes Agent Challenge: Build With Hermes Agent           What I...",
@@ -4619,7 +4327,7 @@
         "author": "tahosin",
         "reactions": 42,
         "comments": 26,
-        "hoursSincePosted": 86.2,
+        "hoursSincePosted": 91.2,
         "readingTime": 13
       },
       "articles": [
@@ -4643,7 +4351,7 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.85,
+          "trendingScore": 2.69,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -4735,7 +4443,7 @@
         "author": "thecodedaniel",
         "reactions": 10,
         "comments": 0,
-        "hoursSincePosted": 79.9,
+        "hoursSincePosted": 84.8,
         "readingTime": 5
       },
       "articles": [
@@ -4758,111 +4466,10 @@
             "gemmachallenge",
             "gemma"
           ],
-          "trendingScore": 0.13,
+          "trendingScore": 0.12,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/LiteRT-LM",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "vectorize-io--hindsight": {
-      "count7d": 3,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3727361,
-        "title": "I built an agent to audit incidents, but it kept forgetting Tuesday by Wednesday.",
-        "url": "https://dev.to/karthik_s_599904b6f055c2c/i-built-an-agent-to-audit-incidents-but-it-kept-forgetting-tuesday-by-wednesday-149c",
-        "author": "karthik_s_599904b6f055c2c",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 10,
-        "readingTime": 3
-      },
-      "articles": [
-        {
-          "id": 3727361,
-          "title": "I built an agent to audit incidents, but it kept forgetting Tuesday by Wednesday.",
-          "description": "When you build an enterprise AI agent, the honeymoon phase lasts exactly until you push to...",
-          "url": "https://dev.to/karthik_s_599904b6f055c2c/i-built-an-agent-to-audit-incidents-but-it-kept-forgetting-tuesday-by-wednesday-149c",
-          "author": {
-            "username": "karthik_s_599904b6f055c2c",
-            "name": "Karthik S",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3944646%2F9bfc3b7c-06dd-448c-a6a5-e8291213fde1.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-22T17:26:24Z",
-          "tags": [
-            "ai",
-            "opensource",
-            "backend",
-            "javascript"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "vectorize-io/hindsight",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3702728,
-          "title": "The cheapest model call is the one you don't make",
-          "description": "I spent the better part of a week building an alert triage co-pilot, and the most useful thing it...",
-          "url": "https://dev.to/wnxd/the-cheapest-model-call-is-the-one-you-dont-make-36kb",
-          "author": {
-            "username": "wnxd",
-            "name": "Sidharth SP",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3940827%2F1587348a-88e1-461e-bd1c-83eb1f725d0d.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-19T17:32:54Z",
-          "tags": [
-            "ai",
-            "automation",
-            "devops",
-            "llm"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "vectorize-io/hindsight",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3695395,
-          "title": "CRMs store data. I built something that remembers context.",
-          "description": "The first question I get when I tell people we have no database is: \"What do you mean, no...",
-          "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
-          "author": {
-            "username": "sandhyagk",
-            "name": "Sandhya G K",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3938594%2F33c002a2-ec2d-4666-a42d-3abbabb292e7.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 1,
-          "readingTime": 6,
-          "publishedAt": "2026-05-18T18:56:33Z",
-          "tags": [
-            "ai",
-            "architecture",
-            "rag",
-            "showdev"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "vectorize-io/hindsight",
               "location": "body"
             }
           ]
@@ -4880,7 +4487,7 @@
         "author": "numbpill3d",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 5.7,
+        "hoursSincePosted": 10.6,
         "readingTime": 7
       },
       "articles": [
@@ -4919,8 +4526,8 @@
       ]
     },
     "juliusbrussee--caveman": {
-      "count7d": 2,
-      "reactionsSum7d": 11,
+      "count7d": 1,
+      "reactionsSum7d": 8,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3710524,
@@ -4929,7 +4536,7 @@
         "author": "bd_perez",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 59.4,
+        "hoursSincePosted": 64.3,
         "readingTime": 7
       },
       "articles": [
@@ -4953,134 +4560,10 @@
             "money",
             "models"
           ],
-          "trendingScore": 0.12,
+          "trendingScore": 0.11,
           "linkedRepos": [
             {
               "fullName": "JuliusBrussee/caveman",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3698382,
-          "title": "KiroGraph: from a personal side project to community-AI-driven tool",
-          "description": "This is the second part of my \"Build in Public with Kiro\" series. I'm an AWS Community Builder, and...",
-          "url": "https://dev.to/aws-builders/kirograph-from-a-personal-side-project-to-community-ai-driven-tool-395e",
-          "author": {
-            "username": "ddesio",
-            "name": "Davide De Sio",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1402618%2F7b0b959e-0a8c-43b6-ad1d-90ae70727bb6.png"
-          },
-          "reactionsCount": 3,
-          "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-20T07:37:28Z",
-          "tags": [
-            "kiro",
-            "ai",
-            "aws"
-          ],
-          "trendingScore": 0.02,
-          "linkedRepos": [
-            {
-              "fullName": "JuliusBrussee/caveman",
-              "location": "body"
-            },
-            {
-              "fullName": "rtk-ai/rtk",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "rtk-ai--rtk": {
-      "count7d": 1,
-      "reactionsSum7d": 3,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3698382,
-        "title": "KiroGraph: from a personal side project to community-AI-driven tool",
-        "url": "https://dev.to/aws-builders/kirograph-from-a-personal-side-project-to-community-ai-driven-tool-395e",
-        "author": "ddesio",
-        "reactions": 3,
-        "comments": 0,
-        "hoursSincePosted": 67.8,
-        "readingTime": 11
-      },
-      "articles": [
-        {
-          "id": 3698382,
-          "title": "KiroGraph: from a personal side project to community-AI-driven tool",
-          "description": "This is the second part of my \"Build in Public with Kiro\" series. I'm an AWS Community Builder, and...",
-          "url": "https://dev.to/aws-builders/kirograph-from-a-personal-side-project-to-community-ai-driven-tool-395e",
-          "author": {
-            "username": "ddesio",
-            "name": "Davide De Sio",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1402618%2F7b0b959e-0a8c-43b6-ad1d-90ae70727bb6.png"
-          },
-          "reactionsCount": 3,
-          "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-20T07:37:28Z",
-          "tags": [
-            "kiro",
-            "ai",
-            "aws"
-          ],
-          "trendingScore": 0.02,
-          "linkedRepos": [
-            {
-              "fullName": "JuliusBrussee/caveman",
-              "location": "body"
-            },
-            {
-              "fullName": "rtk-ai/rtk",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "multica-ai--multica": {
-      "count7d": 1,
-      "reactionsSum7d": 5,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3720461,
-        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-        "author": "arshtechpro",
-        "reactions": 5,
-        "comments": 1,
-        "hoursSincePosted": 29.3,
-        "readingTime": 4
-      },
-      "articles": [
-        {
-          "id": 3720461,
-          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
-          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-          "author": {
-            "username": "arshtechpro",
-            "name": "ArshTechPro",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
-          },
-          "reactionsCount": 5,
-          "commentsCount": 1,
-          "readingTime": 4,
-          "publishedAt": "2026-05-21T22:07:10Z",
-          "tags": [
-            "ai",
-            "agents",
-            "python",
-            "programming"
-          ],
-          "trendingScore": 0.13,
-          "linkedRepos": [
-            {
-              "fullName": "multica-ai/multica",
               "location": "body"
             }
           ]
@@ -5098,7 +4581,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 87.8,
+        "hoursSincePosted": 92.7,
         "readingTime": 5
       },
       "articles": [
@@ -5132,6 +4615,103 @@
         }
       ]
     },
+    "multica-ai--multica": {
+      "count7d": 1,
+      "reactionsSum7d": 5,
+      "commentsSum7d": 1,
+      "topArticle": {
+        "id": 3720461,
+        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
+        "author": "arshtechpro",
+        "reactions": 5,
+        "comments": 1,
+        "hoursSincePosted": 34.3,
+        "readingTime": 4
+      },
+      "articles": [
+        {
+          "id": 3720461,
+          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
+          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
+          "author": {
+            "username": "arshtechpro",
+            "name": "ArshTechPro",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
+          },
+          "reactionsCount": 5,
+          "commentsCount": 1,
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T22:07:10Z",
+          "tags": [
+            "ai",
+            "agents",
+            "python",
+            "programming"
+          ],
+          "trendingScore": 0.11,
+          "linkedRepos": [
+            {
+              "fullName": "multica-ai/multica",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "nextlevelbuilder--goclaw": {
+      "count7d": 1,
+      "reactionsSum7d": 5,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3691887,
+        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+        "author": "truongpx396",
+        "reactions": 5,
+        "comments": 0,
+        "hoursSincePosted": 120.2,
+        "readingTime": 16
+      },
+      "articles": [
+        {
+          "id": 3691887,
+          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
+          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+          "author": {
+            "username": "truongpx396",
+            "name": "Truong Phung",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
+          },
+          "reactionsCount": 5,
+          "commentsCount": 0,
+          "readingTime": 16,
+          "publishedAt": "2026-05-18T08:12:05Z",
+          "tags": [
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents"
+          ],
+          "trendingScore": 0.03,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            },
+            {
+              "fullName": "openclaw/openclaw",
+              "location": "body"
+            },
+            {
+              "fullName": "nextlevelbuilder/goclaw",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "anthropics--claude-code": {
       "count7d": 10,
       "reactionsSum7d": 3,
@@ -5143,7 +4723,7 @@
         "author": "crawleyprint_71",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 131.5,
+        "hoursSincePosted": 136.4,
         "readingTime": 11
       },
       "articles": [
@@ -5445,364 +5025,6 @@
         }
       ]
     },
-    "nextlevelbuilder--goclaw": {
-      "count7d": 1,
-      "reactionsSum7d": 5,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3691887,
-        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
-        "author": "truongpx396",
-        "reactions": 5,
-        "comments": 0,
-        "hoursSincePosted": 115.2,
-        "readingTime": 16
-      },
-      "articles": [
-        {
-          "id": 3691887,
-          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
-          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
-          "author": {
-            "username": "truongpx396",
-            "name": "Truong Phung",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
-          },
-          "reactionsCount": 5,
-          "commentsCount": 0,
-          "readingTime": 16,
-          "publishedAt": "2026-05-18T08:12:05Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
-          ],
-          "trendingScore": 0.03,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            },
-            {
-              "fullName": "openclaw/openclaw",
-              "location": "body"
-            },
-            {
-              "fullName": "nextlevelbuilder/goclaw",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "can1357--oh-my-pi": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3710799,
-        "title": "Secure Agents: Control Policies in the Harness",
-        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
-        "author": "epappas",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 58.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3710799,
-          "title": "Secure Agents: Control Policies in the Harness",
-          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
-          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
-          "author": {
-            "username": "epappas",
-            "name": "Evangelos Pappas",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-20T17:03:09Z",
-          "tags": [
-            "ai",
-            "agents",
-            "cybersecurity",
-            "devops"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "can1357/oh-my-pi",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "fission-ai--openspec": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3690020,
-        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
-        "author": "kenimo49",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 86.4,
-        "readingTime": 6
-      },
-      "articles": [
-        {
-          "id": 3690020,
-          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
-          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
-          "author": {
-            "username": "kenimo49",
-            "name": "Ken Imoto",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-19T13:00:01Z",
-          "tags": [
-            "claudecode",
-            "ai",
-            "spec",
-            "openapi"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Fission-AI/OpenSpec",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "openai--symphony": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3729039,
-        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-        "author": "judy_miranttie",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 2.4,
-        "readingTime": 14
-      },
-      "articles": [
-        {
-          "id": 3729039,
-          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
-          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-          "author": {
-            "username": "judy_miranttie",
-            "name": "Judy",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 14,
-          "publishedAt": "2026-05-23T01:00:08Z",
-          "tags": [
-            "multiagent",
-            "aiteam",
-            "aiautomation",
-            "claudecode"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "openai/symphony",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "anthropics--skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 139.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "mattpocock--skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 139.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "addyosmani--agent-skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 139.4,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "obra--superpowers": {
       "count7d": 3,
       "reactionsSum7d": 1,
@@ -5814,7 +5036,7 @@
         "author": "chen115y",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 50.5,
+        "hoursSincePosted": 55.4,
         "readingTime": 20
       },
       "articles": [
@@ -5920,6 +5142,312 @@
         }
       ]
     },
+    "can1357--oh-my-pi": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3710799,
+        "title": "Secure Agents: Control Policies in the Harness",
+        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+        "author": "epappas",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 63.3,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3710799,
+          "title": "Secure Agents: Control Policies in the Harness",
+          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
+          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+          "author": {
+            "username": "epappas",
+            "name": "Evangelos Pappas",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-20T17:03:09Z",
+          "tags": [
+            "ai",
+            "agents",
+            "cybersecurity",
+            "devops"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "can1357/oh-my-pi",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "fission-ai--openspec": {
+      "count7d": 1,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3690020,
+        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+        "author": "kenimo49",
+        "reactions": 1,
+        "comments": 0,
+        "hoursSincePosted": 91.4,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3690020,
+          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
+          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+          "author": {
+            "username": "kenimo49",
+            "name": "Ken Imoto",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 6,
+          "publishedAt": "2026-05-19T13:00:01Z",
+          "tags": [
+            "claudecode",
+            "ai",
+            "spec",
+            "openapi"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Fission-AI/OpenSpec",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "openai--symphony": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3729039,
+        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+        "author": "judy_miranttie",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 7.4,
+        "readingTime": 14
+      },
+      "articles": [
+        {
+          "id": 3729039,
+          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
+          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+          "author": {
+            "username": "judy_miranttie",
+            "name": "Judy",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 14,
+          "publishedAt": "2026-05-23T01:00:08Z",
+          "tags": [
+            "multiagent",
+            "aiteam",
+            "aiautomation",
+            "claudecode"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "openai/symphony",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "anthropics--skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 144.4,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "mattpocock--skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 144.4,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "addyosmani--agent-skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 144.4,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "openai--codex": {
       "count7d": 4,
       "reactionsSum7d": 1,
@@ -5931,7 +5459,7 @@
         "author": "skyguan92",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 118.4,
+        "hoursSincePosted": 123.4,
         "readingTime": 10
       },
       "articles": [
@@ -6064,7 +5592,7 @@
         "author": "ec1980",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 98.2,
+        "hoursSincePosted": 103.1,
         "readingTime": 5
       },
       "articles": [
@@ -6173,7 +5701,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 20.5,
+        "hoursSincePosted": 25.4,
         "readingTime": 10
       },
       "articles": [
@@ -6218,7 +5746,7 @@
         "author": "maicon_ribeiroesteves_32",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 88.4,
+        "hoursSincePosted": 93.3,
         "readingTime": 3
       },
       "articles": [
@@ -6263,7 +5791,7 @@
         "author": "yahya_bin_naveed",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 43,
+        "hoursSincePosted": 48,
         "readingTime": 12
       },
       "articles": [
@@ -6308,7 +5836,7 @@
         "author": "nickyeolk",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 61.5,
+        "hoursSincePosted": 66.4,
         "readingTime": 7
       },
       "articles": [
@@ -6353,7 +5881,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 142,
+        "hoursSincePosted": 146.9,
         "readingTime": 6
       },
       "articles": [
@@ -6406,7 +5934,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 142,
+        "hoursSincePosted": 146.9,
         "readingTime": 6
       },
       "articles": [
@@ -6459,7 +5987,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 20.4,
+        "hoursSincePosted": 25.4,
         "readingTime": 8
       },
       "articles": [
@@ -6504,7 +6032,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 49.6,
+        "hoursSincePosted": 54.5,
         "readingTime": 9
       },
       "articles": [
@@ -6549,7 +6077,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 73.4,
+        "hoursSincePosted": 78.4,
         "readingTime": 9
       },
       "articles": [
@@ -6594,7 +6122,7 @@
         "author": "wonderlab",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 120.7,
+        "hoursSincePosted": 125.6,
         "readingTime": 8
       },
       "articles": [
@@ -6639,7 +6167,7 @@
         "author": "max_quimby",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 119.5,
+        "hoursSincePosted": 124.5,
         "readingTime": 9
       },
       "articles": [
@@ -6688,7 +6216,7 @@
         "author": "andrew-ooo",
         "reactions": 0,
         "comments": 1,
-        "hoursSincePosted": 184.2,
+        "hoursSincePosted": 189.2,
         "readingTime": 11
       },
       "articles": [
@@ -6733,7 +6261,7 @@
         "author": "madhaviai",
         "reactions": 4,
         "comments": 6,
-        "hoursSincePosted": 108.4,
+        "hoursSincePosted": 113.3,
         "readingTime": 3
       },
       "articles": [
@@ -6756,7 +6284,7 @@
             "mcp",
             "llm"
           ],
-          "trendingScore": 0.04,
+          "trendingScore": 0.03,
           "linkedRepos": [
             {
               "fullName": "github/github-mcp-server",
@@ -6771,21 +6299,21 @@
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3718857,
-        "title": "Measuring AI Gateway Failover: 30 Days of Production Data",
-        "url": "https://dev.to/marcuswwchen/measuring-ai-gateway-failover-30-days-of-production-data-336k",
+        "id": 3722673,
+        "title": "Why Your LLM Eval Harness Is Lying to You (And How to Fix It)",
+        "url": "https://dev.to/marcuswwchen/why-your-llm-eval-harness-is-lying-to-you-and-how-to-fix-it-2dmb",
         "author": "marcuswwchen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 35.4,
-        "readingTime": 3
+        "hoursSincePosted": 25.8,
+        "readingTime": 4
       },
       "articles": [
         {
-          "id": 3718857,
-          "title": "Measuring AI Gateway Failover: 30 Days of Production Data",
-          "description": "TL;DR: We measured failover latency across three AI gateways (Bifrost, LiteLLM, Portkey) during 30...",
-          "url": "https://dev.to/marcuswwchen/measuring-ai-gateway-failover-30-days-of-production-data-336k",
+          "id": 3722673,
+          "title": "Why Your LLM Eval Harness Is Lying to You (And How to Fix It)",
+          "description": "TL;DR: Most eval harnesses I see in production are measuring the wrong thing. They report 87% pass...",
+          "url": "https://dev.to/marcuswwchen/why-your-llm-eval-harness-is-lying-to-you-and-how-to-fix-it-2dmb",
           "author": {
             "username": "marcuswwchen",
             "name": "Marcus Chen",
@@ -6793,69 +6321,13 @@
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-21T16:02:16Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-22T06:32:58Z",
           "tags": [
             "mlops",
             "llm",
-            "infrastructure",
+            "machinelearning",
             "devops"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3718494,
-          "title": "Routing diffusion inference traffic across three providers",
-          "description": "TL;DR: We route a mix of diffusion and LLM traffic across three providers from a single Go-based...",
-          "url": "https://dev.to/elise_moreau/routing-diffusion-inference-traffic-across-three-providers-51h3",
-          "author": {
-            "username": "elise_moreau",
-            "name": "Elise Moreau",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-21T14:52:31Z",
-          "tags": [
-            "machinelearning",
-            "llm",
-            "mlops",
-            "infrastructure"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3722306,
-          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
-          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
-          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
-          "author": {
-            "username": "elise_moreau",
-            "name": "Elise Moreau",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-22T05:37:23Z",
-          "tags": [
-            "machinelearning",
-            "llm",
-            "mlops",
-            "pytorch"
           ],
           "trendingScore": 0,
           "linkedRepos": [
@@ -6924,76 +6396,59 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "datawhalechina--hello-agents": {
-      "count7d": 2,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3728972,
-        "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-        "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
-        "author": "wonderlab",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 2.8,
-        "readingTime": 11
-      },
-      "articles": [
+        },
         {
-          "id": 3728972,
-          "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-          "description": "You Think Your Agent Is \"Thinking.\" It's Actually Just Predicting Tokens.   Here's a...",
-          "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
+          "id": 3718494,
+          "title": "Routing diffusion inference traffic across three providers",
+          "description": "TL;DR: We route a mix of diffusion and LLM traffic across three providers from a single Go-based...",
+          "url": "https://dev.to/elise_moreau/routing-diffusion-inference-traffic-across-three-providers-51h3",
           "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+            "username": "elise_moreau",
+            "name": "Elise Moreau",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-23T00:40:05Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T14:52:31Z",
           "tags": [
-            "agents",
+            "machinelearning",
             "llm",
-            "langchain",
-            "ai"
+            "mlops",
+            "infrastructure"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "datawhalechina/hello-agents",
+              "fullName": "maximhq/bifrost",
               "location": "body"
             }
           ]
         },
         {
-          "id": 3715025,
-          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
-          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
-          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+          "id": 3722306,
+          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
+          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
+          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
           "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+            "username": "elise_moreau",
+            "name": "Elise Moreau",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-21T07:43:56Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-22T05:37:23Z",
           "tags": [
-            "agents",
+            "machinelearning",
             "llm",
-            "ai",
-            "langchain"
+            "mlops",
+            "pytorch"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "datawhalechina/hello-agents",
+              "fullName": "maximhq/bifrost",
               "location": "body"
             }
           ]
@@ -7011,7 +6466,7 @@
         "author": "marcorinaldi_ai",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 34.6,
+        "hoursSincePosted": 39.5,
         "readingTime": 4
       },
       "articles": [
@@ -7060,7 +6515,7 @@
         "author": "anajsana95",
         "reactions": 4,
         "comments": 0,
-        "hoursSincePosted": 107.9,
+        "hoursSincePosted": 112.8,
         "readingTime": 5
       },
       "articles": [
@@ -7093,6 +6548,79 @@
         }
       ]
     },
+    "vectorize-io--hindsight": {
+      "count7d": 2,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 1,
+      "topArticle": {
+        "id": 3695395,
+        "title": "CRMs store data. I built something that remembers context.",
+        "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
+        "author": "sandhyagk",
+        "reactions": 0,
+        "comments": 1,
+        "hoursSincePosted": 109.4,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3695395,
+          "title": "CRMs store data. I built something that remembers context.",
+          "description": "The first question I get when I tell people we have no database is: \"What do you mean, no...",
+          "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
+          "author": {
+            "username": "sandhyagk",
+            "name": "Sandhya G K",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3938594%2F33c002a2-ec2d-4666-a42d-3abbabb292e7.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 1,
+          "readingTime": 6,
+          "publishedAt": "2026-05-18T18:56:33Z",
+          "tags": [
+            "ai",
+            "architecture",
+            "rag",
+            "showdev"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "vectorize-io/hindsight",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3702728,
+          "title": "The cheapest model call is the one you don't make",
+          "description": "I spent the better part of a week building an alert triage co-pilot, and the most useful thing it...",
+          "url": "https://dev.to/wnxd/the-cheapest-model-call-is-the-one-you-dont-make-36kb",
+          "author": {
+            "username": "wnxd",
+            "name": "Sidharth SP",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3940827%2F1587348a-88e1-461e-bd1c-83eb1f725d0d.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 6,
+          "publishedAt": "2026-05-19T17:32:54Z",
+          "tags": [
+            "ai",
+            "automation",
+            "devops",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "vectorize-io/hindsight",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "mcneel--rhinomcp": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -7104,7 +6632,7 @@
         "author": "allelishi",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 84.9,
+        "hoursSincePosted": 89.9,
         "readingTime": 4
       },
       "articles": [
@@ -7149,7 +6677,7 @@
         "author": "selfagency",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 105.2,
+        "hoursSincePosted": 110.1,
         "readingTime": 7
       },
       "articles": [
@@ -7194,7 +6722,7 @@
         "author": "imper_7cde72b79d2529291ec",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 106.5,
+        "hoursSincePosted": 111.4,
         "readingTime": 2
       },
       "articles": [
@@ -7270,7 +6798,7 @@
         "author": "imper_7cde72b79d2529291ec",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 106,
+        "hoursSincePosted": 111,
         "readingTime": 2
       },
       "articles": [
@@ -7315,7 +6843,7 @@
         "author": "adityamitra",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 14.7,
+        "hoursSincePosted": 19.7,
         "readingTime": 4
       },
       "articles": [
@@ -7364,7 +6892,7 @@
         "author": "mir_mursalin_ankur",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 131.9,
+        "hoursSincePosted": 136.9,
         "readingTime": 53
       },
       "articles": [
@@ -7413,7 +6941,7 @@
         "author": "doramagic",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 133.2,
+        "hoursSincePosted": 138.2,
         "readingTime": 3
       },
       "articles": [
@@ -7458,7 +6986,7 @@
         "author": "jadysmgodoi",
         "reactions": 1,
         "comments": 1,
-        "hoursSincePosted": 37.5,
+        "hoursSincePosted": 42.5,
         "readingTime": 3
       },
       "articles": [
@@ -7503,7 +7031,7 @@
         "author": "mervindublin",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 43.1,
+        "hoursSincePosted": 48,
         "readingTime": 3
       },
       "articles": [
@@ -7537,6 +7065,51 @@
         }
       ]
     },
+    "datawhalechina--hello-agents": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3715025,
+        "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
+        "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+        "author": "wonderlab",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 48.6,
+        "readingTime": 9
+      },
+      "articles": [
+        {
+          "id": 3715025,
+          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
+          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
+          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-21T07:43:56Z",
+          "tags": [
+            "agents",
+            "llm",
+            "ai",
+            "langchain"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "datawhalechina/hello-agents",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "czlonkowski--n8n-mcp": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -7548,7 +7121,7 @@
         "author": "rentierdigital",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 157.8,
+        "hoursSincePosted": 162.7,
         "readingTime": 11
       },
       "articles": [
@@ -7582,51 +7155,6 @@
         }
       ]
     },
-    "henrygd--beszel": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3681158,
-        "title": "I Tested 7 Self-Hosted Monitoring Tools on a $3 VPS in 2026 (Here's the One I Kept)",
-        "url": "https://dev.to/vikasprogrammer/i-tested-7-self-hosted-monitoring-tools-on-a-3-vps-in-2026-heres-the-one-i-kept-aoa",
-        "author": "vikasprogrammer",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 167.8,
-        "readingTime": 5
-      },
-      "articles": [
-        {
-          "id": 3681158,
-          "title": "I Tested 7 Self-Hosted Monitoring Tools on a $3 VPS in 2026 (Here's the One I Kept)",
-          "description": "Beszel, Netdata, Grafana, Pulse, Glances, Prometheus, Dozzle - all running on the same 1 CPU / 2 GB box. Here's the full bench, costs, and the one I stopped uninstalling.",
-          "url": "https://dev.to/vikasprogrammer/i-tested-7-self-hosted-monitoring-tools-on-a-3-vps-in-2026-heres-the-one-i-kept-aoa",
-          "author": {
-            "username": "vikasprogrammer",
-            "name": "Vikas Singhal",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3786948%2Fb3e5ac8e-8727-4201-986a-9a04f6053231.png"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-16T03:38:40Z",
-          "tags": [
-            "monitoring",
-            "selfhosted",
-            "devops",
-            "opensource"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "henrygd/beszel",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "tracer-cloud--opensre": {
       "count7d": 1,
       "reactionsSum7d": 5,
@@ -7638,7 +7166,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 114.4,
+        "hoursSincePosted": 119.4,
         "readingTime": 3
       },
       "articles": [
@@ -7683,7 +7211,7 @@
         "author": "hectorvent",
         "reactions": 3,
         "comments": 0,
-        "hoursSincePosted": 152.9,
+        "hoursSincePosted": 157.8,
         "readingTime": 4
       },
       "articles": [
@@ -7721,8 +7249,8 @@
   "leaderboard": [
     {
       "fullName": "NousResearch/hermes-agent",
-      "count7d": 17,
-      "reactionsSum7d": 401
+      "count7d": 15,
+      "reactionsSum7d": 375
     },
     {
       "fullName": "google-ai-edge/gallery",
@@ -7740,14 +7268,14 @@
       "reactionsSum7d": 47
     },
     {
-      "fullName": "JuliusBrussee/caveman",
-      "count7d": 2,
-      "reactionsSum7d": 11
-    },
-    {
       "fullName": "google-ai-edge/LiteRT-LM",
       "count7d": 1,
       "reactionsSum7d": 10
+    },
+    {
+      "fullName": "JuliusBrussee/caveman",
+      "count7d": 1,
+      "reactionsSum7d": 8
     },
     {
       "fullName": "Lum1104/Understand-Anything",
@@ -7790,11 +7318,6 @@
       "reactionsSum7d": 3
     },
     {
-      "fullName": "rtk-ai/rtk",
-      "count7d": 1,
-      "reactionsSum7d": 3
-    },
-    {
       "fullName": "openai/openai-agents-python",
       "count7d": 1,
       "reactionsSum7d": 2
@@ -7825,11 +7348,6 @@
       "reactionsSum7d": 1
     },
     {
-      "fullName": "henrygd/beszel",
-      "count7d": 1,
-      "reactionsSum7d": 1
-    },
-    {
       "fullName": "HKUDS/CLI-Anything",
       "count7d": 1,
       "reactionsSum7d": 1
@@ -7845,17 +7363,12 @@
       "reactionsSum7d": 0
     },
     {
-      "fullName": "vectorize-io/hindsight",
-      "count7d": 3,
-      "reactionsSum7d": 0
-    },
-    {
       "fullName": "CloakHQ/CloakBrowser",
       "count7d": 2,
       "reactionsSum7d": 0
     },
     {
-      "fullName": "datawhalechina/hello-agents",
+      "fullName": "vectorize-io/hindsight",
       "count7d": 2,
       "reactionsSum7d": 0
     },
@@ -7911,6 +7424,11 @@
     },
     {
       "fullName": "daijro/camoufox",
+      "count7d": 1,
+      "reactionsSum7d": 0
+    },
+    {
+      "fullName": "datawhalechina/hello-agents",
       "count7d": 1,
       "reactionsSum7d": 0
     },

--- a/data/devto-trending.json
+++ b/data/devto-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T03:26:29.419Z",
+  "fetchedAt": "2026-05-23T08:22:46.250Z",
   "discoveryVersion": "2026-04-21",
   "windowDays": 7,
   "scannedArticles": 1319,
@@ -179,7 +179,7 @@
   ],
   "sliceCounts": {
     "global-top-7d": 100,
-    "global-rising": 19,
+    "global-rising": 16,
     "global-fresh": 100,
     "tag-ai-top-7d": 100,
     "tag-artificialintelligence-top-7d": 0,
@@ -226,6 +226,74 @@
         "discuss"
       ],
       "trendingScore": 152.44,
+      "linkedRepos": []
+    },
+    {
+      "id": 3730207,
+      "title": "From an Abandoned Hackathon Project to an AI Study Workspace 🚀",
+      "description": "There’s a strange feeling that comes with opening an old project folder again.  You look at the messy...",
+      "url": "https://dev.to/hrishika_malviya_cec808f3/from-an-abandoned-hackathon-project-to-an-ai-study-workspace-c86",
+      "author": {
+        "username": "hrishika_malviya_cec808f3",
+        "name": "Hrishika Malviya",
+        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3945213%2Fa066d045-a346-4d18-a7e1-d1033d5d3e55.png"
+      },
+      "reactionsCount": 130,
+      "commentsCount": 2,
+      "readingTime": 3,
+      "publishedAt": "2026-05-23T05:36:20Z",
+      "tags": [
+        "devchallenge",
+        "githubchallenge",
+        "ai",
+        "githubcopilot"
+      ],
+      "trendingScore": 118.88,
+      "linkedRepos": []
+    },
+    {
+      "id": 3730093,
+      "title": "What If AI Didn’t Need the Internet?",
+      "description": "*How Gemma 4 Could Bring Powerful AI Closer to People, Not Just Servers  For a long time, using...",
+      "url": "https://dev.to/hrishika_malviya_cec808f3/what-if-ai-didnt-need-the-internet-43jf",
+      "author": {
+        "username": "hrishika_malviya_cec808f3",
+        "name": "Hrishika Malviya",
+        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3945213%2Fa066d045-a346-4d18-a7e1-d1033d5d3e55.png"
+      },
+      "reactionsCount": 130,
+      "commentsCount": 3,
+      "readingTime": 4,
+      "publishedAt": "2026-05-23T05:11:59Z",
+      "tags": [
+        "devchallenge",
+        "gemmachallenge",
+        "gemma",
+        "ai"
+      ],
+      "trendingScore": 112.35,
+      "linkedRepos": []
+    },
+    {
+      "id": 3730162,
+      "title": "I Let Hermes Agent Handle Real Work for 24 Hours — Here’s What Surprised Me 🚀",
+      "description": "Google Docs summaries, task planning, research help, workflow automation… I wanted to know whether...",
+      "url": "https://dev.to/hrishika_malviya_cec808f3/i-let-hermes-agent-handle-real-work-for-24-hours-heres-what-surprised-me-5d7m",
+      "author": {
+        "username": "hrishika_malviya_cec808f3",
+        "name": "Hrishika Malviya",
+        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3945213%2Fa066d045-a346-4d18-a7e1-d1033d5d3e55.png"
+      },
+      "reactionsCount": 130,
+      "commentsCount": 2,
+      "readingTime": 4,
+      "publishedAt": "2026-05-23T05:25:44Z",
+      "tags": [
+        "hermesagentchallenge",
+        "devchallenge",
+        "agents"
+      ],
+      "trendingScore": 111.76,
       "linkedRepos": []
     },
     {
@@ -1615,6 +1683,27 @@
       "linkedRepos": []
     },
     {
+      "id": 3597666,
+      "title": "What was your win this week!?",
+      "description": "👋👋👋👋 Looking back on your week -- what was something you're proud of? All wins count -- big or small...",
+      "url": "https://dev.to/devteam/what-was-your-win-this-week-2ohc",
+      "author": {
+        "username": "jess",
+        "name": "Jess Lee",
+        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F264%2Fb75f6edf-df7b-406e-a56b-43facafb352c.jpg"
+      },
+      "reactionsCount": 34,
+      "commentsCount": 30,
+      "readingTime": 1,
+      "publishedAt": "2026-05-22T13:00:00Z",
+      "tags": [
+        "discuss",
+        "weeklyretro"
+      ],
+      "trendingScore": 10.75,
+      "linkedRepos": []
+    },
+    {
       "id": 3655326,
       "title": "Open Vibe -- Ship your SaaS with AI. Without getting stuck.",
       "description": "Open SaaS is live today on Product Hunt! 🎉   Check us out →       You watch a twelve-hour tutorial,...",
@@ -1748,27 +1837,6 @@
         "productivity"
       ],
       "trendingScore": 9.12,
-      "linkedRepos": []
-    },
-    {
-      "id": 3597666,
-      "title": "What was your win this week!?",
-      "description": "👋👋👋👋 Looking back on your week -- what was something you're proud of? All wins count -- big or small...",
-      "url": "https://dev.to/devteam/what-was-your-win-this-week-2ohc",
-      "author": {
-        "username": "jess",
-        "name": "Jess Lee",
-        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F264%2Fb75f6edf-df7b-406e-a56b-43facafb352c.jpg"
-      },
-      "reactionsCount": 27,
-      "commentsCount": 24,
-      "readingTime": 1,
-      "publishedAt": "2026-05-22T13:00:00Z",
-      "tags": [
-        "discuss",
-        "weeklyretro"
-      ],
-      "trendingScore": 9.1,
       "linkedRepos": []
     },
     {
@@ -2492,70 +2560,6 @@
         "agents"
       ],
       "trendingScore": 5.67,
-      "linkedRepos": []
-    },
-    {
-      "id": 3621423,
-      "title": "From Rank 6,000,000 to 26,000: 1.5 Years, 1040 LeetCode Problems, and a Surprise Package That Changed Everything",
-      "description": "I didn’t realize I was starting a 1.5-year journey when I opened my first LeetCode problem.  It...",
-      "url": "https://dev.to/hadil/from-rank-6000000-to-26000-15-years-1040-leetcode-problems-and-a-surprise-package-that-43e2",
-      "author": {
-        "username": "hadil",
-        "name": "Hadil Ben Abdallah",
-        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1209000%2Fb29d37d8-2efe-4391-9796-a6f8a483f1bd.png"
-      },
-      "reactionsCount": 52,
-      "commentsCount": 19,
-      "readingTime": 6,
-      "publishedAt": "2026-05-13T09:00:09Z",
-      "tags": [
-        "programming",
-        "leetcode",
-        "python",
-        "javascript"
-      ],
-      "trendingScore": 5.66,
-      "linkedRepos": []
-    },
-    {
-      "id": 3695578,
-      "title": "Top 7 Featured DEV Posts of the Week",
-      "description": "Welcome to this week's Top 7, where the DEV editorial team handpicks their favorite posts from the...",
-      "url": "https://dev.to/devteam/top-7-featured-dev-posts-of-the-week-1obd",
-      "author": {
-        "username": "jess",
-        "name": "Jess Lee",
-        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F264%2Fb75f6edf-df7b-406e-a56b-43facafb352c.jpg"
-      },
-      "reactionsCount": 27,
-      "commentsCount": 9,
-      "readingTime": 3,
-      "publishedAt": "2026-05-18T20:28:45Z",
-      "tags": [
-        "top7",
-        "discuss"
-      ],
-      "trendingScore": 5.51,
-      "linkedRepos": []
-    },
-    {
-      "id": 3727211,
-      "title": "The subtle impact of AI (& IT) on jobs",
-      "description": "If you are very fortunate you might find a career that excites you. That has certainly been the case...",
-      "url": "https://dev.to/tracygjg/the-subtle-impact-of-ai-it-on-jobs-i55",
-      "author": {
-        "username": "tracygjg",
-        "name": "Tracy Gilmore",
-        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F26068%2Fba1ab730-b1da-4996-b928-91757835587c.jpeg"
-      },
-      "reactionsCount": 14,
-      "commentsCount": 0,
-      "readingTime": 2,
-      "publishedAt": "2026-05-22T16:52:42Z",
-      "tags": [
-        "ai"
-      ],
-      "trendingScore": 5.43,
       "linkedRepos": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh dev.to signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26327983822

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.