### PR TITLE
chore(data): refresh lobsters signals 2026-05-23T10:57:08Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-23T09:24:29.278Z",
+  "ts": "2026-05-23T10:57:08.230Z",
   "count": 1,
-  "durationMs": 3506,
+  "durationMs": 3063,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T09:24:25.793Z",
+  "fetchedAt": "2026-05-23T10:57:05.189Z",
   "windowDays": 7,
-  "scannedStories": 76,
+  "scannedStories": 75,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T09:24:25.793Z",
+  "fetchedAt": "2026-05-23T10:57:05.189Z",
   "windowHours": 72,
-  "scannedTotal": 76,
+  "scannedTotal": 75,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -348,11 +348,11 @@
       "url": "https://susam.net/do-not-roll-your-own.html",
       "commentsUrl": "https://lobste.rs/s/ztam3w/don_t_roll_your_own",
       "by": "",
-      "score": 10,
-      "commentCount": 2,
+      "score": 18,
+      "commentCount": 17,
       "createdUtc": 1779522267,
-      "ageHours": 1.666111111111111,
-      "trendingScore": 1.4245954899844984,
+      "ageHours": 3.2105555555555556,
+      "trendingScore": 1.5133746638996892,
       "tags": [
         "web"
       ],


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26330860022

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.