### PR TITLE
chore(data): refresh lobsters signals 2026-05-23T09:24:29Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-23T07:18:40.315Z",
+  "ts": "2026-05-23T09:24:29.278Z",
   "count": 1,
-  "durationMs": 4462,
+  "durationMs": 3506,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T07:18:35.874Z",
+  "fetchedAt": "2026-05-23T09:24:25.793Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 76,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T07:18:35.874Z",
+  "fetchedAt": "2026-05-23T09:24:25.793Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 76,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -338,6 +338,23 @@
       "tags": [
         "hardware",
         "law"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "ztam3w",
+      "title": "Don't Roll Your Own …",
+      "url": "https://susam.net/do-not-roll-your-own.html",
+      "commentsUrl": "https://lobste.rs/s/ztam3w/don_t_roll_your_own",
+      "by": "",
+      "score": 10,
+      "commentCount": 2,
+      "createdUtc": 1779522267,
+      "ageHours": 1.666111111111111,
+      "trendingScore": 1.4245954899844984,
+      "tags": [
+        "web"
       ],
       "description": "",
       "linkedRepos": []
@@ -877,23 +894,6 @@
       "trendingScore": 0.9561045356564685,
       "tags": [
         "linux"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "4g74mw",
-      "title": "Ascetic Computing",
-      "url": "https://ratfactor.com/ascetic-computing",
-      "commentsUrl": "https://lobste.rs/s/4g74mw/ascetic_computing",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1778924751,
-      "ageHours": 1.0380555555555555,
-      "trendingScore": 0.9442270488541592,
-      "tags": [
-        "practices"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26329156505

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.