### PR TITLE
chore(data): refresh arxiv signals 2026-05-23T08:39:34Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-22T15:42:48.296Z",
+  "ts": "2026-05-23T08:39:30.653Z",
   "count": 1,
-  "durationMs": 63496,
+  "durationMs": 61999,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T15:42:48.351Z",
+  "fetchedAt": "2026-05-23T08:39:30.778Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -20,6 +20,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22820v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22819v1",
@@ -48,6 +55,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22814v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22812v1",
@@ -113,6 +127,13 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22779v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22777v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -169,6 +190,13 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22765v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22763v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -181,6 +209,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22756v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22751v1",
@@ -204,6 +239,27 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22746v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
+      "arxivId": "2605.22743v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
+      "arxivId": "2605.22740v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22738v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -216,6 +272,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22736v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22734v1",
@@ -246,6 +309,13 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22724v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22723v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -258,6 +328,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22719v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22718v1",
@@ -316,6 +393,13 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22703v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22697v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -335,6 +419,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22691v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
+      "arxivId": "2605.22684v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22681v1",
@@ -393,6 +491,13 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22666v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22664v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -428,6 +533,13 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22653v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22651v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -454,6 +566,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22644v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22643v1",
@@ -505,6 +624,20 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22622v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
+      "arxivId": "2605.22621v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22620v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -526,11 +659,25 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
+      "arxivId": "2605.22613v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
       "arxivId": "2605.22612v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22611v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22608v1",
@@ -573,6 +720,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+    },
+    {
+      "arxivId": "2605.22596v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
+      "arxivId": "2605.22593v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22591v1",
@@ -937,167 +1098,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22820v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22814v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22779v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22765v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22756v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22746v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22743v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22740v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22736v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22724v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22719v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22703v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22691v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22684v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22666v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22653v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22644v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22622v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22621v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22613v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22611v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22596v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22593v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-22T15:41:44.820Z",
+  "fetchedAt": "2026-05-23T08:38:28.674Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26328281036

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.