### PR TITLE
chore(data): refresh dev.to signals 2026-05-23T19:14:57Z

### DIFF
--- a/data/_meta/devto.json
+++ b/data/_meta/devto.json
@@ -1,8 +1,8 @@
 {
   "source": "devto",
   "reason": "ok",
-  "ts": "2026-05-23T13:31:22.983Z",
+  "ts": "2026-05-23T19:14:57.085Z",
   "count": 1,
-  "durationMs": 89736,
+  "durationMs": 75473,
   "extra": {}
 }

--- a/data/devto-mentions.json
+++ b/data/devto-mentions.json
@@ -1,8 +1,8 @@
 {
-  "fetchedAt": "2026-05-23T13:29:53.279Z",
+  "fetchedAt": "2026-05-23T19:13:41.646Z",
   "discoveryVersion": "2026-04-21",
   "windowDays": 7,
-  "scannedArticles": 1335,
+  "scannedArticles": 1331,
   "bodyFetchMode": "full",
   "priorityTags": [
     "ai",
@@ -179,7 +179,7 @@
   ],
   "sliceCounts": {
     "global-top-7d": 100,
-    "global-rising": 16,
+    "global-rising": 9,
     "global-fresh": 100,
     "tag-ai-top-7d": 100,
     "tag-artificialintelligence-top-7d": 0,
@@ -216,7 +216,7 @@
         "author": "om_shree_0709",
         "reactions": 47,
         "comments": 26,
-        "hoursSincePosted": 84.8,
+        "hoursSincePosted": 90.5,
         "readingTime": 5
       },
       "articles": [
@@ -240,7 +240,7 @@
             "ai",
             "mcp"
           ],
-          "trendingScore": 3.34,
+          "trendingScore": 3.13,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -268,7 +268,7 @@
             "mcp",
             "devchallenge"
           ],
-          "trendingScore": 1.42,
+          "trendingScore": 1.31,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -289,7 +289,7 @@
         "author": "lovestaco",
         "reactions": 34,
         "comments": 1,
-        "hoursSincePosted": 66.4,
+        "hoursSincePosted": 72.1,
         "readingTime": 11
       },
       "articles": [
@@ -313,7 +313,7 @@
             "go",
             "beginners"
           ],
-          "trendingScore": 0.86,
+          "trendingScore": 0.79,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -341,7 +341,7 @@
             "javascript",
             "beginners"
           ],
-          "trendingScore": 0.61,
+          "trendingScore": 0.58,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -353,16 +353,16 @@
     },
     "openclaw/openclaw": {
       "count7d": 3,
-      "reactionsSum7d": 48,
+      "reactionsSum7d": 49,
       "commentsSum7d": 27,
       "topArticle": {
         "id": 3701157,
         "title": "Hermes Just Killed OpenClaw (Here's Why)",
         "url": "https://dev.to/tahosin/hermes-just-killed-openclaw-heres-why-4c23",
         "author": "tahosin",
-        "reactions": 42,
+        "reactions": 43,
         "comments": 27,
-        "hoursSincePosted": 96.3,
+        "hoursSincePosted": 102,
         "readingTime": 13
       },
       "articles": [
@@ -376,7 +376,7 @@
             "name": "S M Tahosin",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3886453%2F0f012a95-ad46-4c17-97e8-125ec8b4978d.png"
           },
-          "reactionsCount": 42,
+          "reactionsCount": 43,
           "commentsCount": 27,
           "readingTime": 13,
           "publishedAt": "2026-05-19T13:12:33Z",
@@ -386,7 +386,7 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.62,
+          "trendingScore": 2.55,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -468,17 +468,17 @@
       ]
     },
     "NousResearch/hermes-agent": {
-      "count7d": 14,
-      "reactionsSum7d": 105,
+      "count7d": 16,
+      "reactionsSum7d": 96,
       "commentsSum7d": 32,
       "topArticle": {
         "id": 3701157,
         "title": "Hermes Just Killed OpenClaw (Here's Why)",
         "url": "https://dev.to/tahosin/hermes-just-killed-openclaw-heres-why-4c23",
         "author": "tahosin",
-        "reactions": 42,
+        "reactions": 43,
         "comments": 27,
-        "hoursSincePosted": 96.3,
+        "hoursSincePosted": 102,
         "readingTime": 13
       },
       "articles": [
@@ -492,7 +492,7 @@
             "name": "S M Tahosin",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3886453%2F0f012a95-ad46-4c17-97e8-125ec8b4978d.png"
           },
-          "reactionsCount": 42,
+          "reactionsCount": 43,
           "commentsCount": 27,
           "readingTime": 13,
           "publishedAt": "2026-05-19T13:12:33Z",
@@ -502,7 +502,7 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.62,
+          "trendingScore": 2.55,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -534,7 +534,7 @@
             "agents",
             "ai"
           ],
-          "trendingScore": 0.29,
+          "trendingScore": 0.27,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -561,35 +561,7 @@
             "devchallenge",
             "agents"
           ],
-          "trendingScore": 0.17,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3684236,
-          "title": "I Built an Agent That Actually Reviews Your Pull Requests",
-          "description": "This is a submission for the Hermes Agent Challenge           The Problem with AI Code Review   Every...",
-          "url": "https://dev.to/aditya_rasal/i-built-an-agent-that-actually-reviews-your-pull-requests-56ld",
-          "author": {
-            "username": "aditya_rasal",
-            "name": "Aditya Rasal",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3872249%2Fef25ca72-b50e-4917-8f21-5ee3ed98724a.jpeg"
-          },
-          "reactionsCount": 9,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-16T16:39:00Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "ai",
-            "agents"
-          ],
-          "trendingScore": 0.05,
+          "trendingScore": 0.16,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -715,33 +687,6 @@
           ]
         },
         {
-          "id": 3683856,
-          "title": "Samskara and the Self-Improving Agent: A Vedic Lens on Hermes Agent",
-          "description": "submitted for the #hermesagentchallenge Write track              Where I Am Writing This From   I am...",
-          "url": "https://dev.to/divinesouljoy/samskara-and-the-self-improving-agent-a-vedic-lens-on-hermes-agent-58g1",
-          "author": {
-            "username": "divinesouljoy",
-            "name": "Joydeep Das",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3923225%2Ff82d9269-a7a2-46ca-8dde-8b5c916f9af7.jpg"
-          },
-          "reactionsCount": 3,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-16T14:51:38Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
-          ],
-          "trendingScore": 0.01,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
           "id": 3697223,
           "title": "How I Connected Hermes Agent to My Next.js App (And Why It's Not Just Another Chatbot Wrapper)",
           "description": "This is a submission for the Hermes Agent Challenge  Live app: https://devbrief-tau.vercel.app Repo:...",
@@ -770,6 +715,90 @@
           ]
         },
         {
+          "id": 3732931,
+          "title": "The AI Agent That Learns While It Works — A Complete Guide to Hermes Agent",
+          "description": "This is a submission for the Hermes Agent Challenge              Most AI Agents Are Goldfish. Hermes...",
+          "url": "https://dev.to/aditya_007/the-ai-agent-that-learns-while-it-works-a-complete-guide-to-hermes-agent-n2n",
+          "author": {
+            "username": "aditya_007",
+            "name": "Aditya",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F947444%2F6f1f7420-60ac-43a8-98b3-bc6d7052ddc4.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-23T12:55:26Z",
+          "tags": [
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents",
+            "ai"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3725240,
+          "title": "The 4 Levels of Hermes Agent Scaling Framework: From One Hermes Agent to a Fully Automated Team",
+          "description": "A practical framework for scaling from a single AI agent to a self-running team of specialists. Includes setup instructions, progression checkpoints, and the one mistake that ruins everything.",
+          "url": "https://dev.to/shilpamitra/the-4-levels-of-hermes-agent-scaling-framework-from-one-hermes-agent-to-a-fully-automated-team-2gdp",
+          "author": {
+            "username": "shilpamitra",
+            "name": "Shilpa Mitra",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3943639%2F687febe9-259f-4c1e-a2a0-798ce0d6cc2b.png"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-22T11:56:54Z",
+          "tags": [
+            "ai",
+            "opensource",
+            "automation",
+            "productivity"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3734706,
+          "title": "Your AI agent has amnesia. You've just normalized it.",
+          "description": "Three hackathons in three months. Three different agent setups. Three times I wrote a system prompt...",
+          "url": "https://dev.to/soumyadeepdey/your-ai-agent-has-amnesia-youve-just-normalized-it-40bj",
+          "author": {
+            "username": "soumyadeepdey",
+            "name": "Soumyadeep Dey ",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1076361%2F0aa8630b-3826-4103-9ca3-7436013bf933.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-23T17:44:06Z",
+          "tags": [
+            "hermesagentchallenge",
+            "agents",
+            "ai",
+            "devchallenge"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
           "id": 3729077,
           "title": "One Soul, Any Model: Portable Memory for Open-Source Agents with .klickd",
           "description": "This is a submission for the Hermes Agent Challenge: Build With Hermes Agent           What I...",
@@ -783,6 +812,34 @@
           "commentsCount": 0,
           "readingTime": 6,
           "publishedAt": "2026-05-23T01:18:46Z",
+          "tags": [
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents",
+            "ai"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3733838,
+          "title": "The Anatomy of a Self-Improving AI Agent — How Hermes Agent's Closed Learning Loop Actually Works",
+          "description": "This is a submission for the Hermes Agent Challenge: Write About Hermes Agent  Every AI agent...",
+          "url": "https://dev.to/nilambuilds/the-anatomy-of-a-self-improving-ai-agent-how-hermes-agents-closed-learning-loop-actually-works-4jk7",
+          "author": {
+            "username": "nilambuilds",
+            "name": "Nilam Bora",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3892838%2Fd6265034-ff2a-4993-8e9b-56a1b807927b.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 10,
+          "publishedAt": "2026-05-23T15:00:23Z",
           "tags": [
             "hermesagentchallenge",
             "devchallenge",
@@ -894,7 +951,7 @@
         "author": "thecodedaniel",
         "reactions": 10,
         "comments": 0,
-        "hoursSincePosted": 89.9,
+        "hoursSincePosted": 95.7,
         "readingTime": 5
       },
       "articles": [
@@ -917,55 +974,10 @@
             "gemmachallenge",
             "gemma"
           ],
-          "trendingScore": 0.11,
+          "trendingScore": 0.1,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/LiteRT-LM",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "0xMassi/webclaw": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3731296,
-        "title": "Puppeteer networkidle is not a scraping strategy",
-        "url": "https://dev.to/0xmassi/puppeteer-networkidle-is-not-a-scraping-strategy-46ia",
-        "author": "0xmassi",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 4.8,
-        "readingTime": 5
-      },
-      "articles": [
-        {
-          "id": 3731296,
-          "title": "Puppeteer networkidle is not a scraping strategy",
-          "description": "The most suspicious line in a lot of Puppeteer and Playwright scrapers is not page.goto.  It is...",
-          "url": "https://dev.to/0xmassi/puppeteer-networkidle-is-not-a-scraping-strategy-46ia",
-          "author": {
-            "username": "0xmassi",
-            "name": "Massi",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1625049%2F63826551-db5e-4182-92d5-6a234d359f6b.jpeg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-23T08:42:11Z",
-          "tags": [
-            "webscraping",
-            "javascript",
-            "puppeteer",
-            "playwright"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "0xMassi/webclaw",
               "location": "body"
             }
           ]
@@ -983,7 +995,7 @@
         "author": "numbpill3d",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 15.8,
+        "hoursSincePosted": 21.5,
         "readingTime": 7
       },
       "articles": [
@@ -1032,7 +1044,7 @@
         "author": "bd_perez",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 69.5,
+        "hoursSincePosted": 75.2,
         "readingTime": 7
       },
       "articles": [
@@ -1108,7 +1120,7 @@
         "author": "ddesio",
         "reactions": 3,
         "comments": 0,
-        "hoursSincePosted": 77.9,
+        "hoursSincePosted": 83.6,
         "readingTime": 11
       },
       "articles": [
@@ -1145,51 +1157,6 @@
         }
       ]
     },
-    "multica-ai/multica": {
-      "count7d": 1,
-      "reactionsSum7d": 5,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3720461,
-        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-        "author": "arshtechpro",
-        "reactions": 5,
-        "comments": 1,
-        "hoursSincePosted": 39.4,
-        "readingTime": 4
-      },
-      "articles": [
-        {
-          "id": 3720461,
-          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
-          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-          "author": {
-            "username": "arshtechpro",
-            "name": "ArshTechPro",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
-          },
-          "reactionsCount": 5,
-          "commentsCount": 1,
-          "readingTime": 4,
-          "publishedAt": "2026-05-21T22:07:10Z",
-          "tags": [
-            "ai",
-            "agents",
-            "python",
-            "programming"
-          ],
-          "trendingScore": 0.1,
-          "linkedRepos": [
-            {
-              "fullName": "multica-ai/multica",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "Lum1104/Understand-Anything": {
       "count7d": 1,
       "reactionsSum7d": 5,
@@ -1201,7 +1168,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 97.9,
+        "hoursSincePosted": 103.6,
         "readingTime": 5
       },
       "articles": [
@@ -1235,52 +1202,45 @@
         }
       ]
     },
-    "nextlevelbuilder/goclaw": {
+    "multica-ai/multica": {
       "count7d": 1,
       "reactionsSum7d": 5,
-      "commentsSum7d": 0,
+      "commentsSum7d": 1,
       "topArticle": {
-        "id": 3691887,
-        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
-        "author": "truongpx396",
+        "id": 3720461,
+        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
+        "author": "arshtechpro",
         "reactions": 5,
-        "comments": 0,
-        "hoursSincePosted": 125.3,
-        "readingTime": 16
+        "comments": 1,
+        "hoursSincePosted": 45.1,
+        "readingTime": 4
       },
       "articles": [
         {
-          "id": 3691887,
-          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
-          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+          "id": 3720461,
+          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
+          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
           "author": {
-            "username": "truongpx396",
-            "name": "Truong Phung",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
+            "username": "arshtechpro",
+            "name": "ArshTechPro",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
           },
           "reactionsCount": 5,
-          "commentsCount": 0,
-          "readingTime": 16,
-          "publishedAt": "2026-05-18T08:12:05Z",
+          "commentsCount": 1,
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T22:07:10Z",
           "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
+            "ai",
+            "agents",
+            "python",
+            "programming"
           ],
-          "trendingScore": 0.03,
+          "trendingScore": 0.09,
           "linkedRepos": [
             {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            },
-            {
-              "fullName": "openclaw/openclaw",
-              "location": "body"
-            },
-            {
-              "fullName": "nextlevelbuilder/goclaw",
+              "fullName": "multica-ai/multica",
               "location": "body"
             }
           ]
@@ -1288,7 +1248,7 @@
       ]
     },
     "anthropics/claude-code": {
-      "count7d": 10,
+      "count7d": 11,
       "reactionsSum7d": 3,
       "commentsSum7d": 1,
       "topArticle": {
@@ -1298,7 +1258,7 @@
         "author": "crawleyprint_71",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 141.5,
+        "hoursSincePosted": 147.2,
         "readingTime": 11
       },
       "articles": [
@@ -1597,309 +1557,83 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "can1357/oh-my-pi": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3710799,
-        "title": "Secure Agents: Control Policies in the Harness",
-        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
-        "author": "epappas",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 68.4,
-        "readingTime": 7
-      },
-      "articles": [
+        },
         {
-          "id": 3710799,
-          "title": "Secure Agents: Control Policies in the Harness",
-          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
-          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+          "id": 3734738,
+          "title": "Why Claude Code Sessions Diverge: A Mechanism Catalog",
+          "description": "Anthropic's April 2026 postmortem confirmed: Claude Code A/B-routes sessions, behavior is session-sticky, restart actually works. Six mechanisms catalog.",
+          "url": "https://dev.to/vainamoinen/why-claude-code-sessions-diverge-a-mechanism-catalog-4j63",
           "author": {
-            "username": "epappas",
-            "name": "Evangelos Pappas",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
+            "username": "vainamoinen",
+            "name": "Vainamoinen | Pulsed Media",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3879600%2Fce3a6ec3-4bde-4859-baeb-e6f99ed3c817.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-20T17:03:09Z",
+          "readingTime": 3,
+          "publishedAt": "2026-05-23T17:50:30Z",
           "tags": [
             "ai",
+            "llm",
             "agents",
-            "cybersecurity",
             "devops"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "can1357/oh-my-pi",
+              "fullName": "anthropics/claude-code",
               "location": "body"
             }
           ]
         }
       ]
     },
-    "Fission-AI/OpenSpec": {
+    "nextlevelbuilder/goclaw": {
       "count7d": 1,
-      "reactionsSum7d": 1,
+      "reactionsSum7d": 5,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3690020,
-        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
-        "author": "kenimo49",
-        "reactions": 1,
+        "id": 3691887,
+        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+        "author": "truongpx396",
+        "reactions": 5,
         "comments": 0,
-        "hoursSincePosted": 96.5,
-        "readingTime": 6
+        "hoursSincePosted": 131,
+        "readingTime": 16
       },
       "articles": [
         {
-          "id": 3690020,
-          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
-          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+          "id": 3691887,
+          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
+          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
           "author": {
-            "username": "kenimo49",
-            "name": "Ken Imoto",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
+            "username": "truongpx396",
+            "name": "Truong Phung",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 5,
           "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-19T13:00:01Z",
+          "readingTime": 16,
+          "publishedAt": "2026-05-18T08:12:05Z",
           "tags": [
-            "claudecode",
-            "ai",
-            "spec",
-            "openapi"
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.03,
           "linkedRepos": [
             {
-              "fullName": "Fission-AI/OpenSpec",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "openai/symphony": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3729039,
-        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-        "author": "judy_miranttie",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 12.5,
-        "readingTime": 14
-      },
-      "articles": [
-        {
-          "id": 3729039,
-          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
-          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-          "author": {
-            "username": "judy_miranttie",
-            "name": "Judy",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 14,
-          "publishedAt": "2026-05-23T01:00:08Z",
-          "tags": [
-            "multiagent",
-            "aiteam",
-            "aiautomation",
-            "claudecode"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "openai/symphony",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "anthropics/skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 149.5,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
+              "fullName": "NousResearch/hermes-agent",
               "location": "body"
             },
             {
-              "fullName": "mattpocock/skills",
+              "fullName": "openclaw/openclaw",
               "location": "body"
             },
             {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "mattpocock/skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 149.5,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "addyosmani/agent-skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 149.5,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
+              "fullName": "nextlevelbuilder/goclaw",
               "location": "body"
             }
           ]
@@ -1917,7 +1651,7 @@
         "author": "chen115y",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 60.5,
+        "hoursSincePosted": 66.2,
         "readingTime": 20
       },
       "articles": [
@@ -2023,6 +1757,312 @@
         }
       ]
     },
+    "can1357/oh-my-pi": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3710799,
+        "title": "Secure Agents: Control Policies in the Harness",
+        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+        "author": "epappas",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 74.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3710799,
+          "title": "Secure Agents: Control Policies in the Harness",
+          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
+          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+          "author": {
+            "username": "epappas",
+            "name": "Evangelos Pappas",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-20T17:03:09Z",
+          "tags": [
+            "ai",
+            "agents",
+            "cybersecurity",
+            "devops"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "can1357/oh-my-pi",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "Fission-AI/OpenSpec": {
+      "count7d": 1,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3690020,
+        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+        "author": "kenimo49",
+        "reactions": 1,
+        "comments": 0,
+        "hoursSincePosted": 102.2,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3690020,
+          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
+          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+          "author": {
+            "username": "kenimo49",
+            "name": "Ken Imoto",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 6,
+          "publishedAt": "2026-05-19T13:00:01Z",
+          "tags": [
+            "claudecode",
+            "ai",
+            "spec",
+            "openapi"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Fission-AI/OpenSpec",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "openai/symphony": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3729039,
+        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+        "author": "judy_miranttie",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 18.2,
+        "readingTime": 14
+      },
+      "articles": [
+        {
+          "id": 3729039,
+          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
+          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+          "author": {
+            "username": "judy_miranttie",
+            "name": "Judy",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 14,
+          "publishedAt": "2026-05-23T01:00:08Z",
+          "tags": [
+            "multiagent",
+            "aiteam",
+            "aiautomation",
+            "claudecode"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "openai/symphony",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "anthropics/skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 155.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "mattpocock/skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 155.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "addyosmani/agent-skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 155.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "openai/codex": {
       "count7d": 4,
       "reactionsSum7d": 1,
@@ -2034,7 +2074,7 @@
         "author": "skyguan92",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 128.5,
+        "hoursSincePosted": 134.2,
         "readingTime": 10
       },
       "articles": [
@@ -2167,7 +2207,7 @@
         "author": "ec1980",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 108.2,
+        "hoursSincePosted": 114,
         "readingTime": 5
       },
       "articles": [
@@ -2276,7 +2316,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 59.6,
+        "hoursSincePosted": 65.4,
         "readingTime": 9
       },
       "articles": [
@@ -2321,7 +2361,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 30.5,
+        "hoursSincePosted": 36.3,
         "readingTime": 10
       },
       "articles": [
@@ -2366,7 +2406,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 30.5,
+        "hoursSincePosted": 36.2,
         "readingTime": 8
       },
       "articles": [
@@ -2411,7 +2451,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 152,
+        "hoursSincePosted": 157.8,
         "readingTime": 6
       },
       "articles": [
@@ -2464,7 +2504,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 152,
+        "hoursSincePosted": 157.8,
         "readingTime": 6
       },
       "articles": [
@@ -2517,7 +2557,7 @@
         "author": "nickyeolk",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 71.6,
+        "hoursSincePosted": 77.3,
         "readingTime": 7
       },
       "articles": [
@@ -2562,7 +2602,7 @@
         "author": "maicon_ribeiroesteves_32",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 98.5,
+        "hoursSincePosted": 104.2,
         "readingTime": 3
       },
       "articles": [
@@ -2607,7 +2647,7 @@
         "author": "wonderlab",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 130.7,
+        "hoursSincePosted": 136.5,
         "readingTime": 8
       },
       "articles": [
@@ -2652,7 +2692,7 @@
         "author": "yahya_bin_naveed",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 53.1,
+        "hoursSincePosted": 58.8,
         "readingTime": 12
       },
       "articles": [
@@ -2697,7 +2737,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 83.5,
+        "hoursSincePosted": 89.2,
         "readingTime": 9
       },
       "articles": [
@@ -2742,7 +2782,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 12.9,
+        "hoursSincePosted": 18.6,
         "readingTime": 4
       },
       "articles": [
@@ -2787,7 +2827,7 @@
         "author": "max_quimby",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 129.6,
+        "hoursSincePosted": 135.3,
         "readingTime": 9
       },
       "articles": [
@@ -2828,15 +2868,15 @@
     "github/github-mcp-server": {
       "count7d": 1,
       "reactionsSum7d": 4,
-      "commentsSum7d": 7,
+      "commentsSum7d": 8,
       "topArticle": {
         "id": 3690301,
         "title": "The Real Problems Start After Your MCP Server Works",
         "url": "https://dev.to/madhaviai/the-real-problems-start-after-your-mcp-server-works-2al5",
         "author": "madhaviai",
         "reactions": 4,
-        "comments": 7,
-        "hoursSincePosted": 118.5,
+        "comments": 8,
+        "hoursSincePosted": 124.2,
         "readingTime": 3
       },
       "articles": [
@@ -2851,7 +2891,7 @@
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3936149%2F9538f203-64dd-4b89-a2b0-d28126195c04.png"
           },
           "reactionsCount": 4,
-          "commentsCount": 7,
+          "commentsCount": 8,
           "readingTime": 3,
           "publishedAt": "2026-05-18T15:02:13Z",
           "tags": [
@@ -2869,118 +2909,49 @@
         }
       ]
     },
-    "datawhalechina/hello-agents": {
-      "count7d": 2,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3728972,
-        "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-        "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
-        "author": "wonderlab",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 12.8,
-        "readingTime": 11
-      },
-      "articles": [
-        {
-          "id": 3728972,
-          "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-          "description": "You Think Your Agent Is \"Thinking.\" It's Actually Just Predicting Tokens.   Here's a...",
-          "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
-          "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-23T00:40:05Z",
-          "tags": [
-            "agents",
-            "llm",
-            "langchain",
-            "ai"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "datawhalechina/hello-agents",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3715025,
-          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
-          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
-          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
-          "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-21T07:43:56Z",
-          "tags": [
-            "agents",
-            "llm",
-            "ai",
-            "langchain"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "datawhalechina/hello-agents",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "maximhq/bifrost": {
-      "count7d": 2,
+      "count7d": 3,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3697159,
-        "title": "Putting an LLM Gateway in Front of Our Build Agents: Why We Picked Bifrost",
-        "url": "https://dev.to/claire_nguyen/putting-an-llm-gateway-in-front-of-our-build-agents-why-we-picked-bifrost-130g",
-        "author": "claire_nguyen",
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+        "author": "marcorinaldi_ai",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 105.1,
+        "hoursSincePosted": 50.4,
         "readingTime": 4
       },
       "articles": [
         {
-          "id": 3697159,
-          "title": "Putting an LLM Gateway in Front of Our Build Agents: Why We Picked Bifrost",
-          "description": "TL;DR: We bolted an LLM gateway in front of the AI features in our build pipeline tooling and ended...",
-          "url": "https://dev.to/claire_nguyen/putting-an-llm-gateway-in-front-of-our-build-agents-why-we-picked-bifrost-130g",
+          "id": 3719101,
+          "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+          "description": "TL;DR: We added a vision-language stage to an event-camera pipeline at Prophesee and the LLM provider...",
+          "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
           "author": {
-            "username": "claire_nguyen",
-            "name": "claire nguyen",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864932%2F406e92e1-2c8d-4d65-a1f4-a8d4e8c2fd1d.jpg"
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
           "readingTime": 4,
-          "publishedAt": "2026-05-19T04:22:40Z",
+          "publishedAt": "2026-05-21T16:52:22Z",
           "tags": [
-            "infrastructure",
-            "devops",
-            "sre",
+            "machinelearning",
+            "computervision",
+            "mlops",
             "llm"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
               "fullName": "maximhq/bifrost",
+              "location": "body"
+            },
+            {
+              "fullName": "BerriAI/litellm",
               "location": "body"
             }
           ]
@@ -3012,13 +2983,90 @@
               "location": "body"
             }
           ]
+        },
+        {
+          "id": 3697159,
+          "title": "Putting an LLM Gateway in Front of Our Build Agents: Why We Picked Bifrost",
+          "description": "TL;DR: We bolted an LLM gateway in front of the AI features in our build pipeline tooling and ended...",
+          "url": "https://dev.to/claire_nguyen/putting-an-llm-gateway-in-front-of-our-build-agents-why-we-picked-bifrost-130g",
+          "author": {
+            "username": "claire_nguyen",
+            "name": "claire nguyen",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864932%2F406e92e1-2c8d-4d65-a1f4-a8d4e8c2fd1d.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-19T04:22:40Z",
+          "tags": [
+            "infrastructure",
+            "devops",
+            "sre",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "BerriAI/litellm": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+        "author": "marcorinaldi_ai",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 50.4,
+        "readingTime": 4
+      },
+      "articles": [
+        {
+          "id": 3719101,
+          "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+          "description": "TL;DR: We added a vision-language stage to an event-camera pipeline at Prophesee and the LLM provider...",
+          "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+          "author": {
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T16:52:22Z",
+          "tags": [
+            "machinelearning",
+            "computervision",
+            "mlops",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            },
+            {
+              "fullName": "BerriAI/litellm",
+              "location": "body"
+            }
+          ]
         }
       ]
     },
     "vectorize-io/hindsight": {
       "count7d": 2,
       "reactionsSum7d": 0,
-      "commentsSum7d": 1,
+      "commentsSum7d": 0,
       "topArticle": {
         "id": 3702728,
         "title": "The cheapest model call is the one you don't make",
@@ -3026,7 +3074,7 @@
         "author": "wnxd",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 91.9,
+        "hoursSincePosted": 97.7,
         "readingTime": 6
       },
       "articles": [
@@ -3059,24 +3107,24 @@
           ]
         },
         {
-          "id": 3695395,
-          "title": "CRMs store data. I built something that remembers context.",
-          "description": "The first question I get when I tell people we have no database is: \"What do you mean, no...",
-          "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
+          "id": 3697942,
+          "title": "Hindsight Turned Repeat Commenters Into Recognizable People",
+          "description": "I was building EchoEngage an AI-driven comment responder, and ran into a frustrating...",
+          "url": "https://dev.to/vidushi0229/hindsight-turned-repeat-commenters-into-recognizable-people-4fl2",
           "author": {
-            "username": "sandhyagk",
-            "name": "Sandhya G K",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3938594%2F33c002a2-ec2d-4666-a42d-3abbabb292e7.png"
+            "username": "vidushi0229",
+            "name": "Vidushi Goyal",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3939244%2Fbee9b11b-60d0-4808-b17e-2214181e9b46.png"
           },
           "reactionsCount": 0,
-          "commentsCount": 1,
-          "readingTime": 6,
-          "publishedAt": "2026-05-18T18:56:33Z",
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-19T13:31:35Z",
           "tags": [
             "ai",
-            "architecture",
+            "fastapi",
             "rag",
-            "showdev"
+            "react"
           ],
           "trendingScore": 0,
           "linkedRepos": [
@@ -3099,7 +3147,7 @@
         "author": "anajsana95",
         "reactions": 4,
         "comments": 0,
-        "hoursSincePosted": 117.9,
+        "hoursSincePosted": 123.7,
         "readingTime": 5
       },
       "articles": [
@@ -3143,7 +3191,7 @@
         "author": "allelishi",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 95,
+        "hoursSincePosted": 100.7,
         "readingTime": 4
       },
       "articles": [
@@ -3188,7 +3236,7 @@
         "author": "selfagency",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 115.2,
+        "hoursSincePosted": 120.9,
         "readingTime": 7
       },
       "articles": [
@@ -3222,6 +3270,51 @@
         }
       ]
     },
+    "anomalyco/opencode": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3695081,
+        "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
+        "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
+        "author": "imper_7cde72b79d2529291ec",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 121.8,
+        "readingTime": 2
+      },
+      "articles": [
+        {
+          "id": 3695081,
+          "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
+          "description": "I use opencode as my daily TUI coding agent. It's good. But there's one thing that kept biting...",
+          "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
+          "author": {
+            "username": "imper_7cde72b79d2529291ec",
+            "name": "imper",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3812341%2F4a3e352b-d42f-4efe-bb2c-23e8703e87bb.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 2,
+          "publishedAt": "2026-05-18T17:23:30Z",
+          "tags": [
+            "opencode",
+            "cli",
+            "typescript",
+            "opensource"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anomalyco/opencode",
+              "location": "tag"
+            }
+          ]
+        }
+      ]
+    },
     "CloakHQ/CloakBrowser": {
       "count7d": 2,
       "reactionsSum7d": 1,
@@ -3233,7 +3326,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 24.8,
+        "hoursSincePosted": 30.5,
         "readingTime": 4
       },
       "articles": [
@@ -3298,51 +3391,6 @@
         }
       ]
     },
-    "anomalyco/opencode": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3695081,
-        "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
-        "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
-        "author": "imper_7cde72b79d2529291ec",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 116.1,
-        "readingTime": 2
-      },
-      "articles": [
-        {
-          "id": 3695081,
-          "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
-          "description": "I use opencode as my daily TUI coding agent. It's good. But there's one thing that kept biting...",
-          "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
-          "author": {
-            "username": "imper_7cde72b79d2529291ec",
-            "name": "imper",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3812341%2F4a3e352b-d42f-4efe-bb2c-23e8703e87bb.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 2,
-          "publishedAt": "2026-05-18T17:23:30Z",
-          "tags": [
-            "opencode",
-            "cli",
-            "typescript",
-            "opensource"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anomalyco/opencode",
-              "location": "tag"
-            }
-          ]
-        }
-      ]
-    },
     "daijro/camoufox": {
       "count7d": 1,
       "reactionsSum7d": 1,
@@ -3354,7 +3402,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 24.8,
+        "hoursSincePosted": 30.5,
         "readingTime": 4
       },
       "articles": [
@@ -3403,7 +3451,7 @@
         "author": "mir_mursalin_ankur",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 142,
+        "hoursSincePosted": 147.7,
         "readingTime": 53
       },
       "articles": [
@@ -3452,7 +3500,7 @@
         "author": "doramagic",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 143.3,
+        "hoursSincePosted": 149,
         "readingTime": 3
       },
       "articles": [
@@ -3497,7 +3545,7 @@
         "author": "jadysmgodoi",
         "reactions": 1,
         "comments": 1,
-        "hoursSincePosted": 47.6,
+        "hoursSincePosted": 53.3,
         "readingTime": 3
       },
       "articles": [
@@ -3542,7 +3590,7 @@
         "author": "mervindublin",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 53.1,
+        "hoursSincePosted": 58.9,
         "readingTime": 3
       },
       "articles": [
@@ -3576,6 +3624,79 @@
         }
       ]
     },
+    "datawhalechina/hello-agents": {
+      "count7d": 2,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3728972,
+        "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
+        "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
+        "author": "wonderlab",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 18.6,
+        "readingTime": 11
+      },
+      "articles": [
+        {
+          "id": 3728972,
+          "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
+          "description": "You Think Your Agent Is \"Thinking.\" It's Actually Just Predicting Tokens.   Here's a...",
+          "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 11,
+          "publishedAt": "2026-05-23T00:40:05Z",
+          "tags": [
+            "agents",
+            "llm",
+            "langchain",
+            "ai"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "datawhalechina/hello-agents",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3715025,
+          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
+          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
+          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-21T07:43:56Z",
+          "tags": [
+            "agents",
+            "llm",
+            "ai",
+            "langchain"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "datawhalechina/hello-agents",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "czlonkowski/n8n-mcp": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -3587,7 +3708,7 @@
         "author": "rentierdigital",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 167.8,
+        "hoursSincePosted": 173.5,
         "readingTime": 11
       },
       "articles": [
@@ -3632,7 +3753,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 124.5,
+        "hoursSincePosted": 130.2,
         "readingTime": 3
       },
       "articles": [
@@ -3677,7 +3798,7 @@
         "author": "hectorvent",
         "reactions": 3,
         "comments": 0,
-        "hoursSincePosted": 162.9,
+        "hoursSincePosted": 168.6,
         "readingTime": 4
       },
       "articles": [
@@ -3724,7 +3845,7 @@
         "author": "om_shree_0709",
         "reactions": 47,
         "comments": 26,
-        "hoursSincePosted": 84.8,
+        "hoursSincePosted": 90.5,
         "readingTime": 5
       },
       "articles": [
@@ -3748,7 +3869,7 @@
             "ai",
             "mcp"
           ],
-          "trendingScore": 3.34,
+          "trendingScore": 3.13,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -3776,7 +3897,7 @@
             "mcp",
             "devchallenge"
           ],
-          "trendingScore": 1.42,
+          "trendingScore": 1.31,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/gallery",
@@ -3797,7 +3918,7 @@
         "author": "lovestaco",
         "reactions": 34,
         "comments": 1,
-        "hoursSincePosted": 66.4,
+        "hoursSincePosted": 72.1,
         "readingTime": 11
       },
       "articles": [
@@ -3821,7 +3942,7 @@
             "go",
             "beginners"
           ],
-          "trendingScore": 0.86,
+          "trendingScore": 0.79,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -3849,7 +3970,7 @@
             "javascript",
             "beginners"
           ],
-          "trendingScore": 0.61,
+          "trendingScore": 0.58,
           "linkedRepos": [
             {
               "fullName": "HexmosTech/git-lrc",
@@ -3861,16 +3982,16 @@
     },
     "openclaw--openclaw": {
       "count7d": 3,
-      "reactionsSum7d": 48,
+      "reactionsSum7d": 49,
       "commentsSum7d": 27,
       "topArticle": {
         "id": 3701157,
         "title": "Hermes Just Killed OpenClaw (Here's Why)",
         "url": "https://dev.to/tahosin/hermes-just-killed-openclaw-heres-why-4c23",
         "author": "tahosin",
-        "reactions": 42,
+        "reactions": 43,
         "comments": 27,
-        "hoursSincePosted": 96.3,
+        "hoursSincePosted": 102,
         "readingTime": 13
       },
       "articles": [
@@ -3884,7 +4005,7 @@
             "name": "S M Tahosin",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3886453%2F0f012a95-ad46-4c17-97e8-125ec8b4978d.png"
           },
-          "reactionsCount": 42,
+          "reactionsCount": 43,
           "commentsCount": 27,
           "readingTime": 13,
           "publishedAt": "2026-05-19T13:12:33Z",
@@ -3894,7 +4015,7 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.62,
+          "trendingScore": 2.55,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -3976,17 +4097,17 @@
       ]
     },
     "nousresearch--hermes-agent": {
-      "count7d": 14,
-      "reactionsSum7d": 105,
+      "count7d": 16,
+      "reactionsSum7d": 96,
       "commentsSum7d": 32,
       "topArticle": {
         "id": 3701157,
         "title": "Hermes Just Killed OpenClaw (Here's Why)",
         "url": "https://dev.to/tahosin/hermes-just-killed-openclaw-heres-why-4c23",
         "author": "tahosin",
-        "reactions": 42,
+        "reactions": 43,
         "comments": 27,
-        "hoursSincePosted": 96.3,
+        "hoursSincePosted": 102,
         "readingTime": 13
       },
       "articles": [
@@ -4000,7 +4121,7 @@
             "name": "S M Tahosin",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3886453%2F0f012a95-ad46-4c17-97e8-125ec8b4978d.png"
           },
-          "reactionsCount": 42,
+          "reactionsCount": 43,
           "commentsCount": 27,
           "readingTime": 13,
           "publishedAt": "2026-05-19T13:12:33Z",
@@ -4010,7 +4131,7 @@
             "agents",
             "discuss"
           ],
-          "trendingScore": 2.62,
+          "trendingScore": 2.55,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -4042,7 +4163,7 @@
             "agents",
             "ai"
           ],
-          "trendingScore": 0.29,
+          "trendingScore": 0.27,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4069,35 +4190,7 @@
             "devchallenge",
             "agents"
           ],
-          "trendingScore": 0.17,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3684236,
-          "title": "I Built an Agent That Actually Reviews Your Pull Requests",
-          "description": "This is a submission for the Hermes Agent Challenge           The Problem with AI Code Review   Every...",
-          "url": "https://dev.to/aditya_rasal/i-built-an-agent-that-actually-reviews-your-pull-requests-56ld",
-          "author": {
-            "username": "aditya_rasal",
-            "name": "Aditya Rasal",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3872249%2Fef25ca72-b50e-4917-8f21-5ee3ed98724a.jpeg"
-          },
-          "reactionsCount": 9,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-16T16:39:00Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "ai",
-            "agents"
-          ],
-          "trendingScore": 0.05,
+          "trendingScore": 0.16,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4223,33 +4316,6 @@
           ]
         },
         {
-          "id": 3683856,
-          "title": "Samskara and the Self-Improving Agent: A Vedic Lens on Hermes Agent",
-          "description": "submitted for the #hermesagentchallenge Write track              Where I Am Writing This From   I am...",
-          "url": "https://dev.to/divinesouljoy/samskara-and-the-self-improving-agent-a-vedic-lens-on-hermes-agent-58g1",
-          "author": {
-            "username": "divinesouljoy",
-            "name": "Joydeep Das",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3923225%2Ff82d9269-a7a2-46ca-8dde-8b5c916f9af7.jpg"
-          },
-          "reactionsCount": 3,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-16T14:51:38Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
-          ],
-          "trendingScore": 0.01,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
           "id": 3697223,
           "title": "How I Connected Hermes Agent to My Next.js App (And Why It's Not Just Another Chatbot Wrapper)",
           "description": "This is a submission for the Hermes Agent Challenge  Live app: https://devbrief-tau.vercel.app Repo:...",
@@ -4278,6 +4344,90 @@
           ]
         },
         {
+          "id": 3732931,
+          "title": "The AI Agent That Learns While It Works — A Complete Guide to Hermes Agent",
+          "description": "This is a submission for the Hermes Agent Challenge              Most AI Agents Are Goldfish. Hermes...",
+          "url": "https://dev.to/aditya_007/the-ai-agent-that-learns-while-it-works-a-complete-guide-to-hermes-agent-n2n",
+          "author": {
+            "username": "aditya_007",
+            "name": "Aditya",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F947444%2F6f1f7420-60ac-43a8-98b3-bc6d7052ddc4.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-23T12:55:26Z",
+          "tags": [
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents",
+            "ai"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3725240,
+          "title": "The 4 Levels of Hermes Agent Scaling Framework: From One Hermes Agent to a Fully Automated Team",
+          "description": "A practical framework for scaling from a single AI agent to a self-running team of specialists. Includes setup instructions, progression checkpoints, and the one mistake that ruins everything.",
+          "url": "https://dev.to/shilpamitra/the-4-levels-of-hermes-agent-scaling-framework-from-one-hermes-agent-to-a-fully-automated-team-2gdp",
+          "author": {
+            "username": "shilpamitra",
+            "name": "Shilpa Mitra",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3943639%2F687febe9-259f-4c1e-a2a0-798ce0d6cc2b.png"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-22T11:56:54Z",
+          "tags": [
+            "ai",
+            "opensource",
+            "automation",
+            "productivity"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3734706,
+          "title": "Your AI agent has amnesia. You've just normalized it.",
+          "description": "Three hackathons in three months. Three different agent setups. Three times I wrote a system prompt...",
+          "url": "https://dev.to/soumyadeepdey/your-ai-agent-has-amnesia-youve-just-normalized-it-40bj",
+          "author": {
+            "username": "soumyadeepdey",
+            "name": "Soumyadeep Dey ",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1076361%2F0aa8630b-3826-4103-9ca3-7436013bf933.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-23T17:44:06Z",
+          "tags": [
+            "hermesagentchallenge",
+            "agents",
+            "ai",
+            "devchallenge"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
           "id": 3729077,
           "title": "One Soul, Any Model: Portable Memory for Open-Source Agents with .klickd",
           "description": "This is a submission for the Hermes Agent Challenge: Build With Hermes Agent           What I...",
@@ -4291,6 +4441,34 @@
           "commentsCount": 0,
           "readingTime": 6,
           "publishedAt": "2026-05-23T01:18:46Z",
+          "tags": [
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents",
+            "ai"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3733838,
+          "title": "The Anatomy of a Self-Improving AI Agent — How Hermes Agent's Closed Learning Loop Actually Works",
+          "description": "This is a submission for the Hermes Agent Challenge: Write About Hermes Agent  Every AI agent...",
+          "url": "https://dev.to/nilambuilds/the-anatomy-of-a-self-improving-ai-agent-how-hermes-agents-closed-learning-loop-actually-works-4jk7",
+          "author": {
+            "username": "nilambuilds",
+            "name": "Nilam Bora",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3892838%2Fd6265034-ff2a-4993-8e9b-56a1b807927b.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 10,
+          "publishedAt": "2026-05-23T15:00:23Z",
           "tags": [
             "hermesagentchallenge",
             "devchallenge",
@@ -4402,7 +4580,7 @@
         "author": "thecodedaniel",
         "reactions": 10,
         "comments": 0,
-        "hoursSincePosted": 89.9,
+        "hoursSincePosted": 95.7,
         "readingTime": 5
       },
       "articles": [
@@ -4425,55 +4603,10 @@
             "gemmachallenge",
             "gemma"
           ],
-          "trendingScore": 0.11,
+          "trendingScore": 0.1,
           "linkedRepos": [
             {
               "fullName": "google-ai-edge/LiteRT-LM",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "0xmassi--webclaw": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3731296,
-        "title": "Puppeteer networkidle is not a scraping strategy",
-        "url": "https://dev.to/0xmassi/puppeteer-networkidle-is-not-a-scraping-strategy-46ia",
-        "author": "0xmassi",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 4.8,
-        "readingTime": 5
-      },
-      "articles": [
-        {
-          "id": 3731296,
-          "title": "Puppeteer networkidle is not a scraping strategy",
-          "description": "The most suspicious line in a lot of Puppeteer and Playwright scrapers is not page.goto.  It is...",
-          "url": "https://dev.to/0xmassi/puppeteer-networkidle-is-not-a-scraping-strategy-46ia",
-          "author": {
-            "username": "0xmassi",
-            "name": "Massi",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1625049%2F63826551-db5e-4182-92d5-6a234d359f6b.jpeg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 5,
-          "publishedAt": "2026-05-23T08:42:11Z",
-          "tags": [
-            "webscraping",
-            "javascript",
-            "puppeteer",
-            "playwright"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "0xMassi/webclaw",
               "location": "body"
             }
           ]
@@ -4491,7 +4624,7 @@
         "author": "numbpill3d",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 15.8,
+        "hoursSincePosted": 21.5,
         "readingTime": 7
       },
       "articles": [
@@ -4540,7 +4673,7 @@
         "author": "bd_perez",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 69.5,
+        "hoursSincePosted": 75.2,
         "readingTime": 7
       },
       "articles": [
@@ -4616,7 +4749,7 @@
         "author": "ddesio",
         "reactions": 3,
         "comments": 0,
-        "hoursSincePosted": 77.9,
+        "hoursSincePosted": 83.6,
         "readingTime": 11
       },
       "articles": [
@@ -4653,51 +4786,6 @@
         }
       ]
     },
-    "multica-ai--multica": {
-      "count7d": 1,
-      "reactionsSum7d": 5,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3720461,
-        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-        "author": "arshtechpro",
-        "reactions": 5,
-        "comments": 1,
-        "hoursSincePosted": 39.4,
-        "readingTime": 4
-      },
-      "articles": [
-        {
-          "id": 3720461,
-          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
-          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
-          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
-          "author": {
-            "username": "arshtechpro",
-            "name": "ArshTechPro",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
-          },
-          "reactionsCount": 5,
-          "commentsCount": 1,
-          "readingTime": 4,
-          "publishedAt": "2026-05-21T22:07:10Z",
-          "tags": [
-            "ai",
-            "agents",
-            "python",
-            "programming"
-          ],
-          "trendingScore": 0.1,
-          "linkedRepos": [
-            {
-              "fullName": "multica-ai/multica",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "lum1104--understand-anything": {
       "count7d": 1,
       "reactionsSum7d": 5,
@@ -4709,7 +4797,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 97.9,
+        "hoursSincePosted": 103.6,
         "readingTime": 5
       },
       "articles": [
@@ -4743,52 +4831,45 @@
         }
       ]
     },
-    "nextlevelbuilder--goclaw": {
+    "multica-ai--multica": {
       "count7d": 1,
       "reactionsSum7d": 5,
-      "commentsSum7d": 0,
+      "commentsSum7d": 1,
       "topArticle": {
-        "id": 3691887,
-        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
-        "author": "truongpx396",
+        "id": 3720461,
+        "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+        "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
+        "author": "arshtechpro",
         "reactions": 5,
-        "comments": 0,
-        "hoursSincePosted": 125.3,
-        "readingTime": 16
+        "comments": 1,
+        "hoursSincePosted": 45.1,
+        "readingTime": 4
       },
       "articles": [
         {
-          "id": 3691887,
-          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
-          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
-          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+          "id": 3720461,
+          "title": "Multica: An Open-Source Platform for Managing AI Coding Agents Like Teammates",
+          "description": "If you've been using Claude Code, Codex, or similar AI coding agents, you've probably felt the...",
+          "url": "https://dev.to/arshtechpro/multica-an-open-source-platform-for-managing-ai-coding-agents-like-teammates-2469",
           "author": {
-            "username": "truongpx396",
-            "name": "Truong Phung",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
+            "username": "arshtechpro",
+            "name": "ArshTechPro",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3258664%2F7a2cc61a-0b4d-4cf8-884e-52f33905cac3.png"
           },
           "reactionsCount": 5,
-          "commentsCount": 0,
-          "readingTime": 16,
-          "publishedAt": "2026-05-18T08:12:05Z",
+          "commentsCount": 1,
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T22:07:10Z",
           "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
+            "ai",
+            "agents",
+            "python",
+            "programming"
           ],
-          "trendingScore": 0.03,
+          "trendingScore": 0.09,
           "linkedRepos": [
             {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            },
-            {
-              "fullName": "openclaw/openclaw",
-              "location": "body"
-            },
-            {
-              "fullName": "nextlevelbuilder/goclaw",
+              "fullName": "multica-ai/multica",
               "location": "body"
             }
           ]
@@ -4796,7 +4877,7 @@
       ]
     },
     "anthropics--claude-code": {
-      "count7d": 10,
+      "count7d": 11,
       "reactionsSum7d": 3,
       "commentsSum7d": 1,
       "topArticle": {
@@ -4806,7 +4887,7 @@
         "author": "crawleyprint_71",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 141.5,
+        "hoursSincePosted": 147.2,
         "readingTime": 11
       },
       "articles": [
@@ -5105,309 +5186,83 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "can1357--oh-my-pi": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3710799,
-        "title": "Secure Agents: Control Policies in the Harness",
-        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
-        "author": "epappas",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 68.4,
-        "readingTime": 7
-      },
-      "articles": [
+        },
         {
-          "id": 3710799,
-          "title": "Secure Agents: Control Policies in the Harness",
-          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
-          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+          "id": 3734738,
+          "title": "Why Claude Code Sessions Diverge: A Mechanism Catalog",
+          "description": "Anthropic's April 2026 postmortem confirmed: Claude Code A/B-routes sessions, behavior is session-sticky, restart actually works. Six mechanisms catalog.",
+          "url": "https://dev.to/vainamoinen/why-claude-code-sessions-diverge-a-mechanism-catalog-4j63",
           "author": {
-            "username": "epappas",
-            "name": "Evangelos Pappas",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
+            "username": "vainamoinen",
+            "name": "Vainamoinen | Pulsed Media",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3879600%2Fce3a6ec3-4bde-4859-baeb-e6f99ed3c817.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-20T17:03:09Z",
+          "readingTime": 3,
+          "publishedAt": "2026-05-23T17:50:30Z",
           "tags": [
             "ai",
+            "llm",
             "agents",
-            "cybersecurity",
             "devops"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "can1357/oh-my-pi",
+              "fullName": "anthropics/claude-code",
               "location": "body"
             }
           ]
         }
       ]
     },
-    "fission-ai--openspec": {
+    "nextlevelbuilder--goclaw": {
       "count7d": 1,
-      "reactionsSum7d": 1,
+      "reactionsSum7d": 5,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3690020,
-        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
-        "author": "kenimo49",
-        "reactions": 1,
+        "id": 3691887,
+        "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+        "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
+        "author": "truongpx396",
+        "reactions": 5,
         "comments": 0,
-        "hoursSincePosted": 96.5,
-        "readingTime": 6
+        "hoursSincePosted": 131,
+        "readingTime": 16
       },
       "articles": [
         {
-          "id": 3690020,
-          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
-          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
-          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+          "id": 3691887,
+          "title": "🔮 Hermes Agent 🤖: A Practical Guide 🔥 — and How It Stacks Up Against OpenClaw & GoClaw 📊",
+          "description": "This is a submission for the Hermes Agent Challenge   A practical deep-dive for engineers, founders,...",
+          "url": "https://dev.to/truongpx396/hermes-agent-the-self-improving-agent-framework-and-how-it-compares-to-openclaw-goclaw-22mc",
           "author": {
-            "username": "kenimo49",
-            "name": "Ken Imoto",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
+            "username": "truongpx396",
+            "name": "Truong Phung",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2215325%2Ff0dca1b8-525d-45b6-bafc-f3d3141bc934.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 5,
           "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-19T13:00:01Z",
+          "readingTime": 16,
+          "publishedAt": "2026-05-18T08:12:05Z",
           "tags": [
-            "claudecode",
-            "ai",
-            "spec",
-            "openapi"
+            "hermesagentchallenge",
+            "devchallenge",
+            "agents"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.03,
           "linkedRepos": [
             {
-              "fullName": "Fission-AI/OpenSpec",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "openai--symphony": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3729039,
-        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-        "author": "judy_miranttie",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 12.5,
-        "readingTime": 14
-      },
-      "articles": [
-        {
-          "id": 3729039,
-          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
-          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
-          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
-          "author": {
-            "username": "judy_miranttie",
-            "name": "Judy",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 14,
-          "publishedAt": "2026-05-23T01:00:08Z",
-          "tags": [
-            "multiagent",
-            "aiteam",
-            "aiautomation",
-            "claudecode"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "openai/symphony",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "anthropics--skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 149.5,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
+              "fullName": "NousResearch/hermes-agent",
               "location": "body"
             },
             {
-              "fullName": "mattpocock/skills",
+              "fullName": "openclaw/openclaw",
               "location": "body"
             },
             {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "mattpocock--skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 149.5,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "addyosmani--agent-skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3686742,
-        "title": "What Are Claude Skills",
-        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-        "author": "speedy_devv",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 149.5,
-        "readingTime": 7
-      },
-      "articles": [
-        {
-          "id": 3686742,
-          "title": "What Are Claude Skills",
-          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
-          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
-          "author": {
-            "username": "speedy_devv",
-            "name": "speedy_devv",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-17T08:00:53Z",
-          "tags": [
-            "claudecode",
-            "cloudskills",
-            "ai",
-            "buildinpublic"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            },
-            {
-              "fullName": "addyosmani/agent-skills",
-              "location": "body"
-            },
-            {
-              "fullName": "obra/superpowers",
+              "fullName": "nextlevelbuilder/goclaw",
               "location": "body"
             }
           ]
@@ -5425,7 +5280,7 @@
         "author": "chen115y",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 60.5,
+        "hoursSincePosted": 66.2,
         "readingTime": 20
       },
       "articles": [
@@ -5531,6 +5386,312 @@
         }
       ]
     },
+    "can1357--oh-my-pi": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3710799,
+        "title": "Secure Agents: Control Policies in the Harness",
+        "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+        "author": "epappas",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 74.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3710799,
+          "title": "Secure Agents: Control Policies in the Harness",
+          "description": "Secure Agents: Control Policies in the Harness   Alice opens her company's internal HR...",
+          "url": "https://dev.to/epappas/secure-agents-control-policies-in-the-harness-2ak8",
+          "author": {
+            "username": "epappas",
+            "name": "Evangelos Pappas",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F164260%2F1e4df5dd-6d54-44e0-9d40-6968e9143111.jpeg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-20T17:03:09Z",
+          "tags": [
+            "ai",
+            "agents",
+            "cybersecurity",
+            "devops"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "can1357/oh-my-pi",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "fission-ai--openspec": {
+      "count7d": 1,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3690020,
+        "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+        "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+        "author": "kenimo49",
+        "reactions": 1,
+        "comments": 0,
+        "hoursSincePosted": 102.2,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3690020,
+          "title": "I Refused to Write Specs Until Claude Code Generated Wrong Code Three Times",
+          "description": "I called spec-driven development overhead for six months. Then Claude Code wrote a discount feature that applied coupons to itself, three times in a row. Here is what fifteen minutes of OpenAPI bought me.",
+          "url": "https://dev.to/kenimo49/i-refused-to-write-specs-until-claude-code-generated-wrong-code-three-times-35hp",
+          "author": {
+            "username": "kenimo49",
+            "name": "Ken Imoto",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3800250%2F275022f6-cba9-47e3-b69e-e8faf7675a0c.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 6,
+          "publishedAt": "2026-05-19T13:00:01Z",
+          "tags": [
+            "claudecode",
+            "ai",
+            "spec",
+            "openapi"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Fission-AI/OpenSpec",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "openai--symphony": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3729039,
+        "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+        "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+        "author": "judy_miranttie",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 18.2,
+        "readingTime": 14
+      },
+      "articles": [
+        {
+          "id": 3729039,
+          "title": "How I Run 7 AI Models 24/7: Multi-Agent Architecture in Practice",
+          "description": "Seven AI models organized into a 24/7 team via Linear. Drop a task card, supervisor Agent picks it up in 5 minutes, dispatches to the right specialist",
+          "url": "https://dev.to/judy_miranttie/how-i-run-7-ai-models-247-multi-agent-architecture-in-practice-4k6l",
+          "author": {
+            "username": "judy_miranttie",
+            "name": "Judy",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3847007%2Ff92dd14a-2164-44ab-99d9-17acb7fead45.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 14,
+          "publishedAt": "2026-05-23T01:00:08Z",
+          "tags": [
+            "multiagent",
+            "aiteam",
+            "aiautomation",
+            "claudecode"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "openai/symphony",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "anthropics--skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 155.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "mattpocock--skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 155.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "addyosmani--agent-skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3686742,
+        "title": "What Are Claude Skills",
+        "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+        "author": "speedy_devv",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 155.2,
+        "readingTime": 7
+      },
+      "articles": [
+        {
+          "id": 3686742,
+          "title": "What Are Claude Skills",
+          "description": "You keep seeing \"Claude Skills\" in repos, on X, in YouTube thumbnails. You still are not sure what...",
+          "url": "https://dev.to/speedy_devv/what-are-claude-skills-m57",
+          "author": {
+            "username": "speedy_devv",
+            "name": "speedy_devv",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3882972%2F4d901804-cbc3-4bae-95ee-901bf0ed6631.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-17T08:00:53Z",
+          "tags": [
+            "claudecode",
+            "cloudskills",
+            "ai",
+            "buildinpublic"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "mattpocock/skills",
+              "location": "body"
+            },
+            {
+              "fullName": "addyosmani/agent-skills",
+              "location": "body"
+            },
+            {
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "openai--codex": {
       "count7d": 4,
       "reactionsSum7d": 1,
@@ -5542,7 +5703,7 @@
         "author": "skyguan92",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 128.5,
+        "hoursSincePosted": 134.2,
         "readingTime": 10
       },
       "articles": [
@@ -5675,7 +5836,7 @@
         "author": "ec1980",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 108.2,
+        "hoursSincePosted": 114,
         "readingTime": 5
       },
       "articles": [
@@ -5784,7 +5945,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 59.6,
+        "hoursSincePosted": 65.4,
         "readingTime": 9
       },
       "articles": [
@@ -5829,7 +5990,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 30.5,
+        "hoursSincePosted": 36.3,
         "readingTime": 10
       },
       "articles": [
@@ -5874,7 +6035,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 30.5,
+        "hoursSincePosted": 36.2,
         "readingTime": 8
       },
       "articles": [
@@ -5919,7 +6080,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 152,
+        "hoursSincePosted": 157.8,
         "readingTime": 6
       },
       "articles": [
@@ -5972,7 +6133,7 @@
         "author": "vainamoinen",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 152,
+        "hoursSincePosted": 157.8,
         "readingTime": 6
       },
       "articles": [
@@ -6025,7 +6186,7 @@
         "author": "nickyeolk",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 71.6,
+        "hoursSincePosted": 77.3,
         "readingTime": 7
       },
       "articles": [
@@ -6070,7 +6231,7 @@
         "author": "maicon_ribeiroesteves_32",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 98.5,
+        "hoursSincePosted": 104.2,
         "readingTime": 3
       },
       "articles": [
@@ -6115,7 +6276,7 @@
         "author": "wonderlab",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 130.7,
+        "hoursSincePosted": 136.5,
         "readingTime": 8
       },
       "articles": [
@@ -6160,7 +6321,7 @@
         "author": "yahya_bin_naveed",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 53.1,
+        "hoursSincePosted": 58.8,
         "readingTime": 12
       },
       "articles": [
@@ -6205,7 +6366,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 83.5,
+        "hoursSincePosted": 89.2,
         "readingTime": 9
       },
       "articles": [
@@ -6250,7 +6411,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 12.9,
+        "hoursSincePosted": 18.6,
         "readingTime": 4
       },
       "articles": [
@@ -6295,7 +6456,7 @@
         "author": "max_quimby",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 129.6,
+        "hoursSincePosted": 135.3,
         "readingTime": 9
       },
       "articles": [
@@ -6336,15 +6497,15 @@
     "github--github-mcp-server": {
       "count7d": 1,
       "reactionsSum7d": 4,
-      "commentsSum7d": 7,
+      "commentsSum7d": 8,
       "topArticle": {
         "id": 3690301,
         "title": "The Real Problems Start After Your MCP Server Works",
         "url": "https://dev.to/madhaviai/the-real-problems-start-after-your-mcp-server-works-2al5",
         "author": "madhaviai",
         "reactions": 4,
-        "comments": 7,
-        "hoursSincePosted": 118.5,
+        "comments": 8,
+        "hoursSincePosted": 124.2,
         "readingTime": 3
       },
       "articles": [
@@ -6359,7 +6520,7 @@
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3936149%2F9538f203-64dd-4b89-a2b0-d28126195c04.png"
           },
           "reactionsCount": 4,
-          "commentsCount": 7,
+          "commentsCount": 8,
           "readingTime": 3,
           "publishedAt": "2026-05-18T15:02:13Z",
           "tags": [
@@ -6377,118 +6538,49 @@
         }
       ]
     },
-    "datawhalechina--hello-agents": {
-      "count7d": 2,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3728972,
-        "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-        "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
-        "author": "wonderlab",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 12.8,
-        "readingTime": 11
-      },
-      "articles": [
-        {
-          "id": 3728972,
-          "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
-          "description": "You Think Your Agent Is \"Thinking.\" It's Actually Just Predicting Tokens.   Here's a...",
-          "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
-          "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 11,
-          "publishedAt": "2026-05-23T00:40:05Z",
-          "tags": [
-            "agents",
-            "llm",
-            "langchain",
-            "ai"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "datawhalechina/hello-agents",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3715025,
-          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
-          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
-          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
-          "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-21T07:43:56Z",
-          "tags": [
-            "agents",
-            "llm",
-            "ai",
-            "langchain"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "datawhalechina/hello-agents",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "maximhq--bifrost": {
-      "count7d": 2,
+      "count7d": 3,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3697159,
-        "title": "Putting an LLM Gateway in Front of Our Build Agents: Why We Picked Bifrost",
-        "url": "https://dev.to/claire_nguyen/putting-an-llm-gateway-in-front-of-our-build-agents-why-we-picked-bifrost-130g",
-        "author": "claire_nguyen",
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+        "author": "marcorinaldi_ai",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 105.1,
+        "hoursSincePosted": 50.4,
         "readingTime": 4
       },
       "articles": [
         {
-          "id": 3697159,
-          "title": "Putting an LLM Gateway in Front of Our Build Agents: Why We Picked Bifrost",
-          "description": "TL;DR: We bolted an LLM gateway in front of the AI features in our build pipeline tooling and ended...",
-          "url": "https://dev.to/claire_nguyen/putting-an-llm-gateway-in-front-of-our-build-agents-why-we-picked-bifrost-130g",
+          "id": 3719101,
+          "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+          "description": "TL;DR: We added a vision-language stage to an event-camera pipeline at Prophesee and the LLM provider...",
+          "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
           "author": {
-            "username": "claire_nguyen",
-            "name": "claire nguyen",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864932%2F406e92e1-2c8d-4d65-a1f4-a8d4e8c2fd1d.jpg"
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
           },
           "reactionsCount": 0,
           "commentsCount": 0,
           "readingTime": 4,
-          "publishedAt": "2026-05-19T04:22:40Z",
+          "publishedAt": "2026-05-21T16:52:22Z",
           "tags": [
-            "infrastructure",
-            "devops",
-            "sre",
+            "machinelearning",
+            "computervision",
+            "mlops",
             "llm"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
               "fullName": "maximhq/bifrost",
+              "location": "body"
+            },
+            {
+              "fullName": "BerriAI/litellm",
               "location": "body"
             }
           ]
@@ -6520,13 +6612,90 @@
               "location": "body"
             }
           ]
+        },
+        {
+          "id": 3697159,
+          "title": "Putting an LLM Gateway in Front of Our Build Agents: Why We Picked Bifrost",
+          "description": "TL;DR: We bolted an LLM gateway in front of the AI features in our build pipeline tooling and ended...",
+          "url": "https://dev.to/claire_nguyen/putting-an-llm-gateway-in-front-of-our-build-agents-why-we-picked-bifrost-130g",
+          "author": {
+            "username": "claire_nguyen",
+            "name": "claire nguyen",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864932%2F406e92e1-2c8d-4d65-a1f4-a8d4e8c2fd1d.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-19T04:22:40Z",
+          "tags": [
+            "infrastructure",
+            "devops",
+            "sre",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "berriai--litellm": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+        "author": "marcorinaldi_ai",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 50.4,
+        "readingTime": 4
+      },
+      "articles": [
+        {
+          "id": 3719101,
+          "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+          "description": "TL;DR: We added a vision-language stage to an event-camera pipeline at Prophesee and the LLM provider...",
+          "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+          "author": {
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-21T16:52:22Z",
+          "tags": [
+            "machinelearning",
+            "computervision",
+            "mlops",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            },
+            {
+              "fullName": "BerriAI/litellm",
+              "location": "body"
+            }
+          ]
         }
       ]
     },
     "vectorize-io--hindsight": {
       "count7d": 2,
       "reactionsSum7d": 0,
-      "commentsSum7d": 1,
+      "commentsSum7d": 0,
       "topArticle": {
         "id": 3702728,
         "title": "The cheapest model call is the one you don't make",
@@ -6534,7 +6703,7 @@
         "author": "wnxd",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 91.9,
+        "hoursSincePosted": 97.7,
         "readingTime": 6
       },
       "articles": [
@@ -6567,24 +6736,24 @@
           ]
         },
         {
-          "id": 3695395,
-          "title": "CRMs store data. I built something that remembers context.",
-          "description": "The first question I get when I tell people we have no database is: \"What do you mean, no...",
-          "url": "https://dev.to/sandhyagk/crms-store-data-i-built-something-that-remembers-context-5101",
+          "id": 3697942,
+          "title": "Hindsight Turned Repeat Commenters Into Recognizable People",
+          "description": "I was building EchoEngage an AI-driven comment responder, and ran into a frustrating...",
+          "url": "https://dev.to/vidushi0229/hindsight-turned-repeat-commenters-into-recognizable-people-4fl2",
           "author": {
-            "username": "sandhyagk",
-            "name": "Sandhya G K",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3938594%2F33c002a2-ec2d-4666-a42d-3abbabb292e7.png"
+            "username": "vidushi0229",
+            "name": "Vidushi Goyal",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3939244%2Fbee9b11b-60d0-4808-b17e-2214181e9b46.png"
           },
           "reactionsCount": 0,
-          "commentsCount": 1,
-          "readingTime": 6,
-          "publishedAt": "2026-05-18T18:56:33Z",
+          "commentsCount": 0,
+          "readingTime": 7,
+          "publishedAt": "2026-05-19T13:31:35Z",
           "tags": [
             "ai",
-            "architecture",
+            "fastapi",
             "rag",
-            "showdev"
+            "react"
           ],
           "trendingScore": 0,
           "linkedRepos": [
@@ -6607,7 +6776,7 @@
         "author": "anajsana95",
         "reactions": 4,
         "comments": 0,
-        "hoursSincePosted": 117.9,
+        "hoursSincePosted": 123.7,
         "readingTime": 5
       },
       "articles": [
@@ -6651,7 +6820,7 @@
         "author": "allelishi",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 95,
+        "hoursSincePosted": 100.7,
         "readingTime": 4
       },
       "articles": [
@@ -6696,7 +6865,7 @@
         "author": "selfagency",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 115.2,
+        "hoursSincePosted": 120.9,
         "readingTime": 7
       },
       "articles": [
@@ -6730,6 +6899,51 @@
         }
       ]
     },
+    "anomalyco--opencode": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3695081,
+        "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
+        "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
+        "author": "imper_7cde72b79d2529291ec",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 121.8,
+        "readingTime": 2
+      },
+      "articles": [
+        {
+          "id": 3695081,
+          "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
+          "description": "I use opencode as my daily TUI coding agent. It's good. But there's one thing that kept biting...",
+          "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
+          "author": {
+            "username": "imper_7cde72b79d2529291ec",
+            "name": "imper",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3812341%2F4a3e352b-d42f-4efe-bb2c-23e8703e87bb.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 2,
+          "publishedAt": "2026-05-18T17:23:30Z",
+          "tags": [
+            "opencode",
+            "cli",
+            "typescript",
+            "opensource"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anomalyco/opencode",
+              "location": "tag"
+            }
+          ]
+        }
+      ]
+    },
     "cloakhq--cloakbrowser": {
       "count7d": 2,
       "reactionsSum7d": 1,
@@ -6741,7 +6955,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 24.8,
+        "hoursSincePosted": 30.5,
         "readingTime": 4
       },
       "articles": [
@@ -6806,51 +7020,6 @@
         }
       ]
     },
-    "anomalyco--opencode": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3695081,
-        "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
-        "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
-        "author": "imper_7cde72b79d2529291ec",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 116.1,
-        "readingTime": 2
-      },
-      "articles": [
-        {
-          "id": 3695081,
-          "title": "/disconnect for opencode — a tiny TUI plugin I wish existed before I made it",
-          "description": "I use opencode as my daily TUI coding agent. It's good. But there's one thing that kept biting...",
-          "url": "https://dev.to/imper_7cde72b79d2529291ec/disconnect-for-opencode-a-tiny-tui-plugin-i-wish-existed-before-i-made-it-20j9",
-          "author": {
-            "username": "imper_7cde72b79d2529291ec",
-            "name": "imper",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3812341%2F4a3e352b-d42f-4efe-bb2c-23e8703e87bb.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 2,
-          "publishedAt": "2026-05-18T17:23:30Z",
-          "tags": [
-            "opencode",
-            "cli",
-            "typescript",
-            "opensource"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anomalyco/opencode",
-              "location": "tag"
-            }
-          ]
-        }
-      ]
-    },
     "daijro--camoufox": {
       "count7d": 1,
       "reactionsSum7d": 1,
@@ -6862,7 +7031,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 24.8,
+        "hoursSincePosted": 30.5,
         "readingTime": 4
       },
       "articles": [
@@ -6911,7 +7080,7 @@
         "author": "mir_mursalin_ankur",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 142,
+        "hoursSincePosted": 147.7,
         "readingTime": 53
       },
       "articles": [
@@ -6960,7 +7129,7 @@
         "author": "doramagic",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 143.3,
+        "hoursSincePosted": 149,
         "readingTime": 3
       },
       "articles": [
@@ -7005,7 +7174,7 @@
         "author": "jadysmgodoi",
         "reactions": 1,
         "comments": 1,
-        "hoursSincePosted": 47.6,
+        "hoursSincePosted": 53.3,
         "readingTime": 3
       },
       "articles": [
@@ -7050,7 +7219,7 @@
         "author": "mervindublin",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 53.1,
+        "hoursSincePosted": 58.9,
         "readingTime": 3
       },
       "articles": [
@@ -7084,6 +7253,79 @@
         }
       ]
     },
+    "datawhalechina--hello-agents": {
+      "count7d": 2,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3728972,
+        "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
+        "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
+        "author": "wonderlab",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 18.6,
+        "readingTime": 11
+      },
+      "articles": [
+        {
+          "id": 3728972,
+          "title": "Agent Series (2): ReAct — The Most Important Agent Reasoning Paradigm",
+          "description": "You Think Your Agent Is \"Thinking.\" It's Actually Just Predicting Tokens.   Here's a...",
+          "url": "https://dev.to/wonderlab/agent-series-2-react-the-most-important-agent-reasoning-paradigm-2b7k",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 11,
+          "publishedAt": "2026-05-23T00:40:05Z",
+          "tags": [
+            "agents",
+            "llm",
+            "langchain",
+            "ai"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "datawhalechina/hello-agents",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3715025,
+          "title": "Agent Series (1): What Is an Agent — It's Not Just an LLM That Can Call Tools",
+          "description": "You Think You're Using an Agent. You're Not.   In 2023, \"AI Agent\" became a buzzword...",
+          "url": "https://dev.to/wonderlab/agent-series-1-what-is-an-agent-its-not-just-an-llm-that-can-call-tools-4plh",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-21T07:43:56Z",
+          "tags": [
+            "agents",
+            "llm",
+            "ai",
+            "langchain"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "datawhalechina/hello-agents",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "czlonkowski--n8n-mcp": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -7095,7 +7337,7 @@
         "author": "rentierdigital",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 167.8,
+        "hoursSincePosted": 173.5,
         "readingTime": 11
       },
       "articles": [
@@ -7140,7 +7382,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 124.5,
+        "hoursSincePosted": 130.2,
         "readingTime": 3
       },
       "articles": [
@@ -7185,7 +7427,7 @@
         "author": "hectorvent",
         "reactions": 3,
         "comments": 0,
-        "hoursSincePosted": 162.9,
+        "hoursSincePosted": 168.6,
         "readingTime": 4
       },
       "articles": [
@@ -7223,8 +7465,8 @@
   "leaderboard": [
     {
       "fullName": "NousResearch/hermes-agent",
-      "count7d": 14,
-      "reactionsSum7d": 105
+      "count7d": 16,
+      "reactionsSum7d": 96
     },
     {
       "fullName": "google-ai-edge/gallery",
@@ -7239,7 +7481,7 @@
     {
       "fullName": "openclaw/openclaw",
       "count7d": 3,
-      "reactionsSum7d": 48
+      "reactionsSum7d": 49
     },
     {
       "fullName": "JuliusBrussee/caveman",
@@ -7283,7 +7525,7 @@
     },
     {
       "fullName": "anthropics/claude-code",
-      "count7d": 10,
+      "count7d": 11,
       "reactionsSum7d": 3
     },
     {
@@ -7322,11 +7564,6 @@
       "reactionsSum7d": 1
     },
     {
-      "fullName": "0xMassi/webclaw",
-      "count7d": 1,
-      "reactionsSum7d": 1
-    },
-    {
       "fullName": "daijro/camoufox",
       "count7d": 1,
       "reactionsSum7d": 1
@@ -7357,12 +7594,12 @@
       "reactionsSum7d": 1
     },
     {
-      "fullName": "datawhalechina/hello-agents",
-      "count7d": 2,
+      "fullName": "maximhq/bifrost",
+      "count7d": 3,
       "reactionsSum7d": 0
     },
     {
-      "fullName": "maximhq/bifrost",
+      "fullName": "datawhalechina/hello-agents",
       "count7d": 2,
       "reactionsSum7d": 0
     },
@@ -7393,6 +7630,11 @@
     },
     {
       "fullName": "anthropics/skills",
+      "count7d": 1,
+      "reactionsSum7d": 0
+    },
+    {
+      "fullName": "BerriAI/litellm",
       "count7d": 1,
       "reactionsSum7d": 0
     },

--- a/data/devto-trending.json
+++ b/data/devto-trending.json
@@ -1,8 +1,8 @@
 {
-  "fetchedAt": "2026-05-23T13:29:53.279Z",
+  "fetchedAt": "2026-05-23T19:13:41.646Z",
   "discoveryVersion": "2026-04-21",
   "windowDays": 7,
-  "scannedArticles": 1335,
+  "scannedArticles": 1331,
   "bodyFetchMode": "full",
   "priorityTags": [
     "ai",
@@ -179,7 +179,7 @@
   ],
   "sliceCounts": {
     "global-top-7d": 100,
-    "global-rising": 16,
+    "global-rising": 9,
     "global-fresh": 100,
     "tag-ai-top-7d": 100,
     "tag-artificialintelligence-top-7d": 0,
@@ -1318,6 +1318,27 @@
       "linkedRepos": []
     },
     {
+      "id": 3597666,
+      "title": "What was your win this week!?",
+      "description": "👋👋👋👋 Looking back on your week -- what was something you're proud of? All wins count -- big or small...",
+      "url": "https://dev.to/devteam/what-was-your-win-this-week-2ohc",
+      "author": {
+        "username": "jess",
+        "name": "Jess Lee",
+        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F264%2Fb75f6edf-df7b-406e-a56b-43facafb352c.jpg"
+      },
+      "reactionsCount": 50,
+      "commentsCount": 42,
+      "readingTime": 1,
+      "publishedAt": "2026-05-22T13:00:00Z",
+      "tags": [
+        "discuss",
+        "weeklyretro"
+      ],
+      "trendingScore": 14.61,
+      "linkedRepos": []
+    },
+    {
       "id": 3709055,
       "title": "Antigravity & WebMCP: Why Google I/O 2026 is Terrifying for Devs",
       "description": "This is a submission for the Google I/O Writing Challenge      \"It's been 10 years since we pivoted...",
@@ -1451,27 +1472,6 @@
         "security"
       ],
       "trendingScore": 13.1,
-      "linkedRepos": []
-    },
-    {
-      "id": 3597666,
-      "title": "What was your win this week!?",
-      "description": "👋👋👋👋 Looking back on your week -- what was something you're proud of? All wins count -- big or small...",
-      "url": "https://dev.to/devteam/what-was-your-win-this-week-2ohc",
-      "author": {
-        "username": "jess",
-        "name": "Jess Lee",
-        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F264%2Fb75f6edf-df7b-406e-a56b-43facafb352c.jpg"
-      },
-      "reactionsCount": 43,
-      "commentsCount": 34,
-      "readingTime": 1,
-      "publishedAt": "2026-05-22T13:00:00Z",
-      "tags": [
-        "discuss",
-        "weeklyretro"
-      ],
-      "trendingScore": 12.62,
       "linkedRepos": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh dev.to signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26341183328

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.