### PR TITLE
fix(funding): bump mergeAndKeepLastN keepN 50 -> 250

### DIFF
--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -796,7 +796,10 @@ async function main() {
     mergedSignals = mergeAndKeepLastN(existingSignals, allSignals, {
       idKey: "id",
       scoreKey: "publishedAt",
-      keepN: 50,
+      // 250 = ~6-7 items per source at 39 sources. Was 50 (only top scorers),
+      // which crowded out lower-volume sources like crunchbase-news / yc-blog
+      // and prevented their items from reaching TOOLBOX dual-write.
+      keepN: 250,
     });
   }
 


### PR DESCRIPTION
## Summary

Bumps the funding scraper's signal cap from 50 -> 250 so the 12 new sources added in #2351 (crunchbase-news, tc-venture, tc-fundraising, tc-seed, tc-series-a, term-sheet, tech-funding-news, alleywatch, yc-blog, vb-business, vb-enterprise, e27) actually land in `data/funding-news.json` and the TOOLBOX dual-write.

## Why

After #2351 merged + a workflow_dispatch run (`26331600604` at 11:34Z), the scraper successfully **fetched items from all 12 new sources** (e.g. crunchbase-news: 10 items, tc-fundraising: 20, yc-blog: 15). But `data/funding-news.json` on the PR branch `data/collect-funding-signals-26331600604-1` shows only 13 sources represented — same 13 as before. None of the new 12 made it through.

Root cause: `mergeAndKeepLastN(existingSignals, allSignals, { keepN: 50 })` at line 796. With 39 sources crawling, the top 50 by `publishedAt` desc get kept, the long tail of lower-volume sources gets dropped. The TOOLBOX dual-write at line 829 sends the **capped** `mergedSignals` array, so the new sources never reach `tb_signals.funding.startup` either.

Verified: tb_signals query for `produced_at > '2026-05-23 11:20:00 UTC' AND key = 'source_platform'` returned only the original 13 sources, despite 100+ funding signals landing in that window.

## Choice of 250

39 sources × ~6-7 items each = 250 cap. Preserves the windowing intent (drops items older than 21 days via `WINDOW_DAYS` check elsewhere) while giving the long tail room to breathe.

Could go higher (500+) but 250 is conservative — the page reads only top-N for display anyway.

## Test plan

- [x] `node --check scripts/scrape-funding-news.mjs` -> exit 0
- [ ] After merge: trigger `gh workflow run collect-funding.yml --ref main -f sources='full-39-list'`
- [ ] Verify `data/funding-news.json` PR shows the 12 new sources in `sourcePlatform`
- [ ] Verify `tb_signals` query for the dispatch window shows >=15 distinct `source_platform` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)