### PR TITLE
chore(data): refresh huggingface signals 2026-05-23T08:32:55Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-23T04:09:37.535Z",
+  "ts": "2026-05-23T08:32:55.471Z",
   "count": 1,
-  "durationMs": 3048,
+  "durationMs": 3659,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T04:09:34.489Z",
+  "fetchedAt": "2026-05-23T08:32:51.814Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -39,9 +39,9 @@
       "id": "bytedance-research/Lance",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 1001,
-      "likes": 652,
-      "trendingScore": 628,
+      "downloads": 1227,
+      "likes": 659,
+      "trendingScore": 634,
       "pipelineTag": "any-to-any",
       "libraryName": "Lance",
       "tags": [
@@ -60,7 +60,7 @@
         "region:us"
       ],
       "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-22T16:55:56.000Z"
+      "lastModified": "2026-05-23T07:26:12.000Z"
     },
     {
       "rank": 3,
@@ -230,9 +230,9 @@
       "id": "tencent/Hy-MT2-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
-      "downloads": 564,
-      "likes": 281,
-      "trendingScore": 273,
+      "downloads": 2564,
+      "likes": 290,
+      "trendingScore": 282,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -300,77 +300,12 @@
     },
     {
       "rank": 11,
-      "id": "NemoStation/Marlin-2B",
-      "author": "NemoStation",
-      "url": "https://huggingface.co/NemoStation/Marlin-2B",
-      "downloads": 4002,
-      "likes": 252,
-      "trendingScore": 245,
-      "pipelineTag": "video-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "text-generation",
-        "video",
-        "multimodal",
-        "video-captioning",
-        "temporal-grounding",
-        "qwen",
-        "VLM",
-        "video-text-to-text",
-        "custom_code",
-        "en",
-        "arxiv:2501.00513",
-        "arxiv:2407.00634",
-        "arxiv:2512.14698",
-        "base_model:Qwen/Qwen3.5-2B",
-        "base_model:finetune:Qwen/Qwen3.5-2B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:23:12.000Z",
-      "lastModified": "2026-05-20T07:54:57.000Z"
-    },
-    {
-      "rank": 12,
-      "id": "sapientinc/HRM-Text-1B",
-      "author": "sapientinc",
-      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 72470,
-      "likes": 244,
-      "trendingScore": 241,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hrm_text",
-        "text-generation",
-        "hrm",
-        "hierarchical-reasoning",
-        "prefix-lm",
-        "pre-alignment",
-        "non-chat",
-        "non-instruction-tuned",
-        "en",
-        "arxiv:2605.20613",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T15:13:02.000Z",
-      "lastModified": "2026-05-21T05:57:38.000Z"
-    },
-    {
-      "rank": 13,
       "id": "tencent/Hy-MT2-30B-A3B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
-      "downloads": 224,
-      "likes": 244,
-      "trendingScore": 230,
+      "downloads": 970,
+      "likes": 276,
+      "trendingScore": 260,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -407,6 +342,71 @@
       ],
       "createdAt": "2026-05-11T07:43:51.000Z",
       "lastModified": "2026-05-22T05:15:55.000Z"
+    },
+    {
+      "rank": 12,
+      "id": "NemoStation/Marlin-2B",
+      "author": "NemoStation",
+      "url": "https://huggingface.co/NemoStation/Marlin-2B",
+      "downloads": 5283,
+      "likes": 255,
+      "trendingScore": 248,
+      "pipelineTag": "video-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "text-generation",
+        "video",
+        "multimodal",
+        "video-captioning",
+        "temporal-grounding",
+        "qwen",
+        "VLM",
+        "video-text-to-text",
+        "custom_code",
+        "en",
+        "arxiv:2501.00513",
+        "arxiv:2407.00634",
+        "arxiv:2512.14698",
+        "base_model:Qwen/Qwen3.5-2B",
+        "base_model:finetune:Qwen/Qwen3.5-2B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:23:12.000Z",
+      "lastModified": "2026-05-20T07:54:57.000Z"
+    },
+    {
+      "rank": 13,
+      "id": "sapientinc/HRM-Text-1B",
+      "author": "sapientinc",
+      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
+      "downloads": 78771,
+      "likes": 247,
+      "trendingScore": 244,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hrm_text",
+        "text-generation",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "en",
+        "arxiv:2605.20613",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T15:13:02.000Z",
+      "lastModified": "2026-05-21T05:57:38.000Z"
     },
     {
       "rank": 14,
@@ -587,9 +587,9 @@
       "id": "CohereLabs/command-a-plus-05-2026-w4a4",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
-      "downloads": 2127,
-      "likes": 172,
-      "trendingScore": 169,
+      "downloads": 4261,
+      "likes": 173,
+      "trendingScore": 170,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -632,9 +632,9 @@
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
-      "downloads": 28599,
-      "likes": 164,
-      "trendingScore": 162,
+      "downloads": 35795,
+      "likes": 165,
+      "trendingScore": 163,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -944,7 +944,7 @@
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
-      "downloads": 11950,
+      "downloads": 12186,
       "likes": 108,
       "trendingScore": 107,
       "pipelineTag": "image-text-to-text",
@@ -1342,8 +1342,8 @@
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
       "downloads": 0,
-      "likes": 86,
-      "trendingScore": 86,
+      "likes": 87,
+      "trendingScore": 87,
       "pipelineTag": "image-to-video",
       "libraryName": "diffusers",
       "tags": [
@@ -1605,6 +1605,43 @@
     },
     {
       "rank": 55,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 9918,
+      "likes": 80,
+      "trendingScore": 78,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 56,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -1635,43 +1672,6 @@
       ],
       "createdAt": "2026-05-13T10:53:22.000Z",
       "lastModified": "2026-05-17T19:46:30.000Z"
-    },
-    {
-      "rank": 56,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 7576,
-      "likes": 78,
-      "trendingScore": 76,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "image-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
       "rank": 57,
@@ -1885,10 +1885,36 @@
     },
     {
       "rank": 64,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 3282,
+      "likes": 67,
+      "trendingScore": 67,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-23T01:01:26.000Z"
+    },
+    {
+      "rank": 65,
       "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "downloads": 21448,
+      "downloads": 27398,
       "likes": 69,
       "trendingScore": 66,
       "pipelineTag": "text-generation",
@@ -1928,7 +1954,7 @@
       "lastModified": "2026-05-19T23:43:59.000Z"
     },
     {
-      "rank": 65,
+      "rank": 66,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -1971,32 +1997,6 @@
       ],
       "createdAt": "2026-04-29T16:12:36.000Z",
       "lastModified": "2026-05-02T14:32:42.000Z"
-    },
-    {
-      "rank": 66,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 1992,
-      "likes": 65,
-      "trendingScore": 65,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-23T01:01:26.000Z"
     },
     {
       "rank": 67,
@@ -2256,6 +2256,50 @@
     },
     {
       "rank": 76,
+      "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
+      "downloads": 2853,
+      "likes": 60,
+      "trendingScore": 58,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "image",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "science",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T10:48:10.000Z",
+      "lastModified": "2026-05-23T00:39:37.000Z"
+    },
+    {
+      "rank": 77,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -2278,7 +2322,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 77,
+      "rank": 78,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -2309,7 +2353,30 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 78,
+      "rank": 79,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 381,
+      "likes": 57,
+      "trendingScore": 57,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
+    },
+    {
+      "rank": 80,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -2339,7 +2406,35 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 79,
+      "rank": 81,
+      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "downloads": 0,
+      "likes": 57,
+      "trendingScore": 56,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "audio-text-to-video",
+        "audio-image-text-to-video",
+        "audio-driven-video-continuation",
+        "transformers",
+        "avatar",
+        "video-generation",
+        "en",
+        "zh",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:05:55.000Z",
+      "lastModified": "2026-05-22T02:58:39.000Z"
+    },
+    {
+      "rank": 82,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2383,7 +2478,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 80,
+      "rank": 83,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -2401,7 +2496,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 81,
+      "rank": 84,
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
@@ -2428,7 +2523,7 @@
       "lastModified": "2026-05-14T02:37:15.000Z"
     },
     {
-      "rank": 82,
+      "rank": 85,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -2455,7 +2550,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 83,
+      "rank": 86,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2488,30 +2583,7 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 84,
-      "id": "microsoft/Lens-Turbo",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 116,
-      "likes": 53,
-      "trendingScore": 53,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
-    },
-    {
-      "rank": 85,
+      "rank": 87,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2556,7 +2628,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 86,
+      "rank": 88,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2583,7 +2655,7 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 87,
+      "rank": 89,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2611,7 +2683,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 88,
+      "rank": 90,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2645,7 +2717,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 89,
+      "rank": 91,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2675,7 +2747,7 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 90,
+      "rank": 92,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -2695,7 +2767,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 91,
+      "rank": 93,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -2726,7 +2798,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 92,
+      "rank": 94,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -2751,7 +2823,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 93,
+      "rank": 95,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -2788,7 +2860,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 94,
+      "rank": 96,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -2825,51 +2897,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 95,
-      "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
-      "downloads": 4,
-      "likes": 48,
-      "trendingScore": 47,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "image",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "science",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T10:48:10.000Z",
-      "lastModified": "2026-05-23T00:39:37.000Z"
-    },
-    {
-      "rank": 96,
+      "rank": 97,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -2897,7 +2925,7 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 97,
+      "rank": 98,
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
@@ -2921,35 +2949,70 @@
       "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 98,
-      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "rank": 99,
+      "id": "zhen-nan/L2P",
+      "author": "zhen-nan",
+      "url": "https://huggingface.co/zhen-nan/L2P",
       "downloads": 0,
-      "likes": 47,
+      "likes": 46,
       "trendingScore": 46,
       "pipelineTag": null,
-      "libraryName": "diffusers",
+      "libraryName": null,
       "tags": [
-        "diffusers",
-        "onnx",
-        "safetensors",
-        "audio-text-to-video",
-        "audio-image-text-to-video",
-        "audio-driven-video-continuation",
-        "transformers",
-        "avatar",
-        "video-generation",
-        "en",
-        "zh",
-        "license:mit",
+        "arxiv:2605.12013",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-21T09:05:55.000Z",
-      "lastModified": "2026-05-22T02:58:39.000Z"
+      "createdAt": "2026-05-03T13:24:20.000Z",
+      "lastModified": "2026-05-22T07:53:35.000Z"
     },
     {
-      "rank": 99,
+      "rank": 100,
+      "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "downloads": 3532,
+      "likes": 46,
+      "trendingScore": 46,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "devops",
+        "math",
+        "science",
+        "image",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T06:37:47.000Z",
+      "lastModified": "2026-05-23T00:38:45.000Z"
+    },
+    {
+      "rank": 101,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -2972,7 +3035,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 100,
+      "rank": 102,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
@@ -2999,7 +3062,7 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 101,
+      "rank": 103,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -3032,7 +3095,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 102,
+      "rank": 104,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -3063,7 +3126,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 103,
+      "rank": 105,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -3079,7 +3142,7 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 104,
+      "rank": 106,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3098,25 +3161,52 @@
       "lastModified": "2026-05-20T20:31:07.000Z"
     },
     {
-      "rank": 105,
-      "id": "zhen-nan/L2P",
-      "author": "zhen-nan",
-      "url": "https://huggingface.co/zhen-nan/L2P",
-      "downloads": 0,
-      "likes": 41,
+      "rank": 107,
+      "id": "microsoft/Lens",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 296,
+      "likes": 44,
       "trendingScore": 41,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
+    },
+    {
+      "rank": 108,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 6510,
+      "likes": 41,
+      "trendingScore": 40,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "arxiv:2605.12013",
-        "license:apache-2.0",
-        "region:us"
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-05-03T13:24:20.000Z",
-      "lastModified": "2026-05-22T07:53:35.000Z"
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-22T05:15:52.000Z"
     },
     {
-      "rank": 106,
+      "rank": 109,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -3135,11 +3225,11 @@
       "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
-      "rank": 107,
+      "rank": 110,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "downloads": 63779,
+      "downloads": 67964,
       "likes": 76,
       "trendingScore": 38,
       "pipelineTag": "image-text-to-text",
@@ -3167,7 +3257,7 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 108,
+      "rank": 111,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -3194,7 +3284,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 109,
+      "rank": 112,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -3221,7 +3311,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 110,
+      "rank": 113,
       "id": "stabilityai/stable-audio-3-small-music",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
@@ -3248,7 +3338,63 @@
       "lastModified": "2026-05-19T20:02:42.000Z"
     },
     {
-      "rank": 111,
+      "rank": 114,
+      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
+      "downloads": 31296,
+      "likes": 39,
+      "trendingScore": 37,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T19:11:26.000Z",
+      "lastModified": "2026-05-21T21:34:50.000Z"
+    },
+    {
+      "rank": 115,
+      "id": "LatitudeGames/Equinox-31B",
+      "author": "LatitudeGames",
+      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
+      "downloads": 277,
+      "likes": 37,
+      "trendingScore": 37,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "gemma4",
+        "text adventure",
+        "roleplay",
+        "en",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:finetune:google/gemma-4-31B-it",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:45:53.000Z",
+      "lastModified": "2026-05-22T04:55:49.000Z"
+    },
+    {
+      "rank": 116,
       "id": "Alissonerdx/BFS-Best-Face-Swap",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
@@ -3281,12 +3427,12 @@
       "lastModified": "2026-03-08T12:54:54.000Z"
     },
     {
-      "rank": 112,
+      "rank": 117,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
-      "downloads": 1243927,
-      "likes": 4661,
+      "downloads": 1229497,
+      "likes": 4664,
       "trendingScore": 36,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -3307,108 +3453,7 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 113,
-      "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 28438,
-      "likes": 38,
-      "trendingScore": 36,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T19:11:26.000Z",
-      "lastModified": "2026-05-21T21:34:50.000Z"
-    },
-    {
-      "rank": 114,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
-      "downloads": 1823,
-      "likes": 37,
-      "trendingScore": 36,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-22T05:15:52.000Z"
-    },
-    {
-      "rank": 115,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 133,
-      "likes": 39,
-      "trendingScore": 36,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
-    },
-    {
-      "rank": 116,
-      "id": "LatitudeGames/Equinox-31B",
-      "author": "LatitudeGames",
-      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
-      "downloads": 37,
-      "likes": 36,
-      "trendingScore": 36,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gemma4",
-        "text adventure",
-        "roleplay",
-        "en",
-        "base_model:google/gemma-4-31B-it",
-        "base_model:finetune:google/gemma-4-31B-it",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:45:53.000Z",
-      "lastModified": "2026-05-22T04:55:49.000Z"
-    },
-    {
-      "rank": 117,
+      "rank": 118,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -3440,7 +3485,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -3463,7 +3508,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 119,
+      "rank": 120,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -3487,7 +3532,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 120,
+      "rank": 121,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
@@ -3516,7 +3561,7 @@
       "lastModified": "2026-05-20T14:30:55.000Z"
     },
     {
-      "rank": 121,
+      "rank": 122,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -3545,7 +3590,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 122,
+      "rank": 123,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -3569,7 +3614,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 123,
+      "rank": 124,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -3586,7 +3631,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 124,
+      "rank": 125,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -3610,7 +3655,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 125,
+      "rank": 126,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3636,7 +3681,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 126,
+      "rank": 127,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -3652,7 +3697,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 127,
+      "rank": 128,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -3679,7 +3724,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 128,
+      "rank": 129,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -3698,7 +3743,79 @@
       "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 129,
+      "rank": 130,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 12747,
+      "likes": 34,
+      "trendingScore": 34,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
+      "rank": 131,
+      "id": "tencent/Hy-MT2-7B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
+      "downloads": 1321,
+      "likes": 36,
+      "trendingScore": 34,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hunyuan_v1_dense",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T14:56:58.000Z",
+      "lastModified": "2026-05-22T05:16:06.000Z"
+    },
+    {
+      "rank": 132,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -3743,7 +3860,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 130,
+      "rank": 133,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -3788,7 +3905,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 131,
+      "rank": 134,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -3832,7 +3949,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 132,
+      "rank": 135,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3872,7 +3989,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 133,
+      "rank": 136,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -3898,7 +4015,39 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 134,
+      "rank": 137,
+      "id": "pyannote/speaker-diarization-3.1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
+      "downloads": 10150085,
+      "likes": 1928,
+      "trendingScore": 33,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2023-11-16T08:19:01.000Z",
+      "lastModified": "2024-05-10T19:43:23.000Z"
+    },
+    {
+      "rank": 138,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -3942,7 +4091,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 135,
+      "rank": 139,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3967,7 +4116,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 136,
+      "rank": 140,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -4012,11 +4161,11 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 137,
+      "rank": 141,
       "id": "HuggingFaceBio/Carbon-3B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 2993,
+      "downloads": 3311,
       "likes": 34,
       "trendingScore": 32,
       "pipelineTag": "text-generation",
@@ -4038,66 +4187,60 @@
       "lastModified": "2026-05-20T13:39:48.000Z"
     },
     {
-      "rank": 138,
-      "id": "pyannote/speaker-diarization-3.1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 10263344,
-      "likes": 1927,
+      "rank": 142,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2676824,
+      "likes": 2038,
       "trendingScore": 32,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-11-16T08:19:01.000Z",
-      "lastModified": "2024-05-10T19:43:23.000Z"
-    },
-    {
-      "rank": 139,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 8345,
-      "likes": 32,
-      "trendingScore": 32,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": "mask-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "deploy:azure",
+        "region:us"
       ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 140,
+      "rank": 143,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 37,
+      "trendingScore": 32,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-21T14:39:01.000Z"
+    },
+    {
+      "rank": 144,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -4130,7 +4273,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 141,
+      "rank": 145,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -4154,7 +4297,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 142,
+      "rank": 146,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -4181,7 +4324,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 143,
+      "rank": 147,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -4223,7 +4366,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 144,
+      "rank": 148,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -4251,7 +4394,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 145,
+      "rank": 149,
       "id": "ByteDance-Seed/Cola-DLM",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
@@ -4281,7 +4424,7 @@
       "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
-      "rank": 146,
+      "rank": 150,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
@@ -4326,60 +4469,7 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 147,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2719603,
-      "likes": 2035,
-      "trendingScore": 31,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
-        "feature-extraction",
-        "sam3",
-        "mask-generation",
-        "en",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 148,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
-      "downloads": 0,
-      "likes": 36,
-      "trendingScore": 31,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
-        "en",
-        "zh",
-        "arxiv:2605.19833",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-21T14:39:01.000Z"
-    },
-    {
-      "rank": 149,
+      "rank": 151,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4405,7 +4495,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 150,
+      "rank": 152,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4437,7 +4527,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 151,
+      "rank": 153,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4464,7 +4554,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 152,
+      "rank": 154,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -4498,7 +4588,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 153,
+      "rank": 155,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4520,52 +4610,7 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 154,
-      "id": "tencent/Hy-MT2-7B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
-      "downloads": 213,
-      "likes": 30,
-      "trendingScore": 30,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hunyuan_v1_dense",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T14:56:58.000Z",
-      "lastModified": "2026-05-22T05:16:06.000Z"
-    },
-    {
-      "rank": 155,
+      "rank": 156,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -4596,7 +4641,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 156,
+      "rank": 157,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -4621,7 +4666,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 157,
+      "rank": 158,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -4644,7 +4689,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 158,
+      "rank": 159,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -4671,7 +4716,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 159,
+      "rank": 160,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -4702,7 +4747,7 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 160,
+      "rank": 161,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -4729,51 +4774,6 @@
       ],
       "createdAt": "2026-05-14T09:54:29.000Z",
       "lastModified": "2026-05-16T06:48:11.000Z"
-    },
-    {
-      "rank": 161,
-      "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "downloads": 0,
-      "likes": 29,
-      "trendingScore": 29,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "coder",
-        "devops",
-        "math",
-        "science",
-        "image",
-        "text-generation",
-        "en",
-        "zh",
-        "ko",
-        "ru",
-        "ja",
-        "es",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T06:37:47.000Z",
-      "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
       "rank": 162,
@@ -4894,7 +4894,7 @@
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "downloads": 1250,
+      "downloads": 1587,
       "likes": 28,
       "trendingScore": 28,
       "pipelineTag": "text-generation",
@@ -4922,7 +4922,7 @@
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
-      "downloads": 1267,
+      "downloads": 1365,
       "likes": 29,
       "trendingScore": 28,
       "pipelineTag": "image-text-to-text",
@@ -5132,7 +5132,7 @@
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
-      "downloads": 1468,
+      "downloads": 1507,
       "likes": 28,
       "trendingScore": 27,
       "pipelineTag": "text-generation",
@@ -5182,7 +5182,7 @@
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
-      "downloads": 260087615,
+      "downloads": 260118595,
       "likes": 4820,
       "trendingScore": 27,
       "pipelineTag": "sentence-similarity",
@@ -5550,6 +5550,38 @@
     },
     {
       "rank": 187,
+      "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
+      "downloads": 39712,
+      "likes": 49,
+      "trendingScore": 26,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3_5_moe",
+        "qwen3_5",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "mpoa",
+        "mtp",
+        "image-text-to-text",
+        "base_model:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
+        "base_model:quantized:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-08T22:19:56.000Z",
+      "lastModified": "2026-05-09T01:18:02.000Z"
+    },
+    {
+      "rank": 188,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -5587,7 +5619,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 188,
+      "rank": 189,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -5605,7 +5637,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 189,
+      "rank": 190,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -5631,7 +5663,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 190,
+      "rank": 191,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -5651,7 +5683,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 191,
+      "rank": 192,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -5678,7 +5710,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 192,
+      "rank": 193,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -5704,7 +5736,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 193,
+      "rank": 194,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -5730,7 +5762,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -5767,7 +5799,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 195,
+      "rank": 196,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -5783,7 +5815,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -5806,7 +5838,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -5848,7 +5880,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 198,
+      "rank": 199,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -5887,7 +5919,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 199,
+      "rank": 200,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -5932,7 +5964,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 200,
+      "rank": 201,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -5964,7 +5996,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 201,
+      "rank": 202,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -5988,7 +6020,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 202,
+      "rank": 203,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -6015,7 +6047,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 203,
+      "rank": 204,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -6040,7 +6072,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 204,
+      "rank": 205,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -6076,7 +6108,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 205,
+      "rank": 206,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -6092,7 +6124,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 206,
+      "rank": 207,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -6113,7 +6145,33 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 207,
+      "rank": 208,
+      "id": "HuggingFaceBio/Carbon-500M",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
+      "downloads": 1410,
+      "likes": 27,
+      "trendingScore": 24,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "speculative-decoding",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T16:09:33.000Z",
+      "lastModified": "2026-05-20T13:40:43.000Z"
+    },
+    {
+      "rank": 209,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -6140,7 +6198,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 208,
+      "rank": 210,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -6169,7 +6227,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 209,
+      "rank": 211,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -6186,7 +6244,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 210,
+      "rank": 212,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -6207,7 +6265,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 211,
+      "rank": 213,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -6228,7 +6286,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 212,
+      "rank": 214,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6249,7 +6307,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 213,
+      "rank": 215,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -6281,7 +6339,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 214,
+      "rank": 216,
       "id": "oron1208/OOO_Anima",
       "author": "oron1208",
       "url": "https://huggingface.co/oron1208/OOO_Anima",
@@ -6308,33 +6366,7 @@
       "lastModified": "2026-05-21T15:24:20.000Z"
     },
     {
-      "rank": 215,
-      "id": "HuggingFaceBio/Carbon-500M",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
-      "downloads": 1243,
-      "likes": 26,
-      "trendingScore": 23,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "speculative-decoding",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T16:09:33.000Z",
-      "lastModified": "2026-05-20T13:40:43.000Z"
-    },
-    {
-      "rank": 216,
+      "rank": 217,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6365,39 +6397,29 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 217,
-      "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
-      "downloads": 37038,
-      "likes": 46,
+      "rank": 218,
+      "id": "tencent/Hy-MT2-7B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
+      "downloads": 7906,
+      "likes": 24,
       "trendingScore": 23,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": null,
+      "libraryName": null,
       "tags": [
-        "transformers",
         "gguf",
-        "qwen3_5_moe",
-        "qwen3_5",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "mpoa",
-        "mtp",
-        "image-text-to-text",
-        "base_model:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
-        "base_model:quantized:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
-        "license:apache-2.0",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-7B",
+        "base_model:quantized:tencent/Hy-MT2-7B",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-08T22:19:56.000Z",
-      "lastModified": "2026-05-09T01:18:02.000Z"
+      "createdAt": "2026-05-20T06:21:31.000Z",
+      "lastModified": "2026-05-22T05:16:12.000Z"
     },
     {
-      "rank": 218,
+      "rank": 219,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6428,7 +6450,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 219,
+      "rank": 220,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6457,7 +6479,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 220,
+      "rank": 221,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6502,7 +6524,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 221,
+      "rank": 222,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6529,7 +6551,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 222,
+      "rank": 223,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -6555,7 +6577,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 223,
+      "rank": 224,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -6579,7 +6601,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 224,
+      "rank": 225,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -6617,7 +6639,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 225,
+      "rank": 226,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -6634,7 +6656,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 226,
+      "rank": 227,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -6662,7 +6684,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 227,
+      "rank": 228,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -6684,11 +6706,11 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 228,
+      "rank": 229,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
-      "downloads": 2526,
+      "downloads": 2597,
       "likes": 25,
       "trendingScore": 22,
       "pipelineTag": "text-to-video",
@@ -6707,7 +6729,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 229,
+      "rank": 230,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -6752,7 +6774,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 230,
+      "rank": 231,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -6780,7 +6802,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 231,
+      "rank": 232,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -6816,7 +6838,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 232,
+      "rank": 233,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -6843,11 +6865,11 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 233,
+      "rank": 234,
       "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "downloads": 833,
+      "downloads": 1717,
       "likes": 21,
       "trendingScore": 21,
       "pipelineTag": null,
@@ -6863,28 +6885,6 @@
       ],
       "createdAt": "2026-05-20T09:26:32.000Z",
       "lastModified": "2026-05-22T05:15:40.000Z"
-    },
-    {
-      "rank": 234,
-      "id": "tencent/Hy-MT2-7B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 4373,
-      "likes": 21,
-      "trendingScore": 21,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-7B",
-        "base_model:quantized:tencent/Hy-MT2-7B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:31.000Z",
-      "lastModified": "2026-05-22T05:16:12.000Z"
     },
     {
       "rank": 235,
@@ -7302,7 +7302,7 @@
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
-      "downloads": 1945,
+      "downloads": 2339,
       "likes": 20,
       "trendingScore": 20,
       "pipelineTag": null,
@@ -7348,6 +7348,35 @@
     },
     {
       "rank": 250,
+      "id": "stabilityai/stable-diffusion-xl-base-1.0",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "downloads": 1913298,
+      "likes": 7743,
+      "trendingScore": 20,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "text-to-image",
+        "stable-diffusion",
+        "arxiv:2307.01952",
+        "arxiv:2211.01324",
+        "arxiv:2108.01073",
+        "arxiv:2112.10752",
+        "license:openrail++",
+        "endpoints_compatible",
+        "diffusers:StableDiffusionXLPipeline",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2023-07-25T13:25:51.000Z",
+      "lastModified": "2023-10-30T16:03:47.000Z"
+    },
+    {
+      "rank": 251,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -7392,7 +7421,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 251,
+      "rank": 252,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -7425,7 +7454,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 252,
+      "rank": 253,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -7447,7 +7476,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 253,
+      "rank": 254,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -7474,7 +7503,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 254,
+      "rank": 255,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -7490,7 +7519,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 255,
+      "rank": 256,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7507,7 +7536,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 256,
+      "rank": 257,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -7530,7 +7559,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 257,
+      "rank": 258,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -7555,7 +7584,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 258,
+      "rank": 259,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -7591,7 +7620,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -7620,7 +7649,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -7650,7 +7679,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -7695,7 +7724,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -7722,7 +7751,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -7748,7 +7777,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -7776,7 +7805,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -7805,36 +7834,33 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 266,
-      "id": "stabilityai/stable-diffusion-xl-base-1.0",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
-      "downloads": 1915891,
-      "likes": 7742,
+      "rank": 267,
+      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
+      "downloads": 14699,
+      "likes": 21,
       "trendingScore": 19,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
-        "onnx",
+        "transformers",
         "safetensors",
-        "text-to-image",
-        "stable-diffusion",
-        "arxiv:2307.01952",
-        "arxiv:2211.01324",
-        "arxiv:2108.01073",
-        "arxiv:2112.10752",
-        "license:openrail++",
-        "endpoints_compatible",
-        "diffusers:StableDiffusionXLPipeline",
-        "deploy:azure",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2023-07-25T13:25:51.000Z",
-      "lastModified": "2023-10-30T16:03:47.000Z"
+      "createdAt": "2026-03-02T17:12:28.000Z",
+      "lastModified": "2026-05-23T01:01:21.000Z"
     },
     {
-      "rank": 267,
+      "rank": 268,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -7856,7 +7882,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 268,
+      "rank": 269,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -7890,7 +7916,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 269,
+      "rank": 270,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -7914,7 +7940,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 270,
+      "rank": 271,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7940,7 +7966,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 271,
+      "rank": 272,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -7962,7 +7988,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 272,
+      "rank": 273,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -7991,7 +8017,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 273,
+      "rank": 274,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -8023,7 +8049,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 274,
+      "rank": 275,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -8041,7 +8067,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 275,
+      "rank": 276,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -8070,7 +8096,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 276,
+      "rank": 277,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -8097,7 +8123,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 277,
+      "rank": 278,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8115,11 +8141,11 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 278,
+      "rank": 279,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
-      "downloads": 7438,
+      "downloads": 10637,
       "likes": 18,
       "trendingScore": 18,
       "pipelineTag": "image-text-to-text",
@@ -8141,11 +8167,11 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 279,
+      "rank": 280,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
-      "downloads": 19699,
+      "downloads": 24132,
       "likes": 18,
       "trendingScore": 18,
       "pipelineTag": "text-generation",
@@ -8167,33 +8193,40 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 280,
-      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
-      "downloads": 14200,
-      "likes": 20,
+      "rank": 281,
+      "id": "pyannote/speaker-diarization-community-1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
+      "downloads": 2903005,
+      "likes": 396,
       "trendingScore": 18,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
       "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2104.03603",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "arxiv:2110.07058",
+        "license:cc-by-4.0",
         "region:us"
       ],
-      "createdAt": "2026-03-02T17:12:28.000Z",
-      "lastModified": "2026-05-23T01:01:21.000Z"
+      "createdAt": "2025-04-15T21:31:35.000Z",
+      "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 281,
+      "rank": 282,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -8238,7 +8271,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 282,
+      "rank": 283,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -8267,7 +8300,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 283,
+      "rank": 284,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -8296,7 +8329,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 284,
+      "rank": 285,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -8328,7 +8361,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 285,
+      "rank": 286,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -8358,7 +8391,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 286,
+      "rank": 287,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -8379,7 +8412,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 287,
+      "rank": 288,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -8424,7 +8457,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 288,
+      "rank": 289,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -8453,7 +8486,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 289,
+      "rank": 290,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -8481,7 +8514,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 290,
+      "rank": 291,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -8506,7 +8539,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 291,
+      "rank": 292,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -8529,7 +8562,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 292,
+      "rank": 293,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -8556,7 +8589,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 293,
+      "rank": 294,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -8582,7 +8615,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 294,
+      "rank": 295,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -8611,7 +8644,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 295,
+      "rank": 296,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8633,39 +8666,6 @@
       ],
       "createdAt": "2025-12-17T05:55:58.000Z",
       "lastModified": "2025-12-23T13:13:52.000Z"
-    },
-    {
-      "rank": 296,
-      "id": "pyannote/speaker-diarization-community-1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
-      "downloads": 2912607,
-      "likes": 395,
-      "trendingScore": 17,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2104.03603",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "arxiv:2110.07058",
-        "license:cc-by-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-04-15T21:31:35.000Z",
-      "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
       "rank": 297,
@@ -9233,8 +9233,8 @@
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
-      "downloads": 10241,
-      "likes": 16,
+      "downloads": 11174,
+      "likes": 17,
       "trendingScore": 16,
       "pipelineTag": null,
       "libraryName": null,
@@ -9263,7 +9263,7 @@
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
-      "downloads": 1304,
+      "downloads": 6899,
       "likes": 16,
       "trendingScore": 16,
       "pipelineTag": null,
@@ -9287,6 +9287,57 @@
     },
     {
       "rank": 317,
+      "id": "coqui/XTTS-v2",
+      "author": "coqui",
+      "url": "https://huggingface.co/coqui/XTTS-v2",
+      "downloads": 8913147,
+      "likes": 3559,
+      "trendingScore": 16,
+      "pipelineTag": "text-to-speech",
+      "libraryName": "coqui",
+      "tags": [
+        "coqui",
+        "text-to-speech",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2023-10-31T10:11:33.000Z",
+      "lastModified": "2023-12-11T17:50:00.000Z"
+    },
+    {
+      "rank": 318,
+      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "downloads": 19032,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T04:50:12.000Z",
+      "lastModified": "2026-05-21T21:34:54.000Z"
+    },
+    {
+      "rank": 319,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -9313,7 +9364,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -9358,7 +9409,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 319,
+      "rank": 321,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -9388,7 +9439,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 320,
+      "rank": 322,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -9418,7 +9469,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 321,
+      "rank": 323,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -9463,7 +9514,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 322,
+      "rank": 324,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -9498,7 +9549,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 323,
+      "rank": 325,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9526,7 +9577,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 324,
+      "rank": 326,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -9555,7 +9606,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 325,
+      "rank": 327,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -9580,7 +9631,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 326,
+      "rank": 328,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -9608,7 +9659,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 327,
+      "rank": 329,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -9636,7 +9687,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 328,
+      "rank": 330,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -9667,7 +9718,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 329,
+      "rank": 331,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -9712,7 +9763,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 330,
+      "rank": 332,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -9744,7 +9795,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 331,
+      "rank": 333,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -9771,7 +9822,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 332,
+      "rank": 334,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -9794,7 +9845,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 333,
+      "rank": 335,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -9821,26 +9872,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 334,
-      "id": "coqui/XTTS-v2",
-      "author": "coqui",
-      "url": "https://huggingface.co/coqui/XTTS-v2",
-      "downloads": 8597894,
-      "likes": 3549,
-      "trendingScore": 15,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "coqui",
-      "tags": [
-        "coqui",
-        "text-to-speech",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2023-10-31T10:11:33.000Z",
-      "lastModified": "2023-12-11T17:50:00.000Z"
-    },
-    {
-      "rank": 335,
+      "rank": 336,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -9863,7 +9895,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 336,
+      "rank": 337,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -9889,7 +9921,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 337,
+      "rank": 338,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -9919,7 +9951,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 338,
+      "rank": 339,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -9946,11 +9978,11 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 339,
+      "rank": 340,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
-      "downloads": 107856,
+      "downloads": 106074,
       "likes": 79,
       "trendingScore": 15,
       "pipelineTag": "any-to-any",
@@ -9977,7 +10009,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 340,
+      "rank": 341,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -10005,7 +10037,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 341,
+      "rank": 342,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -10035,38 +10067,6 @@
       ],
       "createdAt": "2026-05-15T09:29:30.000Z",
       "lastModified": "2026-05-15T12:12:22.000Z"
-    },
-    {
-      "rank": 342,
-      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "downloads": 15537,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T04:50:12.000Z",
-      "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
       "rank": 343,
@@ -10099,7 +10099,7 @@
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
-      "downloads": 30054,
+      "downloads": 34799,
       "likes": 69,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -10796,7 +10796,7 @@
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
-      "downloads": 10494,
+      "downloads": 12524,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
@@ -10824,7 +10824,7 @@
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "downloads": 14423,
+      "downloads": 16080,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
@@ -10861,6 +10861,47 @@
     },
     {
       "rank": 370,
+      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
+      "author": "NousResearch",
+      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
+      "downloads": 222314,
+      "likes": 438,
+      "trendingScore": 14,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "Llama-3",
+        "instruct",
+        "finetune",
+        "chatml",
+        "gpt4",
+        "synthetic data",
+        "distillation",
+        "function calling",
+        "json mode",
+        "axolotl",
+        "roleplaying",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2408.11857",
+        "base_model:meta-llama/Llama-3.1-8B",
+        "base_model:finetune:meta-llama/Llama-3.1-8B",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-07-28T06:00:57.000Z",
+      "lastModified": "2024-09-08T07:39:55.000Z"
+    },
+    {
+      "rank": 371,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -10889,7 +10930,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 371,
+      "rank": 372,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -10934,7 +10975,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 372,
+      "rank": 373,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -10963,7 +11004,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 373,
+      "rank": 374,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -10990,7 +11031,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 374,
+      "rank": 375,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -11017,7 +11058,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 375,
+      "rank": 376,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -11048,7 +11089,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 376,
+      "rank": 377,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -11072,7 +11113,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 377,
+      "rank": 378,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -11117,7 +11158,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 378,
+      "rank": 379,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -11144,7 +11185,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 379,
+      "rank": 380,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -11180,7 +11221,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 380,
+      "rank": 381,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -11211,7 +11252,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 381,
+      "rank": 382,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -11242,7 +11283,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 382,
+      "rank": 383,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -11275,7 +11316,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 383,
+      "rank": 384,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -11304,7 +11345,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 384,
+      "rank": 385,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -11330,7 +11371,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 385,
+      "rank": 386,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -11360,7 +11401,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 386,
+      "rank": 387,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -11378,7 +11419,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 387,
+      "rank": 388,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -11409,7 +11450,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 388,
+      "rank": 389,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -11430,7 +11471,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 389,
+      "rank": 390,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -11450,12 +11491,12 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 390,
+      "rank": 391,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
-      "downloads": 737862,
-      "likes": 288,
+      "downloads": 729959,
+      "likes": 289,
       "trendingScore": 13,
       "pipelineTag": "image-feature-extraction",
       "libraryName": "transformers",
@@ -11478,7 +11519,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 391,
+      "rank": 392,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -11505,7 +11546,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 392,
+      "rank": 393,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -11535,7 +11576,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 393,
+      "rank": 394,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -11552,11 +11593,11 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 394,
+      "rank": 395,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
-      "downloads": 313,
+      "downloads": 347,
       "likes": 16,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
@@ -11579,7 +11620,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 395,
+      "rank": 396,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11610,11 +11651,11 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 396,
+      "rank": 397,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
-      "downloads": 664906,
+      "downloads": 676268,
       "likes": 259,
       "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
@@ -11635,7 +11676,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 397,
+      "rank": 398,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -11653,53 +11694,12 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 398,
-      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
-      "author": "NousResearch",
-      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 220625,
-      "likes": 437,
-      "trendingScore": 13,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "Llama-3",
-        "instruct",
-        "finetune",
-        "chatml",
-        "gpt4",
-        "synthetic data",
-        "distillation",
-        "function calling",
-        "json mode",
-        "axolotl",
-        "roleplaying",
-        "chat",
-        "conversational",
-        "en",
-        "arxiv:2408.11857",
-        "base_model:meta-llama/Llama-3.1-8B",
-        "base_model:finetune:meta-llama/Llama-3.1-8B",
-        "license:llama3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-07-28T06:00:57.000Z",
-      "lastModified": "2024-09-08T07:39:55.000Z"
-    },
-    {
       "rank": 399,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
       "downloads": 0,
-      "likes": 13,
+      "likes": 14,
       "trendingScore": 13,
       "pipelineTag": "image-to-image",
       "libraryName": null,
@@ -11719,11 +11719,105 @@
     },
     {
       "rank": 400,
+      "id": "Jackrong/Qwopus3.5-9B-Coder",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
+      "downloads": 1993,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "agent",
+        "tool-use",
+        "function-calling",
+        "coder",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:lambda/hermes-agent-reasoning-traces",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T08:15:06.000Z",
+      "lastModified": "2026-05-19T08:45:22.000Z"
+    },
+    {
+      "rank": 401,
+      "id": "netease-youdao/Confucius4",
+      "author": "netease-youdao",
+      "url": "https://huggingface.co/netease-youdao/Confucius4",
+      "downloads": 106,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T10:13:40.000Z",
+      "lastModified": "2026-05-20T08:42:10.000Z"
+    },
+    {
+      "rank": 402,
+      "id": "FINAL-Bench/Darwin-28B-Coder",
+      "author": "FINAL-Bench",
+      "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
+      "downloads": 72,
+      "likes": 15,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "code",
+        "code-generation",
+        "function-calling",
+        "darwin",
+        "text-generation",
+        "conversational",
+        "en",
+        "ko",
+        "dataset:m-a-p/CodeFeedback-Filtered-Instruction",
+        "arxiv:2409.12186",
+        "arxiv:2406.11931",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T04:50:07.000Z",
+      "lastModified": "2026-05-20T04:57:31.000Z"
+    },
+    {
+      "rank": 403,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
-      "downloads": 7570231,
-      "likes": 3024,
+      "downloads": 7645818,
+      "likes": 3025,
       "trendingScore": 12,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
@@ -11763,7 +11857,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 401,
+      "rank": 404,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -11790,7 +11884,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 402,
+      "rank": 405,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -11818,7 +11912,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 403,
+      "rank": 406,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -11851,7 +11945,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 404,
+      "rank": 407,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -11867,7 +11961,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 405,
+      "rank": 408,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -11890,7 +11984,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 406,
+      "rank": 409,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -11924,7 +12018,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 407,
+      "rank": 410,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -11944,7 +12038,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 408,
+      "rank": 411,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -11979,7 +12073,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 409,
+      "rank": 412,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -12009,7 +12103,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 410,
+      "rank": 413,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -12030,7 +12124,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 411,
+      "rank": 414,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -12059,7 +12153,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 412,
+      "rank": 415,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -12089,7 +12183,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 413,
+      "rank": 416,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -12117,7 +12211,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 414,
+      "rank": 417,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -12146,7 +12240,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 415,
+      "rank": 418,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -12178,12 +12272,12 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 416,
+      "rank": 419,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
-      "downloads": 24261,
-      "likes": 13,
+      "downloads": 88043,
+      "likes": 27,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -12207,7 +12301,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 417,
+      "rank": 420,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -12242,7 +12336,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 418,
+      "rank": 421,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -12264,7 +12358,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 419,
+      "rank": 422,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -12302,7 +12396,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 420,
+      "rank": 423,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -12341,7 +12435,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 421,
+      "rank": 424,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -12378,7 +12472,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 422,
+      "rank": 425,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -12402,7 +12496,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 423,
+      "rank": 426,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -12420,7 +12514,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 424,
+      "rank": 427,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -12439,7 +12533,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 425,
+      "rank": 428,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -12467,7 +12561,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -12508,7 +12602,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -12530,7 +12624,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -12567,7 +12661,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -12597,7 +12691,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -12626,7 +12720,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 431,
+      "rank": 434,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -12654,50 +12748,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 432,
-      "id": "Jackrong/Qwopus3.5-9B-Coder",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
-      "downloads": 1534,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "agent",
-        "tool-use",
-        "function-calling",
-        "coder",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:lambda/hermes-agent-reasoning-traces",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:15:06.000Z",
-      "lastModified": "2026-05-19T08:45:22.000Z"
-    },
-    {
-      "rank": 433,
+      "rank": 435,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -12723,7 +12774,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 434,
+      "rank": 436,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12748,11 +12799,11 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 435,
+      "rank": 437,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
-      "downloads": 150400,
+      "downloads": 151146,
       "likes": 482,
       "trendingScore": 12,
       "pipelineTag": "image-to-image",
@@ -12775,11 +12826,11 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 436,
+      "rank": 438,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
-      "downloads": 57,
+      "downloads": 204,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
@@ -12800,25 +12851,59 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 437,
-      "id": "netease-youdao/Confucius4",
-      "author": "netease-youdao",
-      "url": "https://huggingface.co/netease-youdao/Confucius4",
-      "downloads": 100,
-      "likes": 12,
+      "rank": 439,
+      "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
+      "author": "Phr00t",
+      "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
+      "downloads": 0,
+      "likes": 1575,
       "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "image-to-video",
+      "libraryName": "wan2.2",
       "tags": [
-        "safetensors",
-        "qwen3_5",
+        "wan2.2",
+        "wan",
+        "accelerator",
+        "image-to-video",
+        "base_model:Wan-AI/Wan2.2-I2V-A14B",
+        "base_model:finetune:Wan-AI/Wan2.2-I2V-A14B",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-19T10:13:40.000Z",
-      "lastModified": "2026-05-20T08:42:10.000Z"
+      "createdAt": "2025-07-30T16:39:44.000Z",
+      "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 438,
+      "rank": 440,
+      "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
+      "downloads": 590,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion_vlm",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "multimodal",
+        "vlm",
+        "diffusion-language-model",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T17:45:40.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
+    },
+    {
+      "rank": 441,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -12863,7 +12948,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 439,
+      "rank": 442,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -12905,7 +12990,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 440,
+      "rank": 443,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -12931,7 +13016,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 441,
+      "rank": 444,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -12956,7 +13041,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 442,
+      "rank": 445,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -12973,7 +13058,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 443,
+      "rank": 446,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -13001,7 +13086,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 444,
+      "rank": 447,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -13027,7 +13112,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 445,
+      "rank": 448,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -13054,7 +13139,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 446,
+      "rank": 449,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -13082,7 +13167,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 447,
+      "rank": 450,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -13115,7 +13200,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 448,
+      "rank": 451,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -13149,7 +13234,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 449,
+      "rank": 452,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -13178,7 +13263,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 450,
+      "rank": 453,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -13207,7 +13292,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 451,
+      "rank": 454,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -13240,7 +13325,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 452,
+      "rank": 455,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -13267,7 +13352,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 453,
+      "rank": 456,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -13297,30 +13382,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 454,
-      "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
-      "author": "Phr00t",
-      "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
-      "downloads": 0,
-      "likes": 1574,
-      "trendingScore": 11,
-      "pipelineTag": "image-to-video",
-      "libraryName": "wan2.2",
-      "tags": [
-        "wan2.2",
-        "wan",
-        "accelerator",
-        "image-to-video",
-        "base_model:Wan-AI/Wan2.2-I2V-A14B",
-        "base_model:finetune:Wan-AI/Wan2.2-I2V-A14B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-07-30T16:39:44.000Z",
-      "lastModified": "2026-04-06T05:31:09.000Z"
-    },
-    {
-      "rank": 455,
+      "rank": 457,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -13346,7 +13408,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 456,
+      "rank": 458,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -13370,7 +13432,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 457,
+      "rank": 459,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -13397,12 +13459,12 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 458,
+      "rank": 460,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
-      "downloads": 1689850,
-      "likes": 4516,
+      "downloads": 1672972,
+      "likes": 4531,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -13420,14 +13482,14 @@
         "license:llama3",
         "text-generation-inference",
         "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
+        "region:us",
+        "deploy:azure"
       ],
       "createdAt": "2024-04-17T09:35:12.000Z",
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 459,
+      "rank": 461,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -13461,7 +13523,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 460,
+      "rank": 462,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -13477,7 +13539,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 461,
+      "rank": 463,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -13508,7 +13570,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 462,
+      "rank": 464,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -13530,7 +13592,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 463,
+      "rank": 465,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -13550,7 +13612,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 464,
+      "rank": 466,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -13572,7 +13634,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 465,
+      "rank": 467,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -13601,7 +13663,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 466,
+      "rank": 468,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -13626,7 +13688,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 467,
+      "rank": 469,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -13651,7 +13713,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 468,
+      "rank": 470,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -13686,7 +13748,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 469,
+      "rank": 471,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -13710,7 +13772,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 470,
+      "rank": 472,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -13741,7 +13803,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 471,
+      "rank": 473,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -13767,7 +13829,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 472,
+      "rank": 474,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -13797,11 +13859,11 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 473,
+      "rank": 475,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
-      "downloads": 4800,
+      "downloads": 5166,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -13823,7 +13885,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 474,
+      "rank": 476,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -13868,7 +13930,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 475,
+      "rank": 477,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -13895,11 +13957,11 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 476,
+      "rank": 478,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
-      "downloads": 244,
+      "downloads": 247,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-to-image",
@@ -13921,44 +13983,11 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 477,
-      "id": "FINAL-Bench/Darwin-28B-Coder",
-      "author": "FINAL-Bench",
-      "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
-      "downloads": 31,
-      "likes": 13,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "code",
-        "code-generation",
-        "function-calling",
-        "darwin",
-        "text-generation",
-        "conversational",
-        "en",
-        "ko",
-        "dataset:m-a-p/CodeFeedback-Filtered-Instruction",
-        "arxiv:2409.12186",
-        "arxiv:2406.11931",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T04:50:07.000Z",
-      "lastModified": "2026-05-20T04:57:31.000Z"
-    },
-    {
-      "rank": 478,
+      "rank": 479,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
-      "downloads": 65,
+      "downloads": 81,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-to-image",
@@ -13983,7 +14012,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 479,
+      "rank": 480,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -14010,7 +14039,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 480,
+      "rank": 481,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -14055,11 +14084,11 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 481,
+      "rank": 482,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
-      "downloads": 3847,
+      "downloads": 4038,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "image-text-to-text",
@@ -14081,7 +14110,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 482,
+      "rank": 483,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -14107,11 +14136,11 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 483,
+      "rank": 484,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
-      "downloads": 17502119,
+      "downloads": 17386984,
       "likes": 3255,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -14140,11 +14169,11 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 484,
+      "rank": 485,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
-      "downloads": 307,
+      "downloads": 337,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -14169,11 +14198,11 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 485,
+      "rank": 486,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
-      "downloads": 9252,
+      "downloads": 9229,
       "likes": 605,
       "trendingScore": 11,
       "pipelineTag": "text-to-video",
@@ -14194,11 +14223,11 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 486,
+      "rank": 487,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 8034700,
+      "downloads": 8119515,
       "likes": 1421,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -14232,40 +14261,11 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 487,
-      "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
-      "downloads": 359,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion_vlm",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "multimodal",
-        "vlm",
-        "diffusion-language-model",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T17:45:40.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
-    },
-    {
       "rank": 488,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
-      "downloads": 6295,
+      "downloads": 9489,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "image-text-to-text",
@@ -14293,7 +14293,7 @@
       "id": "SupraLabs/Supra-50M-Instruct",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
-      "downloads": 117,
+      "downloads": 537,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -14301,6 +14301,7 @@
       "tags": [
         "transformers",
         "safetensors",
+        "gguf",
         "llama",
         "text-generation",
         "supra",
@@ -14316,17 +14317,163 @@
         "dataset:HuggingFaceFW/fineweb-edu",
         "dataset:yahma/alpaca-cleaned",
         "base_model:SupraLabs/Supra-50M-Base",
-        "base_model:finetune:SupraLabs/Supra-50M-Base",
+        "base_model:quantized:SupraLabs/Supra-50M-Base",
         "license:apache-2.0",
         "text-generation-inference",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "conversational"
       ],
       "createdAt": "2026-05-21T12:06:17.000Z",
-      "lastModified": "2026-05-22T14:54:55.000Z"
+      "lastModified": "2026-05-23T08:10:17.000Z"
     },
     {
       "rank": 490,
+      "id": "ansulev/Darwin-9B-NEG",
+      "author": "ansulev",
+      "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
+      "downloads": 367447,
+      "likes": 13,
+      "trendingScore": 11,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "darwin",
+        "darwin-v8",
+        "darwin-neg",
+        "native-entropy-gating",
+        "NEG",
+        "reasoning",
+        "self-regulated-reasoning",
+        "advanced-reasoning",
+        "thinking",
+        "qwen3.5",
+        "qwen",
+        "gpqa",
+        "benchmark",
+        "open-source",
+        "apache-2.0",
+        "hybrid-vigor",
+        "proto-agi",
+        "vidraft",
+        "eval-results",
+        "text-generation",
+        "conversational",
+        "en",
+        "zh",
+        "ko",
+        "ja",
+        "multilingual"
+      ],
+      "createdAt": "2026-05-18T21:17:33.000Z",
+      "lastModified": "2026-05-18T21:17:34.000Z"
+    },
+    {
+      "rank": 491,
+      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
+      "downloads": 15385,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T13:16:15.000Z",
+      "lastModified": "2026-05-21T21:34:59.000Z"
+    },
+    {
+      "rank": 492,
+      "id": "microsoft/Lens-Base",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Base",
+      "downloads": 132,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:08:02.000Z",
+      "lastModified": "2026-05-22T03:10:01.000Z"
+    },
+    {
+      "rank": 493,
+      "id": "syvai/cohere-transcribe-diarize",
+      "author": "syvai",
+      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
+      "downloads": 92,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere_asr",
+        "automatic-speech-recognition",
+        "audio",
+        "speech-recognition",
+        "transcription",
+        "diarization",
+        "speaker-diarization",
+        "timestamps",
+        "custom_code",
+        "en",
+        "ar",
+        "de",
+        "el",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt",
+        "vi",
+        "zh",
+        "base_model:CohereLabs/cohere-transcribe-03-2026",
+        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T03:51:05.000Z",
+      "lastModified": "2026-05-22T20:56:30.000Z"
+    },
+    {
+      "rank": 494,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -14355,7 +14502,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 491,
+      "rank": 495,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -14389,7 +14536,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 492,
+      "rank": 496,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -14434,7 +14581,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 493,
+      "rank": 497,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -14463,7 +14610,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 494,
+      "rank": 498,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -14488,7 +14635,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 495,
+      "rank": 499,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -14523,7 +14670,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 496,
+      "rank": 500,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -14550,7 +14697,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 497,
+      "rank": 501,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -14595,7 +14742,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 498,
+      "rank": 502,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -14617,7 +14764,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 499,
+      "rank": 503,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -14649,7 +14796,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 500,
+      "rank": 504,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -14674,7 +14821,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 501,
+      "rank": 505,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -14698,7 +14845,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 502,
+      "rank": 506,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -14726,7 +14873,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 503,
+      "rank": 507,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -14769,7 +14916,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 504,
+      "rank": 508,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -14793,7 +14940,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 505,
+      "rank": 509,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -14838,7 +14985,7 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 506,
+      "rank": 510,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -14867,7 +15014,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 507,
+      "rank": 511,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -14899,7 +15046,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 508,
+      "rank": 512,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -14923,7 +15070,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 509,
+      "rank": 513,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -14945,7 +15092,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 510,
+      "rank": 514,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -14970,7 +15117,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 511,
+      "rank": 515,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -14998,7 +15145,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 512,
+      "rank": 516,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -15022,7 +15169,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 513,
+      "rank": 517,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -15049,12 +15196,12 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 514,
+      "rank": 518,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
-      "downloads": 360327,
-      "likes": 173,
+      "downloads": 163268,
+      "likes": 183,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -15074,7 +15221,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 515,
+      "rank": 519,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -15091,7 +15238,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 516,
+      "rank": 520,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -15115,7 +15262,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 517,
+      "rank": 521,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -15139,7 +15286,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 518,
+      "rank": 522,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -15172,7 +15319,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 519,
+      "rank": 523,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -15206,7 +15353,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 520,
+      "rank": 524,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -15228,7 +15375,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 521,
+      "rank": 525,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -15251,7 +15398,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 522,
+      "rank": 526,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -15271,7 +15418,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 523,
+      "rank": 527,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -15303,7 +15450,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 524,
+      "rank": 528,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -15342,7 +15489,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 525,
+      "rank": 529,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -15376,7 +15523,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 526,
+      "rank": 530,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -15400,7 +15547,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 527,
+      "rank": 531,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -15420,7 +15567,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 528,
+      "rank": 532,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -15449,7 +15596,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 529,
+      "rank": 533,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -15471,7 +15618,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 530,
+      "rank": 534,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -15503,7 +15650,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 531,
+      "rank": 535,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -15530,7 +15677,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 532,
+      "rank": 536,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -15574,7 +15721,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 533,
+      "rank": 537,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -15592,7 +15739,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 534,
+      "rank": 538,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -15631,7 +15778,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 535,
+      "rank": 539,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -15670,7 +15817,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 536,
+      "rank": 540,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -15704,7 +15851,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 537,
+      "rank": 541,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -15732,7 +15879,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 538,
+      "rank": 542,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -15754,7 +15901,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 539,
+      "rank": 543,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -15782,7 +15929,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 540,
+      "rank": 544,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -15800,7 +15947,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 541,
+      "rank": 545,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -15828,7 +15975,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 542,
+      "rank": 546,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -15859,7 +16006,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 543,
+      "rank": 547,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -15875,11 +16022,11 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 544,
+      "rank": 548,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
-      "downloads": 190,
+      "downloads": 233,
       "likes": 13,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -15902,7 +16049,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 545,
+      "rank": 549,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -15931,7 +16078,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 546,
+      "rank": 550,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -15959,7 +16106,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 547,
+      "rank": 551,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -15988,11 +16135,11 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 548,
+      "rank": 552,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
-      "downloads": 5227,
+      "downloads": 5864,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -16009,7 +16156,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 549,
+      "rank": 553,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -16030,11 +16177,11 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 550,
+      "rank": 554,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "downloads": 62,
+      "downloads": 120,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -16057,52 +16204,7 @@
       "lastModified": "2026-05-21T02:10:38.000Z"
     },
     {
-      "rank": 551,
-      "id": "ansulev/Darwin-9B-NEG",
-      "author": "ansulev",
-      "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
-      "downloads": 351605,
-      "likes": 12,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "darwin",
-        "darwin-v8",
-        "darwin-neg",
-        "native-entropy-gating",
-        "NEG",
-        "reasoning",
-        "self-regulated-reasoning",
-        "advanced-reasoning",
-        "thinking",
-        "qwen3.5",
-        "qwen",
-        "gpqa",
-        "benchmark",
-        "open-source",
-        "apache-2.0",
-        "hybrid-vigor",
-        "proto-agi",
-        "vidraft",
-        "eval-results",
-        "text-generation",
-        "conversational",
-        "en",
-        "zh",
-        "ko",
-        "ja",
-        "multilingual"
-      ],
-      "createdAt": "2026-05-18T21:17:33.000Z",
-      "lastModified": "2026-05-18T21:17:34.000Z"
-    },
-    {
-      "rank": 552,
+      "rank": 555,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -16131,11 +16233,11 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 553,
+      "rank": 556,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "downloads": 9155,
+      "downloads": 9174,
       "likes": 155,
       "trendingScore": 10,
       "pipelineTag": "text-to-image",
@@ -16151,43 +16253,11 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 554,
-      "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
-      "downloads": 13986,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "base_model:quantized:Jackrong/Qwopus3.6-35B-A3B-v1",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T13:16:15.000Z",
-      "lastModified": "2026-05-21T21:34:59.000Z"
-    },
-    {
-      "rank": 555,
+      "rank": 557,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
-      "downloads": 2131769,
+      "downloads": 2098174,
       "likes": 2141,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -16221,7 +16291,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 556,
+      "rank": 558,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -16251,11 +16321,11 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 557,
+      "rank": 559,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
-      "downloads": 6439,
+      "downloads": 6287,
       "likes": 209,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -16294,11 +16364,11 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 558,
+      "rank": 560,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "downloads": 1038,
+      "downloads": 1142,
       "likes": 32,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -16323,11 +16393,11 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 559,
+      "rank": 561,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13224,
+      "downloads": 13389,
       "likes": 520,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -16350,12 +16420,12 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 560,
+      "rank": 562,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
-      "downloads": 1962065,
-      "likes": 2395,
+      "downloads": 1997493,
+      "likes": 2396,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -16387,30 +16457,31 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 561,
-      "id": "microsoft/Lens-Base",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Base",
-      "downloads": 71,
+      "rank": 563,
+      "id": "HiveLabsAI/hivemind-32b-preview",
+      "author": "HiveLabsAI",
+      "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
+      "downloads": 516,
       "likes": 10,
       "trendingScore": 10,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": null,
+      "libraryName": null,
       "tags": [
-        "diffusers",
         "safetensors",
-        "text-to-image",
+        "qwen3",
+        "emotional-intelligence",
+        "conversational",
         "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
+        "base_model:Qwen/Qwen3-32B",
+        "base_model:finetune:Qwen/Qwen3-32B",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-15T06:08:02.000Z",
-      "lastModified": "2026-05-22T03:10:01.000Z"
+      "createdAt": "2026-04-03T20:46:53.000Z",
+      "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 562,
+      "rank": 564,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -16437,7 +16508,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 563,
+      "rank": 565,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -16463,7 +16534,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 564,
+      "rank": 566,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -16491,7 +16562,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 565,
+      "rank": 567,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -16517,12 +16588,12 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 566,
+      "rank": 568,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
-      "downloads": 261063,
-      "likes": 946,
+      "downloads": 304575,
+      "likes": 950,
       "trendingScore": 9,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
@@ -16561,7 +16632,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 567,
+      "rank": 569,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -16601,7 +16672,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 568,
+      "rank": 570,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -16637,7 +16708,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 569,
+      "rank": 571,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -16681,7 +16752,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 570,
+      "rank": 572,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -16706,7 +16777,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 571,
+      "rank": 573,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -16751,7 +16822,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 572,
+      "rank": 574,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -16770,7 +16841,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 573,
+      "rank": 575,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -16795,7 +16866,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 574,
+      "rank": 576,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -16834,7 +16905,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 575,
+      "rank": 577,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -16851,7 +16922,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 576,
+      "rank": 578,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -16879,7 +16950,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 577,
+      "rank": 579,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -16908,7 +16979,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 578,
+      "rank": 580,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -16933,7 +17004,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 579,
+      "rank": 581,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -16968,7 +17039,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 580,
+      "rank": 582,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -16998,7 +17069,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 581,
+      "rank": 583,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -17034,7 +17105,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 582,
+      "rank": 584,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -17057,7 +17128,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 583,
+      "rank": 585,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -17074,7 +17145,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 584,
+      "rank": 586,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -17094,7 +17165,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 585,
+      "rank": 587,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -17121,7 +17192,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 586,
+      "rank": 588,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -17145,7 +17216,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 587,
+      "rank": 589,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -17167,7 +17238,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 588,
+      "rank": 590,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -17199,7 +17270,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 589,
+      "rank": 591,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -17227,7 +17298,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 590,
+      "rank": 592,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -17245,7 +17316,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 591,
+      "rank": 593,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -17270,7 +17341,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 592,
+      "rank": 594,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -17293,7 +17364,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 593,
+      "rank": 595,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -17311,7 +17382,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 594,
+      "rank": 596,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -17346,7 +17417,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 595,
+      "rank": 597,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -17374,7 +17445,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 596,
+      "rank": 598,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -17396,7 +17467,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 597,
+      "rank": 599,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -17423,7 +17494,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 598,
+      "rank": 600,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -17448,7 +17519,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 599,
+      "rank": 601,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -17482,7 +17553,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 600,
+      "rank": 602,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -17509,7 +17580,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 601,
+      "rank": 603,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -17536,7 +17607,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 602,
+      "rank": 604,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -17577,7 +17648,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 603,
+      "rank": 605,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -17607,7 +17678,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 604,
+      "rank": 606,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -17644,7 +17715,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 605,
+      "rank": 607,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -17676,7 +17747,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 606,
+      "rank": 608,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -17718,7 +17789,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 607,
+      "rank": 609,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -17748,7 +17819,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 608,
+      "rank": 610,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -17793,7 +17864,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 609,
+      "rank": 611,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -17820,7 +17891,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 610,
+      "rank": 612,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -17852,7 +17923,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 611,
+      "rank": 613,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -17886,7 +17957,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 612,
+      "rank": 614,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -17916,7 +17987,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 613,
+      "rank": 615,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -17941,11 +18012,11 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 614,
+      "rank": 616,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
-      "downloads": 1536548,
+      "downloads": 1512305,
       "likes": 2793,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -17968,7 +18039,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 615,
+      "rank": 617,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -18000,7 +18071,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 616,
+      "rank": 618,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -18045,11 +18116,11 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 617,
+      "rank": 619,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
-      "downloads": 3252554,
+      "downloads": 3222628,
       "likes": 3146,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -18073,11 +18144,11 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 618,
+      "rank": 620,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "downloads": 1389639,
+      "downloads": 1328411,
       "likes": 857,
       "trendingScore": 9,
       "pipelineTag": "automatic-speech-recognition",
@@ -18112,11 +18183,11 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 619,
+      "rank": 621,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
-      "downloads": 4474,
+      "downloads": 4827,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -18138,7 +18209,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 620,
+      "rank": 622,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -18167,7 +18238,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 621,
+      "rank": 623,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -18209,7 +18280,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 622,
+      "rank": 624,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -18237,11 +18308,11 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 623,
+      "rank": 625,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
-      "downloads": 8173,
+      "downloads": 14249,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -18267,11 +18338,11 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 624,
+      "rank": 626,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
-      "downloads": 4779,
+      "downloads": 5508,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -18302,7 +18373,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 625,
+      "rank": 627,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -18331,12 +18402,12 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 626,
+      "rank": 628,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
-      "downloads": 19630,
-      "likes": 31,
+      "downloads": 20189,
+      "likes": 32,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -18361,11 +18432,11 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 627,
+      "rank": 629,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
-      "downloads": 1174838,
+      "downloads": 971087,
       "likes": 413,
       "trendingScore": 9,
       "pipelineTag": "sentence-similarity",
@@ -18391,7 +18462,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 628,
+      "rank": 630,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -18418,7 +18489,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 629,
+      "rank": 631,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -18447,7 +18518,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 630,
+      "rank": 632,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -18472,31 +18543,114 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 631,
-      "id": "HiveLabsAI/hivemind-32b-preview",
-      "author": "HiveLabsAI",
-      "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
-      "downloads": 511,
-      "likes": 9,
+      "rank": 633,
+      "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
+      "author": "DavidAU",
+      "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
+      "downloads": 18192,
+      "likes": 141,
       "trendingScore": 9,
-      "pipelineTag": null,
+      "pipelineTag": "text-generation",
       "libraryName": null,
       "tags": [
-        "safetensors",
-        "qwen3",
-        "emotional-intelligence",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3-32B",
-        "base_model:finetune:Qwen/Qwen3-32B",
-        "license:other",
-        "region:us"
+        "gguf",
+        "gpt_oss",
+        "gpt-oss",
+        "openai",
+        "mxfp4",
+        "programming",
+        "code generation",
+        "code",
+        "coding",
+        "coder",
+        "chat",
+        "reasoning",
+        "thinking",
+        "r1",
+        "cot",
+        "deepseek",
+        "128k context",
+        "general usage",
+        "problem solving",
+        "brainstorming",
+        "solve riddles",
+        "uncensored",
+        "abliterated",
+        "Neo",
+        "MOE",
+        "Mixture of Experts",
+        "24 experts",
+        "NEO Imatrix",
+        "Imatrix",
+        "DI-Matrix"
       ],
-      "createdAt": "2026-04-03T20:46:53.000Z",
-      "lastModified": "2026-05-15T14:46:28.000Z"
+      "createdAt": "2025-11-17T05:52:55.000Z",
+      "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 632,
+      "rank": 634,
+      "id": "BAAI/bge-reranker-v2-m3",
+      "author": "BAAI",
+      "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
+      "downloads": 12520433,
+      "likes": 997,
+      "trendingScore": 9,
+      "pipelineTag": "text-classification",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "xlm-roberta",
+        "text-classification",
+        "transformers",
+        "text-embeddings-inference",
+        "multilingual",
+        "arxiv:2312.15503",
+        "arxiv:2402.03216",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-03-15T13:32:18.000Z",
+      "lastModified": "2024-06-24T14:08:45.000Z"
+    },
+    {
+      "rank": 635,
+      "id": "SupraLabs/Supra-50M-Base",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
+      "downloads": 235,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T05:00:44.000Z",
+      "lastModified": "2026-05-23T07:46:11.000Z"
+    },
+    {
+      "rank": 636,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -18523,7 +18677,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 633,
+      "rank": 637,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -18547,7 +18701,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 634,
+      "rank": 638,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -18567,7 +18721,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 635,
+      "rank": 639,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -18586,7 +18740,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 636,
+      "rank": 640,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -18620,7 +18774,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 637,
+      "rank": 641,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -18652,7 +18806,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 638,
+      "rank": 642,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -18674,7 +18828,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 639,
+      "rank": 643,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -18719,7 +18873,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 640,
+      "rank": 644,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -18738,7 +18892,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 641,
+      "rank": 645,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -18772,7 +18926,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 642,
+      "rank": 646,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -18800,7 +18954,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 643,
+      "rank": 647,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -18828,7 +18982,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 644,
+      "rank": 648,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -18851,7 +19005,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 645,
+      "rank": 649,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -18878,7 +19032,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 646,
+      "rank": 650,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -18923,7 +19077,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 647,
+      "rank": 651,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -18959,7 +19113,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 648,
+      "rank": 652,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -18999,7 +19153,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 649,
+      "rank": 653,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -19028,7 +19182,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 650,
+      "rank": 654,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -19056,7 +19210,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 651,
+      "rank": 655,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -19075,7 +19229,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 652,
+      "rank": 656,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -19094,7 +19248,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 653,
+      "rank": 657,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -19126,7 +19280,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 654,
+      "rank": 658,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -19153,7 +19307,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 655,
+      "rank": 659,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -19175,7 +19329,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 656,
+      "rank": 660,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -19193,7 +19347,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 657,
+      "rank": 661,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -19222,7 +19376,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 658,
+      "rank": 662,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -19243,7 +19397,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 659,
+      "rank": 663,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -19271,7 +19425,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 660,
+      "rank": 664,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -19292,7 +19446,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 661,
+      "rank": 665,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -19328,7 +19482,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 662,
+      "rank": 666,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -19373,7 +19527,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 663,
+      "rank": 667,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -19399,7 +19553,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 664,
+      "rank": 668,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -19422,7 +19576,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 665,
+      "rank": 669,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -19447,7 +19601,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 666,
+      "rank": 670,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -19482,7 +19636,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 667,
+      "rank": 671,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -19527,7 +19681,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 668,
+      "rank": 672,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -19554,7 +19708,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 669,
+      "rank": 673,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -19583,7 +19737,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 670,
+      "rank": 674,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -19602,7 +19756,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 671,
+      "rank": 675,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -19623,7 +19777,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 672,
+      "rank": 676,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -19649,7 +19803,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 673,
+      "rank": 677,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -19675,7 +19829,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 674,
+      "rank": 678,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -19712,7 +19866,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 675,
+      "rank": 679,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -19757,7 +19911,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 676,
+      "rank": 680,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -19782,7 +19936,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 677,
+      "rank": 681,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -19799,7 +19953,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 678,
+      "rank": 682,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -19826,7 +19980,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 679,
+      "rank": 683,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -19844,7 +19998,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 680,
+      "rank": 684,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -19869,7 +20023,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 681,
+      "rank": 685,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -19901,7 +20055,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 682,
+      "rank": 686,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -19922,7 +20076,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 683,
+      "rank": 687,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -19941,7 +20095,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 684,
+      "rank": 688,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -19972,7 +20126,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 685,
+      "rank": 689,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -19995,7 +20149,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 686,
+      "rank": 690,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -20012,7 +20166,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 687,
+      "rank": 691,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -20040,7 +20194,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 688,
+      "rank": 692,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -20057,7 +20211,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 689,
+      "rank": 693,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -20093,7 +20247,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 690,
+      "rank": 694,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -20123,7 +20277,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 691,
+      "rank": 695,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -20146,7 +20300,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 692,
+      "rank": 696,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -20179,7 +20333,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 693,
+      "rank": 697,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -20210,7 +20364,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 694,
+      "rank": 698,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -20233,7 +20387,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 695,
+      "rank": 699,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -20266,7 +20420,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 696,
+      "rank": 700,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -20289,7 +20443,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 697,
+      "rank": 701,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -20319,11 +20473,11 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 698,
+      "rank": 702,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
-      "downloads": 23352,
+      "downloads": 22235,
       "likes": 142,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -20346,7 +20500,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 699,
+      "rank": 703,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -20375,7 +20529,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 700,
+      "rank": 704,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -20404,7 +20558,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 701,
+      "rank": 705,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -20440,7 +20594,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 702,
+      "rank": 706,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -20463,7 +20617,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 703,
+      "rank": 707,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -20488,7 +20642,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 704,
+      "rank": 708,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -20518,7 +20672,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 705,
+      "rank": 709,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -20554,7 +20708,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 706,
+      "rank": 710,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -20591,7 +20745,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 707,
+      "rank": 711,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -20618,11 +20772,11 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 708,
+      "rank": 712,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
-      "downloads": 233,
+      "downloads": 544,
       "likes": 9,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -20651,52 +20805,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 709,
-      "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
-      "author": "DavidAU",
-      "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
-      "downloads": 17523,
-      "likes": 140,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "gpt_oss",
-        "gpt-oss",
-        "openai",
-        "mxfp4",
-        "programming",
-        "code generation",
-        "code",
-        "coding",
-        "coder",
-        "chat",
-        "reasoning",
-        "thinking",
-        "r1",
-        "cot",
-        "deepseek",
-        "128k context",
-        "general usage",
-        "problem solving",
-        "brainstorming",
-        "solve riddles",
-        "uncensored",
-        "abliterated",
-        "Neo",
-        "MOE",
-        "Mixture of Experts",
-        "24 experts",
-        "NEO Imatrix",
-        "Imatrix",
-        "DI-Matrix"
-      ],
-      "createdAt": "2025-11-17T05:52:55.000Z",
-      "lastModified": "2025-11-30T01:55:32.000Z"
-    },
-    {
-      "rank": 710,
+      "rank": 713,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -20721,7 +20830,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 711,
+      "rank": 714,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -20746,7 +20855,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 712,
+      "rank": 715,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -20783,7 +20892,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 713,
+      "rank": 716,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -20811,12 +20920,12 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 714,
+      "rank": 717,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
-      "downloads": 972996,
-      "likes": 2773,
+      "downloads": 962757,
+      "likes": 2774,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -20850,11 +20959,11 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 715,
+      "rank": 718,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
-      "downloads": 262599,
+      "downloads": 296378,
       "likes": 446,
       "trendingScore": 8,
       "pipelineTag": "image-to-image",
@@ -20879,11 +20988,11 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 716,
+      "rank": 719,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
-      "downloads": 503,
+      "downloads": 513,
       "likes": 2410,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -20899,11 +21008,11 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 717,
+      "rank": 720,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
-      "downloads": 90,
+      "downloads": 125,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -20915,11 +21024,11 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 718,
+      "rank": 721,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
-      "downloads": 14091,
+      "downloads": 14191,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -20941,39 +21050,11 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 719,
-      "id": "BAAI/bge-reranker-v2-m3",
-      "author": "BAAI",
-      "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
-      "downloads": 12380924,
-      "likes": 996,
-      "trendingScore": 8,
-      "pipelineTag": "text-classification",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "xlm-roberta",
-        "text-classification",
-        "transformers",
-        "text-embeddings-inference",
-        "multilingual",
-        "arxiv:2312.15503",
-        "arxiv:2402.03216",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-03-15T13:32:18.000Z",
-      "lastModified": "2024-06-24T14:08:45.000Z"
-    },
-    {
-      "rank": 720,
+      "rank": 722,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
-      "downloads": 3725,
+      "downloads": 3927,
       "likes": 10,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -21014,11 +21095,11 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 721,
+      "rank": 723,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
-      "downloads": 245,
+      "downloads": 293,
       "likes": 13,
       "trendingScore": 8,
       "pipelineTag": "other",
@@ -21047,11 +21128,11 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 722,
+      "rank": 724,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
-      "downloads": 12100,
+      "downloads": 16087,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -21079,11 +21160,11 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 723,
+      "rank": 725,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "downloads": 8504,
+      "downloads": 9515,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -21107,11 +21188,11 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 724,
-      "id": "SupraLabs/Supra-50M-Base",
-      "author": "SupraLabs",
-      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
-      "downloads": 40,
+      "rank": 726,
+      "id": "Kwai-Klear/GoLongRL-30B-A3B",
+      "author": "Kwai-Klear",
+      "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
+      "downloads": 141,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -21119,29 +21200,138 @@
       "tags": [
         "transformers",
         "safetensors",
-        "llama",
+        "qwen3_moe",
         "text-generation",
-        "supra",
-        "chimera",
-        "50m",
-        "small",
-        "open",
-        "open-source",
-        "cpu",
-        "tiny",
-        "slm",
+        "conversational",
+        "dataset:Kwai-Klear/GoLongRL",
+        "arxiv:2605.19577",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T13:45:22.000Z",
+      "lastModified": "2026-05-22T04:33:05.000Z"
+    },
+    {
+      "rank": 727,
+      "id": "meituan-longcat/LongCat-Video",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
+      "downloads": 1340,
+      "likes": 479,
+      "trendingScore": 8,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "transformers",
+        "image-to-video",
+        "video-continuation",
+        "text-to-video",
         "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
+        "zh",
+        "arxiv:2510.22200",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-10-24T16:04:08.000Z",
+      "lastModified": "2025-10-29T06:22:46.000Z"
+    },
+    {
+      "rank": 728,
+      "id": "tencent/Hy-MT2-30B-A3B-FP8",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
+      "downloads": 919,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "hy_v3",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-30B-A3B",
+        "base_model:quantized:tencent/Hy-MT2-30B-A3B",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T06:09:22.000Z",
+      "lastModified": "2026-05-22T05:16:00.000Z"
+    },
+    {
+      "rank": 729,
+      "id": "zemelee/qwen2.5-jailbreak",
+      "author": "zemelee",
+      "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
+      "downloads": 430,
+      "likes": 20,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "base_model:Qwen/Qwen2.5-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
         "license:apache-2.0",
         "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-21T05:00:44.000Z",
-      "lastModified": "2026-05-22T15:13:03.000Z"
+      "createdAt": "2025-05-08T06:14:45.000Z",
+      "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 725,
+      "rank": 730,
+      "id": "Jackrong/Qwopus3.6-27B-v2",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
+      "downloads": 278,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:20:50.000Z",
+      "lastModified": "2026-05-23T00:38:29.000Z"
+    },
+    {
+      "rank": 731,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -21167,12 +21357,12 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 726,
+      "rank": 732,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
       "downloads": 0,
-      "likes": 4055,
+      "likes": 4068,
       "trendingScore": 7,
       "pipelineTag": null,
       "libraryName": null,
@@ -21184,7 +21374,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 727,
+      "rank": 733,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -21212,7 +21402,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 728,
+      "rank": 734,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -21247,7 +21437,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 729,
+      "rank": 735,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -21272,7 +21462,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 730,
+      "rank": 736,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -21302,7 +21492,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 731,
+      "rank": 737,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -21331,7 +21521,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 732,
+      "rank": 738,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -21358,7 +21548,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 733,
+      "rank": 739,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -21384,7 +21574,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 734,
+      "rank": 740,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -21415,7 +21605,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 735,
+      "rank": 741,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -21433,7 +21623,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 736,
+      "rank": 742,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -21462,7 +21652,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 737,
+      "rank": 743,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -21485,7 +21675,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 738,
+      "rank": 744,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -21530,7 +21720,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 739,
+      "rank": 745,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -21556,7 +21746,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 740,
+      "rank": 746,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -21584,7 +21774,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 741,
+      "rank": 747,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -21622,7 +21812,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 742,
+      "rank": 748,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -21649,7 +21839,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 743,
+      "rank": 749,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -21675,7 +21865,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 744,
+      "rank": 750,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -21693,7 +21883,7 @@
       "lastModified": "2026-05-20T22:18:31.000Z"
     },
     {
-      "rank": 745,
+      "rank": 751,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -21719,7 +21909,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 746,
+      "rank": 752,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -21743,7 +21933,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 747,
+      "rank": 753,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -21784,7 +21974,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 748,
+      "rank": 754,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -21801,7 +21991,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 749,
+      "rank": 755,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -21834,7 +22024,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 750,
+      "rank": 756,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -21868,7 +22058,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 751,
+      "rank": 757,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -21907,7 +22097,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 752,
+      "rank": 758,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -21937,7 +22127,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 753,
+      "rank": 759,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -21973,7 +22163,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 754,
+      "rank": 760,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -21999,7 +22189,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 755,
+      "rank": 761,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -22035,7 +22225,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 756,
+      "rank": 762,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -22065,7 +22255,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 757,
+      "rank": 763,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -22103,7 +22293,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 758,
+      "rank": 764,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -22138,7 +22328,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 759,
+      "rank": 765,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -22163,7 +22353,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 760,
+      "rank": 766,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -22180,7 +22370,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 761,
+      "rank": 767,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -22222,7 +22412,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 762,
+      "rank": 768,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -22252,7 +22442,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 763,
+      "rank": 769,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -22277,7 +22467,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 764,
+      "rank": 770,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -22305,7 +22495,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 765,
+      "rank": 771,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -22322,7 +22512,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 766,
+      "rank": 772,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -22349,7 +22539,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 767,
+      "rank": 773,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -22392,7 +22582,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 768,
+      "rank": 774,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -22432,7 +22622,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 769,
+      "rank": 775,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -22456,7 +22646,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 770,
+      "rank": 776,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -22485,7 +22675,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 771,
+      "rank": 777,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -22511,7 +22701,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 772,
+      "rank": 778,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -22550,7 +22740,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 773,
+      "rank": 779,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -22574,7 +22764,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 774,
+      "rank": 780,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -22602,7 +22792,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 775,
+      "rank": 781,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -22634,7 +22824,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 776,
+      "rank": 782,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -22664,7 +22854,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 777,
+      "rank": 783,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -22693,7 +22883,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 778,
+      "rank": 784,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -22726,7 +22916,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 779,
+      "rank": 785,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -22755,7 +22945,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 780,
+      "rank": 786,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -22775,7 +22965,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 781,
+      "rank": 787,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -22799,7 +22989,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 782,
+      "rank": 788,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -22829,7 +23019,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 783,
+      "rank": 789,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -22859,7 +23049,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 784,
+      "rank": 790,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -22877,7 +23067,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 785,
+      "rank": 791,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -22894,7 +23084,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 786,
+      "rank": 792,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -22930,7 +23120,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 787,
+      "rank": 793,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -22961,7 +23151,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 788,
+      "rank": 794,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -22992,7 +23182,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 789,
+      "rank": 795,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -23025,7 +23215,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 790,
+      "rank": 796,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -23053,7 +23243,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 791,
+      "rank": 797,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -23078,7 +23268,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 792,
+      "rank": 798,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -23101,7 +23291,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 793,
+      "rank": 799,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -23129,7 +23319,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 794,
+      "rank": 800,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -23162,7 +23352,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 795,
+      "rank": 801,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -23192,7 +23382,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 796,
+      "rank": 802,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -23227,7 +23417,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 797,
+      "rank": 803,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -23259,7 +23449,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 798,
+      "rank": 804,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -23284,7 +23474,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 799,
+      "rank": 805,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -23307,7 +23497,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 800,
+      "rank": 806,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -23334,7 +23524,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 801,
+      "rank": 807,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -23357,7 +23547,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 802,
+      "rank": 808,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -23402,7 +23592,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 803,
+      "rank": 809,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -23434,7 +23624,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 804,
+      "rank": 810,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -23461,7 +23651,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 805,
+      "rank": 811,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -23487,7 +23677,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 806,
+      "rank": 812,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -23519,7 +23709,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 807,
+      "rank": 813,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -23548,7 +23738,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 808,
+      "rank": 814,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -23580,7 +23770,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 809,
+      "rank": 815,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -23610,7 +23800,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 810,
+      "rank": 816,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -23627,7 +23817,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 811,
+      "rank": 817,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -23647,7 +23837,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 812,
+      "rank": 818,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -23686,7 +23876,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 813,
+      "rank": 819,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -23724,7 +23914,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 814,
+      "rank": 820,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -23752,7 +23942,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 815,
+      "rank": 821,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -23797,7 +23987,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 816,
+      "rank": 822,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -23821,7 +24011,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 817,
+      "rank": 823,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -23851,7 +24041,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 818,
+      "rank": 824,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -23878,7 +24068,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 819,
+      "rank": 825,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -23904,7 +24094,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 820,
+      "rank": 826,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -23933,7 +24123,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 821,
+      "rank": 827,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -23951,7 +24141,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 822,
+      "rank": 828,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -23983,7 +24173,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 823,
+      "rank": 829,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -24010,7 +24200,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 824,
+      "rank": 830,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -24028,11 +24218,11 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 825,
+      "rank": 831,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
-      "downloads": 11723,
+      "downloads": 12270,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -24055,7 +24245,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 826,
+      "rank": 832,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -24079,11 +24269,11 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 827,
+      "rank": 833,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
-      "downloads": 16012,
+      "downloads": 16353,
       "likes": 9,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -24124,7 +24314,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 828,
+      "rank": 834,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -24155,11 +24345,11 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 829,
+      "rank": 835,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-      "downloads": 1158,
+      "downloads": 1184,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -24195,7 +24385,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 830,
+      "rank": 836,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -24220,11 +24410,11 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 831,
+      "rank": 837,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
-      "downloads": 111213,
+      "downloads": 115111,
       "likes": 169,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -24251,7 +24441,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 832,
+      "rank": 838,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -24285,7 +24475,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 833,
+      "rank": 839,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -24303,7 +24493,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 834,
+      "rank": 840,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -24348,36 +24538,11 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 835,
-      "id": "Kwai-Klear/GoLongRL-30B-A3B",
-      "author": "Kwai-Klear",
-      "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
-      "downloads": 92,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_moe",
-        "text-generation",
-        "conversational",
-        "dataset:Kwai-Klear/GoLongRL",
-        "arxiv:2605.19577",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T13:45:22.000Z",
-      "lastModified": "2026-05-22T04:33:05.000Z"
-    },
-    {
-      "rank": 836,
+      "rank": 841,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
-      "downloads": 281,
+      "downloads": 762,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -24400,11 +24565,11 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 837,
+      "rank": 842,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
-      "downloads": 992,
+      "downloads": 1008,
       "likes": 22,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
@@ -24441,7 +24606,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 838,
+      "rank": 843,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -24468,11 +24633,11 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 839,
+      "rank": 844,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
-      "downloads": 42,
+      "downloads": 50,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -24497,37 +24662,11 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 840,
-      "id": "meituan-longcat/LongCat-Video",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
-      "downloads": 1285,
-      "likes": 478,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "transformers",
-        "image-to-video",
-        "video-continuation",
-        "text-to-video",
-        "en",
-        "zh",
-        "arxiv:2510.22200",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2025-10-24T16:04:08.000Z",
-      "lastModified": "2025-10-29T06:22:46.000Z"
-    },
-    {
-      "rank": 841,
+      "rank": 845,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
-      "downloads": 531,
+      "downloads": 1194,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -24545,11 +24684,11 @@
       "lastModified": "2026-05-22T05:15:45.000Z"
     },
     {
-      "rank": 842,
+      "rank": 846,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
-      "downloads": 468,
+      "downloads": 800,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -24580,11 +24719,11 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 843,
+      "rank": 847,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 37038,
+      "downloads": 36949,
       "likes": 110,
       "trendingScore": 7,
       "pipelineTag": "image-to-video",
@@ -24606,106 +24745,13 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 844,
-      "id": "tencent/Hy-MT2-30B-A3B-FP8",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
-      "downloads": 401,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "hy_v3",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-30B-A3B",
-        "base_model:quantized:tencent/Hy-MT2-30B-A3B",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T06:09:22.000Z",
-      "lastModified": "2026-05-22T05:16:00.000Z"
-    },
-    {
-      "rank": 845,
-      "id": "zemelee/qwen2.5-jailbreak",
-      "author": "zemelee",
-      "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
-      "downloads": 406,
-      "likes": 19,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "conversational",
-        "base_model:Qwen/Qwen2.5-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-05-08T06:14:45.000Z",
-      "lastModified": "2025-05-08T06:56:32.000Z"
-    },
-    {
-      "rank": 846,
-      "id": "syvai/cohere-transcribe-diarize",
-      "author": "syvai",
-      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
-      "downloads": 29,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere_asr",
-        "automatic-speech-recognition",
-        "audio",
-        "speech-recognition",
-        "transcription",
-        "diarization",
-        "speaker-diarization",
-        "timestamps",
-        "custom_code",
-        "en",
-        "ar",
-        "de",
-        "el",
-        "es",
-        "fr",
-        "it",
-        "ja",
-        "ko",
-        "nl",
-        "pl",
-        "pt",
-        "vi",
-        "zh",
-        "base_model:CohereLabs/cohere-transcribe-03-2026",
-        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T03:51:05.000Z",
-      "lastModified": "2026-05-22T20:56:30.000Z"
-    },
-    {
-      "rank": 847,
+      "rank": 848,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
-      "downloads": 2531393,
-      "likes": 6543,
-      "trendingScore": 6,
+      "downloads": 2463393,
+      "likes": 6544,
+      "trendingScore": 7,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -24727,7 +24773,148 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 848,
+      "rank": 849,
+      "id": "Bingsu/adetailer",
+      "author": "Bingsu",
+      "url": "https://huggingface.co/Bingsu/adetailer",
+      "downloads": 15028784,
+      "likes": 703,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": "ultralytics",
+      "tags": [
+        "ultralytics",
+        "pytorch",
+        "dataset:wider_face",
+        "dataset:skytnt/anime-segmentation",
+        "doi:10.57967/hf/3633",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2023-04-26T00:58:45.000Z",
+      "lastModified": "2024-11-21T12:40:27.000Z"
+    },
+    {
+      "rank": 850,
+      "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
+      "downloads": 139163,
+      "likes": 254,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "code",
+        "codeqwen",
+        "chat",
+        "qwen",
+        "qwen-coder",
+        "text-generation",
+        "en",
+        "arxiv:2409.12186",
+        "arxiv:2407.10671",
+        "base_model:Qwen/Qwen2.5-Coder-7B-Instruct",
+        "base_model:quantized:Qwen/Qwen2.5-Coder-7B-Instruct",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2024-09-18T11:40:39.000Z",
+      "lastModified": "2024-11-12T07:59:32.000Z"
+    },
+    {
+      "rank": 851,
+      "id": "openbmb/BitCPM4-CANN-8B-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
+      "downloads": 256,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T06:18:55.000Z",
+      "lastModified": "2026-05-22T10:10:07.000Z"
+    },
+    {
+      "rank": 852,
+      "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
+      "author": "cyberneurova",
+      "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
+      "downloads": 0,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "any-to-any",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "abliterated",
+        "uncensored",
+        "lance",
+        "bytedance",
+        "multimodal",
+        "vision-language",
+        "text-to-image",
+        "text-to-video",
+        "vqa",
+        "research",
+        "transferability",
+        "any-to-any",
+        "en",
+        "base_model:bytedance-research/Lance",
+        "base_model:finetune:bytedance-research/Lance",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T10:33:00.000Z",
+      "lastModified": "2026-05-20T10:40:41.000Z"
+    },
+    {
+      "rank": 853,
+      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "downloads": 132,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "dataset:zerofata/Instruct-Anime",
+        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
+        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
+        "dataset:zerofata/Roleplay-Anime-Characters",
+        "base_model:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T00:40:03.000Z",
+      "lastModified": "2026-05-23T03:47:53.000Z"
+    },
+    {
+      "rank": 854,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -24760,7 +24947,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 849,
+      "rank": 855,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -24789,7 +24976,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 850,
+      "rank": 856,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -24834,7 +25021,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 851,
+      "rank": 857,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -24863,7 +25050,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 852,
+      "rank": 858,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -24908,12 +25095,12 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 853,
+      "rank": 859,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
-      "downloads": 1832194,
-      "likes": 101,
+      "downloads": 970820,
+      "likes": 103,
       "trendingScore": 6,
       "pipelineTag": "image-to-video",
       "libraryName": "diffusers",
@@ -24952,7 +25139,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 854,
+      "rank": 860,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -24978,7 +25165,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 855,
+      "rank": 861,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -25004,7 +25191,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 856,
+      "rank": 862,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -25036,7 +25223,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 857,
+      "rank": 863,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -25059,7 +25246,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 858,
+      "rank": 864,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -25102,7 +25289,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 859,
+      "rank": 865,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -25147,7 +25334,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 860,
+      "rank": 866,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -25192,7 +25379,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 861,
+      "rank": 867,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -25219,7 +25406,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 862,
+      "rank": 868,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -25246,7 +25433,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 863,
+      "rank": 869,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -25271,7 +25458,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 864,
+      "rank": 870,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -25310,7 +25497,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 865,
+      "rank": 871,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -25335,7 +25522,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 866,
+      "rank": 872,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -25363,7 +25550,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 867,
+      "rank": 873,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -25388,7 +25575,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 868,
+      "rank": 874,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -25404,7 +25591,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 869,
+      "rank": 875,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -25431,7 +25618,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 870,
+      "rank": 876,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -25463,7 +25650,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 871,
+      "rank": 877,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -25493,7 +25680,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 872,
+      "rank": 878,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -25525,7 +25712,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 873,
+      "rank": 879,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -25553,7 +25740,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 874,
+      "rank": 880,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -25579,7 +25766,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 875,
+      "rank": 881,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -25604,7 +25791,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 876,
+      "rank": 882,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -25633,7 +25820,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 877,
+      "rank": 883,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -25675,7 +25862,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 878,
+      "rank": 884,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -25702,7 +25889,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 879,
+      "rank": 885,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -25747,7 +25934,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 880,
+      "rank": 886,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -25773,7 +25960,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 881,
+      "rank": 887,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -25793,7 +25980,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 882,
+      "rank": 888,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -25820,7 +26007,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 883,
+      "rank": 889,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -25862,7 +26049,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 884,
+      "rank": 890,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -25889,7 +26076,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 885,
+      "rank": 891,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -25923,7 +26110,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 886,
+      "rank": 892,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -25952,7 +26139,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 887,
+      "rank": 893,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -25979,7 +26166,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 888,
+      "rank": 894,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -26006,7 +26193,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 889,
+      "rank": 895,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -26033,7 +26220,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 890,
+      "rank": 896,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -26061,7 +26248,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 891,
+      "rank": 897,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -26084,7 +26271,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 892,
+      "rank": 898,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -26115,7 +26302,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 893,
+      "rank": 899,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -26160,7 +26347,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 894,
+      "rank": 900,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -26182,7 +26369,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 895,
+      "rank": 901,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -26208,7 +26395,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 896,
+      "rank": 902,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -26239,7 +26426,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 897,
+      "rank": 903,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -26262,7 +26449,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 898,
+      "rank": 904,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -26292,7 +26479,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 899,
+      "rank": 905,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -26324,7 +26511,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 900,
+      "rank": 906,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -26353,7 +26540,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 901,
+      "rank": 907,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -26385,7 +26572,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 902,
+      "rank": 908,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -26417,7 +26604,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 903,
+      "rank": 909,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -26448,7 +26635,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 904,
+      "rank": 910,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -26479,7 +26666,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 905,
+      "rank": 911,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -26502,7 +26689,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 906,
+      "rank": 912,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -26529,7 +26716,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 907,
+      "rank": 913,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -26574,7 +26761,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 908,
+      "rank": 914,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -26592,7 +26779,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 909,
+      "rank": 915,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -26615,7 +26802,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 910,
+      "rank": 916,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -26645,7 +26832,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 911,
+      "rank": 917,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -26684,7 +26871,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 912,
+      "rank": 918,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -26722,7 +26909,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 913,
+      "rank": 919,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -26767,7 +26954,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 914,
+      "rank": 920,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -26792,11 +26979,11 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 915,
+      "rank": 921,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
-      "downloads": 305165,
+      "downloads": 316120,
       "likes": 960,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -26826,7 +27013,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 916,
+      "rank": 922,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -26851,7 +27038,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 917,
+      "rank": 923,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -26884,7 +27071,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 918,
+      "rank": 924,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -26911,7 +27098,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 919,
+      "rank": 925,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -26941,7 +27128,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 920,
+      "rank": 926,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -26973,7 +27160,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 921,
+      "rank": 927,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -27006,7 +27193,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 922,
+      "rank": 928,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -27024,7 +27211,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 923,
+      "rank": 929,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -27047,7 +27234,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 924,
+      "rank": 930,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -27079,7 +27266,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 925,
+      "rank": 931,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -27124,7 +27311,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 926,
+      "rank": 932,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -27163,7 +27350,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 927,
+      "rank": 933,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -27190,7 +27377,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 928,
+      "rank": 934,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -27227,7 +27414,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 929,
+      "rank": 935,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -27263,7 +27450,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 930,
+      "rank": 936,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -27281,7 +27468,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 931,
+      "rank": 937,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -27320,7 +27507,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 932,
+      "rank": 938,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -27349,7 +27536,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 933,
+      "rank": 939,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -27376,7 +27563,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 934,
+      "rank": 940,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -27403,7 +27590,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 935,
+      "rank": 941,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -27433,7 +27620,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 936,
+      "rank": 942,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -27460,7 +27647,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 937,
+      "rank": 943,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -27491,7 +27678,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 938,
+      "rank": 944,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -27510,7 +27697,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 939,
+      "rank": 945,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -27537,7 +27724,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 940,
+      "rank": 946,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -27562,7 +27749,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 941,
+      "rank": 947,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -27592,7 +27779,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 942,
+      "rank": 948,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -27614,7 +27801,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 943,
+      "rank": 949,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -27635,7 +27822,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 944,
+      "rank": 950,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -27671,7 +27858,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 945,
+      "rank": 951,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -27694,7 +27881,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 946,
+      "rank": 952,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -27739,29 +27926,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 947,
-      "id": "Bingsu/adetailer",
-      "author": "Bingsu",
-      "url": "https://huggingface.co/Bingsu/adetailer",
-      "downloads": 15072960,
-      "likes": 702,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": "ultralytics",
-      "tags": [
-        "ultralytics",
-        "pytorch",
-        "dataset:wider_face",
-        "dataset:skytnt/anime-segmentation",
-        "doi:10.57967/hf/3633",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2023-04-26T00:58:45.000Z",
-      "lastModified": "2024-11-21T12:40:27.000Z"
-    },
-    {
-      "rank": 948,
+      "rank": 953,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -27791,7 +27956,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 949,
+      "rank": 954,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -27816,7 +27981,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 950,
+      "rank": 955,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -27849,7 +28014,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 951,
+      "rank": 956,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -27872,7 +28037,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 952,
+      "rank": 957,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -27892,7 +28057,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 953,
+      "rank": 958,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -27937,7 +28102,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 954,
+      "rank": 959,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -27958,7 +28123,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 955,
+      "rank": 960,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -27991,7 +28156,7 @@
       "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 956,
+      "rank": 961,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -28019,7 +28184,7 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 957,
+      "rank": 962,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -28064,7 +28229,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 958,
+      "rank": 963,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -28089,7 +28254,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 959,
+      "rank": 964,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -28117,7 +28282,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 960,
+      "rank": 965,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
@@ -28148,7 +28313,7 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 961,
+      "rank": 966,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
@@ -28167,11 +28332,11 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 962,
+      "rank": 967,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
-      "downloads": 90168,
+      "downloads": 89184,
       "likes": 229,
       "trendingScore": 6,
       "pipelineTag": "image-to-image",
@@ -28193,11 +28358,11 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 963,
+      "rank": 968,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
-      "downloads": 2338693,
+      "downloads": 2335014,
       "likes": 408,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -28220,7 +28385,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 964,
+      "rank": 969,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
@@ -28252,7 +28417,7 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 965,
+      "rank": 970,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -28270,7 +28435,7 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 966,
+      "rank": 971,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -28293,7 +28458,7 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 967,
+      "rank": 972,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
@@ -28320,7 +28485,7 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 968,
+      "rank": 973,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
@@ -28352,7 +28517,7 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 969,
+      "rank": 974,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
@@ -28370,7 +28535,7 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 970,
+      "rank": 975,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
@@ -28403,7 +28568,7 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 971,
+      "rank": 976,
       "id": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
       "author": "Ttimofeyka",
       "url": "https://huggingface.co/Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
@@ -28428,11 +28593,11 @@
       "lastModified": "2024-02-10T11:41:00.000Z"
     },
     {
-      "rank": 972,
+      "rank": 977,
       "id": "HuggingFaceTB/SmolLM2-135M-Instruct",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct",
-      "downloads": 1549120,
+      "downloads": 1424602,
       "likes": 325,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -28459,7 +28624,7 @@
       "lastModified": "2025-09-22T20:43:15.000Z"
     },
     {
-      "rank": 973,
+      "rank": 978,
       "id": "mistralai/Ministral-3-8B-Instruct-2512-GGUF",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF",
@@ -28494,11 +28659,11 @@
       "lastModified": "2026-01-15T11:18:05.000Z"
     },
     {
-      "rank": 974,
+      "rank": 979,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
-      "downloads": 8349,
+      "downloads": 8508,
       "likes": 544,
       "trendingScore": 6,
       "pipelineTag": "automatic-speech-recognition",
@@ -28539,11 +28704,11 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 975,
+      "rank": 980,
       "id": "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
       "author": "hampsonw",
       "url": "https://huggingface.co/hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
-      "downloads": 14361,
+      "downloads": 16800,
       "likes": 15,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -28565,11 +28730,11 @@
       "lastModified": "2026-05-14T19:42:51.000Z"
     },
     {
-      "rank": 976,
+      "rank": 981,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
-      "downloads": 55,
+      "downloads": 65,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -28604,12 +28769,12 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 977,
+      "rank": 982,
       "id": "Qwen/QwQ-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/QwQ-32B",
-      "downloads": 63180,
-      "likes": 2917,
+      "downloads": 61994,
+      "likes": 2919,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -28635,11 +28800,11 @@
       "lastModified": "2025-03-11T12:15:48.000Z"
     },
     {
-      "rank": 978,
+      "rank": 983,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
-      "downloads": 849189,
+      "downloads": 865690,
       "likes": 1730,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -28663,7 +28828,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 979,
+      "rank": 984,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -28679,7 +28844,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 980,
+      "rank": 985,
       "id": "inclusionAI/ARGenSeg-8B",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/ARGenSeg-8B",
@@ -28699,7 +28864,7 @@
       "lastModified": "2026-05-15T02:36:20.000Z"
     },
     {
-      "rank": 981,
+      "rank": 986,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -28725,7 +28890,7 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 982,
+      "rank": 987,
       "id": "Wan-AI/Wan2.2-Animate-14B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B",
@@ -28749,7 +28914,7 @@
       "lastModified": "2025-11-05T10:15:40.000Z"
     },
     {
-      "rank": 983,
+      "rank": 988,
       "id": "dx8152/LTX2.3-Multifunctional",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/LTX2.3-Multifunctional",
@@ -28770,7 +28935,7 @@
       "lastModified": "2026-04-30T07:06:19.000Z"
     },
     {
-      "rank": 984,
+      "rank": 989,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -28788,43 +28953,11 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 985,
-      "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
-      "downloads": 139135,
-      "likes": 253,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "code",
-        "codeqwen",
-        "chat",
-        "qwen",
-        "qwen-coder",
-        "text-generation",
-        "en",
-        "arxiv:2409.12186",
-        "arxiv:2407.10671",
-        "base_model:Qwen/Qwen2.5-Coder-7B-Instruct",
-        "base_model:quantized:Qwen/Qwen2.5-Coder-7B-Instruct",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2024-09-18T11:40:39.000Z",
-      "lastModified": "2024-11-12T07:59:32.000Z"
-    },
-    {
-      "rank": 986,
+      "rank": 990,
       "id": "FINAL-Bench/Darwin-2B-Opus-LoRA",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-2B-Opus-LoRA",
-      "downloads": 21,
+      "downloads": 23,
       "likes": 9,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -28846,7 +28979,7 @@
       "lastModified": "2026-05-15T02:29:20.000Z"
     },
     {
-      "rank": 987,
+      "rank": 991,
       "id": "FINAL-Bench/Darwin-28B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Opus",
@@ -28891,11 +29024,11 @@
       "lastModified": "2026-05-15T02:27:32.000Z"
     },
     {
-      "rank": 988,
+      "rank": 992,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
-      "downloads": 321,
+      "downloads": 399,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "text-to-image",
@@ -28924,7 +29057,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 989,
+      "rank": 993,
       "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
       "author": "Baraje",
       "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
@@ -28947,11 +29080,11 @@
       "lastModified": "2026-04-22T06:19:53.000Z"
     },
     {
-      "rank": 990,
+      "rank": 994,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
-      "downloads": 949,
+      "downloads": 1316,
       "likes": 7,
       "trendingScore": 6,
       "pipelineTag": "text-ranking",
@@ -28982,7 +29115,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 991,
+      "rank": 995,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -29007,11 +29140,11 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 992,
+      "rank": 996,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
-      "downloads": 66,
+      "downloads": 72,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -29027,11 +29160,11 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 993,
+      "rank": 997,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
-      "downloads": 859,
+      "downloads": 1319,
       "likes": 6,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
@@ -29064,7 +29197,7 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 994,
+      "rank": 998,
       "id": "google/gemma-2-2b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-2-2b-it",
@@ -29109,11 +29242,11 @@
       "lastModified": "2024-08-27T19:41:44.000Z"
     },
     {
-      "rank": 995,
+      "rank": 999,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
-      "downloads": 10075457,
+      "downloads": 10556636,
       "likes": 463,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -29139,11 +29272,11 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 996,
+      "rank": 1000,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
-      "downloads": 514,
+      "downloads": 530,
       "likes": 176,
       "trendingScore": 6,
       "pipelineTag": "text-generation",
@@ -29167,107 +29300,6 @@
       ],
       "createdAt": "2025-09-29T06:09:17.000Z",
       "lastModified": "2026-01-05T17:19:35.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "facebook/lagernvs_general_512",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/lagernvs_general_512",
-      "downloads": 1884,
-      "likes": 25,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": "lagernvs",
-      "tags": [
-        "lagernvs",
-        "meta-ai",
-        "facebook",
-        "meta-pytorch",
-        "en",
-        "arxiv:2603.20176",
-        "license:fair-noncommercial-research-license",
-        "region:us"
-      ],
-      "createdAt": "2026-03-05T11:15:51.000Z",
-      "lastModified": "2026-05-21T15:22:11.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "Emanon14/Nameless-Anima",
-      "author": "Emanon14",
-      "url": "https://huggingface.co/Emanon14/Nameless-Anima",
-      "downloads": 0,
-      "likes": 15,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "text-to-image",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T06:02:43.000Z",
-      "lastModified": "2026-05-17T04:01:50.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "openbmb/BitCPM4-CANN-3B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-3B",
-      "downloads": 37,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "llama",
-        "text-generation",
-        "conversational",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T13:10:02.000Z",
-      "lastModified": "2026-05-22T10:04:55.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
-      "author": "canada-quant",
-      "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
-      "downloads": 7347,
-      "likes": 13,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": "vllm",
-      "tags": [
-        "vllm",
-        "safetensors",
-        "deepseek_v4",
-        "mixture-of-experts",
-        "moe",
-        "compressed-tensors",
-        "w4a16",
-        "gptq",
-        "fp8-block",
-        "deepseek",
-        "deepseek-v4",
-        "en",
-        "zh",
-        "base_model:deepseek-ai/DeepSeek-V4-Flash",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-04T06:15:20.000Z",
-      "lastModified": "2026-05-21T20:52:08.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26328171936

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.