### PR TITLE
chore(data): refresh lobsters signals 2026-05-23T12:38:38Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-23T10:57:08.230Z",
+  "ts": "2026-05-23T12:38:38.877Z",
   "count": 1,
-  "durationMs": 3063,
+  "durationMs": 3304,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T10:57:05.189Z",
+  "fetchedAt": "2026-05-23T12:38:35.594Z",
   "windowDays": 7,
   "scannedStories": 75,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T10:57:05.189Z",
+  "fetchedAt": "2026-05-23T12:38:35.594Z",
   "windowHours": 72,
   "scannedTotal": 75,
   "stories": [
@@ -213,6 +213,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "ztam3w",
+      "title": "Don't Roll Your Own …",
+      "url": "https://susam.net/do-not-roll-your-own.html",
+      "commentsUrl": "https://lobste.rs/s/ztam3w/don_t_roll_your_own",
+      "by": "",
+      "score": 38,
+      "commentCount": 26,
+      "createdUtc": 1779522267,
+      "ageHours": 4.902222222222222,
+      "trendingScore": 2.095560434938486,
+      "tags": [
+        "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "03djyt",
       "title": "New design for the FreeBSD website",
       "url": "https://www.freebsd.org/",
@@ -338,23 +355,6 @@
       "tags": [
         "hardware",
         "law"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "ztam3w",
-      "title": "Don't Roll Your Own …",
-      "url": "https://susam.net/do-not-roll-your-own.html",
-      "commentsUrl": "https://lobste.rs/s/ztam3w/don_t_roll_your_own",
-      "by": "",
-      "score": 18,
-      "commentCount": 17,
-      "createdUtc": 1779522267,
-      "ageHours": 3.2105555555555556,
-      "trendingScore": 1.5133746638996892,
-      "tags": [
-        "web"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26332867145

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.