### PR TITLE
feat(funding): +12 free-tier RSS sources (Crunchbase News, TC funding sub-tags, Term Sheet, YC blog, ...)

### DIFF
--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: '22'
       - run: npm ci
-      - run: npm run scrape:funding -- --sources ${{ github.event.inputs.sources || 'techcrunch,venturebeat,sifted,arstechnica,techeu,pymnts,bbc,wired,geekwire,eu-startups,siliconcanals,techstartups,techcrunch-ai,venturebeat-ai,ai-news,ai-business,the-decoder,marktechpost,unite-ai,analytics-india,mit-tech-review-ai,synced,prnewswire-vc,newcomer,ai-snake-oil,generative-value,import-ai' }} --enrich ${{ github.event.inputs.dry_run == 'true' && '--output .tmp/funding-preview.json' || '' }}
+      - run: npm run scrape:funding -- --sources ${{ github.event.inputs.sources || 'techcrunch,venturebeat,sifted,arstechnica,techeu,pymnts,bbc,wired,geekwire,eu-startups,siliconcanals,techstartups,techcrunch-ai,venturebeat-ai,ai-news,ai-business,the-decoder,marktechpost,unite-ai,analytics-india,mit-tech-review-ai,synced,prnewswire-vc,newcomer,ai-snake-oil,generative-value,import-ai,crunchbase-news,tc-venture,tc-fundraising,tc-seed,tc-series-a,term-sheet,tech-funding-news,alleywatch,yc-blog,vb-business,vb-enterprise,e27' }} --enrich ${{ github.event.inputs.dry_run == 'true' && '--output .tmp/funding-preview.json' || '' }}
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
           # Dual-write to TOOLBOX signal lake (funding.startup + GitHub

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -78,6 +78,22 @@ const RSS_FEEDS = {
   "ai-snake-oil": "https://www.normaltech.ai/feed",
   "generative-value": "https://www.generativevalue.com/feed",
   "import-ai": "https://importai.substack.com/feed",
+  // Wave-4 (2026-05-23): funding-dense sources. Every item from these feeds
+  // is funding/VC by category, so they're added to AI_TAGGED_SOURCES below
+  // to skip the AI-keyword gate (the page covers AI + tech, not AI-only).
+  "crunchbase-news": "https://news.crunchbase.com/feed/",
+  "tc-venture": "https://techcrunch.com/category/venture/feed/",
+  "tc-fundraising": "https://techcrunch.com/category/fundraising/feed/",
+  "tc-seed": "https://techcrunch.com/tag/seed-funding/feed/",
+  "tc-series-a": "https://techcrunch.com/tag/series-a/feed/",
+  "term-sheet": "https://termsheet.substack.com/feed",
+  "tech-funding-news": "https://techfundingnews.com/feed",
+  "alleywatch": "https://www.alleywatch.com/feed/",
+  "yc-blog": "https://www.ycombinator.com/blog/rss",
+  // Wave-4 (2026-05-23): tech-business category feeds (AI gate still applies).
+  "vb-business": "https://venturebeat.com/category/business/feed/",
+  "vb-enterprise": "https://venturebeat.com/category/enterprise/feed/",
+  e27: "https://e27.co/feed/",
 };
 
 // AI-tagged sources skip the AI-keyword gate (publisher already classified).
@@ -96,6 +112,17 @@ const AI_TAGGED_SOURCES = new Set([
   "ai-snake-oil",
   "generative-value",
   "import-ai",
+  // Wave-4 (2026-05-23): funding-native — every item is funding/VC by
+  // category. Skip the AI gate so non-AI rounds also surface on /funding.
+  "crunchbase-news",
+  "tc-venture",
+  "tc-fundraising",
+  "tc-seed",
+  "tc-series-a",
+  "term-sheet",
+  "tech-funding-news",
+  "alleywatch",
+  "yc-blog",
 ]);
 
 // AI-funding-only mode: non-AI-tagged feeds must show an AI marker in


### PR DESCRIPTION
## Summary

Adds **12 new free-tier RSS sources** to the funding scraper (`scripts/scrape-funding-news.mjs`) to fatten `https://trendingrepo.com/funding`. The previous version listed 27 sources in the cron default; this raises it to 39.

The current `/funding` page reads only ~3 rounds in 7 days (header reports `13 of 38 SOURCES UP`) — not because the cron is broken (it ran successfully every 2h up to today), but because **source coverage is genuinely thin** and the AI-keyword gate filters out non-AI funding rounds even from funding-by-definition sources.

## What's new

**Funding-native** (added to `AI_TAGGED_SOURCES` to skip the AI gate — every item is a funding/VC announcement by category):

| Slug | URL | Why |
|---|---|---|
| `crunchbase-news` | `news.crunchbase.com/feed/` | Top funding news site |
| `tc-venture` | `techcrunch.com/category/venture/feed/` | TC venture category |
| `tc-fundraising` | `techcrunch.com/category/fundraising/feed/` | TC fundraising category |
| `tc-seed` | `techcrunch.com/tag/seed-funding/feed/` | TC seed tag |
| `tc-series-a` | `techcrunch.com/tag/series-a/feed/` | TC Series A tag |
| `term-sheet` | `termsheet.substack.com/feed` | Daily VC briefing |
| `tech-funding-news` | `techfundingnews.com/feed` | Funding by name |
| `alleywatch` | `alleywatch.com/feed/` | NYC startup funding |
| `yc-blog` | `ycombinator.com/blog/rss` | YC batch announcements |

**General business/tech** (AI gate still applies):

| Slug | URL |
|---|---|
| `vb-business` | `venturebeat.com/category/business/feed/` |
| `vb-enterprise` | `venturebeat.com/category/enterprise/feed/` |
| `e27` | `e27.co/feed/` |

## Why these?

- All free-tier — no API key, no quota
- All verified **200 OK** with the script's `TrendingRepoBot/1.0` UA (a 403/404 sweep eliminated `finsmes`, `fastcompany`, `axios-pro-rata`, others — those need different fetch strategies and are deferred)
- Funding-native sources skip the AI keyword filter, so non-AI rounds (deep-tech, climate, defense, fintech) also surface on `/funding`. The page is "Capital flows for AI + tech", not "AI-only"
- TC sub-tags (venture/fundraising/seed/series-a) are highest density — every TC article in those tags is by definition a funding round

## TOOLBOX dual-write — already wired

`scripts/_toolbox-ingest.mjs` already writes funding events to TOOLBOX as `signal_type: "funding.startup"`. New sources land in `tb_signals` automatically, no TOOLBOX-side changes needed.

## Deferred (out of scope for this PR)

| Source | Status | Reason |
|---|---|---|
| Wellfound (AngelList) | deferred | No public RSS; would need stealth browser |
| Tracxn | skip | Paid only |
| PitchBook | skip | Paid only |
| The Information | skip | Paywall, no public RSS |
| Telegram VC channels | deferred | Needs `TELEGRAM_BOT_TOKEN` (Mirko-side) |
| `finsmes`, `axios-pro-rata`, `fastcompany` | deferred | 403/blocked even with right UA |
| Reddit/Apify quota cascade | separate session | Tracked in `project_reddit_apify_pivot` memory |

## Test plan

- [x] `node --check scripts/scrape-funding-news.mjs` → exit 0 (syntax)
- [x] Cron yml default sources list = 39 (was 27)
- [x] All 12 new RSS endpoints return 200 OK with script UA (probed locally)
- [ ] After merge: workflow_dispatch run of `Collect Funding Signals` to seed Redis with first batch of new-source items
- [ ] After first scheduled cron tick (next `0 */2 * * *`): page reload of `https://trendingrepo.com/funding` should show >5 rounds in 7d + new publisher pills + populated sector heatmap

## Verification commands

```bash
# Trigger fresh fetch immediately after merge
gh workflow run collect-funding.yml -R 0motionguy/starscreener

# Then check TOOLBOX signal-lake row count for funding.startup
ssh -i ~/.ssh/AndyAikey.pem root@193.53.40.118 \
  'docker exec toolbox-postgres-1 psql -U toolbox -d toolbox -tA -c \
   "SELECT count(*) FROM tb_signals WHERE signal_type = '\''funding.startup'\'' AND created_at > now() - interval '\''2 hours'\''"'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)