### PR TITLE
chore(data): refresh huggingface space signals 2026-05-23T14:12:41Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-23T08:38:03.231Z",
+  "ts": "2026-05-23T14:12:41.942Z",
   "count": 1,
-  "durationMs": 5156,
+  "durationMs": 4292,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T08:37:58.077Z",
+  "fetchedAt": "2026-05-23T14:12:37.653Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -390,6 +390,23 @@
     },
     {
       "rank": 24,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 69,
+      "trendingScore": 43,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 25,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -402,23 +419,6 @@
       ],
       "createdAt": "2025-12-10T03:50:25.000Z",
       "lastModified": "2025-12-17T06:32:54.000Z",
-      "models": []
-    },
-    {
-      "rank": 25,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 67,
-      "trendingScore": 41,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -637,6 +637,22 @@
     },
     {
       "rank": 39,
+      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
+      "author": "Saravutw",
+      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
+      "likes": 44,
+      "trendingScore": 26,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-09T19:01:39.000Z",
+      "lastModified": "2026-03-13T17:12:16.000Z",
+      "models": []
+    },
+    {
+      "rank": 40,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -652,7 +668,24 @@
       "models": []
     },
     {
-      "rank": 40,
+      "rank": 41,
+      "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
+      "author": "r3gm",
+      "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
+      "likes": 28,
+      "trendingScore": 25,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T22:11:49.000Z",
+      "lastModified": "2026-05-16T22:14:21.000Z",
+      "models": []
+    },
+    {
+      "rank": 42,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -672,7 +705,7 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 43,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -689,23 +722,7 @@
       "models": []
     },
     {
-      "rank": 42,
-      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
-      "author": "Saravutw",
-      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 42,
-      "trendingScore": 24,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-12-09T19:01:39.000Z",
-      "lastModified": "2026-03-13T17:12:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 43,
+      "rank": 44,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -722,7 +739,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -738,7 +755,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -754,7 +771,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
@@ -774,7 +791,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -790,7 +807,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "Overworld/waypoint-1-5",
       "author": "Overworld",
       "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
@@ -806,7 +823,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "carlofkl/DreamLite",
       "author": "carlofkl",
       "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
@@ -823,23 +840,6 @@
       ],
       "createdAt": "2026-04-26T10:19:51.000Z",
       "lastModified": "2026-04-28T15:12:34.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "huggingface/physics-intern",
-      "author": "huggingface",
-      "url": "https://huggingface.co/spaces/huggingface/physics-intern",
-      "likes": 23,
-      "trendingScore": 21,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "research-article-template",
-        "region:us"
-      ],
-      "createdAt": "2026-04-09T06:56:52.000Z",
-      "lastModified": "2026-05-12T14:59:53.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26334880956

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.