### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-23T16:11:03Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-23T12:06:14.152Z",
+  "ts": "2026-05-23T16:11:03.795Z",
   "count": 1,
-  "durationMs": 8953,
+  "durationMs": 16555,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-23T12:06:12.732Z",
+  "lastFetchedAt": "2026-05-23T16:10:58.663Z",
   "windowDays": 7,
   "launches": [
     {


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26337423138

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.