### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-23T08:34:12Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-23T04:13:02.430Z",
+  "ts": "2026-05-23T08:34:12.287Z",
   "count": 1,
-  "durationMs": 2115,
+  "durationMs": 1915,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T04:13:00.317Z",
+  "fetchedAt": "2026-05-23T08:34:10.374Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -127,7 +127,7 @@
       "id": "GD-ML/TransitLM",
       "author": "GD-ML",
       "url": "https://huggingface.co/datasets/GD-ML/TransitLM",
-      "downloads": 570,
+      "downloads": 814,
       "likes": 72,
       "trendingScore": 70,
       "tags": [
@@ -225,7 +225,7 @@
       "id": "5CD-AI/Viet-Handwriting-OCR-v2",
       "author": "5CD-AI",
       "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
-      "downloads": 416,
+      "downloads": 477,
       "likes": 52,
       "trendingScore": 46,
       "tags": [
@@ -457,7 +457,7 @@
       "id": "actava/chi-bench",
       "author": "actava",
       "url": "https://huggingface.co/datasets/actava/chi-bench",
-      "downloads": 1362,
+      "downloads": 1500,
       "likes": 31,
       "trendingScore": 28,
       "tags": [
@@ -494,7 +494,7 @@
       "id": "wikimedia/structured-wikipedia",
       "author": "wikimedia",
       "url": "https://huggingface.co/datasets/wikimedia/structured-wikipedia",
-      "downloads": 2480,
+      "downloads": 2916,
       "likes": 131,
       "trendingScore": 28,
       "tags": [
@@ -1011,7 +1011,7 @@
       "id": "LukaDev13/Liminal-Dreamcore-1K",
       "author": "LukaDev13",
       "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
-      "downloads": 2378,
+      "downloads": 2481,
       "likes": 18,
       "trendingScore": 17,
       "tags": [
@@ -1032,7 +1032,7 @@
       "id": "HuggingFaceBio/carbon-pretraining-corpus",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/datasets/HuggingFaceBio/carbon-pretraining-corpus",
-      "downloads": 3168,
+      "downloads": 3825,
       "likes": 19,
       "trendingScore": 17,
       "tags": [
@@ -1060,7 +1060,7 @@
       "id": "zhifeixie/Voices-in-the-Wild-2M",
       "author": "zhifeixie",
       "url": "https://huggingface.co/datasets/zhifeixie/Voices-in-the-Wild-2M",
-      "downloads": 5095,
+      "downloads": 6214,
       "likes": 17,
       "trendingScore": 17,
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26328196382

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.